### PR TITLE
Home Page: update 'become a sponsor' link

### DIFF
--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -483,7 +483,7 @@ class HomePage extends React.Component {
                   we’ll gladly set them up and get them going.
                 </P>
 
-                <Link route="/organizations/new" passHref>
+                <Link route="marketing" params={{ pageSlug: 'become-a-sponsor' }} passHref>
                   <StyledLink
                     bg="#3385FF"
                     borderRadius="50px"


### PR DESCRIPTION
With the deployment of #939, the link to "Become a sponsor" on the home page needs to be updated. 