### PR TITLE
Skip graphql query if no slug provided for createCollective

### DIFF
--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -768,7 +768,9 @@ export const getCollectiveApplicationsQuery = gql`
 `;
 
 export const addCollectiveData = graphql(getCollectiveQuery);
-export const addCollectiveCoverData = graphql(getCollectiveCoverQuery);
+export const addCollectiveCoverData = (component, options) => {
+  return graphql(getCollectiveCoverQuery, options)(component);
+};
 export const addCollectiveToEditData = graphql(getCollectiveToEditQuery);
 export const addEventCollectiveData = graphql(getEventCollectiveQuery);
 export const addTiersData = graphql(getTiersQuery);

--- a/src/pages/createCollective.js
+++ b/src/pages/createCollective.js
@@ -19,7 +19,7 @@ class CreateCollectivePage extends React.Component {
 
   static propTypes = {
     slug: PropTypes.string, // for addCollectiveCoverData
-    data: PropTypes.object.isRequired, // from withData
+    data: PropTypes.object, // from withData
     getLoggedInUser: PropTypes.func.isRequired, // from withLoggedInUser
   };
 
@@ -35,13 +35,9 @@ class CreateCollectivePage extends React.Component {
   }
 
   render() {
-    const { data } = this.props;
+    const { data = {} } = this.props;
 
-    const bypassErrorPage = get(data, 'error.message', '').includes(
-      'Please provide a slug or an id',
-    );
-
-    if ((this.state.loading || !data.Collective) && !bypassErrorPage) {
+    if (this.state.loading || data.error) {
       return <ErrorPage loading={this.state.loading} data={data} />;
     }
 
@@ -55,5 +51,11 @@ class CreateCollectivePage extends React.Component {
 }
 
 export default withData(
-  withIntl(withLoggedInUser(addCollectiveCoverData(CreateCollectivePage))),
+  withIntl(
+    withLoggedInUser(
+      addCollectiveCoverData(CreateCollectivePage, {
+        skip: props => !props.slug,
+      }),
+    ),
+  ),
 );


### PR DESCRIPTION
To serve as a base discussion for #816. As demonstrated in the screenshot below, this PR totally skip the request if slug is not provided on CreateCollective page.

More info about the `skip` option [here](https://www.apollographql.com/docs/react/api/react-apollo.html#graphql-config-skip).

@znarf What do you think of this approach?

![Requests preview](https://user-images.githubusercontent.com/1556356/46964811-5f329100-d0a9-11e8-925d-ec8739760341.png)
