### PR TITLE
Pledges: bug fixes

### DIFF
--- a/src/pages/claimCollective.js
+++ b/src/pages/claimCollective.js
@@ -103,7 +103,7 @@ class ClaimCollectivePage extends React.Component {
     const websitePath = new RegExp(website.split('://')[1], 'i');
     const [repo] = repos.filter(({ html_url }) => html_url.match(websitePath));
 
-    const isAdmin = repo && repo.pemissions.admin;
+    const isAdmin = repo && repo.permissions.admin;
 
     const invalid = repos.length > 0 && !isAdmin;
 

--- a/src/pages/createPledge.js
+++ b/src/pages/createPledge.js
@@ -193,7 +193,7 @@ class CreatePledgePage extends React.Component {
       } = await this.props.createOrder(order);
       if (result.collective.slug) {
         const params = { slug: result.collective.slug };
-        if (data.Collective) {
+        if (data && data.Collective) {
           params.refetch = true;
         }
         Router.pushRoute('collective', params);


### PR DESCRIPTION
When going through the final testing for the pledges workflow, I found two places that needed some quick fixes.

- fixed a small typo that caused an error for checking if the current user is the admin of the collective to be claimed.
- added an extra logic to check for `data` before setting parameters in the createPledge page