### PR TITLE
Add .prettierrc to match eslint config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}


### PR DESCRIPTION
To better match the `eslint` configuration, i.e. single quotes and trailing commas, this PR adds a `.prettierrc` file. 