### PR TITLE
InputField debounce bugs

### DIFF
--- a/src/components/InputField.js
+++ b/src/components/InputField.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { get, debounce } from 'lodash';
+import { get } from 'lodash';
 import { capitalize } from '../lib/utils';
 import DateTime from 'react-datetime';
 import stylesheet from '../styles/react-datetime.css';
@@ -133,7 +133,6 @@ class InputField extends React.Component {
     super(props);
     this.state = { value: props.value, validationState: null };
     this.handleChange = this.handleChange.bind(this);
-    this.debouncedHandleChange = debounce(props.onChange, 500);
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
@@ -167,7 +166,7 @@ class InputField extends React.Component {
       this.setState({ validationState: 'error' });
     }
     this.setState({ value });
-    this.debouncedHandleChange(value);
+    this.props.onChange(value);
   }
 
   render() {

--- a/src/components/InputFieldPresets.js
+++ b/src/components/InputFieldPresets.js
@@ -23,8 +23,7 @@ class InputFieldPresets extends React.Component {
     let { values } = this.state;
     values[index] = val;
     values = values.filter(v => v !== null);
-    this.setState({ values });
-    this.onChange();
+    this.setState({ values }, () => this.onChange());
   }
 
   onChange() {

--- a/src/components/InputTypeLocation.js
+++ b/src/components/InputTypeLocation.js
@@ -25,6 +25,10 @@ class InputTypeLocation extends React.Component {
   }
 
   handleChange(value) {
+    if (!value) {
+      this.setState({ value: {} });
+      return this.props.onChange({});
+    }
     const label = value.label && value.label.replace(/,.+/, '');
     const location = {
       name: label,


### PR DESCRIPTION
Fixes opencollective/opencollective#1301 by removing the `debounce` from `onChange` for the `InputField` component. This should prevent accidental inputs not being deleted. This also fixes a bug in the `InputTypeLocation` component preventing people from fully deleting values from that input.