### PR TITLE
Fix markdown editor resize grip display issue

### DIFF
--- a/src/components/MarkdownEditor.js
+++ b/src/components/MarkdownEditor.js
@@ -80,6 +80,10 @@ class MarkdownEditor extends React.Component {
             .public-DraftEditor-content {
               height: 100%;
             }
+            .react-mde .grip svg {
+              display: block;
+              margin: 0 auto;
+            }
           `}
         </style>
         <ReactMde


### PR DESCRIPTION
## Fix a display issue with small `react-mde` forms

![react-mde](https://user-images.githubusercontent.com/1556356/48257691-7dbf4a00-e413-11e8-957a-cbc7261657d6.png)
