### PR TITLE
Show VirtualCard emitter on transaction

### DIFF
--- a/src/apps/expenses/components/Transaction.js
+++ b/src/apps/expenses/components/Transaction.js
@@ -10,6 +10,7 @@ import { P, Span } from '../../../components/Text';
 
 import TransactionDetails from './TransactionDetails';
 import AmountCurrency from './AmountCurrency';
+import Link from '../../../components/Link';
 
 class Transaction extends React.Component {
   static propTypes = {
@@ -40,6 +41,10 @@ class Transaction extends React.Component {
       name: PropTypes.string.isRequired,
       slug: PropTypes.string.isRequired,
     }),
+    usingVirtualCardFromCollective: PropTypes.shape({
+      slug: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+    }),
     collective: PropTypes.shape({
       id: PropTypes.number.isRequired,
       type: PropTypes.string.isRequired,
@@ -63,6 +68,7 @@ class Transaction extends React.Component {
       createdAt,
       currency,
       fromCollective,
+      usingVirtualCardFromCollective,
       collective,
       type,
       paymentProcessorFeeInHostCurrency,
@@ -98,6 +104,23 @@ class Transaction extends React.Component {
             <a href={`/${fromCollective.slug}`} title={fromCollective.name}>
               {fromCollective.name}
             </a>
+            {usingVirtualCardFromCollective && ' '}
+            {usingVirtualCardFromCollective && (
+              <FormattedMessage
+                id="transaction.usingGiftCardFrom"
+                defaultMessage="using a gift card from {collectiveLink}"
+                values={{
+                  collectiveLink: (
+                    <Link
+                      route="collective"
+                      params={{ slug: usingVirtualCardFromCollective.slug }}
+                    >
+                      {usingVirtualCardFromCollective.name}
+                    </Link>
+                  ),
+                }}
+              />
+            )}
             {' | '}
             <Moment relative={true} value={createdAt} />
             {paymentProcessorFeeInHostCurrency !== undefined && (

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -28,6 +28,10 @@ export const transactionFields = `
     path
     image
   }
+  usingVirtualCardFromCollective {
+    slug
+    name
+  }
   host {
     id
     slug

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -61,6 +61,7 @@
   "transaction.refund.yes.btn": "Yes, refund!",
   "transaction.refund.no.btn": "no",
   "expense.reject.btn": "reject",
+  "transaction.usingGiftCardFrom": "using a gift card from {collectiveLink}",
   "transaction.closeDetails": "Close Details",
   "transaction.viewDetails": "View Details",
   "transaction.hostFeeInHostCurrency": "{hostFeePercent} host fee",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -61,6 +61,7 @@
   "transaction.refund.yes.btn": "Oui, rembourser!",
   "transaction.refund.no.btn": "non",
   "expense.reject.btn": "refuser",
+  "transaction.usingGiftCardFrom": "avec un chèque cadeau de {collectiveLink}",
   "transaction.closeDetails": "Fermer les détails",
   "transaction.viewDetails": "Voir les détails",
   "transaction.hostFeeInHostCurrency": "{hostFeePercent} commission de l'hôte",


### PR DESCRIPTION
This PR adds a link to the collective that created the VirtualCard (when using one) on the transactions.

**Before**

![Before](https://user-images.githubusercontent.com/1556356/48231052-4ae26b00-e3ad-11e8-8283-fd835002792a.png)

**After**

![After](https://user-images.githubusercontent.com/1556356/48231053-4ae26b00-e3ad-11e8-8ec1-1b3b501cfe2e.png)

---
:information_source: Require https://github.com/opencollective/opencollective-api/pull/1506
