### PR TITLE
OrderForm: fix state race-condition for paypal button

### DIFF
--- a/src/components/OrderForm.js
+++ b/src/components/OrderForm.js
@@ -576,15 +576,16 @@ class OrderForm extends React.Component {
       });
     }
 
-    this.setState(newState);
-    if (typeof window !== 'undefined') {
-      window.state = newState;
-    }
+    this.setState(newState, () => {
+      if (typeof window !== 'undefined') {
+        window.state = newState;
+      }
 
-    /* This is the type of the PayPal payment method */
-    if (this.isPayPalSelected()) {
-      this.loadPayPalButton();
-    }
+      /* This is the type of the PayPal payment method */
+      if (this.isPayPalSelected()) {
+        this.loadPayPalButton();
+      }
+    });
   };
 
   /** Return true if PayPal is the selected payment method


### PR DESCRIPTION
Fixes opencollective/opencollective#1319

[As the React docs state:](https://reactjs.org/docs/faq-state.html#why-is-setstate-giving-me-the-wrong-value)

> Calls to setState are asynchronous - don’t rely on this.state to reflect the new value immediately after calling setState.

The `loadPayPalButton()` method depends on the component to have re-rendered immediately after the `paypal` payment method is selected, so we need to use the `setState` callback to guarantee the component has rendered with the new state before loading PayPal. 

Preview:
<img width="810" alt="screen shot 2018-09-21 at 12 44 06 pm" src="https://user-images.githubusercontent.com/3051193/45894407-39f97e00-bd9c-11e8-8e3c-995c6080d1f6.png">
