### PR TITLE
Logout without reload

### DIFF
--- a/src/components/OrderForm.js
+++ b/src/components/OrderForm.js
@@ -480,7 +480,7 @@ class OrderForm extends React.Component {
   logout = () => {
     window.localStorage.removeItem('accessToken');
     window.localStorage.removeItem('LoggedInUser');
-    window.location.replace(window.location.href);
+    this.props.client.resetStore();
   };
 
   selectProfile = profile => {

--- a/src/components/TopBarProfileMenu.js
+++ b/src/components/TopBarProfileMenu.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { withApollo } from 'react-apollo';
 import { Link } from '../server/pages';
 import { FormattedMessage, defineMessages } from 'react-intl';
 import withIntl from '../lib/withIntl';
@@ -58,11 +59,12 @@ class TopBarProfileMenu extends React.Component {
     document.removeEventListener('click', this.onClickOutside);
   }
 
-  logout = () => {
+  logout = async () => {
     this.setState({ showProfileMenu: false, status: 'loggingout' });
     window.localStorage.removeItem('accessToken');
     window.localStorage.removeItem('LoggedInUser');
-    window.location.reload();
+    await this.props.client.resetStore();
+    this.setState({ status: 'loggedout' });
   };
 
   onClickOutside = () => {
@@ -197,10 +199,7 @@ class TopBarProfileMenu extends React.Component {
                   >
                     <Flex alignItems="center">
                       <Avatar
-                        src={get(
-                          membership,
-                          'collective.image',
-                        )}
+                        src={get(membership, 'collective.image')}
                         type={get(membership, 'collective.type')}
                         name={get(membership, 'collective.name')}
                         radius="2.8rem"
@@ -267,10 +266,7 @@ class TopBarProfileMenu extends React.Component {
                   >
                     <Flex alignItems="center">
                       <Avatar
-                        src={get(
-                          membership,
-                          'collective.image',
-                        )}
+                        src={get(membership, 'collective.image')}
                         type={get(membership, 'collective.type')}
                         name={get(membership, 'collective.name')}
                         radius="2.8rem"
@@ -488,4 +484,4 @@ class TopBarProfileMenu extends React.Component {
   }
 }
 
-export default withIntl(TopBarProfileMenu);
+export default withIntl(withApollo(TopBarProfileMenu));

--- a/src/lib/withLoggedInUser.js
+++ b/src/lib/withLoggedInUser.js
@@ -44,7 +44,7 @@ export default WrappedComponent => {
         }
       });
 
-    getLoggedInUser = async () => {
+    getLoggedInUser = async setState => {
       // only Client Side for now
       if (!process.browser || !window) {
         return null;
@@ -56,6 +56,8 @@ export default WrappedComponent => {
         storage.set('LoggedInUser', null);
         return null;
       }
+
+      this.props.client.onResetStore(() => setState({ LoggedInUser: null }));
 
       // refresh Access Token in the background if needed
       maybeRefreshAccessToken(token);

--- a/src/pages/action.js
+++ b/src/pages/action.js
@@ -49,7 +49,7 @@ class ActionPage extends React.Component {
       console.log('>>> error', JSON.stringify(error));
       this.setState({ loading: false, error: error.graphQLErrors[0] });
     }
-    const LoggedInUser = await getLoggedInUser();
+    const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     this.setState({ LoggedInUser });
   }
 

--- a/src/pages/applications.js
+++ b/src/pages/applications.js
@@ -38,7 +38,7 @@ class Apps extends React.Component {
     const bustCache = new Date().getTime();
 
     const [LoggedInUser] = await Promise.all([
-      getLoggedInUser(),
+      getLoggedInUser(this.setState.bind(this)),
       this.props.data.refetch({ bustCache }), // Force Client side refetch
     ]);
 

--- a/src/pages/claimCollective.js
+++ b/src/pages/claimCollective.js
@@ -43,7 +43,8 @@ class ClaimCollectivePage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser, token } = this.props;
-    const LoggedInUser = getLoggedInUser && (await getLoggedInUser());
+    const LoggedInUser =
+      getLoggedInUser && (await getLoggedInUser(this.setState.bind(this)));
     this.setState({
       LoggedInUser,
       loadingUserLogin: false,
@@ -83,12 +84,15 @@ class ClaimCollectivePage extends React.Component {
 
   render() {
     const { data, slug, token } = this.props;
-    const { error, LoggedInUser, loadingUserLogin, loadingRepos, repos } = this.state;
-
     const {
-      Collective: { id, name, website } = {},
-      loading,
-    } = data;
+      error,
+      LoggedInUser,
+      loadingUserLogin,
+      loadingRepos,
+      repos,
+    } = this.state;
+
+    const { Collective: { id, name, website } = {}, loading } = data;
 
     if (error) {
       data.error = data.error || error;
@@ -162,18 +166,13 @@ class ClaimCollectivePage extends React.Component {
                         with your GitHub account.
                       </H5>
 
-                      <P
-                        fontSize="LeadParagraph"
-                        textAlign="left"
-                        mb={2}
-                      >
+                      <P fontSize="LeadParagraph" textAlign="left" mb={2}>
                         Why are we asking you to do this?
                       </P>
 
-                      <P
-                        fontSize="Caption"
-                      >
-                        We need to validate that you have owner rights to the repository linked to this pledged collective.
+                      <P fontSize="Caption">
+                        We need to validate that you have owner rights to the
+                        repository linked to this pledged collective.
                       </P>
 
                       <P
@@ -182,12 +181,11 @@ class ClaimCollectivePage extends React.Component {
                         mb={2}
                         mt={3}
                       >
-                        Want to onboard an organization instead of a single repository?
+                        Want to onboard an organization instead of a single
+                        repository?
                       </P>
 
-                      <P
-                        fontSize="Caption"
-                      >
+                      <P fontSize="Caption">
                         Make sure to Grant access in the GitHub permission page.
                       </P>
 
@@ -239,22 +237,15 @@ class ClaimCollectivePage extends React.Component {
                       </svg>
                     </Flex>
 
-                    <H5
-                      fontWeight="medium"
-                      mb={4}
-                      textAlign="center"
-                    >
+                    <H5 fontWeight="medium" mb={4} textAlign="center">
                       Validation unsuccessful
                     </H5>
-                    <P
-                      textAlign="center"
-                      color="black.600"
-                      mb={4}
-                    >
+                    <P textAlign="center" color="black.600" mb={4}>
                       Sorry, we were unable to succesfully validated your admin
                       status. Try again, or if you believe this is a mistake,
-                      please get in touch with the repository owners.
-                      Make sure you granted us access as an organization if that&apos;s what you are trying to onboard. 
+                      please get in touch with the repository owners. Make sure
+                      you granted us access as an organization if that&apos;s
+                      what you are trying to onboard.
                     </P>
                     <StyledLink
                       buttonStyle="standard"
@@ -301,18 +292,10 @@ class ClaimCollectivePage extends React.Component {
                           />
                         </svg>
                       </Flex>
-                      <H5
-                        fontWeight="medium"
-                        mb={4}
-                        textAlign="center"
-                      >
+                      <H5 fontWeight="medium" mb={4} textAlign="center">
                         Congratulations!
                       </H5>
-                      <P
-                        textAlign="center"
-                        color="black.600"
-                        mb={4}
-                      >
+                      <P textAlign="center" color="black.600" mb={4}>
                         We have succesfully validated your admin status. Press
                         the button below to activate this open collective. It
                         will also email all pledgers to fulfill their pledges.

--- a/src/pages/collective.js
+++ b/src/pages/collective.js
@@ -35,7 +35,7 @@ class CollectivePage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser, query, data = {} } = this.props;
-    const LoggedInUser = await getLoggedInUser();
+    const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     this.setState({ LoggedInUser });
     window.OC = window.OC || {};
     window.OC.LoggedInUser = LoggedInUser;

--- a/src/pages/completePledge.js
+++ b/src/pages/completePledge.js
@@ -31,7 +31,8 @@ class CompletePledgePage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = getLoggedInUser && (await getLoggedInUser());
+    const LoggedInUser =
+      getLoggedInUser && (await getLoggedInUser(this.setState.bind(this)));
     this.setState({
       LoggedInUser,
       loadingUserLogin: false,

--- a/src/pages/createApplication.js
+++ b/src/pages/createApplication.js
@@ -56,7 +56,7 @@ class Apps extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = await getLoggedInUser();
+    const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     this.setState({ LoggedInUser, loading: false });
   }
 

--- a/src/pages/createCollective.js
+++ b/src/pages/createCollective.js
@@ -29,7 +29,7 @@ class CreateCollectivePage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = await getLoggedInUser();
+    const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     this.setState({ LoggedInUser, loading: false });
   }
 

--- a/src/pages/createEvent.js
+++ b/src/pages/createEvent.js
@@ -30,7 +30,7 @@ class CreateEventPage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = await getLoggedInUser();
+    const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     this.setState({ LoggedInUser, loading: false });
   }
 

--- a/src/pages/createExpense.js
+++ b/src/pages/createExpense.js
@@ -40,7 +40,7 @@ class CreateExpensePage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = await getLoggedInUser();
+    const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     this.setState({ LoggedInUser });
   }
 

--- a/src/pages/createHost.js
+++ b/src/pages/createHost.js
@@ -26,7 +26,8 @@ class CreateHostPage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = getLoggedInUser && (await getLoggedInUser());
+    const LoggedInUser =
+      getLoggedInUser && (await getLoggedInUser(this.setState.bind(this)));
     this.setState({ LoggedInUser, loading: false });
   }
 

--- a/src/pages/createOrder.js
+++ b/src/pages/createOrder.js
@@ -140,7 +140,7 @@ class CreateOrderPage extends React.Component {
   async componentDidMount() {
     const { getLoggedInUser, data } = this.props;
     const newState = {};
-    newState.LoggedInUser = await getLoggedInUser();
+    newState.LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     if (!data.Tier && data.fetchData) {
       data.fetchData();
     }

--- a/src/pages/createOrganization.js
+++ b/src/pages/createOrganization.js
@@ -20,7 +20,7 @@ class CreateOrganizationPage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = await getLoggedInUser();
+    const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     this.setState({ LoggedInUser, loading: false });
   }
 

--- a/src/pages/createPledge.js
+++ b/src/pages/createPledge.js
@@ -138,7 +138,8 @@ class CreatePledgePage extends React.Component {
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
     try {
-      const LoggedInUser = getLoggedInUser && (await getLoggedInUser());
+      const LoggedInUser =
+        getLoggedInUser && (await getLoggedInUser(this.setState.bind(this)));
       this.setState({
         loadingUserLogin: false,
         LoggedInUser,

--- a/src/pages/createUpdate.js
+++ b/src/pages/createUpdate.js
@@ -41,7 +41,7 @@ class CreateUpdatePage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = await getLoggedInUser();
+    const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     this.setState({ LoggedInUser });
   }
 

--- a/src/pages/editApplication.js
+++ b/src/pages/editApplication.js
@@ -72,7 +72,7 @@ class EditApplication extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = await getLoggedInUser();
+    const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     this.setState({ LoggedInUser, loading: false });
   }
 

--- a/src/pages/editCollective.js
+++ b/src/pages/editCollective.js
@@ -43,7 +43,7 @@ class EditCollectivePage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = await getLoggedInUser();
+    const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     this.setState({ LoggedInUser, loading: false });
     const queryParams = getQueryParams();
     if (queryParams.HostedCollectiveId) {

--- a/src/pages/editEvent.js
+++ b/src/pages/editEvent.js
@@ -30,7 +30,7 @@ class EditEventPage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = await getLoggedInUser();
+    const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     this.setState({ LoggedInUser, loading: false });
   }
 

--- a/src/pages/event.js
+++ b/src/pages/event.js
@@ -39,7 +39,7 @@ class EventPage extends React.Component {
     const { getLoggedInUser, data } = this.props;
     const event = data.Collective;
 
-    const LoggedInUser = await getLoggedInUser();
+    const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     this.setState({ LoggedInUser });
 
     if (LoggedInUser && LoggedInUser.canEditEvent(event)) {

--- a/src/pages/expense.js
+++ b/src/pages/expense.js
@@ -38,7 +38,7 @@ class ExpensePage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = await getLoggedInUser();
+    const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     this.setState({ LoggedInUser });
   }
 

--- a/src/pages/expenses.js
+++ b/src/pages/expenses.js
@@ -38,7 +38,7 @@ class ExpensesPage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = await getLoggedInUser();
+    const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     this.setState({ LoggedInUser });
   }
 

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -161,7 +161,9 @@ class HomePage extends React.Component {
   };
 
   async componentDidMount() {
-    const LoggedInUser = await this.props.getLoggedInUser();
+    const LoggedInUser = await this.props.getLoggedInUser(
+      this.setState.bind(this),
+    );
     this.setState({ LoggedInUser });
 
     // separate request to not block showing LoggedInUser
@@ -223,21 +225,30 @@ class HomePage extends React.Component {
               justifyContent="space-between"
               mx="auto"
             >
-              <Container
-                width={[1, null, 0.6]}
-                pr={[0, null, 4]}
-              >
-                <H1 fontSize={['H3', null, 'H1']} lineHeight={['H3', null, 'H1']} fontWeight="normal" textAlign="left" mb={4}>
+              <Container width={[1, null, 0.6]} pr={[0, null, 4]}>
+                <H1
+                  fontSize={['H3', null, 'H1']}
+                  lineHeight={['H3', null, 'H1']}
+                  fontWeight="normal"
+                  textAlign="left"
+                  mb={4}
+                >
                   A new form of association, <br />{' '}
                   <strong>transparent by design.</strong>
                 </H1>
 
                 <Container maxWidth={500}>
-                  <P fontSize="LeadParagraph" lineHeight="LeadParagraph" my={3} color="black.700">
+                  <P
+                    fontSize="LeadParagraph"
+                    lineHeight="LeadParagraph"
+                    my={3}
+                    color="black.700"
+                  >
                     The Internet generation needs organizations that reflect who
                     we are; where anybody can contribute to a shared mission;
-                    where leaders can easily change; and where money flows in full
-                    transparency. Create an Open Collective for your community.
+                    where leaders can easily change; and where money flows in
+                    full transparency. Create an Open Collective for your
+                    community.
                   </P>
                 </Container>
 
@@ -415,7 +426,11 @@ class HomePage extends React.Component {
                   <a href="/discover">Learn more.</a>
                 </P>
 
-                <Flex mx={['auto', null, 4]} my={4} justifyContent={['center', null, 'flex-start']}>
+                <Flex
+                  mx={['auto', null, 4]}
+                  my={4}
+                  justifyContent={['center', null, 'flex-start']}
+                >
                   <Link route="/create" passHref>
                     <StyledLink
                       buttonStyle="primary"
@@ -471,8 +486,16 @@ class HomePage extends React.Component {
                   we’ll gladly set them up and get them going.
                 </P>
 
-                <Flex mx={['auto', null, 4]} my={4} justifyContent={['center', null, 'flex-start']}>
-                    <Link route="marketing" params={{ pageSlug: 'become-a-sponsor' }} passHref>
+                <Flex
+                  mx={['auto', null, 4]}
+                  my={4}
+                  justifyContent={['center', null, 'flex-start']}
+                >
+                  <Link
+                    route="marketing"
+                    params={{ pageSlug: 'become-a-sponsor' }}
+                    passHref
+                  >
                     <StyledLink
                       buttonStyle="primary"
                       buttonSize="large"
@@ -534,7 +557,11 @@ class HomePage extends React.Component {
                   <strong>Become part of the movement.</strong>
                 </P>
 
-                <Flex mx={['auto', null, 4]} my={4} justifyContent={['center', null, 'flex-start']}>
+                <Flex
+                  mx={['auto', null, 4]}
+                  my={4}
+                  justifyContent={['center', null, 'flex-start']}
+                >
                   <StyledLink
                     buttonStyle="primary"
                     buttonSize="large"
@@ -577,7 +604,9 @@ class HomePage extends React.Component {
                   pointerEvents="none"
                 >
                   <Container
-                    background={`linear-gradient(to left, ${colors.primary[200]}, rgba(255, 255, 255, 0) 50%)`}
+                    background={`linear-gradient(to left, ${
+                      colors.primary[200]
+                    }, rgba(255, 255, 255, 0) 50%)`}
                     width="100%"
                     height="100%"
                   />
@@ -675,16 +704,20 @@ class HomePage extends React.Component {
                 </H4>
 
                 <P {...sectionDetailStyles}>
-                  <strong>Grow the movement</strong> by becoming a
-                  host of open collectives in your city or your industry. Hosts
-                  are acting as fiscal sponsors. They collect the money on
-                  behalf of the collectives and enable them to issue invoices.
-                  They are mutualising the legal and accounting overhead that
-                  come with creating and maintaining a legal entity so that the
-                  open collectives that they host can focus on their mission.
+                  <strong>Grow the movement</strong> by becoming a host of open
+                  collectives in your city or your industry. Hosts are acting as
+                  fiscal sponsors. They collect the money on behalf of the
+                  collectives and enable them to issue invoices. They are
+                  mutualising the legal and accounting overhead that come with
+                  creating and maintaining a legal entity so that the open
+                  collectives that they host can focus on their mission.
                 </P>
 
-                <Flex mx={['auto', null, 4]} my={4} justifyContent={['center', null, 'flex-start']}>
+                <Flex
+                  mx={['auto', null, 4]}
+                  my={4}
+                  justifyContent={['center', null, 'flex-start']}
+                >
                   <Link route="/hosts" passHref>
                     <StyledLink
                       buttonStyle="primary"
@@ -766,7 +799,12 @@ class HomePage extends React.Component {
             </Container>
 
             <Container mt={5} px={3}>
-              <H3 textAlign="center" fontSize={['H4', null, 'H2']} lineHeight={['H4', null, 'H2']} pb={4}>
+              <H3
+                textAlign="center"
+                fontSize={['H4', null, 'H2']}
+                lineHeight={['H4', null, 'H2']}
+                pb={4}
+              >
                 Spread the word!
               </H3>
 
@@ -871,7 +909,11 @@ class HomePage extends React.Component {
                   that need financial support.
                 </H4>
 
-                <P color="white.full" fontSize="LeadParagraph" lineHeight="24px">
+                <P
+                  color="white.full"
+                  fontSize="LeadParagraph"
+                  lineHeight="24px"
+                >
                   BackYourStack is a community project initiated by Open
                   Collective.
                   <StyledLink

--- a/src/pages/host.dashboard.js
+++ b/src/pages/host.dashboard.js
@@ -38,7 +38,7 @@ class HostExpensesPage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = await getLoggedInUser();
+    const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     this.setState({ LoggedInUser });
   }
 

--- a/src/pages/hosts.js
+++ b/src/pages/hosts.js
@@ -19,7 +19,8 @@ class HostsPage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = getLoggedInUser && (await getLoggedInUser());
+    const LoggedInUser =
+      getLoggedInUser && (await getLoggedInUser(this.setState.bind(this)));
     this.setState({ LoggedInUser });
   }
 

--- a/src/pages/marketingPage.js
+++ b/src/pages/marketingPage.js
@@ -32,7 +32,7 @@ class MarketingPage extends React.Component {
   }
 
   async componentDidMount() {
-    this.props.getLoggedInUser().then(LoggedInUser => {
+    this.props.getLoggedInUser(this.setState.bind(this)).then(LoggedInUser => {
       this.setState({ LoggedInUser });
     });
 

--- a/src/pages/redeem.js
+++ b/src/pages/redeem.js
@@ -127,7 +127,7 @@ class RedeemPage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = await getLoggedInUser();
+    const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     this.setState({ LoggedInUser });
   }
 

--- a/src/pages/redeemed.js
+++ b/src/pages/redeemed.js
@@ -80,7 +80,7 @@ class RedeemedPage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = await getLoggedInUser();
+    const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     this.setState({ LoggedInUser });
   }
 

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -82,7 +82,7 @@ class SearchPage extends React.Component {
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
     try {
-      const LoggedInUser = await getLoggedInUser();
+      const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
       this.setState({
         loadingUserLogin: false,
         LoggedInUser,
@@ -182,7 +182,11 @@ class SearchPage extends React.Component {
                       </em>
                     </p>
                     {usePledges && (
-                      <Link route="createPledge" params={{ name: term }} passHref>
+                      <Link
+                        route="createPledge"
+                        params={{ name: term }}
+                        passHref
+                      >
                         <StyledLink
                           display="block"
                           fontSize="Paragraph"
@@ -242,7 +246,8 @@ class SearchPage extends React.Component {
                 >
                   <p>
                     <em>
-                      If you don&apos;t see the collective you&apos;re searching for:
+                      If you don&apos;t see the collective you&apos;re searching
+                      for:
                     </em>
                   </p>
 

--- a/src/pages/signin.js
+++ b/src/pages/signin.js
@@ -12,6 +12,7 @@ import * as api from '../lib/api';
 import { isValidUrl } from '../lib/utils';
 
 import withIntl from '../lib/withIntl';
+import withData from '../lib/withData';
 
 class SigninPage extends React.Component {
   static getInitialProps({ query: { token, next } }) {
@@ -89,4 +90,4 @@ class SigninPage extends React.Component {
   }
 }
 
-export default withIntl(SigninPage);
+export default withIntl(withData(SigninPage));

--- a/src/pages/staticPage.js
+++ b/src/pages/staticPage.js
@@ -67,7 +67,8 @@ class StaticPage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = getLoggedInUser && (await getLoggedInUser());
+    const LoggedInUser =
+      getLoggedInUser && (await getLoggedInUser(this.setState.bind(this)));
     this.setState({ LoggedInUser });
   }
 

--- a/src/pages/subscriptions-redirect.js
+++ b/src/pages/subscriptions-redirect.js
@@ -25,7 +25,7 @@ class SubscriptionsRedirectPage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = await getLoggedInUser();
+    const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     this.setState({ LoggedInUser });
 
     if (!LoggedInUser) {

--- a/src/pages/subscriptions.js
+++ b/src/pages/subscriptions.js
@@ -29,7 +29,7 @@ class SubscriptionsPage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = await getLoggedInUser();
+    const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     this.setState({ LoggedInUser });
   }
 

--- a/src/pages/transactions.js
+++ b/src/pages/transactions.js
@@ -33,7 +33,7 @@ class TransactionsPage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = await getLoggedInUser();
+    const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     this.setState({ LoggedInUser });
   }
 

--- a/src/pages/update.js
+++ b/src/pages/update.js
@@ -41,7 +41,7 @@ class UpdatePage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = await getLoggedInUser();
+    const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     this.setState({ LoggedInUser });
   }
 

--- a/src/pages/updates.js
+++ b/src/pages/updates.js
@@ -33,7 +33,7 @@ class UpdatesPage extends React.Component {
 
   async componentDidMount() {
     const { getLoggedInUser } = this.props;
-    const LoggedInUser = await getLoggedInUser();
+    const LoggedInUser = await getLoggedInUser(this.setState.bind(this));
     this.setState({ LoggedInUser });
   }
 


### PR DESCRIPTION
This current implementation of logging out as a user requires deleting the json web token from the localStorage cache and doing a full page refresh to remove the `LoggedInUser` object from any frontend components. This can be a slow process depending on the user connection. 

While researching the Apollo docs, I found a [`resetStore` method](https://www.apollographql.com/docs/react/advanced/caching.html#reset-store) on the Apollo client that will clear the cached data, like the current logged in user. Based on how we fetch the LoggedInUser using the `withLoggedInUser` helper and `getLoggedInUser` function, we need access to the page's `setState` method to clear the `LoggedInUser` state once the Apollo cache is cleared. 

The result of this PR is dramatically improved user experience times around logging out and sets a better pattern of preventing full page reloads when navigating around the app.

One caveat exposed by this PR is the drawback of repeating the same `getLoggedInUser` logic on every page. This could be refactored to have `withLoggedInUser` helper implement the `getLoggedInUser` fetch and pass the `LoggedInUser` object as a prop to the `WrappedComponent`. Or maybe we can create a [`UserProvider` ](https://reactjs.org/docs/context.html#when-to-use-context) to prevent the constant passing of the `LoggedInUser` object as a prop to every child component. 