### PR TITLE
Add delete link on updates

### DIFF
--- a/src/components/Update.js
+++ b/src/components/Update.js
@@ -3,16 +3,16 @@ import PropTypes from 'prop-types';
 import withIntl from '../lib/withIntl';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { capitalize, formatDate } from '../lib/utils';
-import { graphql } from 'react-apollo';
+import { graphql, compose } from 'react-apollo';
 import gql from 'graphql-tag';
+import { get } from 'lodash';
 import Avatar from './Avatar';
 import Role from './Role';
 import UpdateTextWithData from './UpdateTextWithData';
-import { Link } from '../server/pages';
+import { Router, Link } from '../server/pages';
 import SmallButton from './SmallButton';
 import EditUpdateForm from './EditUpdateForm';
 import PublishUpdateBtnWithData from './PublishUpdateBtnWithData';
-import { get } from 'lodash';
 
 class Update extends React.Component {
   static propTypes = {
@@ -36,6 +36,7 @@ class Update extends React.Component {
     this.save = this.save.bind(this);
     this.handleChange = this.handleChange.bind(this);
     this.toggleEdit = this.toggleEdit.bind(this);
+    this.deleteUpdate = this.deleteUpdate.bind(this);
     this.messages = defineMessages({
       pending: { id: 'update.pending', defaultMessage: 'pending' },
       paid: { id: 'update.paid', defaultMessage: 'paid' },
@@ -60,6 +61,18 @@ class Update extends React.Component {
 
   toggleEdit() {
     this.state.mode === 'edit' ? this.cancelEdit() : this.edit();
+  }
+
+  async deleteUpdate() {
+    if (!confirm('😱 Are you really sure you want to delete this update?'))
+      return;
+
+    try {
+      await this.props.deleteUpdate(this.props.update.id);
+      Router.pushRoute('collective', { slug: this.props.collective.slug });
+    } catch (err) {
+      console.error('>>> deleteUpdate error: ', JSON.stringify(err));
+    }
   }
 
   handleChange(update) {
@@ -212,13 +225,25 @@ class Update extends React.Component {
               </div>
             )}
             {editable && (
-              <div>
-                <a className="toggleEditUpdate" onClick={this.toggleEdit}>
-                  {intl.formatMessage(
-                    this.messages[`${mode === 'edit' ? 'cancelEdit' : 'edit'}`],
-                  )}
-                </a>
-              </div>
+              <React.Fragment>
+                <div>
+                  <a className="toggleEditUpdate" onClick={this.toggleEdit}>
+                    {intl.formatMessage(
+                      this.messages[
+                        `${mode === 'edit' ? 'cancelEdit' : 'edit'}`
+                      ],
+                    )}
+                  </a>
+                </div>
+                <div>
+                  <a className="deleteUpdateUpdate" onClick={this.deleteUpdate}>
+                    <FormattedMessage
+                      id="update.delete"
+                      defaultMessage="delete"
+                    />
+                  </a>
+                </div>
+              </React.Fragment>
             )}
           </div>
 
@@ -287,7 +312,15 @@ const editUpdateQuery = gql`
   }
 `;
 
-const addMutation = graphql(editUpdateQuery, {
+const deleteUpdateQuery = gql`
+  mutation deleteUpdate($id: Int!) {
+    deleteUpdate(id: $id) {
+      id
+    }
+  }
+`;
+
+const editUpdateMutation = graphql(editUpdateQuery, {
   props: ({ mutate }) => ({
     editUpdate: async update => {
       return await mutate({ variables: { update } });
@@ -295,4 +328,17 @@ const addMutation = graphql(editUpdateQuery, {
   }),
 });
 
-export default withIntl(addMutation(Update));
+const deleteUpdateMutation = graphql(deleteUpdateQuery, {
+  props: ({ mutate }) => ({
+    deleteUpdate: async updateID => {
+      return await mutate({ variables: { id: updateID } });
+    },
+  }),
+});
+
+const addUpdateMutations = compose(
+  editUpdateMutation,
+  deleteUpdateMutation,
+);
+
+export default withIntl(addUpdateMutations(Update));

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -603,6 +603,7 @@
   "update.paid": "paid",
   "update.approved": "approved",
   "update.rejected": "rejected",
+  "update.delete": "delete",
   "update.edit": "edit",
   "update.cancelEdit": "cancel edit",
   "update.viewLatestUpdates": "View latest updates",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -603,6 +603,7 @@
   "update.paid": "paid",
   "update.approved": "approved",
   "update.rejected": "rejected",
+  "update.delete": "delete",
   "update.edit": "edit",
   "update.cancelEdit": "cancel edit",
   "update.viewLatestUpdates": "View latest updates",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -603,6 +603,7 @@
   "update.paid": "payé",
   "update.approved": "approuvé",
   "update.rejected": "rejeté",
+  "update.delete": "supprimer",
   "update.edit": "éditer",
   "update.cancelEdit": "annuler les changements",
   "update.viewLatestUpdates": "Voir les dernières news",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -603,6 +603,7 @@
   "update.paid": "paid",
   "update.approved": "approved",
   "update.rejected": "rejected",
+  "update.delete": "delete",
   "update.edit": "edit",
   "update.cancelEdit": "cancel edit",
   "update.viewLatestUpdates": "View latest updates",


### PR DESCRIPTION
# Feature

Resolves opencollective/opencollective#965 and opencollective/opencollective#1311
Require https://github.com/opencollective/opencollective-api/pull/1477

## Behavior 

* Added a link next to `edit`

![Link to delete update](https://user-images.githubusercontent.com/1556356/46756025-cd9cdb00-ccc6-11e8-91dd-b48d42f99ec6.png)

* When clicked, a JS confirm appears 

![Confirm](https://user-images.githubusercontent.com/1556356/46756120-00df6a00-ccc7-11e8-8808-d0e3073da0df.png)


* If confirmed, update is deleted and user get redirected to the collective's updates page

# About error display

If there's an error, we log it in the console and nothing is shown to the user. While implementing this feature I tried different ways to show them and found none that really convinced me. I may have missed something but I think that a component to display errors as notifications like in the screenshot below could be useful:

![Error notification proposal](https://user-images.githubusercontent.com/1556356/46755876-7d257d80-ccc6-11e8-9064-354d5bcff1b2.png)

Any thoughts or advice regarding this ?