### PR TITLE
Fix Next.js server crash

### DIFF
--- a/src/lib/initClient.js
+++ b/src/lib/initClient.js
@@ -42,11 +42,17 @@ function createClient(initialState, options = {}) {
 
   const errorLink = onError(({ graphQLErrors, networkError }) => {
     if (graphQLErrors) {
-      graphQLErrors.map(({ message, locations, path }) =>
-        console.error(
-          `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`,
-        ),
-      );
+      graphQLErrors.map((error) => {
+        if (error) {
+          const { message, locations, path } = error;
+          console.error(
+            `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`,
+          );
+          return;
+        }
+
+        console.error('[GraphQL error]: Received null error');
+      });
     }
 
     if (networkError) {


### PR DESCRIPTION
I ran into an issue while doing my local set-up where running the UI with an unseeded API was generating null values in the graphQLErrors list. The parameter destructuring was causing the whole Next.js server to crash when the error was null. I didn't manage to figure out what was causing the null to be in the list yet. Should I make a separate ticket for that?

Relevant stacktrace:
```
info: POST /api/graphql 200 9ms {"meta":{}}
[ { message: 'Cannot read property \'dataValues\' of undefined',
    locations: [ [Object] ],
    path: [ 'recent' ] },
  null ]
[GraphQL error]: Message: Cannot read property 'dataValues' of undefined, Location: [object Object], Path: recent
[GraphQL error]: Received null error
>>> apollo error:  { Error: GraphQL error: Cannot read property 'dataValues' of undefined
GraphQL error: Error message not found.
    at new ApolloError (/Users/bartvanremortele/projects/opencollective-frontend/node_modules/src/errors/ApolloError.ts:56:5)
    at /Users/bartvanremortele/projects/opencollective-frontend/node_modules/src/core/QueryManager.ts:520:31
    at /Users/bartvanremortele/projects/opencollective-frontend/node_modules/src/core/QueryManager.ts:1061:11
    at Array.forEach (<anonymous>)
    at /Users/bartvanremortele/projects/opencollective-frontend/node_modules/src/core/QueryManager.ts:1060:10
    at Map.forEach (<anonymous>)
    at QueryManager.broadcastQueries (/Users/bartvanremortele/projects/opencollective-frontend/node_modules/src/core/QueryManager.ts:1054:18)
    at Object.next (/Users/bartvanremortele/projects/opencollective-frontend/node_modules/src/core/QueryManager.ts:1150:18)
    at notifySubscription (/Users/bartvanremortele/projects/opencollective-frontend/node_modules/zen-observable/lib/Observable.js:126:18)
    at onNotify (/Users/bartvanremortele/projects/opencollective-frontend/node_modules/zen-observable/lib/Observable.js:161:3)
    at SubscriptionObserver.next (/Users/bartvanremortele/projects/opencollective-frontend/node_modules/zen-observable/lib/Observable.js:215:7)
    at /Users/bartvanremortele/projects/opencollective-frontend/node_modules/apollo-link-dedup/src/dedupLink.ts:60:43
    at Array.forEach (<anonymous>)
    at Object.next (/Users/bartvanremortele/projects/opencollective-frontend/node_modules/apollo-link-dedup/src/dedupLink.ts:60:27)
    at notifySubscription (/Users/bartvanremortele/projects/opencollective-frontend/node_modules/zen-observable/lib/Observable.js:126:18)
    at onNotify (/Users/bartvanremortele/projects/opencollective-frontend/node_modules/zen-observable/lib/Observable.js:161:3)
  graphQLErrors: 
   [ { message: 'Cannot read property \'dataValues\' of undefined',
       locations: [Array],
       path: [Array] },
     null ],
  networkError: null,
  message: 'GraphQL error: Cannot read property \'dataValues\' of undefined\nGraphQL error: Error message not found.',
  extraInfo: undefined }

```