### PR TITLE
Pledged subscriptions

### DIFF
--- a/src/components/PledgeCard.js
+++ b/src/components/PledgeCard.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 
 import { imagePreview } from '../lib/utils';
 import { defaultImage } from '../constants/collectives';
@@ -73,7 +74,13 @@ const PledgeCard = ({
           abbreviate
         />
 
-        {interval ? ` / ${interval}` : null}
+        {interval && (
+          <FormattedMessage
+            id="order.interval"
+            values={{ interval }}
+            defaultMessage=" / {interval, select, month {mo.} year {yr.}}"
+          />
+        )}
       </Span>
     </P>
 

--- a/src/components/Subscriptions.js
+++ b/src/components/Subscriptions.js
@@ -23,6 +23,10 @@ class Subscriptions extends React.Component {
         id: 'subscription.cancelled.label',
         defaultMessage: 'Cancelled Subscriptions',
       },
+      'subscription.pending.label': {
+        id: 'subscription.pending.label',
+        defaultMessage: 'Pending Subscriptions',
+      },
       'subscription.login.message': {
         id: 'subscription.login.message',
         defaultMessage:
@@ -61,7 +65,10 @@ class Subscriptions extends React.Component {
       .filter(s => s.isSubscriptionActive)
       .sort(this.sortBycreatedAt);
     const canceledSubs = subscriptions
-      .filter(s => !s.isSubscriptionActive)
+      .filter(s => !s.isSubscriptionActive && s.status !== 'PENDING')
+      .sort(this.sortBycreatedAt);
+    const pendingSubs = subscriptions
+      .filter(({ status }) => status === 'PENDING')
       .sort(this.sortBycreatedAt);
 
     let userString = `${collective.name || collective.slug} isn't`;
@@ -91,7 +98,8 @@ class Subscriptions extends React.Component {
               width: 33%;
             }
             .active,
-            .canceled {
+            .canceled,
+            .pending {
               display: flex;
               flex-wrap: wrap;
               flex-direction: row;
@@ -179,6 +187,25 @@ class Subscriptions extends React.Component {
         )}
         <div className="canceled">
           {canceledSubs.map(subscription => (
+            <SubscriptionCard
+              subscription={subscription}
+              key={`canceled-${subscription.id}`}
+              LoggedInUser={LoggedInUser}
+              paymentMethods={collective.paymentMethods}
+              slug={collective.slug}
+            />
+          ))}
+        </div>
+        {pendingSubs.length > 0 && (
+          <div className="subscriptions-cancelled-label">
+            {' '}
+            <span>
+              {intl.formatMessage(this.messages['subscription.pending.label'])}{' '}
+            </span>
+          </div>
+        )}
+        <div className="pending">
+          {pendingSubs.map(subscription => (
             <SubscriptionCard
               subscription={subscription}
               key={`canceled-${subscription.id}`}

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -656,6 +656,7 @@ export const getSubscriptionsQuery = gql`
         createdAt
         isSubscriptionActive
         isPastDue
+        status
         collective {
           id
           name

--- a/src/pages/createPledge.js
+++ b/src/pages/createPledge.js
@@ -159,6 +159,7 @@ class CreatePledgePage extends React.Component {
           fromCollective,
           website,
           publicMessage,
+          interval,
         },
       },
     } = event;
@@ -173,6 +174,7 @@ class CreatePledgePage extends React.Component {
       },
       totalAmount: Number(totalAmount.value) * 100,
       publicMessage: publicMessage.value,
+      interval: interval.value,
     };
 
     if (data) {
@@ -395,10 +397,10 @@ class CreatePledgePage extends React.Component {
                       name="interval"
                       defaultValue="monthly"
                     >
-                      <option key="monthly" value="monthly">
+                      <option key="monthly" value="month">
                         Monthly
                       </option>
-                      <option key="yearly" value="yearly">
+                      <option key="yearly" value="year">
                         Yearly
                       </option>
                       <option key="none" value={null}>


### PR DESCRIPTION
With the addition of pledged subscriptions support (https://github.com/opencollective/opencollective-api/pull/1491), this PR displays the correctly formatted interval for pledges and creates a new "Pending subscriptions" section when viewing a user's subscriptions. 

Preview:

**Pledge Card:**
<img width="395" alt="screen shot 2018-10-24 at 5 22 10 pm" src="https://user-images.githubusercontent.com/3051193/47464090-2df74680-d7b6-11e8-8626-17e585c5b9d2.png">


**/:collectiveSlug/subscriptions**
<img width="1138" alt="screen shot 2018-10-24 at 5 44 05 pm" src="https://user-images.githubusercontent.com/3051193/47464103-351e5480-d7b6-11e8-89e6-c676f61c8297.png">
