### PR TITLE
Fix tiers remove action

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,5 +15,6 @@
     "graphql/named-operations": ["error"],
     "graphql/capitalized-type-name": ["error"],
     "graphql/no-deprecated-fields": ["error"],
+    "react/no-array-index-key": ["warn"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6392,8 +6392,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": false,
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "optional": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
@@ -6414,14 +6413,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": false,
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "optional": true
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6436,20 +6433,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "optional": true
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "optional": true
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "optional": true
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6566,8 +6560,7 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": false,
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "optional": true
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
@@ -6579,7 +6572,6 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6594,7 +6586,6 @@
           "version": "3.0.4",
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6602,14 +6593,12 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": false,
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "optional": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6628,7 +6617,6 @@
           "version": "0.5.1",
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6709,8 +6697,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "optional": true
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6722,7 +6709,6 @@
           "version": "1.4.0",
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6808,8 +6794,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "resolved": false,
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "optional": true
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6845,7 +6830,6 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6865,7 +6849,6 @@
           "version": "3.0.1",
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6909,14 +6892,12 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": false,
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "optional": true
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": false,
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "optional": true
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
         }
       }
     },
@@ -14959,10 +14940,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-      "dev": true
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "v8flags": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "styled-components": "3.4.10",
     "styled-jsx": "3.1.0",
     "styled-system": "3.1.11",
+    "uuid": "^3.3.2",
     "webpack": "4.20.2",
     "winston": "3.1.0"
   },

--- a/src/components/EditTiers.js
+++ b/src/components/EditTiers.js
@@ -296,7 +296,6 @@ class EditTiers extends React.Component {
   render() {
     const { intl, defaultType = 'TICKET' } = this.props;
 
-    console.log(this.state.tiers);
     return (
       <div className="EditTiers">
         <style jsx>

--- a/src/components/EditTiers.js
+++ b/src/components/EditTiers.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import { Button, Form } from 'react-bootstrap';
 import { defineMessages, injectIntl } from 'react-intl';
+import uuidv4 from 'uuid/v4';
 
 import InputField from './InputField';
 import InputFieldPresets from './InputFieldPresets';
@@ -234,7 +235,7 @@ class EditTiers extends React.Component {
 
   addTier(tier) {
     const tiers = this.state.tiers;
-    tiers.push(tier || {});
+    tiers.push({ ...(tier || {}), __uuid: uuidv4() });
     this.setState({ tiers });
   }
 
@@ -248,6 +249,7 @@ class EditTiers extends React.Component {
 
   renderTier(tier, index) {
     const { intl } = this.props;
+    const key = tier.id ? `tier-${tier.id}` : `newTier-${tier.__uuid};`;
 
     const defaultValues = {
       ...tier,
@@ -256,7 +258,7 @@ class EditTiers extends React.Component {
     };
 
     return (
-      <div className={`tier ${tier.slug}`} key={`tier-${index}`}>
+      <div className={`tier ${tier.slug}`} key={key}>
         <div className="tierActions">
           <a
             className="removeTier"
@@ -294,6 +296,7 @@ class EditTiers extends React.Component {
   render() {
     const { intl, defaultType = 'TICKET' } = this.props;
 
+    console.log(this.state.tiers);
     return (
       <div className="EditTiers">
         <style jsx>


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/1364

## Issue origin

```jsx
<div className={`tier ${tier.slug}`} key={`tier-${index}`}>
```

Using `index` as key is usually considered a bad practice. In this case it was not re-rendering tiers from the list when removing because indexes were permuted.

From React's point of view:

* Initial list
```
tier-1 <--- Remove this
tier-2
tier-3
```

* New list
```
tier-1 (previously tier-2) => key was here before, no need to re-render
tier-2 (previously tier-3) => key was here before, no need to re-render
```

## Fix

Existing tiers keys are now generated using their `id` while new tiers are created with a special `__uuid` that makes them unique. It uses [uuid](https://www.npmjs.com/package/uuid). 

I've also added [react/no-access-state-in-setstate](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-access-state-in-setstate.md) to `.eslintrc` to progressively migrate lists using indexes as keys in the future.