### PR TITLE
BackYourStack section on the Homepage

### DIFF
--- a/src/components/Body.js
+++ b/src/components/Body.js
@@ -19,7 +19,7 @@ export default class Body extends React.Component {
             }
 
             a {
-              text-decoration: none !important;
+              text-decoration: none;
               cursor: pointer;
             }
             button {

--- a/src/components/StyledLink.js
+++ b/src/components/StyledLink.js
@@ -11,10 +11,15 @@ import {
   fontWeight,
   maxWidth,
   space,
+  style,
   textAlign,
   width,
 } from 'styled-system';
 import { whiteSpace } from './Text';
+
+const textDecoration = style({
+  prop: 'textDecoration',
+});
 
 const StyledLink = styled.a`
   ${active}
@@ -29,6 +34,7 @@ const StyledLink = styled.a`
   ${maxWidth}
   ${space}
   ${textAlign}
+  ${textDecoration}
   ${whiteSpace}
   ${width}
 `;

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -4,6 +4,7 @@ import {
   display,
   fontFamily,
   fontSize,
+  fontStyle,
   fontWeight,
   lineHeight,
   letterSpacing,
@@ -25,6 +26,7 @@ export const Span = styled.span`
   ${display}
   ${fontFamily}
   ${fontSize}
+  ${fontStyle}
   ${fontWeight}
   ${lineHeight}
   ${letterSpacing}
@@ -39,6 +41,7 @@ export const P = styled.p`
   ${display}
   ${fontFamily}
   ${fontSize}
+  ${fontStyle}
   ${fontWeight}
   ${lineHeight}
   ${letterSpacing}
@@ -58,6 +61,7 @@ export const H1 = styled.h1`
   ${display}
   ${fontFamily}
   ${fontSize}
+  ${fontStyle}
   ${fontWeight}
   ${lineHeight}
   ${letterSpacing}
@@ -78,6 +82,7 @@ export const H2 = styled.h2`
   ${display}
   ${fontFamily}
   ${fontSize}
+  ${fontStyle}
   ${fontWeight}
   ${lineHeight}
   ${letterSpacing}
@@ -98,6 +103,7 @@ export const H3 = styled.h3`
   ${display}
   ${fontFamily}
   ${fontSize}
+  ${fontStyle}
   ${fontWeight}
   ${lineHeight}
   ${letterSpacing}
@@ -118,6 +124,7 @@ export const H4 = styled.h4`
   ${display}
   ${fontFamily}
   ${fontSize}
+  ${fontStyle}
   ${fontWeight}
   ${lineHeight}
   ${letterSpacing}
@@ -138,6 +145,7 @@ export const H5 = styled.h5`
   ${display}
   ${fontFamily}
   ${fontSize}
+  ${fontStyle}
   ${fontWeight}
   ${lineHeight}
   ${letterSpacing}

--- a/src/pages/__tests__/__snapshots__/search.test.js.snap
+++ b/src/pages/__tests__/__snapshots__/search.test.js.snap
@@ -748,7 +748,7 @@ exports[`Search Page renders empty results message 1`] = `
     </div>
   </header>
   <main
-    className="jsx-96768397"
+    className="jsx-2712905933"
   >
     <div
       className="c19"
@@ -2089,7 +2089,7 @@ exports[`Search Page renders error message 1`] = `
     </div>
   </header>
   <main
-    className="jsx-96768397"
+    className="jsx-2712905933"
   >
     <div
       className="content"
@@ -3405,7 +3405,7 @@ exports[`Search Page renders loading grid SVG 1`] = `
     </div>
   </header>
   <main
-    className="jsx-96768397"
+    className="jsx-2712905933"
   >
     <div
       className="c19"
@@ -4896,7 +4896,7 @@ exports[`Search Page renders search results with pagination 1`] = `
     </div>
   </header>
   <main
-    className="jsx-96768397"
+    className="jsx-2712905933"
   >
     <div
       className="c19"

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -15,7 +15,7 @@ import Body from '../components/Body';
 import Footer from '../components/Footer';
 import Header from '../components/Header';
 import TransactionSimple from '../components/TransactionSimple';
-import { Span, P, H1, H2, H3 } from '../components/Text';
+import { Span, P, H1, H2, H3, H4 } from '../components/Text';
 import ListItem from '../components/ListItem';
 import Hide from '../components/Hide';
 import Container from '../components/Container';
@@ -856,6 +856,89 @@ class HomePage extends React.Component {
                   </Container>
                 </StyledLink>
               </Flex>
+            </Container>
+          </Container>
+
+          <Container
+            background="linear-gradient(182.45deg, #222584 4.38%, #6266EC 118.14%)"
+            position="relative"
+            py={6}
+          >
+            <Container
+              background="#EBF1FA"
+              height="15rem"
+              position="absolute"
+              style={{ clipPath: 'ellipse(58% 48% at 50% 52%)' }}
+              top={-80}
+              width={1}
+            />
+            <Container
+              alignItems="center"
+              display="flex"
+              flexDirection={['column', null, 'row']}
+              justifyContent="space-around"
+              maxWidth={1200}
+              mx="auto"
+            >
+              <Container maxWidth={550} px={[3, null, 0]}>
+                <P color="rgba(255, 255, 255, 0.5)" fontSize="1.6rem" mb={4}>
+                  Introducing
+                </P>
+
+                <H3
+                  color="white"
+                  fontSize={['3.2rem', null, '4.8rem']}
+                  fontStyle="italic"
+                  fontWeight="800"
+                  mb={4}
+                >
+                  back
+                  <Span color="#9092FF" fontWeight="300">
+                    your
+                  </Span>
+                  stack
+                </H3>
+
+                <H4 color="white" fontSize="2.4rem" mb={4}>
+                  Discover the Open Source projects your organization is using
+                  that need financial support.
+                </H4>
+
+                <P color="white" fontSize="1.6rem">
+                  BackYourStack is a community project initiated by Open
+                  Collective.
+                  <StyledLink
+                    href="https://backyourstack.com/contributing"
+                    color="white"
+                    px={2}
+                    textDecoration="underline"
+                  >
+                    Learn how to contribute here.
+                  </StyledLink>
+                </P>
+
+                <StyledLink
+                  href="https://backyourstack.com/"
+                  bg="#FFF"
+                  borderRadius="50px"
+                  color="#3C40AE"
+                  display="block"
+                  fontSize="1.6rem"
+                  fontWeight="bold"
+                  maxWidth="220px"
+                  mx={['auto', null, 0]}
+                  mt={4}
+                  py={3}
+                  textAlign="center"
+                  width={[250, null, 320]}
+                >
+                  Go to Back Your Stack
+                </StyledLink>
+              </Container>
+
+              <Box order={[-1, null, 1]}>
+                <img src="/static/images/bys-logo.svg" alt="Back Your Stack" />
+              </Box>
             </Container>
           </Container>
 

--- a/src/static/images/bys-logo.svg
+++ b/src/static/images/bys-logo.svg
@@ -1,0 +1,52 @@
+<svg width="328" height="344" viewBox="0 0 328 344" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g filter="url(#filter0_d)">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M187.429 14.3213L255.466 54.0975C265.725 60.095 272 70.8839 272 82.5247V167.468C272 179.374 265.438 190.367 254.807 196.271L186.55 234.179C172.576 241.94 155.424 241.94 141.45 234.179L73.1925 196.271C62.5616 190.367 56 179.374 56 167.468L56 82.5247C56 70.8839 62.275 60.095 72.5338 54.0975L140.571 14.3213C154.988 5.8929 173.012 5.8929 187.429 14.3213Z" fill="url(#paint0_linear)"/>
+    <path d="M186.958 116.778L236.113 145.317C241.504 148.447 243.265 155.235 240.047 160.478C239.072 162.065 237.705 163.389 236.068 164.329L180.006 196.542C173.67 200.183 171.174 201.123 168.236 201.74C165.297 202.357 162.432 202.353 159.496 201.728C156.559 201.104 154.066 200.157 147.74 196.499L90.2727 163.267C84.8761 160.146 83.1026 153.361 86.3115 148.113C87.2898 146.513 88.6679 145.179 90.3177 144.235L138.559 116.629C148.074 111.184 151.82 109.781 156.229 108.864C160.639 107.946 164.936 107.959 169.339 108.904C173.742 109.849 177.479 111.275 186.958 116.778Z" fill="url(#paint1_linear)"/>
+    <path d="M186.958 86.8962L236.113 115.435C241.504 118.565 243.265 125.352 240.047 130.595C239.072 132.182 237.705 133.507 236.068 134.447L180.006 166.66C173.67 170.301 171.174 171.241 168.236 171.858C165.297 172.474 162.432 172.471 159.496 171.846C156.559 171.221 154.066 170.274 147.74 166.616L90.2727 133.384C84.8761 130.264 83.1026 123.479 86.3115 118.231C87.2899 116.63 88.6679 115.296 90.3177 114.352L138.559 86.7466C148.074 81.302 151.82 79.8985 156.229 78.9812C160.639 78.0639 164.936 78.0772 169.339 79.0217C173.742 79.9663 177.479 81.3929 186.958 86.8962Z" fill="url(#paint2_linear)" style="mix-blend-mode:screen"/>
+    <g filter="url(#filter1_d)">
+      <path d="M186.958 57.0158L236.113 85.5546C241.504 88.6845 243.265 95.4721 240.047 100.715C239.072 102.302 237.705 103.626 236.068 104.566L180.006 136.78C173.67 140.421 171.174 141.361 168.236 141.977C165.297 142.594 162.432 142.59 159.496 141.966C156.559 141.341 154.066 140.394 147.74 136.736L90.2727 103.504C84.8761 100.383 83.1026 93.5986 86.3115 88.3503C87.2899 86.7501 88.6679 85.4161 90.3177 84.472L138.56 56.8663C148.074 51.4217 151.82 50.0182 156.229 49.1008C160.639 48.1835 164.936 48.1968 169.339 49.1413C173.742 50.0859 177.479 51.5125 186.958 57.0158Z" fill="url(#paint3_linear)" style="mix-blend-mode:screen"/>
+    </g>
+  </g>
+
+  <defs>
+    <filter id="filter0_d" x="0" y="0" width="328" height="344" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+      <feOffset dy="48"/>
+      <feGaussianBlur stdDeviation="28"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.0793272 0 0 0 0 0.0874277 0 0 0 0 0.349345 0 0 0 0.24 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+    </filter>
+
+    <filter id="filter1_d" x="68.7128" y="48.4229" width="188.943" height="126.014" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+      <feOffset dy="16"/>
+      <feGaussianBlur stdDeviation="8"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.0768 0 0 0 0 0.07808 0 0 0 0 0.08 0 0 0 0.08 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+    </filter>
+
+    <linearGradient id="paint0_linear" x1="164" y1="8" x2="164" y2="240" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#282878"/>
+      <stop offset="1" stop-color="#3131A0"/>
+    </linearGradient>
+
+    <linearGradient id="paint1_linear" x1="207.502" y1="179.738" x2="140.686" y2="107.562" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FDE75B"/>
+      <stop offset="1" stop-color="#FC57B3"/>
+    </linearGradient>
+
+    <linearGradient id="paint2_linear" x1="211.609" y1="148.925" x2="142.504" y2="75.8593" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F67AFE"/>
+      <stop offset="1" stop-color="#662DFF"/>
+    </linearGradient>
+
+    <linearGradient id="paint3_linear" x1="209.986" y1="119.956" x2="116.03" y2="12.1045" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#4AF2FF"/>
+      <stop offset="1" stop-color="#3D44FF"/>
+    </linearGradient>
+  </defs>
+</svg>


### PR DESCRIPTION
This PR adds a new section to the homepage to promote BackYourStack and link to the external tool. 

Large screens:
<img width="1387" alt="screen shot 2018-09-20 at 4 51 48 pm" src="https://user-images.githubusercontent.com/3051193/45846359-948bcf00-bcf5-11e8-9abd-39e02c114c05.png">

Small screens:
<img width="409" alt="screen shot 2018-09-20 at 4 52 11 pm" src="https://user-images.githubusercontent.com/3051193/45846370-981f5600-bcf5-11e8-8057-bd04d7ad3eac.png">
