### PR TITLE
Allow cancelling pending subscription

### DIFF
--- a/src/components/CancelSubscriptionBtn.js
+++ b/src/components/CancelSubscriptionBtn.js
@@ -53,6 +53,7 @@ const cancelSubscriptionQuery = gql`
     cancelSubscription(id: $id) {
       id
       isSubscriptionActive
+      status
     }
   }
 `;

--- a/src/components/SubscriptionCard.js
+++ b/src/components/SubscriptionCard.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 import { graphql } from 'react-apollo';
@@ -449,7 +449,7 @@ class SubscriptionCard extends React.Component {
           )}
 
           {canEditSubscription &&
-            subscription.isSubscriptionActive && (
+            (subscription.isSubscriptionActive || subscription.status === 'PENDING') && (
               <div
                 className={`actions ${this.state.showMenu ? 'selected' : ''}`}
                 onClick={() =>
@@ -476,25 +476,29 @@ class SubscriptionCard extends React.Component {
                     />
                   </CustomToggle>
                   <Dropdown.Menu className="menu-item">
-                    <MenuItem
-                      style={menuItemStyle}
-                      eventKey={this.stateConstants.editPaymentMethod}
-                    >
-                      <FormattedMessage
-                        id="subscription.menu.editPaymentMethod"
-                        defaultMessage="Update payment method"
-                      />
-                    </MenuItem>
-                    <MenuItem
-                      style={menuItemStyle}
-                      eventKey={this.stateConstants.editAmount}
-                    >
-                      <FormattedMessage
-                        id="subscription.menu.editAmount"
-                        defaultMessage="Update amount"
-                      />
-                    </MenuItem>
-                    <MenuItem style={{ margin: '2px' }} divider />
+                    {subscription.status !== 'PENDING' && (
+                      <Fragment>
+                        <MenuItem
+                          style={menuItemStyle}
+                          eventKey={this.stateConstants.editPaymentMethod}
+                        >
+                          <FormattedMessage
+                            id="subscription.menu.editPaymentMethod"
+                            defaultMessage="Update payment method"
+                          />
+                        </MenuItem>
+                        <MenuItem
+                          style={menuItemStyle}
+                          eventKey={this.stateConstants.editAmount}
+                        >
+                          <FormattedMessage
+                            id="subscription.menu.editAmount"
+                            defaultMessage="Update amount"
+                          />
+                        </MenuItem>
+                        <MenuItem style={{ margin: '2px' }} divider />
+                      </Fragment>
+                    )}
                     <MenuItem
                       style={menuItemStyle}
                       eventKey={this.stateConstants.cancelConf}

--- a/src/pages/createPledge.js
+++ b/src/pages/createPledge.js
@@ -568,7 +568,7 @@ class CreatePledgePage extends React.Component {
             )}
 
             <Container
-              clear={slug ? 'both' : 'none'}
+              clear={(!LoggedInUser && slug) ? 'both' : 'none'}
               float={['none', null, 'right']}
               mt={5}
               px={[3, null, 5]}


### PR DESCRIPTION
Fixes opencollective/opencollective#1398

This PR enables people to cancel a pending subscription for a pledged collective. It does not allow updating payment method (because that isn't required when pledging) or the pledged amount (because that can be updated when completing the pledge and API automatically activates the subscription if the amount is updated). 

PR also includes a small layout fix to the `createPledge` form. 

Preview:

<img width="1049" alt="screen shot 2018-11-05 at 11 31 23 am" src="https://user-images.githubusercontent.com/3051193/48012110-438e3980-e0ef-11e8-8d8f-0dd523fb5e46.png">
