### PR TITLE
Fix getCurrencySymbol returning unwanted 0 for some locales

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4152,6 +4152,11 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.5.tgz",
       "integrity": "sha512-EGMjeoiN3aqEX5u/cyH5mSdGBDGdLcCQvcEcBWNGFSPXKd9uOTIeVG91YQ22OxI44DKpvI+4C7VUSmEpsHWJaA=="
     },
+    "currency-symbol-map": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/currency-symbol-map/-/currency-symbol-map-4.0.4.tgz",
+      "integrity": "sha512-hkSCCopJXVsvIZIiumJc6FoNXR5LQ646c3ufzF0yfv3155PYygysHw24JuzPSg4j86EFpvtgeX+vEhzRtcJ5Ag=="
+    },
     "cyclist": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
@@ -6298,15 +6303,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "optional": true,
+          "bundled": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6319,21 +6320,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6436,9 +6431,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6447,9 +6440,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "optional": true,
+          "bundled": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6461,23 +6452,18 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "optional": true,
+          "bundled": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
-          "resolved": false,
-          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
-          "optional": true,
+          "bundled": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6494,7 +6480,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6567,9 +6552,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6578,9 +6561,7 @@
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "optional": true,
+          "bundled": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6685,9 +6666,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "optional": true,
+          "bundled": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6966,7 +6945,7 @@
         },
         "node-fetch": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
           "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
         }
       }
@@ -18371,7 +18350,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "clean-tag": "2.0.2",
     "cloudflare-ip": "0.0.7",
     "cross-fetch": "2.2.3",
+    "currency-symbol-map": "4.0.4",
     "dotenv": "6.1.0",
     "draft-js": "0.10.5",
     "express": "4.16.4",

--- a/src/lib/__tests__/utils.test.js
+++ b/src/lib/__tests__/utils.test.js
@@ -11,4 +11,10 @@ describe('utils lib', () => {
     const arr = [undefined];
     expect(utils.capitalize(arr)).toEqual('');
   });
+
+  test('getCurrencySymbol', () => {
+    expect(utils.getCurrencySymbol('USD')).toEqual('$');
+    expect(utils.getCurrencySymbol('EUR')).toEqual('€');
+    expect(utils.getCurrencySymbol('JPY')).toEqual('¥');
+  });
 });

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,4 +1,5 @@
 import { get } from 'lodash';
+import getSymbolFromCurrency from 'currency-symbol-map';
 
 import loadScript from 'load-script';
 
@@ -62,14 +63,19 @@ export const isValidEmail = email => {
   );
 };
 
+function getCurrencySymbolFallback(currency) {
+  return Number(0)
+    .toLocaleString('en-US', {
+      style: 'currency',
+      currency,
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    })
+    .replace(/(^0\s?)|(\s?0$)/, '');
+}
+
 export function getCurrencySymbol(currency) {
-  const r = Number(0).toLocaleString(currency, {
-    style: 'currency',
-    currency,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  });
-  return r.replace(/(^0\s)|(\s0$)/, '');
+  return getSymbolFromCurrency(currency) || getCurrencySymbolFallback(currency);
 }
 
 /** Retrieve variables set in the environment */


### PR DESCRIPTION
Started doing hacky stuff with `getCurrencySymbol` to fix the bug with locales, realized currency symbol is international and actually doesn't depend on the locale. 

Did a quick benchmark with [`currency-symbol-map`](https://github.com/bengourley/currency-symbol-map) (that is basically just a map of locale<>currency):
```
Hacky: 10,752 ops/s
Library: 576,010,291 ops/s
Result: Hacky is 100% slower
```

This still fallbacks on "hacky" implementation as it may know a locale that library don't (there's good chances Chrome/Firefox will be updated before this library if a new currency appears).

---

*Following #1027*