### PR TITLE
Fix name/logos mismatch in Memberships

### DIFF
--- a/src/components/Membership.js
+++ b/src/components/Membership.js
@@ -11,7 +11,6 @@ class Membership extends React.Component {
 
   constructor(props) {
     super(props);
-
   }
 
   render() {
@@ -28,13 +27,15 @@ class Membership extends React.Component {
     if (!name) return (<div />);
 
     return (
-      <div>
+      <React.Fragment>
         <style jsx>{`
         .Membership {
           float: left;
           margin: 1rem;
         }
-        `}</style>
+        `}
+        </style>
+
         <div className="Membership">
           <CollectiveCard
             key={membership.id}
@@ -43,7 +44,7 @@ class Membership extends React.Component {
             LoggedInUser={LoggedInUser}
             />
         </div>
-      </div>
+      </React.Fragment>
     )
   }
 

--- a/src/components/Memberships.js
+++ b/src/components/Memberships.js
@@ -23,7 +23,7 @@ class Collectives extends React.Component {
     if (!memberships || memberships.length === 0) return (<div />);
 
     return (
-      <div className="Collectives" >
+      <div className="Collectives">
         <style jsx>{`
         .Collectives {
           margin: 3rem auto 3rem;
@@ -33,7 +33,8 @@ class Collectives extends React.Component {
           flex-wrap: wrap;
           justify-content: center;
         }
-        `}</style>
+        `}
+        </style>
 
         {memberships.map(membership => (
           <Membership


### PR DESCRIPTION
Looks like the root cause is actually a React bug, but that would take time and energy to track it.

Explanation: We're doing a first rendering with node on the server side. Then, we do the client side rendering, with Memberships ordered differently in some browsers. Instead of just displaying the Memberships in different order, React is messing up while doing the reconciliation.

In this PR we fix it 2 times on our side:
1. make sure that memberships are ordered the same on node and all browsers
2. help react with a key in CollectiveCard (the one on Membership should be enough, that's the issue).

Edit: the 2. thing was not helping in the end.

Issue: https://github.com/opencollective/opencollective/issues/1092