### PR TITLE
Fix invoices pdf footer

### DIFF
--- a/src/pages/invoice.js
+++ b/src/pages/invoice.js
@@ -126,7 +126,7 @@ class InvoicePage extends React.Component {
             }
 
             .footer {
-              position: absolute;
+              position: inherit;
               top: ${this.page.footerTop} ${this.dimensions.unit};
               width: ${this.page.width} ${this.dimensions.unit};
               margin: 0 -2rem;


### PR DESCRIPTION
Footer is not showing up properly today, this PR will make it show up.

PS: The pdf is generated based on the `src/pages/invoice` html. when looking at the html the footer is centralized but on the pdf it's slightly to the right. I'll create an issue to fix this for once.

fixes opencollective/opencollective#1374