### PR TITLE
Marketing Page: use inline file-loader to prevent staticPage errors

### DIFF
--- a/src/next.config.js
+++ b/src/next.config.js
@@ -73,17 +73,6 @@ const nextConfig = {
         },
       },
       {
-        test: /static\/.*\.(js)$/,
-        use: {
-          loader: 'file-loader',
-          options: {
-            publicPath: '/_next/static/js/',
-            outputPath: 'static/js/',
-            name: '[name]-[hash].[ext]',
-          },
-        },
-      },
-      {
         test: /static\/.*\.(jpg|gif|png|svg)$/,
         use: {
           loader: 'file-loader',

--- a/src/pages/marketingPage.js
+++ b/src/pages/marketingPage.js
@@ -12,7 +12,8 @@ import withLoggedInUser from '../lib/withLoggedInUser';
 import { loadScriptAsync } from '../lib/utils';
 
 import sponsorPageHtml from '../static/sponsor-page/index.html';
-import sponsorPageScript from '../static/sponsor-page/js/scripts.js';
+// hardcode loaders for specific files
+import sponsorPageScript from '!file-loader?publicPath=/_next/static/js/&outputPath=static/js/&name=[name]-[hash].[ext]!../static/sponsor-page/js/scripts.js'; // eslint-disable-line
 import sponsorPageStyle from '!css-loader!../static/sponsor-page/css/styles.css'; // eslint-disable-line
 
 class MarketingPage extends React.Component {


### PR DESCRIPTION
@piamancini noticed errors in production related to loading the FAQ pages. I traced the issue down to importing `src/pages/static/index.js` being converted into file paths instead of returning the exported object containing the static html content. This regression was added with `file-loader` configuration for the recently added marketing page component for `/become-a-sponsor` route. 

The quickest fix was to inline the `file-loader` in the `marketingPage` component until we figure out a better regex for the webpack config file. 