### PR TITLE
Fix validateDOMNesting warning on OrderCreated page

### DIFF
--- a/src/components/OrderCreated.js
+++ b/src/components/OrderCreated.js
@@ -218,17 +218,17 @@ class OrderCreated extends React.Component {
                     id="collective.user.orderCreated.helpUsRaise.shareUrl"
                     defaultMessage="Share this URL:"
                   />
-                  <div>
-                    <a
-                      href={`https://opencollective.com${
-                        collective.path
-                      }?referral=${fromCollective.id}`}
-                    >
-                      {`https://opencollective.com${collective.path}?referral=${
-                        fromCollective.id
-                      }`}
-                    </a>
-                  </div>
+                  <br />
+                  <a
+                    href={`https://opencollective.com${
+                      collective.path
+                    }?referral=${fromCollective.id}`}
+                  >
+                    {`https://opencollective.com${collective.path}?referral=${
+                      fromCollective.id
+                    }`}
+                  </a>
+                  <br />
                   {type === 'COLLECTIVE' && (
                     <FormattedMessage
                       id="collective.user.orderCreated.helpUsRaise.description"


### PR DESCRIPTION
Fix the following warning that was occurring in dev on OrderCreated page.

Replacing `<p>` by a `<div>` would have changed styles. Using `<br/>` keeps them intact. 

```
index.js:2178 Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
    in div (created by OrderCreated)
    in p (created by OrderCreated)
    in div (created by OrderCreated)
    in div (created by OrderCreated)
    in div (created by OrderCreated)
    in div (created by OrderCreated)
    in OrderCreated (created by InjectIntl(OrderCreated))
    in InjectIntl(OrderCreated) (created by WithIntl(undefined))
    in IntlProvider (created by WithIntl(undefined))
    in WithIntl(undefined) (created by UserCollective)
    in div (created by UserCollective)
    in div (created by UserCollective)
    in main (created by Body)
    in Body (created by UserCollective)
    in div (created by UserCollective)
    in UserCollective (created by InjectIntl(UserCollective))
    in InjectIntl(UserCollective) (created by WithIntl(undefined))
    in IntlProvider (created by WithIntl(undefined))
    in WithIntl(undefined) (created by CollectivePage)
    in CollectivePage (created by Query)
    in Query (created by Apollo(CollectivePage))
    in Apollo(CollectivePage) (created by withLoggedInUser(Apollo(CollectivePage)))
    in withLoggedInUser(Apollo(CollectivePage)) (created by InjectIntl(withLoggedInUser(Apollo(CollectivePage))))
    in InjectIntl(withLoggedInUser(Apollo(CollectivePage))) (created by WithIntl(withLoggedInUser(Apollo(CollectivePage))))
    in IntlProvider (created by WithIntl(withLoggedInUser(Apollo(CollectivePage))))
    in WithIntl(withLoggedInUser(Apollo(CollectivePage))) (created by WithData(WithIntl(withLoggedInUser(Apollo(CollectivePage)))))
    in ApolloProvider (created by WithData(WithIntl(withLoggedInUser(Apollo(CollectivePage)))))
    in WithData(WithIntl(withLoggedInUser(Apollo(CollectivePage)))) (created by OpenCollectiveFrontendApp)
    in ThemeProvider (created by OpenCollectiveFrontendApp)
    in Container (created by OpenCollectiveFrontendApp)
    in OpenCollectiveFrontendApp
```