### PR TITLE
AddFundsForm: recompute amount field 'pre' value on render

### DIFF
--- a/src/components/AddFundsForm.js
+++ b/src/components/AddFundsForm.js
@@ -81,13 +81,15 @@ class AddFundsForm extends React.Component {
       'website.label': { id: 'user.website.label', defaultMessage: 'website' },
     });
 
+    this.totalAmountField = {
+      name: 'totalAmount',
+      type: 'currency',
+      focus: true,
+      pre: getCurrencySymbol(props.collective.currency),
+    };
+
     this.fields = [
-      {
-        name: 'totalAmount',
-        type: 'currency',
-        pre: getCurrencySymbol(props.collective.currency),
-        focus: true,
-      },
+      this.totalAmountField,
       {
         name: 'description',
       },
@@ -249,6 +251,9 @@ class AddFundsForm extends React.Component {
       this.isAddFundsToOrg &&
       this.state.form.totalAmount > 0 &&
       (hostFeePercent > 0 || platformFeePercent > 0);
+
+    // recompute this value based on new props
+    this.totalAmountField.pre = getCurrencySymbol(this.props.collective.currency);
 
     return (
       <div className="AddFundsForm">


### PR DESCRIPTION
Fixes https://github.com/opencollective/opencollective/issues/1329

In the issue, WWCode is seen as entered euros in the amount field but the details field shows the totals in USD. This is bug where that `pre` value is computed in the constructor of the `AddFundsForm` component based on the initial props, so if a new collective is selected to fill the `AddFundsForm` then the render function is called using the previously computed value instead of the new props. 

The quickest fix for this issue is updating that amount field data in the render function with the latest props. 

