### PR TITLE
Create pledged collective with default tags

### DIFF
--- a/src/pages/createPledge.js
+++ b/src/pages/createPledge.js
@@ -183,6 +183,7 @@ class CreatePledgePage extends React.Component {
       order.collective = {
         name: name.value,
         slug: slug.value,
+        tags: ['open source', 'pledged'],
         website: website.value,
       };
     }


### PR DESCRIPTION
To keep track of collectives created through the Pledges flow, those created through the createPledge page have the tags 'open source' and 'pledged'. 