### PR TITLE
Fix currency inputs size

### DIFF
--- a/src/components/Tier.js
+++ b/src/components/Tier.js
@@ -255,7 +255,7 @@ class Tier extends React.Component {
               color: var(--charcoal-grey-three);
             }
             .customAmount {
-              width: 12rem;
+              width: 13rem;
             }
             .customAmount .error {
               font-size: 11px;
@@ -326,7 +326,7 @@ class Tier extends React.Component {
               margin: 0.5rem 0;
             }
             .tier :global(.inputAmount) {
-              width: 12rem;
+              width: 13rem;
               margin: 0.2rem 0;
             }
             .tier :global(input[name='amount']) {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -69,7 +69,7 @@ export function getCurrencySymbol(currency) {
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
   });
-  return r.replace(/0$/, '');
+  return r.replace(/(^0\s)|(\s0$)/, '');
 }
 
 /** Retrieve variables set in the environment */


### PR DESCRIPTION
:information_source:  Fix https://github.com/opencollective/opencollective/issues/1405

## Fix getCurrencySymbol

Regex in `getCurrencySymbol` was not correct and returned `0 $US` for certain locales, taking more space than expected. Note that this fixes the regex for all other amount fields, for example in tiers an expenses:

![selection_090](https://user-images.githubusercontent.com/1556356/48260333-58363e80-e41b-11e8-8c59-46db4848c1a7.png)

---

![selection_091](https://user-images.githubusercontent.com/1556356/48260311-4359ab00-e41b-11e8-9ca9-50b32c96d826.png)


## Make input bigger

**Before**
![Before](https://user-images.githubusercontent.com/1556356/48259753-46539c00-e419-11e8-8938-03684708d885.png)

**After**
![After](https://user-images.githubusercontent.com/1556356/48259757-49e72300-e419-11e8-99f3-aa46f4e8ca6c.png)
