### PR TITLE
fix(components/AddFundsSourcePicker): show host name, use optgroup

### DIFF
--- a/src/components/AddFundsSourcePicker.js
+++ b/src/components/AddFundsSourcePicker.js
@@ -199,4 +199,10 @@ export const AddFundsSourcePickerForUserWithData = withIntl(
   AddFundsSourcePickerForUser,
 );
 
+// for testing
+export const MockAddFundsSourcePicker = withIntl(AddFundsSourcePicker);
+export const MockAddFundsSourcePickerForUser = withIntl(
+  AddFundsSourcePickerForUser,
+);
+
 export default AddFundsSourcePickerWithData;

--- a/src/components/AddFundsSourcePicker.js
+++ b/src/components/AddFundsSourcePicker.js
@@ -39,25 +39,14 @@ class AddFundsSourcePicker extends React.Component {
     this.props.onChange(FromCollectiveId);
   }
 
-  renderSeparator(type) {
-    if (!this.fromCollectivesByType[type]) return;
+  getGroupLabel(type) {
     const { intl } = this.props;
 
-    let label = intl.formatMessage(this.messages[type.toLowerCase()], {
-      n: this.fromCollectivesByType[type].length,
-    });
-    if (label.length % 2 !== 0) {
-      label += ' ';
-    }
-
-    let dashes = '';
-    for (let i = 0; i < (40 - label.length) / 2; i++) {
-      dashes += '-';
-    }
-
-    return (
-      <option value="">{`${dashes} ${label.toUpperCase()} ${dashes}`}</option>
-    );
+    return intl
+      .formatMessage(this.messages[type.toLowerCase()], {
+        n: this.fromCollectivesByType[type].length,
+      })
+      .toUpperCase();
   }
 
   renderSourceEntry(fromCollective) {
@@ -96,32 +85,44 @@ class AddFundsSourcePicker extends React.Component {
         placeholder="select"
         onChange={this.onChange}
       >
-        <option value={host.id}>
-          <FormattedMessage
-            id="addfunds.fromCollective.host"
-            values={{ host: host.name }}
-            defaultMessage="Host ({host})"
-          />
-        </option>
-        {this.fromCollectivesByType['COLLECTIVE'].length > 0 &&
-          this.renderSeparator('COLLECTIVE')}
-        {this.fromCollectivesByType['COLLECTIVE'].map(this.renderSourceEntry)}
+        <FormattedMessage
+          id="addfunds.fromCollective.host"
+          values={{ host: host.name }}
+          defaultMessage="Host ({host})"
+        >
+          {message => <option value={host.id}>{message}</option>}
+        </FormattedMessage>
 
-        {this.fromCollectivesByType['ORGANIZATION'].length > 0 &&
-          this.renderSeparator('ORGANIZATION')}
-        {this.fromCollectivesByType['ORGANIZATION'].map(this.renderSourceEntry)}
+        {this.fromCollectivesByType['COLLECTIVE'].length > 0 && (
+          <optgroup label={this.getGroupLabel('COLLECTIVE')}>
+            {this.fromCollectivesByType['COLLECTIVE'].map(
+              this.renderSourceEntry,
+            )}
+          </optgroup>
+        )}
 
-        {this.fromCollectivesByType['USER'].length > 0 &&
-          this.renderSeparator('USER')}
-        {this.fromCollectivesByType['USER'].map(this.renderSourceEntry)}
+        {this.fromCollectivesByType['ORGANIZATION'].length > 0 && (
+          <optgroup label={this.getGroupLabel('ORGANIZATION')}>
+            {this.fromCollectivesByType['ORGANIZATION'].map(
+              this.renderSourceEntry,
+            )}
+          </optgroup>
+        )}
 
-        <option value="">---------------</option>
-        <option value="other">
+        {this.fromCollectivesByType['USER'].length > 0 && (
+          <optgroup label={this.getGroupLabel('USER')}>
+            {this.fromCollectivesByType['USER'].map(this.renderSourceEntry)}
+          </optgroup>
+        )}
+
+        <optgroup label="OTHER">
           <FormattedMessage
             id="addfunds.fromCollective.other"
             defaultMessage="other (please specify)"
-          />
-        </option>
+          >
+            {message => <option value="other">{message}</option>}
+          </FormattedMessage>
+        </optgroup>
       </FormControl>
     );
   }

--- a/src/components/__tests__/AddFundsSourcePicker.test.js
+++ b/src/components/__tests__/AddFundsSourcePicker.test.js
@@ -1,0 +1,119 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
+import 'jest-styled-components';
+
+import {
+  MockAddFundsSourcePicker,
+  MockAddFundsSourcePickerForUser,
+} from '../AddFundsSourcePicker';
+
+describe('AddFundsSourcePicker component', () => {
+  const defaultProps = {
+    collective: {},
+    data: {},
+    host: {},
+    onChange: () => {},
+    paymentMethod: {},
+  };
+
+  it('renders default options', () => {
+    const tree = renderer.create(<MockAddFundsSourcePicker {...defaultProps} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders loading state', () => {
+    const props = {
+      ...defaultProps,
+      data: {
+        loading: true,
+      },
+    };
+    const tree = renderer.create(<MockAddFundsSourcePicker {...props} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders host name as first option', () => {
+    const props = {
+      ...defaultProps,
+      host: {
+        id: 'example-id',
+        name: 'Example Host',
+      },
+    };
+
+    const tree = renderer.create(<MockAddFundsSourcePicker {...props} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders fromCollectives by type in optgroup', () => {
+    const props = {
+      ...defaultProps,
+      data: {
+        PaymentMethod: {
+          fromCollectives: {
+            collectives: [{
+              id: 'collective-id',
+              name: 'Example Collective',
+              type: 'COLLECTIVE',
+            }, {
+              id: 'organization-id',
+              name: 'Example Organzation',
+              type: 'ORGANIZATION'
+            }, {
+              id: 'user-id',
+              name: 'Example Person',
+              type: 'USER',
+            }],
+          },
+        },
+      },
+    };
+
+    const tree = renderer.create(<MockAddFundsSourcePicker {...props} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('calls onChange prop function when selection changes', () => {
+    const onChange = jest.fn();
+    const props = {
+      ...defaultProps,
+      onChange,
+    };
+
+    const component = mount(<MockAddFundsSourcePicker {...props} />);
+
+    component.find('select').simulate('change', { target: { value: 'test' } });
+
+    expect(onChange).toHaveBeenCalledWith('test');
+  });
+});
+
+describe('AddFundsSourcePickerForUser component', () => {
+  const defaultProps = {
+    LoggedInUser: {
+      hostsUserIsAdminOf: () => [],
+    },
+    onChange: () => {},
+  };
+
+  it('renders default options', () => {
+    const tree = renderer.create(<MockAddFundsSourcePickerForUser {...defaultProps} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('render host options', () => {
+    const props = {
+      ...defaultProps,
+      LoggedInUser: {
+        hostsUserIsAdminOf: () => [{
+          id: 'host-id',
+          name: 'Example Host',
+        }],
+      },
+    };
+
+    const tree = renderer.create(<MockAddFundsSourcePickerForUser {...props} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/__tests__/__snapshots__/AddFundsSourcePicker.test.js.snap
+++ b/src/components/__tests__/__snapshots__/AddFundsSourcePicker.test.js.snap
@@ -1,0 +1,138 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AddFundsSourcePicker component renders default options 1`] = `
+<select
+  className="form-control"
+  id="sourcePicker"
+  name="template"
+  onChange={[Function]}
+  placeholder="select"
+>
+  <option>
+    Host ()
+  </option>
+  <optgroup
+    label="OTHER"
+  >
+    <option
+      value="other"
+    >
+      other (please specify)
+    </option>
+  </optgroup>
+</select>
+`;
+
+exports[`AddFundsSourcePicker component renders fromCollectives by type in optgroup 1`] = `
+<select
+  className="form-control"
+  id="sourcePicker"
+  name="template"
+  onChange={[Function]}
+  placeholder="select"
+>
+  <option>
+    Host ()
+  </option>
+  <optgroup
+    label="COLLECTIVE"
+  >
+    <option
+      value="collective-id"
+    >
+      Example Collective
+    </option>
+  </optgroup>
+  <optgroup
+    label="ORGANIZATION"
+  >
+    <option
+      value="organization-id"
+    >
+      Example Organzation
+    </option>
+  </optgroup>
+  <optgroup
+    label="PEOPLE"
+  >
+    <option
+      value="user-id"
+    >
+      Example Person
+    </option>
+  </optgroup>
+  <optgroup
+    label="OTHER"
+  >
+    <option
+      value="other"
+    >
+      other (please specify)
+    </option>
+  </optgroup>
+</select>
+`;
+
+exports[`AddFundsSourcePicker component renders host name as first option 1`] = `
+<select
+  className="form-control"
+  id="sourcePicker"
+  name="template"
+  onChange={[Function]}
+  placeholder="select"
+>
+  <option
+    value="example-id"
+  >
+    Host (Example Host)
+  </option>
+  <optgroup
+    label="OTHER"
+  >
+    <option
+      value="other"
+    >
+      other (please specify)
+    </option>
+  </optgroup>
+</select>
+`;
+
+exports[`AddFundsSourcePicker component renders loading state 1`] = `<div />`;
+
+exports[`AddFundsSourcePickerForUser component render host options 1`] = `
+<div>
+  <select
+    className="form-control"
+    id="sourcePicker"
+    name="template"
+    onChange={[Function]}
+    placeholder="select"
+  >
+    <option
+      value=""
+    />
+    <option
+      value="host-id"
+    >
+      Example Host
+    </option>
+  </select>
+</div>
+`;
+
+exports[`AddFundsSourcePickerForUser component renders default options 1`] = `
+<div>
+  <select
+    className="form-control"
+    id="sourcePicker"
+    name="template"
+    onChange={[Function]}
+    placeholder="select"
+  >
+    <option
+      value=""
+    />
+  </select>
+</div>
+`;


### PR DESCRIPTION
Fixes opencollective/opencollective#1309

This PR uses the `children` prop of the `FormattedMessage` component to render an `option` tag instead of being a child of an `option` tag ([as referenced here](https://github.com/yahoo/react-intl/issues/987#issuecomment-334153101)).

While working on that component, I also converted the use of null options as separators to use [`optgroup`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup) tags instead. This prevents people from accidentally selecting null values

Before:

<img width="796" alt="screen shot 2018-09-17 at 5 28 47 pm" src="https://user-images.githubusercontent.com/3051193/45651365-51382300-ba9f-11e8-8c78-6f3d3ab3f1df.png">


After:

<img width="757" alt="screen shot 2018-09-17 at 5 28 16 pm" src="https://user-images.githubusercontent.com/3051193/45651370-572e0400-ba9f-11e8-8cb3-af71aeef085d.png">
