### PR TITLE
Button component: scroll to top after pushRoute

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import colors from '../constants/colors';
-import router from '../server/pages';
+import { Router } from '../server/pages';
 import HashLink from 'react-scrollchor';
 
 const star = '/static/images/icons/star.svg';
@@ -28,12 +28,14 @@ class Button extends React.Component {
     this.onClick = this.onClick.bind(this);
   }
 
-  onClick(e) {
+  async onClick(e) {
     const { type, href, onClick, disabled } = this.props;
     if (type === 'submit') return;
     e.preventDefault();
     if (href && href.substr(0, 1) !== '#') {
-      return router.Router.pushRoute(href);
+      await Router.pushRoute(href);
+      window.scrollTo(0, 0);
+      document.body.focus();
     }
     if (!onClick) return;
     return !disabled && onClick && onClick();


### PR DESCRIPTION
Fixes issue brought up in a previous PR: https://github.com/opencollective/opencollective-frontend/pull/913#discussion_r224769685

Now mimics the behavior of [`next/link`](https://github.com/zeit/next.js/blob/canary/packages/next-server/lib/link.js#L90-L97) until we have a component that renders a styled Link. 