### PR TITLE
Search: set default empty string for query

### DIFF
--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -30,7 +30,7 @@ class SearchPage extends React.Component {
     return {
       limit: query.limit || 20,
       offset: query.offset || 0,
-      term: query.q,
+      term: query.q || '',
     };
   }
 


### PR DESCRIPTION
After pushing to staging, I noticed an error when going to `/search` without a preset `?q=query`. This will default an empty string and return all collectives.