### PR TITLE
Force HTML editor for comments

### DIFF
--- a/src/components/Comment.js
+++ b/src/components/Comment.js
@@ -7,7 +7,7 @@ import gql from 'graphql-tag';
 import Avatar from './Avatar';
 import Link from './Link';
 import SmallButton from './SmallButton';
-import { get, pick } from 'lodash';
+import { pick } from 'lodash';
 import InputField from './InputField';
 
 class Comment extends React.Component {
@@ -68,21 +68,16 @@ class Comment extends React.Component {
   }
 
   async save() {
-    const comment = pick(this.state.comment, ['id', 'markdown', 'html']);
+    const comment = pick(this.state.comment, ['id', 'html']);
     await this.props.editComment(comment);
     this.setState({ modified: false, mode: 'details' });
   }
 
   render() {
-    const { intl, collective, LoggedInUser, editable } = this.props;
+    const { intl, LoggedInUser, editable } = this.props;
 
     const { comment } = this.state;
     if (!comment) return <div />;
-    const editor =
-      get(LoggedInUser, 'collective.settings.editor') === 'markdown' ||
-      get(collective, 'settings.editor') === 'markdown'
-        ? 'markdown'
-        : 'html';
 
     return (
       <div className={`comment ${this.state.mode}View`}>
@@ -209,9 +204,10 @@ class Comment extends React.Component {
               )}
               {this.state.mode === 'edit' && (
                 <InputField
-                  type={editor}
-                  defaultValue={comment[editor]}
-                  onChange={value => this.handleChange(editor, value)}
+                  name={`comment-${comment.id}`}
+                  type="html"
+                  defaultValue={comment.html}
+                  onChange={value => this.handleChange('html', value)}
                 />
               )}
             </div>

--- a/src/components/CommentForm.js
+++ b/src/components/CommentForm.js
@@ -6,8 +6,12 @@ import InputField from './InputField';
 import SmallButton from './SmallButton';
 import Avatar from './Avatar';
 import Link from './Link';
-import { get, pick } from 'lodash';
+import { pick } from 'lodash';
 
+/**
+ * Component to render for for **new** comments. Comment Edit form is created
+ * with an `InputField` (see `opencollective-frontend/src/components/Comment.js`).
+ */
 class CommentForm extends React.Component {
   static propTypes = {
     collective: PropTypes.object,
@@ -38,9 +42,7 @@ class CommentForm extends React.Component {
   }
 
   async onSubmit() {
-    const res = await this.props.onSubmit(
-      pick(this.state.comment, ['html', 'markdown']),
-    );
+    const res = await this.props.onSubmit(pick(this.state.comment, ['html']));
     const comment = res.data && res.data.createComment;
     if (comment) {
       const newEmptyComment = { id: comment.id++ };
@@ -58,7 +60,7 @@ class CommentForm extends React.Component {
   }
 
   render() {
-    const { LoggedInUser, collective, notice } = this.props;
+    const { LoggedInUser, notice } = this.props;
     if (!LoggedInUser) return <div />;
 
     const comment = {
@@ -70,11 +72,6 @@ class CommentForm extends React.Component {
         image: LoggedInUser.image,
       },
     };
-    const editor =
-      get(LoggedInUser, 'collective.settings.editor') === 'markdown' ||
-      get(collective, 'settings.editor') === 'markdown'
-        ? 'markdown'
-        : 'html';
 
     return (
       <div className={'CommentForm'}>
@@ -141,10 +138,10 @@ class CommentForm extends React.Component {
             <div className="description">
               <div className="comment">
                 <InputField
-                  key={`comment-${this.state.comment.id}`}
-                  type={editor}
-                  defaultValue={this.state.comment[editor]}
-                  onChange={value => this.handleChange(editor, value)}
+                  name="comment-new"
+                  type="html"
+                  defaultValue={this.state.comment.html}
+                  onChange={value => this.handleChange('html', value)}
                   className="small"
                 />
               </div>


### PR DESCRIPTION
1. Behaviour with comment editor settings was odd: we were using collective settings first to choose between markdown or html editor, ignoring user settings if he preferred to user html.

2. Comment form edit with markdown **could not** work as we were not fetching it in `getCommentsQuery`.

3. If going from html editor to comment editor, it would have been impossible to edit old comments as their `markdown` field would have been null.

---

**Also fixed the following warning by providing a name to comments `InputField`**

```
Warning: Failed prop type: The prop `name` is marked as required in `InputField`, but its value is `undefined`.
```