### PR TITLE
Body: remove `overflow: scroll` for code blocks

### DIFF
--- a/src/components/Body.js
+++ b/src/components/Body.js
@@ -76,7 +76,6 @@ export default class Body extends React.Component {
           .content code {
             background-color: #f6f8fa;
             padding: 0.5rem;
-            overflow: scroll;
             max-width: 100%;
           }
 


### PR DESCRIPTION
Fixes opencollective/opencollective#1355

There is a global style for `code` blocks in content areas that uses `overflow: scroll`, presumably to avoid large blocks of code from taking over the screen in a post. However, this causes some weird styling in Chrome on Windows (as seen in the linked issue). I'm removing the overflow styling as it appears most collectives use it for inline code highlighting. 