### PR TITLE
style(buttons): styling buttons according to Figma standards

### DIFF
--- a/src/pages/global-styles.js
+++ b/src/pages/global-styles.js
@@ -108,7 +108,14 @@ injectGlobal`
   }
 
   a:hover {
-    color: #797d80;
+    color: #ffffff;
+    background-color: #66A3FF;
+    text-decoration: none;
+  }
+
+  a:active {
+    color: #ffffff;
+    background-color: #145ECC;
     text-decoration: none;
   }
 


### PR DESCRIPTION
The buttons should follow the design standards according to Figma:

![screen shot 2018-09-07 at 10 21 15 am](https://user-images.githubusercontent.com/8717041/45224738-b7939900-b288-11e8-94d6-7f5d00cdd0bd.png)


Fixes opencollective/opencollective#1277