### PR TITLE
Share LoggedInUser as Context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2341,6 +2341,14 @@
         "zen-observable-ts": "^0.8.11"
       }
     },
+    "apollo-link-context": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/apollo-link-context/-/apollo-link-context-1.0.9.tgz",
+      "integrity": "sha512-gcC1WH7mTyNtS0bF4fPijepXqnERwZjm1JCkuOT6ADBTpDTXIqK+Ec+/QkVawDO26EV9OX5ujWe4kI1qC6T6tA==",
+      "requires": {
+        "apollo-link": "^1.2.3"
+      }
+    },
     "apollo-link-dedup": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/apollo-link-dedup/-/apollo-link-dedup-1.0.11.tgz",
@@ -7463,11 +7471,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "hoist-non-react-statics": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
-      "integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
-    },
     "home-or-tmp": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
@@ -10924,6 +10927,13 @@
         "prop-types": "^15.6.0",
         "react-lifecycles-compat": "^3.0.4",
         "shallowequal": "^1.0.2"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        }
       }
     },
     "minimalistic-assert": {
@@ -11591,7 +11601,7 @@
       "dependencies": {
         "JSONStream": {
           "version": "1.3.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
           "requires": {
             "jsonparse": "^1.2.0",
@@ -11600,12 +11610,12 @@
         },
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "agent-base": {
           "version": "4.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
           "requires": {
             "es6-promisify": "^5.0.0"
@@ -11613,7 +11623,7 @@
         },
         "agentkeepalive": {
           "version": "3.4.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-MPIwsZU9PP9kOrZpyu2042kYA8Fdt/AedQYkYXucHgF9QoD9dXVp0ypuGnHXSR0hTstBxdt85Xkh4JolYfK5wg==",
           "requires": {
             "humanize-ms": "^1.2.1"
@@ -11621,7 +11631,7 @@
         },
         "ajv": {
           "version": "5.5.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "requires": {
             "co": "^4.6.0",
@@ -11632,7 +11642,7 @@
         },
         "ansi-align": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
           "requires": {
             "string-width": "^2.0.0"
@@ -11640,12 +11650,12 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
             "color-convert": "^1.9.0"
@@ -11653,27 +11663,27 @@
         },
         "ansicolors": {
           "version": "0.3.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
         },
         "ansistyles": {
           "version": "0.1.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk="
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "requires": {
             "delegates": "^1.0.0",
@@ -11682,12 +11692,12 @@
         },
         "asap": {
           "version": "2.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
         },
         "asn1": {
           "version": "0.2.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
           "requires": {
             "safer-buffer": "~2.1.0"
@@ -11695,32 +11705,32 @@
         },
         "assert-plus": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         },
         "asynckit": {
           "version": "0.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
           "version": "1.8.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
           "optional": true,
           "requires": {
@@ -11729,7 +11739,7 @@
         },
         "bin-links": {
           "version": "1.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-8eEHVgYP03nILphilltWjeIjMbKyJo3wvp9K816pHbhP301ismzw15mxAAEVQ/USUwcP++1uNrbERbp8lOA6Fg==",
           "requires": {
             "bluebird": "^3.5.0",
@@ -11741,7 +11751,7 @@
         },
         "block-stream": {
           "version": "0.0.9",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
           "requires": {
             "inherits": "~2.0.0"
@@ -11749,12 +11759,12 @@
         },
         "bluebird": {
           "version": "3.5.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
         },
         "boxen": {
           "version": "1.3.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
           "requires": {
             "ansi-align": "^2.0.0",
@@ -11768,7 +11778,7 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
             "balanced-match": "^1.0.0",
@@ -11777,32 +11787,32 @@
         },
         "buffer-from": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
         },
         "builtins": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
         },
         "byline": {
           "version": "5.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
         },
         "byte-size": {
           "version": "4.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-JGC3EV2bCzJH/ENSh3afyJrH4vwxbHTuO5ljLoI5+2iJOcEpMgP8T782jH9b5qGxf2mSUIp1lfGnfKNrRHpvVg=="
         },
         "cacache": {
           "version": "11.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-IFWl6lfK6wSeYCHUXh+N1lY72UDrpyrYQJNIVQf48paDuWbv5RbAtJYf/4gUQFObTCHZwdZ5sI8Iw7nqwP6nlQ==",
           "requires": {
             "bluebird": "^3.5.1",
@@ -11823,27 +11833,27 @@
         },
         "call-limit": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o="
         },
         "camelcase": {
           "version": "4.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
         "capture-stack-trace": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
         },
         "caseless": {
           "version": "0.12.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
         "chalk": {
           "version": "2.4.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -11853,17 +11863,17 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
         },
         "ci-info": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Oqmw2pVfCl8sCL+1QgMywPfdxPJPkC51y4usw0iiE2S9qnEOAqXy8bwl1CpMpnoU39g4iKJTz6QZj+28FvOnjQ=="
         },
         "cidr-regex": {
           "version": "2.0.9",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-F7/fBRUU45FnvSPjXdpIrc++WRSBdCiSTlyq4ZNhLKOlHFNWgtzZ0Fd+zrqI/J1j0wmlx/f5ZQDmD2GcbrNcmw==",
           "requires": {
             "ip-regex": "^2.1.0"
@@ -11871,12 +11881,12 @@
         },
         "cli-boxes": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
         },
         "cli-columns": {
           "version": "3.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
           "requires": {
             "string-width": "^2.0.0",
@@ -11885,7 +11895,7 @@
         },
         "cli-table3": {
           "version": "0.5.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-c7YHpUyO1SaKaO7kYtxd5NZ8FjAmSK3LpKkuzdwn+2CwpFxBpdoQLm+OAnnCfoEl7onKhN9PKQi1lsHuAIUqGQ==",
           "requires": {
             "colors": "^1.1.2",
@@ -11895,7 +11905,7 @@
         },
         "cliui": {
           "version": "4.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "requires": {
             "string-width": "^2.1.1",
@@ -11905,12 +11915,12 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -11920,12 +11930,12 @@
         },
         "clone": {
           "version": "1.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
         },
         "cmd-shim": {
           "version": "2.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -11934,17 +11944,17 @@
         },
         "co": {
           "version": "4.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "color-convert": {
           "version": "1.9.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
           "requires": {
             "color-name": "^1.1.1"
@@ -11952,18 +11962,18 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "colors": {
           "version": "1.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
           "optional": true
         },
         "columnify": {
           "version": "1.5.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
           "requires": {
             "strip-ansi": "^3.0.0",
@@ -11972,7 +11982,7 @@
         },
         "combined-stream": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "requires": {
             "delayed-stream": "~1.0.0"
@@ -11980,12 +11990,12 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "concat-stream": {
           "version": "1.6.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "requires": {
             "buffer-from": "^1.0.0",
@@ -11996,7 +12006,7 @@
         },
         "config-chain": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
           "requires": {
             "ini": "^1.3.4",
@@ -12005,7 +12015,7 @@
         },
         "configstore": {
           "version": "3.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
           "requires": {
             "dot-prop": "^4.1.0",
@@ -12018,12 +12028,12 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "copy-concurrently": {
           "version": "1.0.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
           "requires": {
             "aproba": "^1.1.1",
@@ -12036,19 +12046,19 @@
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
             }
           }
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "create-error-class": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
           "requires": {
             "capture-stack-trace": "^1.0.0"
@@ -12056,7 +12066,7 @@
         },
         "cross-spawn": {
           "version": "5.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "requires": {
             "lru-cache": "^4.0.1",
@@ -12066,17 +12076,17 @@
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
         },
         "cyclist": {
           "version": "0.2.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
         },
         "dashdash": {
           "version": "1.14.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "requires": {
             "assert-plus": "^1.0.0"
@@ -12084,7 +12094,7 @@
         },
         "debug": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
@@ -12092,34 +12102,34 @@
           "dependencies": {
             "ms": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
         },
         "decamelize": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
         },
         "deep-extend": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
         },
         "defaults": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
           "requires": {
             "clone": "^1.0.2"
@@ -12127,27 +12137,27 @@
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
         },
         "detect-indent": {
           "version": "5.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
         },
         "detect-newline": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
         },
         "dezalgo": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
           "requires": {
             "asap": "^2.0.0",
@@ -12156,7 +12166,7 @@
         },
         "dot-prop": {
           "version": "4.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
           "requires": {
             "is-obj": "^1.0.0"
@@ -12164,17 +12174,17 @@
         },
         "dotenv": {
           "version": "5.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
         },
         "duplexer3": {
           "version": "0.1.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
         },
         "duplexify": {
           "version": "3.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
           "requires": {
             "end-of-stream": "^1.0.0",
@@ -12185,7 +12195,7 @@
         },
         "ecc-jsbn": {
           "version": "0.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
           "optional": true,
           "requires": {
@@ -12195,12 +12205,12 @@
         },
         "editor": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I="
         },
         "encoding": {
           "version": "0.1.12",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
           "requires": {
             "iconv-lite": "~0.4.13"
@@ -12208,7 +12218,7 @@
         },
         "end-of-stream": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "requires": {
             "once": "^1.4.0"
@@ -12216,12 +12226,12 @@
         },
         "err-code": {
           "version": "1.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
         },
         "errno": {
           "version": "0.1.7",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
           "requires": {
             "prr": "~1.0.1"
@@ -12229,12 +12239,12 @@
         },
         "es6-promise": {
           "version": "4.2.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
         },
         "es6-promisify": {
           "version": "5.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
           "requires": {
             "es6-promise": "^4.0.3"
@@ -12242,12 +12252,12 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "requires": {
             "cross-spawn": "^5.0.1",
@@ -12261,37 +12271,37 @@
         },
         "extend": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "extsprintf": {
           "version": "1.3.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
         },
         "figgy-pudding": {
           "version": "3.4.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-j1SAT641cerGuOvoSBoaE9LbSzh1N/E5ufk9oMpOKuyK8MyW3sGg4rh+4qhLmVTEAzipO5XTHYT4gjb6JYLE8g=="
         },
         "find-npm-prefix": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA=="
         },
         "find-up": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
             "locate-path": "^2.0.0"
@@ -12299,7 +12309,7 @@
         },
         "flush-write-stream": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
           "requires": {
             "inherits": "^2.0.1",
@@ -12308,12 +12318,12 @@
         },
         "forever-agent": {
           "version": "0.6.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
         },
         "form-data": {
           "version": "2.3.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "requires": {
             "asynckit": "^0.4.0",
@@ -12323,7 +12333,7 @@
         },
         "from2": {
           "version": "2.3.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
           "requires": {
             "inherits": "^2.0.1",
@@ -12332,7 +12342,7 @@
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "requires": {
             "minipass": "^2.2.1"
@@ -12340,7 +12350,7 @@
         },
         "fs-vacuum": {
           "version": "1.2.10",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -12350,7 +12360,7 @@
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -12361,19 +12371,19 @@
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
             }
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fstream": {
           "version": "1.0.11",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -12384,7 +12394,7 @@
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "requires": {
             "aproba": "^1.0.3",
@@ -12399,7 +12409,7 @@
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -12411,12 +12421,12 @@
         },
         "genfun": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E="
         },
         "gentle-fs": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-cEng5+3fuARewXktTEGbwsktcldA+YsnUEaXZwcK/3pjSE1X9ObnTs+/8rYf8s+RnIcQm2D5x3rwpN7Zom8Bew==",
           "requires": {
             "aproba": "^1.1.2",
@@ -12431,24 +12441,24 @@
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
             }
           }
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
         },
         "getpass": {
           "version": "0.1.7",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "requires": {
             "assert-plus": "^1.0.0"
@@ -12456,7 +12466,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -12469,7 +12479,7 @@
         },
         "global-dirs": {
           "version": "0.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
           "requires": {
             "ini": "^1.3.4"
@@ -12477,7 +12487,7 @@
         },
         "got": {
           "version": "6.7.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "requires": {
             "create-error-class": "^3.0.0",
@@ -12495,17 +12505,17 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
         },
         "har-schema": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
         "har-validator": {
           "version": "5.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
           "requires": {
             "ajv": "^5.3.0",
@@ -12514,27 +12524,27 @@
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
         },
         "hosted-git-info": {
           "version": "2.7.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
         },
         "http-cache-semantics": {
           "version": "3.8.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
         },
         "http-proxy-agent": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
           "requires": {
             "agent-base": "4",
@@ -12543,7 +12553,7 @@
         },
         "http-signature": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "requires": {
             "assert-plus": "^1.0.0",
@@ -12553,7 +12563,7 @@
         },
         "https-proxy-agent": {
           "version": "2.2.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
           "requires": {
             "agent-base": "^4.1.0",
@@ -12562,7 +12572,7 @@
         },
         "humanize-ms": {
           "version": "1.2.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
           "requires": {
             "ms": "^2.0.0"
@@ -12570,7 +12580,7 @@
         },
         "iconv-lite": {
           "version": "0.4.23",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
@@ -12578,12 +12588,12 @@
         },
         "iferr": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg=="
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "requires": {
             "minimatch": "^3.0.4"
@@ -12591,17 +12601,17 @@
         },
         "import-lazy": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
             "once": "^1.3.0",
@@ -12610,17 +12620,17 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "init-package-json": {
           "version": "1.10.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
           "requires": {
             "glob": "^7.1.1",
@@ -12635,22 +12645,22 @@
         },
         "invert-kv": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
         },
         "ip": {
           "version": "1.1.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
         },
         "ip-regex": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
         },
         "is-builtin-module": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
           "requires": {
             "builtin-modules": "^1.0.0"
@@ -12658,7 +12668,7 @@
         },
         "is-ci": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
           "requires": {
             "ci-info": "^1.0.0"
@@ -12666,7 +12676,7 @@
         },
         "is-cidr": {
           "version": "2.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-A578p1dV22TgPXn6NCaDAPj6vJvYsBgAzUrAd28a4oldeXJjWqEUuSZOLIW3im51mazOKsoyVp8NU/OItlWacw==",
           "requires": {
             "cidr-regex": "^2.0.8"
@@ -12674,7 +12684,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -12682,7 +12692,7 @@
         },
         "is-installed-globally": {
           "version": "0.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
           "requires": {
             "global-dirs": "^0.1.0",
@@ -12691,17 +12701,17 @@
         },
         "is-npm": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
         },
         "is-obj": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
         },
         "is-path-inside": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
           "requires": {
             "path-is-inside": "^1.0.1"
@@ -12709,73 +12719,73 @@
         },
         "is-redirect": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
         },
         "is-retry-allowed": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
         },
         "is-stream": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "isexe": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "isstream": {
           "version": "0.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "jsbn": {
           "version": "0.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "optional": true
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
         },
         "json-schema": {
           "version": "0.2.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
         },
         "json-schema-traverse": {
           "version": "0.3.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
         },
         "jsonparse": {
           "version": "1.3.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
         },
         "jsprim": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
           "requires": {
             "assert-plus": "1.0.0",
@@ -12786,7 +12796,7 @@
         },
         "latest-version": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
           "requires": {
             "package-json": "^4.0.0"
@@ -12794,12 +12804,12 @@
         },
         "lazy-property": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc="
         },
         "lcid": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "requires": {
             "invert-kv": "^1.0.0"
@@ -12807,7 +12817,7 @@
         },
         "libcipm": {
           "version": "2.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-9uZ6/LAflVEijksTRq/RX0e+pGA4mr8tND9Cmk2JMg7j2fFUBrs8PpFX2DOAJR/XoxPzz+5h8bkWmtIYLunKAg==",
           "requires": {
             "bin-links": "^1.1.2",
@@ -12828,7 +12838,7 @@
         },
         "libnpmhook": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-3qqpfqvBD1712WA6iGe0stkG40WwAeoWcujA6BlC0Be1JArQbqwabnEnZ0CRcD05Tf1fPYJYdCbSfcfedEJCOg==",
           "requires": {
             "figgy-pudding": "^3.1.0",
@@ -12837,7 +12847,7 @@
           "dependencies": {
             "npm-registry-fetch": {
               "version": "3.1.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-xBobENeenvjIG8PgQ1dy77AXTI25IbYhmA3DusMIfw/4EL5BaQ5e1V9trkPrqHvyjR3/T0cnH6o0Wt/IzcI5Ag==",
               "requires": {
                 "bluebird": "^3.5.1",
@@ -12851,7 +12861,7 @@
         },
         "libnpx": {
           "version": "10.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-X28coei8/XRCt15cYStbLBph+KGhFra4VQhRBPuH/HHMkC5dxM8v24RVgUsvODKCrUZ0eTgiTqJp6zbl0sskQQ==",
           "requires": {
             "dotenv": "^5.0.1",
@@ -12866,7 +12876,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "requires": {
             "p-locate": "^2.0.0",
@@ -12875,7 +12885,7 @@
         },
         "lock-verify": {
           "version": "2.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-QNVwK0EGZBS4R3YQ7F1Ox8p41Po9VGl2QG/2GsuvTbkJZYSsPeWHKMbbH6iZMCHWSMww5nrJroZYnGzI4cePuw==",
           "requires": {
             "npm-package-arg": "^5.1.2 || 6",
@@ -12884,7 +12894,7 @@
         },
         "lockfile": {
           "version": "1.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
           "requires": {
             "signal-exit": "^3.0.2"
@@ -12892,12 +12902,12 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw="
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
           "requires": {
             "lodash._createset": "~4.0.0",
@@ -12906,17 +12916,17 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI="
         },
         "lodash._createcache": {
           "version": "3.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
           "requires": {
             "lodash._getnative": "^3.0.0"
@@ -12924,52 +12934,52 @@
         },
         "lodash._createset": {
           "version": "4.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY="
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
         },
         "lodash._root": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
         },
         "lodash.union": {
           "version": "4.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
         },
         "lodash.uniq": {
           "version": "4.5.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
         },
         "lodash.without": {
           "version": "4.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
         },
         "lowercase-keys": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
         },
         "lru-cache": {
           "version": "4.1.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "requires": {
             "pseudomap": "^1.0.2",
@@ -12978,7 +12988,7 @@
         },
         "make-dir": {
           "version": "1.3.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
           "requires": {
             "pify": "^3.0.0"
@@ -12986,7 +12996,7 @@
         },
         "make-fetch-happen": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-7R5ivfy9ilRJ1EMKIOziwrns9fGeAD4bAha8EB7BIiBBLHm2KeTUGCrICFt2rbHfzheTLynv50GnNTK1zDTrcQ==",
           "requires": {
             "agentkeepalive": "^3.4.1",
@@ -13004,12 +13014,12 @@
         },
         "meant": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg=="
         },
         "mem": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
           "requires": {
             "mimic-fn": "^1.0.0"
@@ -13017,12 +13027,12 @@
         },
         "mime-db": {
           "version": "1.35.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
         },
         "mime-types": {
           "version": "2.1.19",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
           "requires": {
             "mime-db": "~1.35.0"
@@ -13030,12 +13040,12 @@
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -13043,12 +13053,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.3.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -13057,14 +13067,14 @@
           "dependencies": {
             "yallist": {
               "version": "3.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
             }
           }
         },
         "minizlib": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "requires": {
             "minipass": "^2.2.1"
@@ -13072,7 +13082,7 @@
         },
         "mississippi": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
           "requires": {
             "concat-stream": "^1.5.0",
@@ -13089,7 +13099,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
@@ -13097,7 +13107,7 @@
         },
         "move-concurrently": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
           "requires": {
             "aproba": "^1.1.1",
@@ -13110,17 +13120,17 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
         "mute-stream": {
           "version": "0.0.7",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
         },
         "node-fetch-npm": {
           "version": "2.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
           "requires": {
             "encoding": "^0.1.11",
@@ -13130,7 +13140,7 @@
         },
         "node-gyp": {
           "version": "3.8.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
           "requires": {
             "fstream": "^1.0.0",
@@ -13149,7 +13159,7 @@
           "dependencies": {
             "nopt": {
               "version": "3.0.6",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
               "requires": {
                 "abbrev": "1"
@@ -13157,12 +13167,12 @@
             },
             "semver": {
               "version": "5.3.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
             },
             "tar": {
               "version": "2.2.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
               "requires": {
                 "block-stream": "*",
@@ -13174,7 +13184,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "requires": {
             "abbrev": "1",
@@ -13183,7 +13193,7 @@
         },
         "normalize-package-data": {
           "version": "2.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "requires": {
             "hosted-git-info": "^2.1.4",
@@ -13194,7 +13204,7 @@
         },
         "npm-audit-report": {
           "version": "1.3.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-SjTF8ZP4rOu3JiFrTMi4M1CmVo2tni2sP4TzhyCMHwnMGf6XkdGLZKt9cdZ12esKf0mbQqFyU9LtY0SoeahL7g==",
           "requires": {
             "cli-table3": "^0.5.0",
@@ -13203,17 +13213,17 @@
         },
         "npm-bundled": {
           "version": "1.0.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g=="
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE="
         },
         "npm-install-checks": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
           "requires": {
             "semver": "^2.3.0 || 3.x || 4 || 5"
@@ -13221,7 +13231,7 @@
         },
         "npm-lifecycle": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-QbBfLlGBKsktwBZLj6AviHC6Q9Y3R/AY4a2PYSIRhSKSS0/CxRyD/PfxEX6tPeOCXQgMSNdwGeECacstgptc+g==",
           "requires": {
             "byline": "^5.0.0",
@@ -13236,12 +13246,12 @@
         },
         "npm-logical-tree": {
           "version": "1.2.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg=="
         },
         "npm-package-arg": {
           "version": "6.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
           "requires": {
             "hosted-git-info": "^2.6.0",
@@ -13252,7 +13262,7 @@
         },
         "npm-packlist": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-CxKlZ24urLkJk+9kCm48RTQ7L4hsmgSVzEk0TLGPzzyuFxD7VNgy5Sl24tOLMzQv773a/NeJ1ce1DKeacqffEA==",
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -13261,7 +13271,7 @@
         },
         "npm-pick-manifest": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-q9zLP8cTr8xKPmMZN3naxp1k/NxVFsjxN6uWuO1tiw9gxg7wZWQ/b5UTfzD0ANw2q1lQxdLKTeCCksq+bPSgbQ==",
           "requires": {
             "npm-package-arg": "^6.0.0",
@@ -13270,7 +13280,7 @@
         },
         "npm-profile": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-rEJOFR6PbwOvvhGa2YTNOJQKNuc6RovJ6T50xPU7pS9h/zKPNCJ+VHZY2OFXyZvEi+UQYtHRTp8O/YM3tUD20A==",
           "requires": {
             "aproba": "^1.1.2 || 2",
@@ -13279,7 +13289,7 @@
         },
         "npm-registry-client": {
           "version": "8.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Qs6P6nnopig+Y8gbzpeN/dkt+n7IyVd8f45NTMotGk6Qo7GfBmzwYx6jRLoOOgKiMnaQfYxsuyQlD8Mc3guBhg==",
           "requires": {
             "concat-stream": "^1.5.2",
@@ -13298,12 +13308,12 @@
           "dependencies": {
             "retry": {
               "version": "0.10.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
             },
             "ssri": {
               "version": "5.3.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
               "requires": {
                 "safe-buffer": "^5.1.1"
@@ -13313,7 +13323,7 @@
         },
         "npm-registry-fetch": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-XJPIBfMtgaooRtZmuA42xCeLf3tkxdIX0xqRsGWwNrcVvJ9UYFccD7Ho7QWCzvkM3i/QrkUC37Hu0a+vDBmt5g==",
           "requires": {
             "bluebird": "^3.5.1",
@@ -13326,7 +13336,7 @@
           "dependencies": {
             "cacache": {
               "version": "10.0.4",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
               "requires": {
                 "bluebird": "^3.5.1",
@@ -13346,7 +13356,7 @@
               "dependencies": {
                 "mississippi": {
                   "version": "2.0.0",
-                  "resolved": false,
+                  "resolved": "",
                   "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
                   "requires": {
                     "concat-stream": "^1.5.0",
@@ -13365,12 +13375,12 @@
             },
             "figgy-pudding": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-yIJPhIBi/oFdU/P+GSXjmk/rmGjuZkm7A5LTXZxNrEprXJXRK012FiI1BR1Pga+0d/d6taWWD+B5d2ozqaxHig=="
             },
             "make-fetch-happen": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-FmWY7gC0mL6Z4N86vE14+m719JKE4H0A+pyiOH18B025gF/C113pyfb4gHDDYP5cqnRMHOz06JGdmffC/SES+w==",
               "requires": {
                 "agentkeepalive": "^3.4.1",
@@ -13388,7 +13398,7 @@
             },
             "pump": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
               "requires": {
                 "end-of-stream": "^1.1.0",
@@ -13397,12 +13407,12 @@
             },
             "smart-buffer": {
               "version": "1.1.15",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
             },
             "socks": {
               "version": "1.1.10",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
               "requires": {
                 "ip": "^1.1.4",
@@ -13411,7 +13421,7 @@
             },
             "socks-proxy-agent": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
               "requires": {
                 "agent-base": "^4.1.0",
@@ -13420,7 +13430,7 @@
             },
             "ssri": {
               "version": "5.3.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
               "requires": {
                 "safe-buffer": "^5.1.1"
@@ -13430,7 +13440,7 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "requires": {
             "path-key": "^2.0.0"
@@ -13438,12 +13448,12 @@
         },
         "npm-user-validate": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE="
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "requires": {
             "are-we-there-yet": "~1.1.2",
@@ -13454,22 +13464,22 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "oauth-sign": {
           "version": "0.9.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1"
@@ -13477,17 +13487,17 @@
         },
         "opener": {
           "version": "1.5.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-MD4s/o61y2slS27zm2s4229V2gAUHX0/e3/XOmY/jsXwhysjjCIHN8lx7gqZCrZk19ym+HjCUWHeMKD7YJtKCQ=="
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
         },
         "os-locale": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "requires": {
             "execa": "^0.7.0",
@@ -13497,12 +13507,12 @@
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "requires": {
             "os-homedir": "^1.0.0",
@@ -13511,12 +13521,12 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
         },
         "p-limit": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
           "requires": {
             "p-try": "^1.0.0"
@@ -13524,7 +13534,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "requires": {
             "p-limit": "^1.1.0"
@@ -13532,12 +13542,12 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
         },
         "package-json": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
           "requires": {
             "got": "^6.7.1",
@@ -13548,7 +13558,7 @@
         },
         "pacote": {
           "version": "8.1.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-wTOOfpaAQNEQNtPEx92x9Y9kRWVu45v583XT8x2oEV2xRB74+xdqMZIeGW4uFvAyZdmSBtye+wKdyyLaT8pcmw==",
           "requires": {
             "bluebird": "^3.5.1",
@@ -13580,7 +13590,7 @@
         },
         "parallel-transform": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
           "requires": {
             "cyclist": "~0.2.2",
@@ -13590,52 +13600,52 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
         },
         "performance-now": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         },
         "prepend-http": {
           "version": "1.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
         },
         "promise-retry": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
           "requires": {
             "err-code": "^1.0.0",
@@ -13644,14 +13654,14 @@
           "dependencies": {
             "retry": {
               "version": "0.10.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
             }
           }
         },
         "promzard": {
           "version": "0.3.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
           "requires": {
             "read": "1"
@@ -13659,12 +13669,12 @@
         },
         "proto-list": {
           "version": "1.2.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
         },
         "protoduck": {
           "version": "5.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-agsGWD8/RZrS4ga6v82Fxb0RHIS2RZnbsSue6A9/MBRhB/jcqOANAMNrqM9900b8duj+Gx+T/JMy5IowDoO/hQ==",
           "requires": {
             "genfun": "^4.0.1"
@@ -13672,22 +13682,22 @@
         },
         "prr": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
         },
         "pseudomap": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
         },
         "psl": {
           "version": "1.1.29",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
         },
         "pump": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -13696,7 +13706,7 @@
         },
         "pumpify": {
           "version": "1.5.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
           "requires": {
             "duplexify": "^3.6.0",
@@ -13706,7 +13716,7 @@
           "dependencies": {
             "pump": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
               "requires": {
                 "end-of-stream": "^1.1.0",
@@ -13717,22 +13727,22 @@
         },
         "punycode": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
         "qrcode-terminal": {
           "version": "0.12.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ=="
         },
         "qs": {
           "version": "6.5.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "query-string": {
           "version": "6.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-pNB/Gr8SA8ff8KpUFM36o/WFAlthgaThka5bV19AD9PNTH20Pwq5Zxodif2YyHwrctp6SkL4GqlOot0qR/wGaw==",
           "requires": {
             "decode-uri-component": "^0.2.0",
@@ -13741,12 +13751,12 @@
         },
         "qw": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ="
         },
         "rc": {
           "version": "1.2.7",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "requires": {
             "deep-extend": "^0.5.1",
@@ -13757,14 +13767,14 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
             }
           }
         },
         "read": {
           "version": "1.0.7",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
           "requires": {
             "mute-stream": "~0.0.4"
@@ -13772,7 +13782,7 @@
         },
         "read-cmd-shim": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
           "requires": {
             "graceful-fs": "^4.1.2"
@@ -13780,7 +13790,7 @@
         },
         "read-installed": {
           "version": "4.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
           "requires": {
             "debuglog": "^1.0.1",
@@ -13794,7 +13804,7 @@
         },
         "read-package-json": {
           "version": "2.0.13",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
           "requires": {
             "glob": "^7.1.1",
@@ -13806,7 +13816,7 @@
         },
         "read-package-tree": {
           "version": "5.2.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-2CNoRoh95LxY47LvqrehIAfUVda2JbuFE/HaGYs42bNrGG+ojbw1h3zOcPcQ+1GQ3+rkzNndZn85u1XyZ3UsIA==",
           "requires": {
             "debuglog": "^1.0.1",
@@ -13818,7 +13828,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -13832,7 +13842,7 @@
         },
         "readdir-scoped-modules": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
           "requires": {
             "debuglog": "^1.0.1",
@@ -13843,7 +13853,7 @@
         },
         "registry-auth-token": {
           "version": "3.3.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
           "requires": {
             "rc": "^1.1.6",
@@ -13852,7 +13862,7 @@
         },
         "registry-url": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
           "requires": {
             "rc": "^1.0.1"
@@ -13860,7 +13870,7 @@
         },
         "request": {
           "version": "2.88.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
           "requires": {
             "aws-sign2": "~0.7.0",
@@ -13887,27 +13897,27 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
         },
         "retry": {
           "version": "0.12.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "requires": {
             "glob": "^7.0.5"
@@ -13915,7 +13925,7 @@
         },
         "run-queue": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
           "requires": {
             "aproba": "^1.1.1"
@@ -13923,22 +13933,22 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
         },
         "semver-diff": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
           "requires": {
             "semver": "^5.0.3"
@@ -13946,12 +13956,12 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
         },
         "sha": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -13960,7 +13970,7 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -13968,32 +13978,32 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
         },
         "slash": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
         },
         "slide": {
           "version": "1.1.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
         },
         "smart-buffer": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-RFqinRVJVcCAL9Uh1oVqE6FZkqsyLiVOYEZ20TqIOjuX7iFVJ+zsbs4RIghnw/pTs7mZvt8ZHhvm1ZUrR4fykg=="
         },
         "socks": {
           "version": "2.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-uRKV9uXQ9ytMbGm2+DilS1jB7N3AC0mmusmW5TVWjNuBZjxS8+lX38fasKVY9I4opv/bY/iqTbcpFFaTwpfwRg==",
           "requires": {
             "ip": "^1.1.5",
@@ -14002,7 +14012,7 @@
         },
         "socks-proxy-agent": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Kezx6/VBguXOsEe5oU3lXYyKMi4+gva72TwJ7pQY5JfqUx2nMk7NXA6z/mpNqIlfQjWYVfeuNvQjexiTaTn6Nw==",
           "requires": {
             "agent-base": "~4.2.0",
@@ -14011,12 +14021,12 @@
         },
         "sorted-object": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw="
         },
         "sorted-union-stream": {
           "version": "2.1.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
           "requires": {
             "from2": "^1.3.0",
@@ -14025,7 +14035,7 @@
           "dependencies": {
             "from2": {
               "version": "1.3.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
               "requires": {
                 "inherits": "~2.0.1",
@@ -14034,12 +14044,12 @@
             },
             "isarray": {
               "version": "0.0.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
             },
             "readable-stream": {
               "version": "1.1.14",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -14050,14 +14060,14 @@
             },
             "string_decoder": {
               "version": "0.10.31",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
             }
           }
         },
         "spdx-correct": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
           "requires": {
             "spdx-expression-parse": "^3.0.0",
@@ -14066,12 +14076,12 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
           "requires": {
             "spdx-exceptions": "^2.1.0",
@@ -14080,12 +14090,12 @@
         },
         "spdx-license-ids": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
         },
         "sshpk": {
           "version": "1.14.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
           "requires": {
             "asn1": "~0.2.3",
@@ -14101,12 +14111,12 @@
         },
         "ssri": {
           "version": "6.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-zYOGfVHPhxyzwi8MdtdNyxv3IynWCIM4jYReR48lqu0VngxgH1c+C6CmipRdJ55eVByTJV/gboFEEI7TEQI8DA=="
         },
         "stream-each": {
           "version": "1.2.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -14115,7 +14125,7 @@
         },
         "stream-iterate": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
           "requires": {
             "readable-stream": "^2.1.5",
@@ -14124,17 +14134,17 @@
         },
         "stream-shift": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
         },
         "strict-uri-encode": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -14143,17 +14153,17 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -14163,7 +14173,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -14171,12 +14181,12 @@
         },
         "stringify-package": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-JIQqiWmLiEozOC0b0BtxZ/AOUtdUZHCBPgqIZ2kSJJqGwgb9neo44XdTHUC4HZSGqi03hOeB7W/E8rAlKnGe9g=="
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -14184,17 +14194,17 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         },
         "supports-color": {
           "version": "5.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
             "has-flag": "^3.0.0"
@@ -14202,7 +14212,7 @@
         },
         "tar": {
           "version": "4.4.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==",
           "requires": {
             "chownr": "^1.0.1",
@@ -14216,14 +14226,14 @@
           "dependencies": {
             "yallist": {
               "version": "3.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
             }
           }
         },
         "term-size": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
           "requires": {
             "execa": "^0.7.0"
@@ -14231,17 +14241,17 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
         },
         "through": {
           "version": "2.3.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
         },
         "through2": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "requires": {
             "readable-stream": "^2.1.5",
@@ -14250,17 +14260,17 @@
         },
         "timed-out": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
         },
         "tiny-relative-date": {
           "version": "1.3.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A=="
         },
         "tough-cookie": {
           "version": "2.4.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
           "requires": {
             "psl": "^1.1.24",
@@ -14269,7 +14279,7 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "requires": {
             "safe-buffer": "^5.0.1"
@@ -14277,28 +14287,28 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "optional": true
         },
         "typedarray": {
           "version": "0.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
         "uid-number": {
           "version": "0.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
         },
         "umask": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0="
         },
         "unique-filename": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
           "requires": {
             "unique-slug": "^2.0.0"
@@ -14306,7 +14316,7 @@
         },
         "unique-slug": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
           "requires": {
             "imurmurhash": "^0.1.4"
@@ -14314,7 +14324,7 @@
         },
         "unique-string": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
           "requires": {
             "crypto-random-string": "^1.0.0"
@@ -14322,17 +14332,17 @@
         },
         "unpipe": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
         },
         "unzip-response": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
         },
         "update-notifier": {
           "version": "2.5.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
           "requires": {
             "boxen": "^1.2.1",
@@ -14349,7 +14359,7 @@
         },
         "url-parse-lax": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "requires": {
             "prepend-http": "^1.0.1"
@@ -14357,22 +14367,22 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "util-extend": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8="
         },
         "uuid": {
           "version": "3.3.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
           "requires": {
             "spdx-correct": "^3.0.0",
@@ -14381,7 +14391,7 @@
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
           "requires": {
             "builtins": "^1.0.3"
@@ -14389,7 +14399,7 @@
         },
         "verror": {
           "version": "1.10.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "requires": {
             "assert-plus": "^1.0.0",
@@ -14399,7 +14409,7 @@
         },
         "wcwidth": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
           "requires": {
             "defaults": "^1.0.3"
@@ -14407,7 +14417,7 @@
         },
         "which": {
           "version": "1.3.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "requires": {
             "isexe": "^2.0.0"
@@ -14415,12 +14425,12 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
         },
         "wide-align": {
           "version": "1.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "requires": {
             "string-width": "^1.0.2"
@@ -14428,7 +14438,7 @@
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -14440,7 +14450,7 @@
         },
         "widest-line": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
           "requires": {
             "string-width": "^2.1.1"
@@ -14448,7 +14458,7 @@
         },
         "worker-farm": {
           "version": "1.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
           "requires": {
             "errno": "~0.1.7"
@@ -14456,7 +14466,7 @@
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "requires": {
             "string-width": "^1.0.1",
@@ -14465,7 +14475,7 @@
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -14477,12 +14487,12 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "write-file-atomic": {
           "version": "2.3.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -14492,27 +14502,27 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
         },
         "xtend": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         },
         "y18n": {
           "version": "4.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         },
         "yargs": {
           "version": "11.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
           "requires": {
             "cliui": "^4.0.0",
@@ -14531,14 +14541,14 @@
           "dependencies": {
             "y18n": {
               "version": "3.2.1",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
             }
           }
         },
         "yargs-parser": {
           "version": "9.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "requires": {
             "camelcase": "^4.1.0"
@@ -15893,6 +15903,11 @@
         "shallowequal": "^1.0.2"
       },
       "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        },
         "recompose": {
           "version": "0.27.1",
           "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.27.1.tgz",
@@ -16624,6 +16639,21 @@
         "hoist-non-react-statics": "^2.3.1",
         "react-lifecycles-compat": "^3.0.2",
         "symbol-observable": "^1.0.4"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.1.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
+          "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
+          "requires": {
+            "regenerator-runtime": "^0.12.0"
+          }
+        },
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        }
       }
     },
     "recursive-copy": {
@@ -18319,6 +18349,11 @@
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
           }
+        },
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "apollo-cache-inmemory": "1.3.11",
     "apollo-client": "2.4.7",
     "apollo-link": "1.2.4",
+    "apollo-link-context": "1.0.9",
     "apollo-link-error": "1.1.2",
     "apollo-link-http": "1.5.7",
     "bluebird": "3.5.3",

--- a/src/components/Collective.js
+++ b/src/components/Collective.js
@@ -219,7 +219,7 @@ class Collective extends React.Component {
               error={this.state.error}
             />
 
-            <CollectiveCover collective={collective} cta={cta} LoggedInUser={LoggedInUser} />
+            <CollectiveCover collective={collective} cta={cta} LoggedInUser={LoggedInUser} key={collective.slug} />
 
             <div>
               <div>

--- a/src/components/CollectiveCover.js
+++ b/src/components/CollectiveCover.js
@@ -444,7 +444,7 @@ ${description}`;
           )}
         </div>
 
-        {className !== 'small' && <MenuBar collective={collective} LoggedInUser={LoggedInUser} cta={cta} />}
+        {className !== 'small' && <MenuBar collective={collective} cta={cta} />}
       </div>
     );
   }

--- a/src/components/CollectiveCover.js
+++ b/src/components/CollectiveCover.js
@@ -324,10 +324,17 @@ ${description}`;
           <div className="content">
             <Link route={href} className="goBack">
               {collective.type === 'USER' && (
-                <Avatar src={logo} className="logo" radius="10rem" {...pick(collective, ['type', 'name'])} />
+                <Avatar src={logo} className="logo" radius="10rem" key={logo} {...pick(collective, ['type', 'name'])} />
               )}
               {collective.type !== 'USER' && (
-                <Logo src={logo} className="logo" type={collective.type} website={collective.website} height="10rem" />
+                <Logo
+                  src={logo}
+                  className="logo"
+                  type={collective.type}
+                  website={collective.website}
+                  height="10rem"
+                  key={logo}
+                />
               )}
             </Link>
             <h1>{title}</h1>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -57,7 +57,7 @@ class Header extends React.Component {
           ))}
         </Head>
         <div id="top" />
-        <TopBar className={className} LoggedInUser={this.props.LoggedInUser} showSearch={this.props.showSearch} />
+        <TopBar className={className} showSearch={this.props.showSearch} />
       </header>
     );
   }

--- a/src/components/MenuBar.js
+++ b/src/components/MenuBar.js
@@ -13,6 +13,7 @@ import { Pencil } from 'styled-icons/octicons/Pencil.cjs';
 
 import colors from '../constants/colors';
 import withIntl from '../lib/withIntl';
+import { withUser } from './UserProvider';
 
 import Avatar from './Avatar';
 import Logo from './Logo';
@@ -619,4 +620,4 @@ const addMutationForAddFundsToOrg = graphql(addFundsToOrgQuery, {
   }),
 });
 
-export default addMutationForAddFundsToOrg(withIntl(MenuBar));
+export default addMutationForAddFundsToOrg(withIntl(withUser(MenuBar)));

--- a/src/components/MenuBar.js
+++ b/src/components/MenuBar.js
@@ -542,6 +542,7 @@ class MenuBar extends React.Component {
                             src={collective.image}
                             type={collective.type}
                             name={collective.name}
+                            key={collective.image}
                             className="logo"
                             radius="4.8rem"
                           />
@@ -549,6 +550,7 @@ class MenuBar extends React.Component {
                         {collective.type !== 'USER' && (
                           <Logo
                             src={collective.image}
+                            key={collective.image}
                             className="logo"
                             type={collective.type}
                             website={collective.website}

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -1,54 +1,49 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 
-import withData from '../lib/withData';
-import withLoggedInUser from '../lib/withLoggedInUser';
+import { withUser } from './UserProvider';
 
-import Body from './Body';
-import ErrorPage from './ErrorPage';
-import Footer from './Footer';
-import Header from './Header';
+import Body from '../components/Body';
+import ErrorPage from '../components/ErrorPage';
+import Footer from '../components/Footer';
+import Header from '../components/Header';
 
 class Page extends React.Component {
-  static propTypes = {
-    getLoggedInUser: PropTypes.func,
-    title: PropTypes.string,
-  };
-
-  state = {
-    error: null,
-    loadingLoggedInUser: true,
-    LoggedInUser: null,
-  };
-
-  async componentDidMount() {
-    const { getLoggedInUser } = this.props;
-    try {
-      const LoggedInUser = await getLoggedInUser();
-      this.setState({ LoggedInUser });
-    } catch (error) {
-      this.setState({ error });
-    } finally {
-      this.setState({ loadingLoggedInUser: false });
-    }
-  }
-
   render() {
-    const { children, title } = this.props;
-    const { error, loadingLoggedInUser, LoggedInUser } = this.state;
+    const { children, data, loadingLoggedInUser, LoggedInUser, title, showSearch } = this.props;
 
-    if (error) {
-      return <ErrorPage message={error.message} />;
+    if (data.error) {
+      return <ErrorPage data={data} LoggedInUser={LoggedInUser} />;
     }
+
+    const childProps = { LoggedInUser, loadingLoggedInUser };
 
     return (
       <Fragment>
-        <Header className={loadingLoggedInUser ? 'loading' : ''} LoggedInUser={LoggedInUser} title={title} />
-        <Body>{children(this.state)}</Body>
+        <Header
+          className={loadingLoggedInUser ? 'loading' : ''}
+          LoggedInUser={LoggedInUser}
+          showSearch={showSearch}
+          title={title}
+        />
+        <Body>{typeof children === 'function' ? children(childProps) : children}</Body>
         <Footer />
       </Fragment>
     );
   }
 }
 
-export default withData(withLoggedInUser(Page));
+Page.propTypes = {
+  data: PropTypes.shape({
+    error: PropTypes.shape({}),
+  }),
+  LoggedInUser: PropTypes.shape({}),
+  showSearch: PropTypes.bool,
+  title: PropTypes.string,
+};
+
+Page.defaultProps = {
+  showSearch: true,
+};
+
+export default withUser(Page);

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -10,7 +10,7 @@ import Header from '../components/Header';
 
 class Page extends React.Component {
   render() {
-    const { children, data, loadingLoggedInUser, LoggedInUser, title, showSearch } = this.props;
+    const { children, data = {}, loadingLoggedInUser, LoggedInUser, title, showSearch } = this.props;
 
     if (data.error) {
       return <ErrorPage data={data} LoggedInUser={LoggedInUser} />;

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -8,35 +8,29 @@ import ErrorPage from '../components/ErrorPage';
 import Footer from '../components/Footer';
 import Header from '../components/Header';
 
-class Page extends React.Component {
-  render() {
-    const { children, data = {}, loadingLoggedInUser, LoggedInUser, title, showSearch } = this.props;
-
-    if (data.error) {
-      return <ErrorPage data={data} LoggedInUser={LoggedInUser} />;
-    }
-
-    const childProps = { LoggedInUser, loadingLoggedInUser };
-
-    return (
-      <Fragment>
-        <Header
-          className={loadingLoggedInUser ? 'loading' : ''}
-          LoggedInUser={LoggedInUser}
-          showSearch={showSearch}
-          title={title}
-        />
-        <Body>{typeof children === 'function' ? children(childProps) : children}</Body>
-        <Footer />
-      </Fragment>
-    );
+const Page = ({ children, data = {}, loadingLoggedInUser, LoggedInUser, title, showSearch }) => {
+  if (data.error) {
+    return <ErrorPage data={data} LoggedInUser={LoggedInUser} />;
   }
-}
+
+  const childProps = { LoggedInUser, loadingLoggedInUser };
+
+  return (
+    <Fragment>
+      <Header showSearch={showSearch} title={title} />
+      <Body>{typeof children === 'function' ? children(childProps) : children}</Body>
+      <Footer />
+    </Fragment>
+  );
+};
+
+Page.displayName = 'Page';
 
 Page.propTypes = {
   data: PropTypes.shape({
     error: PropTypes.shape({}),
   }),
+  loadingLoggedInUser: PropTypes.bool,
   LoggedInUser: PropTypes.shape({}),
   showSearch: PropTypes.bool,
   title: PropTypes.string,

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -13,6 +13,7 @@ import { Box, Flex } from 'grid-styled';
 import styled from 'styled-components';
 
 import { rotateMixin } from '../constants/animations';
+import { withUser } from './UserProvider';
 
 const Logo = styled.img.attrs({
   src: '/static/images/opencollective-icon.svg',
@@ -40,6 +41,7 @@ const NavLink = styled.a`
 class TopBar extends React.Component {
   static propTypes = {
     className: PropTypes.string,
+    loadingLoggedInUser: PropTypes.bool,
     showSearch: PropTypes.bool,
   };
 
@@ -59,8 +61,8 @@ class TopBar extends React.Component {
   }
 
   render() {
-    const { className, showSearch } = this.props;
-    const shouldAnimate = Array.isArray(className) && className.includes('loading');
+    const { className, loadingLoggedInUser, showSearch } = this.props;
+    const shouldAnimate = (Array.isArray(className) && className.includes('loading')) || loadingLoggedInUser;
 
     return (
       <Flex px={3} py={showSearch ? 2 : 3} alignItems="center" flexDirection="row" justifyContent="space-around">
@@ -135,4 +137,4 @@ class TopBar extends React.Component {
   }
 }
 
-export default withIntl(TopBar);
+export default withIntl(withUser(TopBar));

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -40,7 +40,6 @@ const NavLink = styled.a`
 class TopBar extends React.Component {
   static propTypes = {
     className: PropTypes.string,
-    LoggedInUser: PropTypes.object,
     showSearch: PropTypes.bool,
   };
 
@@ -60,7 +59,7 @@ class TopBar extends React.Component {
   }
 
   render() {
-    const { className, LoggedInUser, showSearch } = this.props;
+    const { className, showSearch } = this.props;
     const shouldAnimate = Array.isArray(className) && className.includes('loading');
 
     return (
@@ -129,7 +128,7 @@ class TopBar extends React.Component {
             </NavList>
           </Hide>
 
-          <TopBarProfileMenu LoggedInUser={LoggedInUser} />
+          <TopBarProfileMenu />
         </Flex>
       </Flex>
     );

--- a/src/components/TopBarProfileMenu.js
+++ b/src/components/TopBarProfileMenu.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Link } from '../server/pages';
 import { FormattedMessage, defineMessages } from 'react-intl';
 import withIntl from '../lib/withIntl';
+import { withUser } from './UserProvider';
 import { formatCurrency, capitalize } from '../lib/utils';
 import { Badge } from 'react-bootstrap';
 import { get, uniqBy } from 'lodash';
@@ -60,9 +61,8 @@ class TopBarProfileMenu extends React.Component {
 
   logout = () => {
     this.setState({ showProfileMenu: false, status: 'loggingout' });
-    window.localStorage.removeItem('accessToken');
-    window.localStorage.removeItem('LoggedInUser');
-    window.location.reload();
+    this.props.logout();
+    this.setState({ status: 'loggedout' });
   };
 
   onClickOutside = () => {
@@ -335,12 +335,15 @@ class TopBarProfileMenu extends React.Component {
 
   render() {
     const { loading } = this.state;
-    const { LoggedInUser } = this.props;
+    const { LoggedInUser, loadingLoggedInUser } = this.props;
 
     let status;
     if (this.state.status) {
       status = this.state.status;
-    } else if (loading && typeof LoggedInUser === 'undefined') {
+    } else if (
+      (loading || loadingLoggedInUser) &&
+      typeof LoggedInUser === 'undefined'
+    ) {
       status = 'loading';
     } else if (!LoggedInUser) {
       status = 'loggedout';
@@ -372,4 +375,4 @@ class TopBarProfileMenu extends React.Component {
   }
 }
 
-export default withIntl(TopBarProfileMenu);
+export default withIntl(withUser(TopBarProfileMenu));

--- a/src/components/TopBarProfileMenu.js
+++ b/src/components/TopBarProfileMenu.js
@@ -340,10 +340,7 @@ class TopBarProfileMenu extends React.Component {
     let status;
     if (this.state.status) {
       status = this.state.status;
-    } else if (
-      (loading || loadingLoggedInUser) &&
-      typeof LoggedInUser === 'undefined'
-    ) {
+    } else if ((loading || loadingLoggedInUser) && typeof LoggedInUser === 'undefined') {
       status = 'loading';
     } else if (!LoggedInUser) {
       status = 'loggedout';

--- a/src/components/UserProvider.js
+++ b/src/components/UserProvider.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import { isEqual } from 'lodash';
+
+import { withApollo } from 'react-apollo';
+import withLoggedInUser from '../lib/withLoggedInUser';
+import UserClass from '../classes/LoggedInUser';
+
+export const UserContext = React.createContext({
+  loadingLoggedInUser: true,
+  LoggedInUser: null,
+  logout() {},
+  login() {},
+});
+
+class UserProvider extends React.Component {
+  state = {
+    loadingLoggedInUser: true,
+    LoggedInUser: null,
+  };
+
+  async componentDidMount() {
+    window.addEventListener('storage', this.checkLogin);
+    await this.login();
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('storage', this.checkLogin);
+  }
+
+  checkLogin = event => {
+    if (event.key === 'LoggedInUser') {
+      if (event.oldValue && !event.newValue) {
+        return this.setState({ LoggedInUser: null });
+      }
+      if (!event.oldValue && event.newValue) {
+        const { value } = JSON.parse(event.newValue);
+        return this.setState({ LoggedInUser: new UserClass(value) });
+      }
+
+      const { value: oldValue } = JSON.parse(event.oldValue);
+      const { value } = JSON.parse(event.newValue);
+
+      if (!isEqual(oldValue, value)) {
+        this.setState({ LoggedInUser: new UserClass(value) });
+      }
+    }
+  };
+
+  logout = async () => {
+    window.localStorage.removeItem('accessToken');
+    window.localStorage.removeItem('LoggedInUser');
+    this.props.client.resetStore();
+    this.setState({ LoggedInUser: null });
+  };
+
+  login = async () => {
+    const { getLoggedInUser } = this.props;
+    try {
+      const LoggedInUser = await getLoggedInUser();
+      this.setState({
+        loadingLoggedInUser: false,
+        LoggedInUser,
+      });
+    } catch (error) {
+      this.setState({ loadingLoggedInUser: false });
+    }
+    return true;
+  };
+
+  render() {
+    return (
+      <UserContext.Provider
+        value={{ ...this.state, logout: this.logout, login: this.login }}
+      >
+        {this.props.children}
+      </UserContext.Provider>
+    );
+  }
+}
+
+const { Consumer: UserConsumer } = UserContext;
+
+const withUser = WrappedComponent => {
+  const WithUser = props => (
+    <UserConsumer>
+      {context => <WrappedComponent {...context} {...props} />}
+    </UserConsumer>
+  );
+
+  WithUser.getInitialProps = async context => {
+    return WrappedComponent.getInitialProps
+      ? await WrappedComponent.getInitialProps(context)
+      : {};
+  };
+
+  return WithUser;
+};
+
+export default withApollo(withLoggedInUser(UserProvider));
+export { UserConsumer, withUser };

--- a/src/components/UserProvider.js
+++ b/src/components/UserProvider.js
@@ -69,9 +69,7 @@ class UserProvider extends React.Component {
 
   render() {
     return (
-      <UserContext.Provider
-        value={{ ...this.state, logout: this.logout, login: this.login }}
-      >
+      <UserContext.Provider value={{ ...this.state, logout: this.logout, login: this.login }}>
         {this.props.children}
       </UserContext.Provider>
     );
@@ -81,16 +79,10 @@ class UserProvider extends React.Component {
 const { Consumer: UserConsumer } = UserContext;
 
 const withUser = WrappedComponent => {
-  const WithUser = props => (
-    <UserConsumer>
-      {context => <WrappedComponent {...context} {...props} />}
-    </UserConsumer>
-  );
+  const WithUser = props => <UserConsumer>{context => <WrappedComponent {...context} {...props} />}</UserConsumer>;
 
   WithUser.getInitialProps = async context => {
-    return WrappedComponent.getInitialProps
-      ? await WrappedComponent.getInitialProps(context)
-      : {};
+    return WrappedComponent.getInitialProps ? await WrappedComponent.getInitialProps(context) : {};
   };
 
   return WithUser;

--- a/src/lib/initClient.js
+++ b/src/lib/initClient.js
@@ -6,6 +6,7 @@ import { ApolloClient } from 'apollo-client';
 import { HttpLink } from 'apollo-link-http';
 import { ApolloLink } from 'apollo-link';
 import { onError } from 'apollo-link-error';
+import { setContext } from 'apollo-link-context';
 import { InMemoryCache, IntrospectionFragmentMatcher } from 'apollo-cache-inmemory';
 
 import { getGraphqlUrl } from './utils';
@@ -26,11 +27,16 @@ const fragmentMatcher = new IntrospectionFragmentMatcher({
   },
 });
 
-function createClient(initialState, options = {}) {
-  const headers = {};
-  if (options.accessToken) {
-    headers.authorization = `Bearer ${options.accessToken}`;
-  }
+function createClient(initialState) {
+  const authLink = setContext((_, { headers }) => {
+    const token = process.browser && window.localStorage.getItem('accessToken');
+    return {
+      headers: {
+        ...headers,
+        authorization: token ? `Bearer ${token}` : '',
+      },
+    };
+  });
 
   const cache = new InMemoryCache({
     dataIdFromObject: result =>
@@ -59,10 +65,9 @@ function createClient(initialState, options = {}) {
   const httpLink = new HttpLink({
     uri: getGraphqlUrl(),
     fetch,
-    headers,
   });
 
-  const link = ApolloLink.from([errorLink, httpLink]);
+  const link = ApolloLink.from([errorLink, authLink.concat(httpLink)]);
 
   return new ApolloClient({
     connectToDevTools: process.browser,
@@ -72,17 +77,16 @@ function createClient(initialState, options = {}) {
   });
 }
 
-export default function initClient(initialState, options = {}) {
+export default function initClient(initialState) {
   // Make sure to create a new client for every server-side request so that data
   // isn't shared between connections (which would be bad)
   if (!process.browser) {
-    return createClient(initialState, options);
+    return createClient(initialState);
   }
 
   // Reuse client on the client-side
   if (!apolloClient) {
-    options.accessToken = process.browser && window.localStorage.getItem('accessToken');
-    apolloClient = createClient(initialState, options);
+    apolloClient = createClient(initialState);
   }
 
   return apolloClient;

--- a/src/lib/withData.js
+++ b/src/lib/withData.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Head from 'next/head';
-import { ApolloProvider, getDataFromTree } from 'react-apollo';
+import { getDataFromTree } from 'react-apollo';
 
 import initClient from './initClient';
 
@@ -15,6 +15,12 @@ function getComponentDisplayName(Component) {
 
 export default ComposedComponent => {
   return class WithData extends React.Component {
+    static defaultProps = {
+      serverState: {
+        apollo: {},
+      },
+    };
+
     static async getInitialProps(ctx) {
       // Initial serverState with apollo (empty)
       let serverState = {
@@ -35,7 +41,7 @@ export default ComposedComponent => {
 
       // Run all GraphQL queries in the component tree
       // and extract the resulting data
-      const apollo = initClient(undefined, options);
+      const apollo = initClient(undefined);
       try {
         // create the url prop which is passed to every page
         const url = {
@@ -98,15 +104,11 @@ export default ComposedComponent => {
     constructor(props) {
       super(props);
       const { serverState } = this.props;
-      this.apollo = initClient(serverState.apollo.data, this.props.options);
+      this.apollo = initClient(serverState.apollo.data);
     }
 
     render() {
-      return (
-        <ApolloProvider client={this.apollo}>
-          <ComposedComponent {...this.props} client={this.apollo} />
-        </ApolloProvider>
-      );
+      return <ComposedComponent {...this.props} client={this.apollo} />;
     }
   };
 };

--- a/src/lib/withData.js
+++ b/src/lib/withData.js
@@ -28,6 +28,7 @@ export default ComposedComponent => {
           data: {},
         },
       };
+      const { Component, router } = ctx;
 
       const options = {
         headers: ctx.req ? ctx.req.headers : {},
@@ -51,21 +52,30 @@ export default ComposedComponent => {
         };
 
         // Run all GraphQL queries
-        await getDataFromTree(<ComposedComponent ctx={ctx} url={url} {...composedInitialProps} />, {
-          router: {
-            asPath: ctx.asPath,
-            pathname: ctx.pathname,
-            query: ctx.query,
+        await getDataFromTree(
+          <ComposedComponent
+            ctx={ctx}
+            url={url}
+            client={apollo}
+            Component={Component}
+            router={router}
+            {...composedInitialProps}
+          />,
+          {
+            router: {
+              asPath: ctx.asPath,
+              pathname: ctx.pathname,
+              query: ctx.query,
+            },
+            client: apollo,
           },
-          client: apollo,
-        });
+        );
       } catch (error) {
         // Prevent Apollo Client GraphQL errors from crashing SSR.
         // Handle them in components via the data.error prop:
         // http://dev.apollodata.com/react/api-queries.html#graphql-query-data-error
         if (process.env.DEBUG) console.error('>>> apollo error: ', error);
       }
-
       if (!process.browser) {
         // getDataFromTree does not call componentWillUnmount
         // head side effect therefore need to be cleared manually

--- a/src/pages/__tests__/__snapshots__/search.test.js.snap
+++ b/src/pages/__tests__/__snapshots__/search.test.js.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Search Page renders "Make pledge" button with empty results 1`] = `
-.c1 {
+Array [
+  .c1 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
@@ -13,79 +14,36 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
   box-sizing: border-box;
 }
 
-.c5 {
+.c6 {
   box-sizing: border-box;
   margin-left: 8px;
   margin-right: 8px;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
 }
 
-.c9 {
+.c10 {
   box-sizing: border-box;
   margin-left: 16px;
   margin-right: 16px;
 }
 
-.c14 {
+.c15 {
   margin: 0;
   box-sizing: border-box;
   margin: 0px;
   padding: 0px;
 }
 
-.c15 {
+.c16 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
-}
-
-.c19 {
-  box-sizing: border-box;
-  width: 100%;
-}
-
-.c21 {
-  box-sizing: border-box;
-  margin-top: 16px;
-  margin-bottom: 16px;
-}
-
-.c26 {
-  box-sizing: border-box;
-  width: 100%;
-  padding-top: 16px;
-  padding-bottom: 16px;
-}
-
-.c30 {
-  max-width: 1300px;
-  box-sizing: border-box;
-  margin-left: auto;
-  margin-right: auto;
-  padding: 8px;
-}
-
-.c42 {
-  box-sizing: border-box;
-  margin-top: 16px;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c43 {
-  box-sizing: border-box;
-  width: 50%;
-  margin-bottom: 16px;
 }
 
 .c0 {
@@ -117,7 +75,7 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
   align-items: center;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -132,14 +90,14 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
   justify-content: flex-end;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c13 {
+.c14 {
   margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
@@ -151,180 +109,13 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
   justify-content: space-around;
 }
 
-.c20 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-}
-
-.c24 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c29 {
-  max-width: 1300px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c32 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c41 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c25 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c33 {
-  color: #6E747A;
-  font-size: 1.4rem;
-  line-height: Paragraph;
-  -webkit-letter-spacing: -0.2px;
-  -moz-letter-spacing: -0.2px;
-  -ms-letter-spacing: -0.2px;
-  letter-spacing: -0.2px;
-  margin: 0px;
-  padding-top: 8px;
-  padding-bottom: 8px;
-  text-align: center;
-}
-
-.c44 {
-  color: #C2C6CC;
-  font-size: 1.2rem;
-  line-height: Paragraph;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  margin: 0px;
-  padding-bottom: 16px;
-  text-align: center;
-}
-
-.c11 {
+.c12 {
   display: inline-block;
   vertical-align: -.125em;
   overflow: hidden;
 }
 
 .c18 {
-  max-width: 1200px;
-  margin-left: auto;
-  margin-right: auto;
-  padding-left: 16px;
-  padding-right: 16px;
-  width: 100%;
-}
-
-.c28 {
-  border-top: 1px solid #aaaaaa;
-  bottom: 0px;
-  background-color: white;
-  min-height: 7.5rem;
-  padding: 1rem;
-  width: 100%;
-}
-
-.c31 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  max-width: 300px;
-  margin-top: 16px;
-  width: 100%;
-}
-
-.c34 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: space-evenly;
-  -webkit-justify-content: space-evenly;
-  -ms-flex-pack: space-evenly;
-  justify-content: space-evenly;
-  max-width: 300px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-  margin-top: 16px;
-  margin-bottom: 16px;
-  width: 100%;
-}
-
-.c17 {
   border: 1px solid #D5DAE0;
   border-radius: 20px;
   color: #3385FF;
@@ -336,7 +127,276 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
   padding-bottom: 8px;
 }
 
-.c27 {
+.c4 {
+  -webkit-animation: iECmZH 0.8s infinite linear;
+  animation: iECmZH 0.8s infinite linear;
+}
+
+.c13 {
+  list-style: none;
+  min-width: 20rem;
+  text-align: right;
+}
+
+.c17 {
+  color: #777777;
+  font-size: 1.4rem;
+}
+
+@media screen and (max-width:40em) {
+  .c5 {
+    display: none;
+  }
+}
+
+@media screen and (min-width:40em) and (max-width:52em) {
+  .c9 {
+    display: none;
+  }
+}
+
+@media screen and (min-width:52em) and (max-width:64em) {
+  .c9 {
+    display: none;
+  }
+}
+
+@media screen and (min-width:64em) {
+  .c9 {
+    display: none;
+  }
+}
+
+<header>
+    <div
+      id="top"
+    />
+    <div
+      className="c0 c1 sc-bdVaJa c2"
+    >
+      <a
+        className="c3 c2"
+        href="/"
+        onClick={[Function]}
+      >
+        <img
+          alt="Open Collective logo"
+          className="c4"
+          height="24"
+          src="/static/images/opencollective-icon.svg"
+          width="24"
+        />
+        <div
+          className="c5 c2"
+        >
+          <div
+            className="c6"
+          >
+            <img
+              height="16px"
+              src="/static/images/logotype.svg"
+            />
+          </div>
+        </div>
+      </a>
+      <div
+        className="c7 c8 sc-bdVaJa c2"
+      >
+        <div
+          className="c9 c2"
+        >
+          <div
+            className="c10"
+          >
+            <a
+              className="c11 c2"
+              onClick={[Function]}
+            >
+              <svg
+                height={24}
+                version="1.1"
+                viewBox="10 10 30 30"
+                width={24}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <title>
+                  magnifying glass icon
+                </title>
+                <path
+                  d="M28.5404814,30.1903972 C26.7995948,31.5736628 24.5962981,32.4 22.2,32.4 C16.5666956,32.4 12,27.8333044 12,22.2 C12,16.5666956 16.5666956,12 22.2,12 C27.8333044,12 32.4,16.5666956 32.4,22.2 C32.4,24.5962981 31.5736628,26.7995948 30.1903972,28.5404814 L35.6582912,34.0083754 C36.1139029,34.4639871 36.1139029,35.2026796 35.6582912,35.6582912 C35.2026796,36.1139029 34.4639871,36.1139029 34.0083754,35.6582912 L28.5404814,30.1903972 Z M22.2,30 C26.507821,30 30,26.507821 30,22.2 C30,17.892179 26.507821,14.4 22.2,14.4 C17.892179,14.4 14.4,17.892179 14.4,22.2 C14.4,26.507821 17.892179,30 22.2,30 Z"
+                  fill="#aaaaaa"
+                  fillRule="nonzero"
+                  id="magnifying-glass"
+                />
+              </svg>
+            </a>
+          </div>
+        </div>
+        <div
+          className="c9 c2"
+        >
+          <div
+            className="c10"
+          >
+            <a
+              className="c11 c2"
+              onClick={[Function]}
+            >
+              <svg
+                aria-hidden="true"
+                className="c12"
+                color="#aaaaaa"
+                fill="currentColor"
+                focusable="false"
+                height={24}
+                size={24}
+                viewBox="0 0 448 512"
+                width={24}
+              >
+                <path
+                  d="M16 132h416c8.837 0 16-7.163 16-16V76c0-8.837-7.163-16-16-16H16C7.163 60 0 67.163 0 76v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16z"
+                  fill="currentColor"
+                />
+              </svg>
+            </a>
+          </div>
+        </div>
+        <div
+          className="c5 c2"
+        >
+          <ul
+            className="c13 c14 c15"
+          >
+            <li
+              className="c16"
+            >
+              <a
+                className="c17"
+                href="/discover"
+                onClick={[Function]}
+              >
+                <span>
+                  Discover
+                </span>
+              </a>
+            </li>
+            <li
+              className="c16"
+            >
+              <a
+                className="c17"
+                href="/learn-more"
+              >
+                <span>
+                  How it Works
+                </span>
+              </a>
+            </li>
+            <li
+              className="c16"
+            >
+              <a
+                className="c17"
+                href="https://medium.com/open-collective"
+              >
+                <span>
+                  Blog
+                </span>
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div
+          className="LoginTopBarProfileButton"
+        >
+          <a
+            className="c18"
+            href="/signin?next=%2F"
+            onClick={[Function]}
+          >
+            <span>
+              Login
+            </span>
+          </a>
+        </div>
+      </div>
+    </div>
+  </header>,
+  .c4 {
+  box-sizing: border-box;
+}
+
+.c1 {
+  box-sizing: border-box;
+  width: 100%;
+}
+
+.c3 {
+  box-sizing: border-box;
+  margin-top: 16px;
+  margin-bottom: 16px;
+}
+
+.c9 {
+  box-sizing: border-box;
+  width: 100%;
+  padding-top: 16px;
+  padding-bottom: 16px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c0 {
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 16px;
+  padding-right: 16px;
+  width: 100%;
+}
+
+.c10 {
   display: block;
   font-size: Paragraph;
   font-weight: bold;
@@ -348,54 +408,295 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
   text-align: center;
 }
 
-.c46 {
+.c5.c5.c5 {
+  border: none;
+  border-bottom: 2px solid #3385FF;
+  border-radius: 0;
+  box-shadow: none;
+  display: block;
+  height: 3.4rem;
+  padding: 0;
+}
+
+.c6.c6 {
+  padding: 0 2rem;
+}
+
+@media screen and (min-width:40em) {
+  .c7 {
+    -webkit-box-pack: center;
+    -webkit-justify-content: center;
+    -ms-flex-pack: center;
+    justify-content: center;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c7 {
+    -webkit-box-pack: start;
+    -webkit-justify-content: flex-start;
+    -ms-flex-pack: start;
+    justify-content: flex-start;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c0 {
+    width: 85%;
+  }
+}
+
+<main
+    className="jsx-916984404"
+  >
+    <div
+      className="c0"
+    >
+      <div
+        className="c1"
+      >
+        <form
+          method="GET"
+          onSubmit={[Function]}
+        >
+          <div
+            className="form-group form-group-lg"
+          >
+            <label
+              className="h1 control-label"
+              htmlFor="search"
+            >
+              Search Open Collective
+            </label>
+            <div
+              className="c2 c3 sc-bdVaJa c4"
+            >
+              <input
+                className="c5 form-control"
+                defaultValue="test"
+                id="search"
+                name="q"
+                placeholder="open source"
+                type="search"
+              />
+              <button
+                className="jsx-1144918383 jsx-3101740563 Button blue c6"
+                onClick={[Function]}
+                type="submit"
+              >
+                <span
+                  className="fa fa-search"
+                />
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+      <div
+        className="c7 c4 sc-bdVaJa c4"
+      >
+        <div
+          className="c8 c9 sc-bdVaJa c4"
+        >
+          <p>
+            <em>
+              No collectives found matching your query: "
+              test
+              "
+            </em>
+          </p>
+          <a
+            className="c10"
+            href="createPledge"
+            onClick={[Function]}
+          >
+            Make a pledge
+          </a>
+        </div>
+      </div>
+    </div>
+  </main>,
+  .c3 {
+  box-sizing: border-box;
+}
+
+.c2 {
+  max-width: 1300px;
+  box-sizing: border-box;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 8px;
+}
+
+.c15 {
+  box-sizing: border-box;
+  margin-top: 16px;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c16 {
+  box-sizing: border-box;
+  width: 50%;
+  margin-bottom: 16px;
+}
+
+.c1 {
+  max-width: 1300px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c0 {
+  border-top: 1px solid #aaaaaa;
+  bottom: 0px;
+  background-color: white;
+  min-height: 7.5rem;
+  padding: 1rem;
+  width: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  max-width: 300px;
+  margin-top: 16px;
+  width: 100%;
+}
+
+.c7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: space-evenly;
+  -webkit-justify-content: space-evenly;
+  -ms-flex-pack: space-evenly;
+  justify-content: space-evenly;
+  max-width: 300px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+  margin-top: 16px;
+  margin-bottom: 16px;
+  width: 100%;
+}
+
+.c6 {
+  color: #6E747A;
+  font-size: 1.4rem;
+  line-height: Paragraph;
+  -webkit-letter-spacing: -0.2px;
+  -moz-letter-spacing: -0.2px;
+  -ms-letter-spacing: -0.2px;
+  letter-spacing: -0.2px;
+  margin: 0px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  text-align: center;
+}
+
+.c17 {
+  color: #C2C6CC;
+  font-size: 1.2rem;
+  line-height: Paragraph;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  margin: 0px;
+  padding-bottom: 16px;
+  text-align: center;
+}
+
+.c19 {
   list-style: none;
   margin-bottom: 8px;
   text-align: center;
 }
 
+.c11 {
+  display: inline-block;
+  vertical-align: -.125em;
+  overflow: hidden;
+}
+
+.c9 {
+  display: inline-block;
+  vertical-align: -.125em;
+  overflow: hidden;
+}
+
 .c12 {
-  list-style: none;
-  min-width: 20rem;
-  text-align: right;
-}
-
-.c16 {
-  color: #777777;
-  font-size: 1.4rem;
-}
-
-.c38 {
   display: inline-block;
   vertical-align: -.125em;
   overflow: hidden;
 }
 
-.c36 {
+.c10 {
   display: inline-block;
   vertical-align: -.125em;
   overflow: hidden;
 }
 
-.c39 {
-  display: inline-block;
-  vertical-align: -.125em;
-  overflow: hidden;
-}
-
-.c37 {
-  display: inline-block;
-  vertical-align: -.125em;
-  overflow: hidden;
-}
-
-.c40 {
+.c13 {
   display: inline-block;
   vertical-align: middle;
   overflow: hidden;
 }
 
-.c35 {
+.c8 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -415,12 +716,12 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
   width: 48px;
 }
 
-.c35:hover,
-.c35:focus {
+.c8:hover,
+.c8:focus {
   opacity: 1;
 }
 
-.c47 {
+.c20 {
   color: #6e747a;
   display: block;
   fontsize: 1.4rem;
@@ -429,7 +730,7 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
   padding: 0;
 }
 
-.c45 {
+.c18 {
   box-sizing: border-box;
   padding-left: 0px;
   padding-right: 8px;
@@ -446,22 +747,8 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
   justify-content: center;
 }
 
-.c22.c22.c22 {
-  border: none;
-  border-bottom: 2px solid #3385FF;
-  border-radius: 0;
-  box-shadow: none;
-  display: block;
-  height: 3.4rem;
-  padding: 0;
-}
-
-.c23.c23 {
-  padding: 0 2rem;
-}
-
 @media screen and (min-width:52em) {
-  .c42 {
+  .c15 {
     -webkit-order: 2;
     -ms-flex-order: 2;
     order: 2;
@@ -469,31 +756,13 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c43 {
+  .c16 {
     width: 25%;
   }
 }
 
-@media screen and (min-width:40em) {
-  .c24 {
-    -webkit-box-pack: center;
-    -webkit-justify-content: center;
-    -ms-flex-pack: center;
-    justify-content: center;
-  }
-}
-
 @media screen and (min-width:52em) {
-  .c24 {
-    -webkit-box-pack: start;
-    -webkit-justify-content: flex-start;
-    -ms-flex-pack: start;
-    justify-content: flex-start;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c29 {
+  .c1 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -501,7 +770,7 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c29 {
+  .c1 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -510,7 +779,7 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c32 {
+  .c5 {
     -webkit-box-pack: start;
     -webkit-justify-content: flex-start;
     -ms-flex-pack: start;
@@ -519,305 +788,49 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c33 {
-    text-align: left;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c44 {
-    text-align: left;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c18 {
-    width: 85%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c31 {
+  .c4 {
     width: 33.33333333333333%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c34 {
+  .c7 {
     -webkit-order: 3;
     -ms-flex-order: 3;
     order: 3;
   }
 }
 
-@media screen and (max-width:40em) {
-  .c4 {
-    display: none;
-  }
-}
-
-@media screen and (min-width:40em) and (max-width:52em) {
-  .c8 {
-    display: none;
-  }
-}
-
-@media screen and (min-width:52em) and (max-width:64em) {
-  .c8 {
-    display: none;
-  }
-}
-
-@media screen and (min-width:64em) {
-  .c8 {
-    display: none;
-  }
-}
-
 @media screen and (min-width:52em) {
-  .c46 {
+  .c6 {
     text-align: left;
   }
 }
 
-<div>
-  <header>
-    <div
-      id="top"
-    />
-    <div
-      className="c0 c1 sc-bdVaJa c2"
-    >
-      <a
-        className="c3 c2"
-        href="/"
-        onClick={[Function]}
-      >
-        <img
-          alt="Open Collective logo"
-          className=""
-          height="24"
-          src="/static/images/opencollective-icon.svg"
-          width="24"
-        />
-        <div
-          className="c4 c2"
-        >
-          <div
-            className="c5"
-          >
-            <img
-              height="16px"
-              src="/static/images/logotype.svg"
-            />
-          </div>
-        </div>
-      </a>
-      <div
-        className="c6 c7 sc-bdVaJa c2"
-      >
-        <div
-          className="c8 c2"
-        >
-          <div
-            className="c9"
-          >
-            <a
-              className="c10 c2"
-              onClick={[Function]}
-            >
-              <svg
-                height={24}
-                version="1.1"
-                viewBox="10 10 30 30"
-                width={24}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <title>
-                  magnifying glass icon
-                </title>
-                <path
-                  d="M28.5404814,30.1903972 C26.7995948,31.5736628 24.5962981,32.4 22.2,32.4 C16.5666956,32.4 12,27.8333044 12,22.2 C12,16.5666956 16.5666956,12 22.2,12 C27.8333044,12 32.4,16.5666956 32.4,22.2 C32.4,24.5962981 31.5736628,26.7995948 30.1903972,28.5404814 L35.6582912,34.0083754 C36.1139029,34.4639871 36.1139029,35.2026796 35.6582912,35.6582912 C35.2026796,36.1139029 34.4639871,36.1139029 34.0083754,35.6582912 L28.5404814,30.1903972 Z M22.2,30 C26.507821,30 30,26.507821 30,22.2 C30,17.892179 26.507821,14.4 22.2,14.4 C17.892179,14.4 14.4,17.892179 14.4,22.2 C14.4,26.507821 17.892179,30 22.2,30 Z"
-                  fill="#aaaaaa"
-                  fillRule="nonzero"
-                  id="magnifying-glass"
-                />
-              </svg>
-            </a>
-          </div>
-        </div>
-        <div
-          className="c8 c2"
-        >
-          <div
-            className="c9"
-          >
-            <a
-              className="c10 c2"
-              onClick={[Function]}
-            >
-              <svg
-                aria-hidden="true"
-                className="c11"
-                color="#aaaaaa"
-                fill="currentColor"
-                focusable="false"
-                height={24}
-                size={24}
-                viewBox="0 0 448 512"
-                width={24}
-              >
-                <path
-                  d="M16 132h416c8.837 0 16-7.163 16-16V76c0-8.837-7.163-16-16-16H16C7.163 60 0 67.163 0 76v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16z"
-                  fill="currentColor"
-                />
-              </svg>
-            </a>
-          </div>
-        </div>
-        <div
-          className="c4 c2"
-        >
-          <ul
-            className="c12 c13 c14"
-          >
-            <li
-              className="c15"
-            >
-              <a
-                className="c16"
-                href="/discover"
-                onClick={[Function]}
-              >
-                <span>
-                  Discover
-                </span>
-              </a>
-            </li>
-            <li
-              className="c15"
-            >
-              <a
-                className="c16"
-                href="/learn-more"
-              >
-                <span>
-                  How it Works
-                </span>
-              </a>
-            </li>
-            <li
-              className="c15"
-            >
-              <a
-                className="c16"
-                href="https://medium.com/open-collective"
-              >
-                <span>
-                  Blog
-                </span>
-              </a>
-            </li>
-          </ul>
-        </div>
-        <div
-          className="LoginTopBarProfileButton"
-        >
-          <a
-            className="c17"
-            href="/signin?next=%2F"
-            onClick={[Function]}
-          >
-            <span>
-              Login
-            </span>
-          </a>
-        </div>
-      </div>
-    </div>
-  </header>
-  <main
-    className="jsx-916984404"
-  >
-    <div
-      className="c18"
-    >
-      <div
-        className="c19"
-      >
-        <form
-          method="GET"
-          onSubmit={[Function]}
-        >
-          <div
-            className="form-group form-group-lg"
-          >
-            <label
-              className="h1 control-label"
-              htmlFor="search"
-            >
-              Search Open Collective
-            </label>
-            <div
-              className="c20 c21 sc-bdVaJa c2"
-            >
-              <input
-                className="c22 form-control"
-                defaultValue="test"
-                id="search"
-                name="q"
-                placeholder="open source"
-                type="search"
-              />
-              <button
-                className="jsx-1144918383 jsx-3101740563 Button blue c23"
-                onClick={[Function]}
-                type="submit"
-              >
-                <span
-                  className="fa fa-search"
-                />
-              </button>
-            </div>
-          </div>
-        </form>
-      </div>
-      <div
-        className="c24 c2 sc-bdVaJa c2"
-      >
-        <div
-          className="c25 c26 sc-bdVaJa c2"
-        >
-          <p>
-            <em>
-              No collectives found matching your query: "
-              test
-              "
-            </em>
-          </p>
-          <a
-            className="c27"
-            href="createPledge"
-            onClick={[Function]}
-          >
-            Make a pledge
-          </a>
-        </div>
-      </div>
-    </div>
-  </main>
-  <div
-    className="c28"
+@media screen and (min-width:52em) {
+  .c17 {
+    text-align: left;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c19 {
+    text-align: left;
+  }
+}
+
+<div
+    className="c0"
     id="footer"
   >
     <div
-      className="c29 c30 sc-bdVaJa c2"
+      className="c1 c2 sc-bdVaJa c3"
     >
       <div
-        className="c31"
+        className="c4"
       >
         <div
-          className="c32 c2 sc-bdVaJa c2"
+          className="c5 c3 sc-bdVaJa c3"
         >
           <object
             data="/static/images/opencollectivelogo-footer.svg"
@@ -826,21 +839,21 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
           />
         </div>
         <p
-          className="c33"
+          className="c6"
         >
           An organization for your community, transparent by design.
         </p>
       </div>
       <div
-        className="c34"
+        className="c7"
       >
         <a
-          className="c35"
+          className="c8"
           href="https://medium.com/open-collective"
         >
           <svg
             aria-hidden="true"
-            className="c36"
+            className="c9"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -856,12 +869,12 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
           </svg>
         </a>
         <a
-          className="c35"
+          className="c8"
           href="https://twitter.com/opencollect"
         >
           <svg
             aria-hidden="true"
-            className="c37"
+            className="c10"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -877,12 +890,12 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
           </svg>
         </a>
         <a
-          className="c35"
+          className="c8"
           href="https://github.com/opencollective"
         >
           <svg
             aria-hidden="true"
-            className="c38"
+            className="c11"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -898,12 +911,12 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
           </svg>
         </a>
         <a
-          className="c35"
+          className="c8"
           href="https://slack.opencollective.com"
         >
           <svg
             aria-hidden="true"
-            className="c39"
+            className="c12"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -919,12 +932,12 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
           </svg>
         </a>
         <a
-          className="c35"
+          className="c8"
           href="mailto:info@opencollective.com"
         >
           <svg
             aria-hidden="true"
-            className="c40"
+            className="c13"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -940,24 +953,24 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
         </a>
       </div>
       <nav
-        className="c41 c42"
+        className="c14 c15"
       >
         <div
-          className="c43"
+          className="c16"
         >
           <p
-            className="c44"
+            className="c17"
           >
             PLATFORM
           </p>
           <ul
-            className="c45"
+            className="c18"
           >
             <li
-              className="c46"
+              className="c19"
             >
               <a
-                className="c47 "
+                className="c20 "
                 href="/discover"
                 onClick={[Function]}
               >
@@ -965,20 +978,20 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
               </a>
             </li>
             <li
-              className="c46"
+              className="c19"
             >
               <a
-                className="c47 "
+                className="c20 "
                 href="/learn-more"
               >
                 How it Works
               </a>
             </li>
             <li
-              className="c46"
+              className="c19"
             >
               <a
-                className="c47 "
+                className="c20 "
                 href="/signin"
                 onClick={[Function]}
               >
@@ -986,10 +999,10 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
               </a>
             </li>
             <li
-              className="c46"
+              className="c19"
             >
               <a
-                className="c47 "
+                className="c20 "
                 href="/signin"
                 onClick={[Function]}
               >
@@ -999,21 +1012,21 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
           </ul>
         </div>
         <div
-          className="c43"
+          className="c16"
         >
           <p
-            className="c44"
+            className="c17"
           >
             JOIN THE MOVEMENT
           </p>
           <ul
-            className="c45"
+            className="c18"
           >
             <li
-              className="c46"
+              className="c19"
             >
               <a
-                className="c47 "
+                className="c20 "
                 href="/create"
                 onClick={[Function]}
               >
@@ -1021,10 +1034,10 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
               </a>
             </li>
             <li
-              className="c46"
+              className="c19"
             >
               <a
-                className="c47 "
+                className="c20 "
                 href="/become-a-sponsor"
                 onClick={[Function]}
               >
@@ -1032,10 +1045,10 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
               </a>
             </li>
             <li
-              className="c46"
+              className="c19"
             >
               <a
-                className="c47 "
+                className="c20 "
                 href="/chapters"
                 onClick={[Function]}
               >
@@ -1045,21 +1058,21 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
           </ul>
         </div>
         <div
-          className="c43"
+          className="c16"
         >
           <p
-            className="c44"
+            className="c17"
           >
             COMMUNITY
           </p>
           <ul
-            className="c45"
+            className="c18"
           >
             <li
-              className="c46"
+              className="c19"
             >
               <a
-                className="c47 "
+                className="c20 "
                 href="/opensource"
                 onClick={[Function]}
               >
@@ -1067,10 +1080,10 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
               </a>
             </li>
             <li
-              className="c46"
+              className="c19"
             >
               <a
-                className="c47 "
+                className="c20 "
                 href="https://github.com/opencollective/opencollective/issues"
                 onClick={[Function]}
               >
@@ -1078,10 +1091,10 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
               </a>
             </li>
             <li
-              className="c46"
+              className="c19"
             >
               <a
-                className="c47 "
+                className="c20 "
                 href="https://slack.opencollective.com"
                 onClick={[Function]}
               >
@@ -1089,10 +1102,10 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
               </a>
             </li>
             <li
-              className="c46"
+              className="c19"
             >
               <a
-                className="c47 "
+                className="c20 "
                 href="https://github.com/opencollective/opencollective/wiki"
                 onClick={[Function]}
               >
@@ -1100,10 +1113,10 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
               </a>
             </li>
             <li
-              className="c46"
+              className="c19"
             >
               <a
-                className="c47 "
+                className="c20 "
                 href="mailto:support@opencollective.com"
                 onClick={[Function]}
               >
@@ -1113,21 +1126,21 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
           </ul>
         </div>
         <div
-          className="c43"
+          className="c16"
         >
           <p
-            className="c44"
+            className="c17"
           >
             COMPANY
           </p>
           <ul
-            className="c45"
+            className="c18"
           >
             <li
-              className="c46"
+              className="c19"
             >
               <a
-                className="c47 "
+                className="c20 "
                 href="/about"
                 onClick={[Function]}
               >
@@ -1135,10 +1148,10 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
               </a>
             </li>
             <li
-              className="c46"
+              className="c19"
             >
               <a
-                className="c47 "
+                className="c20 "
                 href="/faq"
                 onClick={[Function]}
               >
@@ -1146,10 +1159,10 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
               </a>
             </li>
             <li
-              className="c46"
+              className="c19"
             >
               <a
-                className="c47 "
+                className="c20 "
                 href="https://medium.com/open-collective"
                 onClick={[Function]}
               >
@@ -1157,10 +1170,10 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
               </a>
             </li>
             <li
-              className="c46"
+              className="c19"
             >
               <a
-                className="c47 "
+                className="c20 "
                 href="/tos"
                 onClick={[Function]}
               >
@@ -1168,10 +1181,10 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
               </a>
             </li>
             <li
-              className="c46"
+              className="c19"
             >
               <a
-                className="c47 "
+                className="c20 "
                 href="/privacypolicy"
                 onClick={[Function]}
               >
@@ -1182,12 +1195,13 @@ exports[`Search Page renders "Make pledge" button with empty results 1`] = `
         </div>
       </nav>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`Search Page renders empty results message 1`] = `
-.c1 {
+Array [
+  .c1 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
@@ -1199,79 +1213,36 @@ exports[`Search Page renders empty results message 1`] = `
   box-sizing: border-box;
 }
 
-.c5 {
+.c6 {
   box-sizing: border-box;
   margin-left: 8px;
   margin-right: 8px;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
 }
 
-.c9 {
+.c10 {
   box-sizing: border-box;
   margin-left: 16px;
   margin-right: 16px;
 }
 
-.c14 {
+.c15 {
   margin: 0;
   box-sizing: border-box;
   margin: 0px;
   padding: 0px;
 }
 
-.c15 {
+.c16 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
-}
-
-.c19 {
-  box-sizing: border-box;
-  width: 100%;
-}
-
-.c21 {
-  box-sizing: border-box;
-  margin-top: 16px;
-  margin-bottom: 16px;
-}
-
-.c26 {
-  box-sizing: border-box;
-  width: 100%;
-  padding-top: 16px;
-  padding-bottom: 16px;
-}
-
-.c29 {
-  max-width: 1300px;
-  box-sizing: border-box;
-  margin-left: auto;
-  margin-right: auto;
-  padding: 8px;
-}
-
-.c41 {
-  box-sizing: border-box;
-  margin-top: 16px;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c42 {
-  box-sizing: border-box;
-  width: 50%;
-  margin-bottom: 16px;
 }
 
 .c0 {
@@ -1303,7 +1274,7 @@ exports[`Search Page renders empty results message 1`] = `
   align-items: center;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1318,14 +1289,14 @@ exports[`Search Page renders empty results message 1`] = `
   justify-content: flex-end;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c13 {
+.c14 {
   margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1337,180 +1308,13 @@ exports[`Search Page renders empty results message 1`] = `
   justify-content: space-around;
 }
 
-.c20 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-}
-
-.c24 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c28 {
-  max-width: 1300px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c31 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c40 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c25 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c32 {
-  color: #6E747A;
-  font-size: 1.4rem;
-  line-height: Paragraph;
-  -webkit-letter-spacing: -0.2px;
-  -moz-letter-spacing: -0.2px;
-  -ms-letter-spacing: -0.2px;
-  letter-spacing: -0.2px;
-  margin: 0px;
-  padding-top: 8px;
-  padding-bottom: 8px;
-  text-align: center;
-}
-
-.c43 {
-  color: #C2C6CC;
-  font-size: 1.2rem;
-  line-height: Paragraph;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  margin: 0px;
-  padding-bottom: 16px;
-  text-align: center;
-}
-
-.c11 {
+.c12 {
   display: inline-block;
   vertical-align: -.125em;
   overflow: hidden;
 }
 
 .c18 {
-  max-width: 1200px;
-  margin-left: auto;
-  margin-right: auto;
-  padding-left: 16px;
-  padding-right: 16px;
-  width: 100%;
-}
-
-.c27 {
-  border-top: 1px solid #aaaaaa;
-  bottom: 0px;
-  background-color: white;
-  min-height: 7.5rem;
-  padding: 1rem;
-  width: 100%;
-}
-
-.c30 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  max-width: 300px;
-  margin-top: 16px;
-  width: 100%;
-}
-
-.c33 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: space-evenly;
-  -webkit-justify-content: space-evenly;
-  -ms-flex-pack: space-evenly;
-  justify-content: space-evenly;
-  max-width: 300px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-  margin-top: 16px;
-  margin-bottom: 16px;
-  width: 100%;
-}
-
-.c17 {
   border: 1px solid #D5DAE0;
   border-radius: 20px;
   color: #3385FF;
@@ -1522,240 +1326,47 @@ exports[`Search Page renders empty results message 1`] = `
   padding-bottom: 8px;
 }
 
-.c45 {
-  list-style: none;
-  margin-bottom: 8px;
-  text-align: center;
+.c4 {
+  -webkit-animation: iECmZH 0.8s infinite linear;
+  animation: iECmZH 0.8s infinite linear;
 }
 
-.c12 {
+.c13 {
   list-style: none;
   min-width: 20rem;
   text-align: right;
 }
 
-.c16 {
+.c17 {
   color: #777777;
   font-size: 1.4rem;
 }
 
-.c37 {
-  display: inline-block;
-  vertical-align: -.125em;
-  overflow: hidden;
-}
-
-.c35 {
-  display: inline-block;
-  vertical-align: -.125em;
-  overflow: hidden;
-}
-
-.c38 {
-  display: inline-block;
-  vertical-align: -.125em;
-  overflow: hidden;
-}
-
-.c36 {
-  display: inline-block;
-  vertical-align: -.125em;
-  overflow: hidden;
-}
-
-.c39 {
-  display: inline-block;
-  vertical-align: middle;
-  overflow: hidden;
-}
-
-.c34 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 1px solid #9399a3;
-  border-radius: 50%;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  height: 48px;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  opacity: 0.6;
-  width: 48px;
-}
-
-.c34:hover,
-.c34:focus {
-  opacity: 1;
-}
-
-.c46 {
-  color: #6e747a;
-  display: block;
-  fontsize: 1.4rem;
-  fontweight: 400;
-  margin: 0;
-  padding: 0;
-}
-
-.c44 {
-  box-sizing: border-box;
-  padding-left: 0px;
-  padding-right: 8px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c22.c22.c22 {
-  border: none;
-  border-bottom: 2px solid #3385FF;
-  border-radius: 0;
-  box-shadow: none;
-  display: block;
-  height: 3.4rem;
-  padding: 0;
-}
-
-.c23.c23 {
-  padding: 0 2rem;
-}
-
-@media screen and (min-width:52em) {
-  .c41 {
-    -webkit-order: 2;
-    -ms-flex-order: 2;
-    order: 2;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c42 {
-    width: 25%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c24 {
-    -webkit-box-pack: center;
-    -webkit-justify-content: center;
-    -ms-flex-pack: center;
-    justify-content: center;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c24 {
-    -webkit-box-pack: start;
-    -webkit-justify-content: flex-start;
-    -ms-flex-pack: start;
-    justify-content: flex-start;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c28 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c28 {
-    -webkit-align-items: flex-start;
-    -webkit-box-align: flex-start;
-    -ms-flex-align: flex-start;
-    align-items: flex-start;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c31 {
-    -webkit-box-pack: start;
-    -webkit-justify-content: flex-start;
-    -ms-flex-pack: start;
-    justify-content: flex-start;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c32 {
-    text-align: left;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c43 {
-    text-align: left;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c18 {
-    width: 85%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c30 {
-    width: 33.33333333333333%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c33 {
-    -webkit-order: 3;
-    -ms-flex-order: 3;
-    order: 3;
-  }
-}
-
 @media screen and (max-width:40em) {
-  .c4 {
+  .c5 {
     display: none;
   }
 }
 
 @media screen and (min-width:40em) and (max-width:52em) {
-  .c8 {
+  .c9 {
     display: none;
   }
 }
 
 @media screen and (min-width:52em) and (max-width:64em) {
-  .c8 {
+  .c9 {
     display: none;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c8 {
+  .c9 {
     display: none;
   }
 }
 
-@media screen and (min-width:52em) {
-  .c45 {
-    text-align: left;
-  }
-}
-
-<div>
-  <header>
+<header>
     <div
       id="top"
     />
@@ -1769,16 +1380,16 @@ exports[`Search Page renders empty results message 1`] = `
       >
         <img
           alt="Open Collective logo"
-          className=""
+          className="c4"
           height="24"
           src="/static/images/opencollective-icon.svg"
           width="24"
         />
         <div
-          className="c4 c2"
+          className="c5 c2"
         >
           <div
-            className="c5"
+            className="c6"
           >
             <img
               height="16px"
@@ -1788,16 +1399,16 @@ exports[`Search Page renders empty results message 1`] = `
         </div>
       </a>
       <div
-        className="c6 c7 sc-bdVaJa c2"
+        className="c7 c8 sc-bdVaJa c2"
       >
         <div
-          className="c8 c2"
+          className="c9 c2"
         >
           <div
-            className="c9"
+            className="c10"
           >
             <a
-              className="c10 c2"
+              className="c11 c2"
               onClick={[Function]}
             >
               <svg
@@ -1821,18 +1432,18 @@ exports[`Search Page renders empty results message 1`] = `
           </div>
         </div>
         <div
-          className="c8 c2"
+          className="c9 c2"
         >
           <div
-            className="c9"
+            className="c10"
           >
             <a
-              className="c10 c2"
+              className="c11 c2"
               onClick={[Function]}
             >
               <svg
                 aria-hidden="true"
-                className="c11"
+                className="c12"
                 color="#aaaaaa"
                 fill="currentColor"
                 focusable="false"
@@ -1850,16 +1461,16 @@ exports[`Search Page renders empty results message 1`] = `
           </div>
         </div>
         <div
-          className="c4 c2"
+          className="c5 c2"
         >
           <ul
-            className="c12 c13 c14"
+            className="c13 c14 c15"
           >
             <li
-              className="c15"
+              className="c16"
             >
               <a
-                className="c16"
+                className="c17"
                 href="/discover"
                 onClick={[Function]}
               >
@@ -1869,10 +1480,10 @@ exports[`Search Page renders empty results message 1`] = `
               </a>
             </li>
             <li
-              className="c15"
+              className="c16"
             >
               <a
-                className="c16"
+                className="c17"
                 href="/learn-more"
               >
                 <span>
@@ -1881,10 +1492,10 @@ exports[`Search Page renders empty results message 1`] = `
               </a>
             </li>
             <li
-              className="c15"
+              className="c16"
             >
               <a
-                className="c16"
+                className="c17"
                 href="https://medium.com/open-collective"
               >
                 <span>
@@ -1898,7 +1509,7 @@ exports[`Search Page renders empty results message 1`] = `
           className="LoginTopBarProfileButton"
         >
           <a
-            className="c17"
+            className="c18"
             href="/signin?next=%2F"
             onClick={[Function]}
           >
@@ -1909,15 +1520,127 @@ exports[`Search Page renders empty results message 1`] = `
         </div>
       </div>
     </div>
-  </header>
-  <main
+  </header>,
+  .c4 {
+  box-sizing: border-box;
+}
+
+.c1 {
+  box-sizing: border-box;
+  width: 100%;
+}
+
+.c3 {
+  box-sizing: border-box;
+  margin-top: 16px;
+  margin-bottom: 16px;
+}
+
+.c9 {
+  box-sizing: border-box;
+  width: 100%;
+  padding-top: 16px;
+  padding-bottom: 16px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c0 {
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 16px;
+  padding-right: 16px;
+  width: 100%;
+}
+
+.c5.c5.c5 {
+  border: none;
+  border-bottom: 2px solid #3385FF;
+  border-radius: 0;
+  box-shadow: none;
+  display: block;
+  height: 3.4rem;
+  padding: 0;
+}
+
+.c6.c6 {
+  padding: 0 2rem;
+}
+
+@media screen and (min-width:40em) {
+  .c7 {
+    -webkit-box-pack: center;
+    -webkit-justify-content: center;
+    -ms-flex-pack: center;
+    justify-content: center;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c7 {
+    -webkit-box-pack: start;
+    -webkit-justify-content: flex-start;
+    -ms-flex-pack: start;
+    justify-content: flex-start;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c0 {
+    width: 85%;
+  }
+}
+
+<main
     className="jsx-916984404"
   >
     <div
-      className="c18"
+      className="c0"
     >
       <div
-        className="c19"
+        className="c1"
       >
         <form
           method="GET"
@@ -1933,10 +1656,10 @@ exports[`Search Page renders empty results message 1`] = `
               Search Open Collective
             </label>
             <div
-              className="c20 c21 sc-bdVaJa c2"
+              className="c2 c3 sc-bdVaJa c4"
             >
               <input
-                className="c22 form-control"
+                className="c5 form-control"
                 defaultValue="test"
                 id="search"
                 name="q"
@@ -1944,7 +1667,7 @@ exports[`Search Page renders empty results message 1`] = `
                 type="search"
               />
               <button
-                className="jsx-1144918383 jsx-3101740563 Button blue c23"
+                className="jsx-1144918383 jsx-3101740563 Button blue c6"
                 onClick={[Function]}
                 type="submit"
               >
@@ -1957,10 +1680,10 @@ exports[`Search Page renders empty results message 1`] = `
         </form>
       </div>
       <div
-        className="c24 c2 sc-bdVaJa c2"
+        className="c7 c4 sc-bdVaJa c4"
       >
         <div
-          className="c25 c26 sc-bdVaJa c2"
+          className="c8 c9 sc-bdVaJa c4"
         >
           <p>
             <em>
@@ -1972,19 +1695,322 @@ exports[`Search Page renders empty results message 1`] = `
         </div>
       </div>
     </div>
-  </main>
-  <div
-    className="c27"
+  </main>,
+  .c3 {
+  box-sizing: border-box;
+}
+
+.c2 {
+  max-width: 1300px;
+  box-sizing: border-box;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 8px;
+}
+
+.c15 {
+  box-sizing: border-box;
+  margin-top: 16px;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c16 {
+  box-sizing: border-box;
+  width: 50%;
+  margin-bottom: 16px;
+}
+
+.c1 {
+  max-width: 1300px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c0 {
+  border-top: 1px solid #aaaaaa;
+  bottom: 0px;
+  background-color: white;
+  min-height: 7.5rem;
+  padding: 1rem;
+  width: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  max-width: 300px;
+  margin-top: 16px;
+  width: 100%;
+}
+
+.c7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: space-evenly;
+  -webkit-justify-content: space-evenly;
+  -ms-flex-pack: space-evenly;
+  justify-content: space-evenly;
+  max-width: 300px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+  margin-top: 16px;
+  margin-bottom: 16px;
+  width: 100%;
+}
+
+.c6 {
+  color: #6E747A;
+  font-size: 1.4rem;
+  line-height: Paragraph;
+  -webkit-letter-spacing: -0.2px;
+  -moz-letter-spacing: -0.2px;
+  -ms-letter-spacing: -0.2px;
+  letter-spacing: -0.2px;
+  margin: 0px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  text-align: center;
+}
+
+.c17 {
+  color: #C2C6CC;
+  font-size: 1.2rem;
+  line-height: Paragraph;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  margin: 0px;
+  padding-bottom: 16px;
+  text-align: center;
+}
+
+.c19 {
+  list-style: none;
+  margin-bottom: 8px;
+  text-align: center;
+}
+
+.c11 {
+  display: inline-block;
+  vertical-align: -.125em;
+  overflow: hidden;
+}
+
+.c9 {
+  display: inline-block;
+  vertical-align: -.125em;
+  overflow: hidden;
+}
+
+.c12 {
+  display: inline-block;
+  vertical-align: -.125em;
+  overflow: hidden;
+}
+
+.c10 {
+  display: inline-block;
+  vertical-align: -.125em;
+  overflow: hidden;
+}
+
+.c13 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+}
+
+.c8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #9399a3;
+  border-radius: 50%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 48px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  opacity: 0.6;
+  width: 48px;
+}
+
+.c8:hover,
+.c8:focus {
+  opacity: 1;
+}
+
+.c20 {
+  color: #6e747a;
+  display: block;
+  fontsize: 1.4rem;
+  fontweight: 400;
+  margin: 0;
+  padding: 0;
+}
+
+.c18 {
+  box-sizing: border-box;
+  padding-left: 0px;
+  padding-right: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+@media screen and (min-width:52em) {
+  .c15 {
+    -webkit-order: 2;
+    -ms-flex-order: 2;
+    order: 2;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c16 {
+    width: 25%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c1 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c1 {
+    -webkit-align-items: flex-start;
+    -webkit-box-align: flex-start;
+    -ms-flex-align: flex-start;
+    align-items: flex-start;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c5 {
+    -webkit-box-pack: start;
+    -webkit-justify-content: flex-start;
+    -ms-flex-pack: start;
+    justify-content: flex-start;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c4 {
+    width: 33.33333333333333%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c7 {
+    -webkit-order: 3;
+    -ms-flex-order: 3;
+    order: 3;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c6 {
+    text-align: left;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c17 {
+    text-align: left;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c19 {
+    text-align: left;
+  }
+}
+
+<div
+    className="c0"
     id="footer"
   >
     <div
-      className="c28 c29 sc-bdVaJa c2"
+      className="c1 c2 sc-bdVaJa c3"
     >
       <div
-        className="c30"
+        className="c4"
       >
         <div
-          className="c31 c2 sc-bdVaJa c2"
+          className="c5 c3 sc-bdVaJa c3"
         >
           <object
             data="/static/images/opencollectivelogo-footer.svg"
@@ -1993,21 +2019,21 @@ exports[`Search Page renders empty results message 1`] = `
           />
         </div>
         <p
-          className="c32"
+          className="c6"
         >
           An organization for your community, transparent by design.
         </p>
       </div>
       <div
-        className="c33"
+        className="c7"
       >
         <a
-          className="c34"
+          className="c8"
           href="https://medium.com/open-collective"
         >
           <svg
             aria-hidden="true"
-            className="c35"
+            className="c9"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -2023,12 +2049,12 @@ exports[`Search Page renders empty results message 1`] = `
           </svg>
         </a>
         <a
-          className="c34"
+          className="c8"
           href="https://twitter.com/opencollect"
         >
           <svg
             aria-hidden="true"
-            className="c36"
+            className="c10"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -2044,12 +2070,12 @@ exports[`Search Page renders empty results message 1`] = `
           </svg>
         </a>
         <a
-          className="c34"
+          className="c8"
           href="https://github.com/opencollective"
         >
           <svg
             aria-hidden="true"
-            className="c37"
+            className="c11"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -2065,12 +2091,12 @@ exports[`Search Page renders empty results message 1`] = `
           </svg>
         </a>
         <a
-          className="c34"
+          className="c8"
           href="https://slack.opencollective.com"
         >
           <svg
             aria-hidden="true"
-            className="c38"
+            className="c12"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -2086,12 +2112,12 @@ exports[`Search Page renders empty results message 1`] = `
           </svg>
         </a>
         <a
-          className="c34"
+          className="c8"
           href="mailto:info@opencollective.com"
         >
           <svg
             aria-hidden="true"
-            className="c39"
+            className="c13"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -2107,24 +2133,24 @@ exports[`Search Page renders empty results message 1`] = `
         </a>
       </div>
       <nav
-        className="c40 c41"
+        className="c14 c15"
       >
         <div
-          className="c42"
+          className="c16"
         >
           <p
-            className="c43"
+            className="c17"
           >
             PLATFORM
           </p>
           <ul
-            className="c44"
+            className="c18"
           >
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/discover"
                 onClick={[Function]}
               >
@@ -2132,20 +2158,20 @@ exports[`Search Page renders empty results message 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/learn-more"
               >
                 How it Works
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/signin"
                 onClick={[Function]}
               >
@@ -2153,10 +2179,10 @@ exports[`Search Page renders empty results message 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/signin"
                 onClick={[Function]}
               >
@@ -2166,21 +2192,21 @@ exports[`Search Page renders empty results message 1`] = `
           </ul>
         </div>
         <div
-          className="c42"
+          className="c16"
         >
           <p
-            className="c43"
+            className="c17"
           >
             JOIN THE MOVEMENT
           </p>
           <ul
-            className="c44"
+            className="c18"
           >
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/create"
                 onClick={[Function]}
               >
@@ -2188,10 +2214,10 @@ exports[`Search Page renders empty results message 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/become-a-sponsor"
                 onClick={[Function]}
               >
@@ -2199,10 +2225,10 @@ exports[`Search Page renders empty results message 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/chapters"
                 onClick={[Function]}
               >
@@ -2212,21 +2238,21 @@ exports[`Search Page renders empty results message 1`] = `
           </ul>
         </div>
         <div
-          className="c42"
+          className="c16"
         >
           <p
-            className="c43"
+            className="c17"
           >
             COMMUNITY
           </p>
           <ul
-            className="c44"
+            className="c18"
           >
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/opensource"
                 onClick={[Function]}
               >
@@ -2234,10 +2260,10 @@ exports[`Search Page renders empty results message 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="https://github.com/opencollective/opencollective/issues"
                 onClick={[Function]}
               >
@@ -2245,10 +2271,10 @@ exports[`Search Page renders empty results message 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="https://slack.opencollective.com"
                 onClick={[Function]}
               >
@@ -2256,10 +2282,10 @@ exports[`Search Page renders empty results message 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="https://github.com/opencollective/opencollective/wiki"
                 onClick={[Function]}
               >
@@ -2267,10 +2293,10 @@ exports[`Search Page renders empty results message 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="mailto:support@opencollective.com"
                 onClick={[Function]}
               >
@@ -2280,21 +2306,21 @@ exports[`Search Page renders empty results message 1`] = `
           </ul>
         </div>
         <div
-          className="c42"
+          className="c16"
         >
           <p
-            className="c43"
+            className="c17"
           >
             COMPANY
           </p>
           <ul
-            className="c44"
+            className="c18"
           >
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/about"
                 onClick={[Function]}
               >
@@ -2302,10 +2328,10 @@ exports[`Search Page renders empty results message 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/faq"
                 onClick={[Function]}
               >
@@ -2313,10 +2339,10 @@ exports[`Search Page renders empty results message 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="https://medium.com/open-collective"
                 onClick={[Function]}
               >
@@ -2324,10 +2350,10 @@ exports[`Search Page renders empty results message 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/tos"
                 onClick={[Function]}
               >
@@ -2335,10 +2361,10 @@ exports[`Search Page renders empty results message 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/privacypolicy"
                 onClick={[Function]}
               >
@@ -2349,8 +2375,8 @@ exports[`Search Page renders empty results message 1`] = `
         </div>
       </nav>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`Search Page renders error message 1`] = `
@@ -2358,44 +2384,44 @@ exports[`Search Page renders error message 1`] = `
   box-sizing: border-box;
 }
 
-.c5 {
+.c6 {
   box-sizing: border-box;
   margin-left: 8px;
   margin-right: 8px;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
 }
 
-.c21 {
+.c22 {
   box-sizing: border-box;
   margin-left: 16px;
   margin-right: 16px;
 }
 
-.c25 {
+.c26 {
   margin: 0;
   box-sizing: border-box;
   margin: 0px;
   padding: 0px;
 }
 
-.c26 {
+.c27 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
 }
 
-.c8 {
+.c9 {
   box-sizing: border-box;
   width: 100%;
 }
 
-.c31 {
+.c32 {
   max-width: 1300px;
   box-sizing: border-box;
   margin-left: auto;
@@ -2403,7 +2429,7 @@ exports[`Search Page renders error message 1`] = `
   padding: 8px;
 }
 
-.c43 {
+.c44 {
   box-sizing: border-box;
   margin-top: 16px;
   -webkit-flex: 1 1 auto;
@@ -2414,7 +2440,7 @@ exports[`Search Page renders error message 1`] = `
   order: 3;
 }
 
-.c44 {
+.c45 {
   box-sizing: border-box;
   width: 50%;
   margin-bottom: 16px;
@@ -2428,17 +2454,17 @@ exports[`Search Page renders error message 1`] = `
   padding-bottom: 8px;
 }
 
-.c10 {
+.c11 {
   box-sizing: border-box;
   padding: 8px;
 }
 
-.c13 {
+.c14 {
   box-sizing: border-box;
   padding: 4px;
 }
 
-.c15 {
+.c16 {
   box-sizing: border-box;
   width: 100%;
   padding-left: 16px;
@@ -2446,7 +2472,7 @@ exports[`Search Page renders error message 1`] = `
   padding-bottom: 4px;
 }
 
-.c18 {
+.c19 {
   box-sizing: border-box;
   margin-right: 4px;
   padding: 4px;
@@ -2481,7 +2507,7 @@ exports[`Search Page renders error message 1`] = `
   align-items: center;
 }
 
-.c19 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2496,14 +2522,14 @@ exports[`Search Page renders error message 1`] = `
   justify-content: flex-end;
 }
 
-.c17 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c24 {
+.c25 {
   margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2515,7 +2541,7 @@ exports[`Search Page renders error message 1`] = `
   justify-content: space-around;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2526,7 +2552,7 @@ exports[`Search Page renders error message 1`] = `
   justify-content: center;
 }
 
-.c30 {
+.c31 {
   max-width: 1300px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2545,7 +2571,7 @@ exports[`Search Page renders error message 1`] = `
   justify-content: space-between;
 }
 
-.c33 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2556,7 +2582,7 @@ exports[`Search Page renders error message 1`] = `
   justify-content: center;
 }
 
-.c42 {
+.c43 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2570,7 +2596,7 @@ exports[`Search Page renders error message 1`] = `
   justify-content: center;
 }
 
-.c12 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2585,40 +2611,13 @@ exports[`Search Page renders error message 1`] = `
   justify-content: space-between;
 }
 
-.c34 {
-  color: #6E747A;
-  font-size: 1.4rem;
-  line-height: Paragraph;
-  -webkit-letter-spacing: -0.2px;
-  -moz-letter-spacing: -0.2px;
-  -ms-letter-spacing: -0.2px;
-  letter-spacing: -0.2px;
-  margin: 0px;
-  padding-top: 8px;
-  padding-bottom: 8px;
-  text-align: center;
-}
-
-.c45 {
-  color: #C2C6CC;
-  font-size: 1.2rem;
-  line-height: Paragraph;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  margin: 0px;
-  padding-bottom: 16px;
-  text-align: center;
-}
-
-.c22 {
+.c23 {
   display: inline-block;
   vertical-align: -.125em;
   overflow: hidden;
 }
 
-.c29 {
+.c30 {
   border-top: 1px solid #aaaaaa;
   bottom: 0px;
   background-color: white;
@@ -2627,7 +2626,7 @@ exports[`Search Page renders error message 1`] = `
   width: 100%;
 }
 
-.c32 {
+.c33 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2640,7 +2639,7 @@ exports[`Search Page renders error message 1`] = `
   width: 100%;
 }
 
-.c35 {
+.c36 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2662,7 +2661,34 @@ exports[`Search Page renders error message 1`] = `
   width: 100%;
 }
 
-.c28 {
+.c35 {
+  color: #6E747A;
+  font-size: 1.4rem;
+  line-height: Paragraph;
+  -webkit-letter-spacing: -0.2px;
+  -moz-letter-spacing: -0.2px;
+  -ms-letter-spacing: -0.2px;
+  letter-spacing: -0.2px;
+  margin: 0px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  text-align: center;
+}
+
+.c46 {
+  color: #C2C6CC;
+  font-size: 1.2rem;
+  line-height: Paragraph;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  margin: 0px;
+  padding-bottom: 16px;
+  text-align: center;
+}
+
+.c29 {
   border: 1px solid #D5DAE0;
   border-radius: 20px;
   color: #3385FF;
@@ -2674,18 +2700,18 @@ exports[`Search Page renders error message 1`] = `
   padding-bottom: 8px;
 }
 
-.c47 {
+.c48 {
   list-style: none;
   margin-bottom: 8px;
   text-align: center;
 }
 
-.c11 {
+.c12 {
   border: solid 1px var(--silver-four);
   border-radius: 20px;
 }
 
-.c14.c14 {
+.c15.c15 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -2698,7 +2724,7 @@ exports[`Search Page renders error message 1`] = `
   letter-spacing: 0.1rem;
 }
 
-.c16.c16 {
+.c17.c17 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -2706,32 +2732,25 @@ exports[`Search Page renders error message 1`] = `
   border: none;
 }
 
-.c9 {
+.c4 {
+  -webkit-animation: iECmZH 0.8s infinite linear;
+  animation: iECmZH 0.8s infinite linear;
+}
+
+.c10 {
   max-width: 30rem;
   min-width: 10rem;
 }
 
-.c23 {
+.c24 {
   list-style: none;
   min-width: 20rem;
   text-align: right;
 }
 
-.c27 {
+.c28 {
   color: #777777;
   font-size: 1.4rem;
-}
-
-.c39 {
-  display: inline-block;
-  vertical-align: -.125em;
-  overflow: hidden;
-}
-
-.c37 {
-  display: inline-block;
-  vertical-align: -.125em;
-  overflow: hidden;
 }
 
 .c40 {
@@ -2748,11 +2767,23 @@ exports[`Search Page renders error message 1`] = `
 
 .c41 {
   display: inline-block;
+  vertical-align: -.125em;
+  overflow: hidden;
+}
+
+.c39 {
+  display: inline-block;
+  vertical-align: -.125em;
+  overflow: hidden;
+}
+
+.c42 {
+  display: inline-block;
   vertical-align: middle;
   overflow: hidden;
 }
 
-.c36 {
+.c37 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2772,12 +2803,12 @@ exports[`Search Page renders error message 1`] = `
   width: 48px;
 }
 
-.c36:hover,
-.c36:focus {
+.c37:hover,
+.c37:focus {
   opacity: 1;
 }
 
-.c48 {
+.c49 {
   color: #6e747a;
   display: block;
   fontsize: 1.4rem;
@@ -2786,7 +2817,7 @@ exports[`Search Page renders error message 1`] = `
   padding: 0;
 }
 
-.c46 {
+.c47 {
   box-sizing: border-box;
   padding-left: 0px;
   padding-right: 8px;
@@ -2804,7 +2835,7 @@ exports[`Search Page renders error message 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c43 {
+  .c44 {
     -webkit-order: 2;
     -ms-flex-order: 2;
     order: 2;
@@ -2812,13 +2843,13 @@ exports[`Search Page renders error message 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c44 {
+  .c45 {
     width: 25%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c30 {
+  .c31 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -2826,7 +2857,7 @@ exports[`Search Page renders error message 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c30 {
+  .c31 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -2835,7 +2866,7 @@ exports[`Search Page renders error message 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c33 {
+  .c34 {
     -webkit-box-pack: start;
     -webkit-justify-content: flex-start;
     -ms-flex-pack: start;
@@ -2844,25 +2875,13 @@ exports[`Search Page renders error message 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c34 {
-    text-align: left;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c45 {
-    text-align: left;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c32 {
+  .c33 {
     width: 33.33333333333333%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c35 {
+  .c36 {
     -webkit-order: 3;
     -ms-flex-order: 3;
     order: 3;
@@ -2870,31 +2889,43 @@ exports[`Search Page renders error message 1`] = `
 }
 
 @media screen and (max-width:40em) {
-  .c4 {
+  .c5 {
     display: none;
   }
 }
 
 @media screen and (min-width:40em) and (max-width:52em) {
-  .c20 {
+  .c21 {
     display: none;
   }
 }
 
 @media screen and (min-width:52em) and (max-width:64em) {
-  .c20 {
+  .c21 {
     display: none;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c20 {
+  .c21 {
     display: none;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c47 {
+  .c35 {
+    text-align: left;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c46 {
+    text-align: left;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c48 {
     text-align: left;
   }
 }
@@ -2916,16 +2947,16 @@ exports[`Search Page renders error message 1`] = `
       >
         <img
           alt="Open Collective logo"
-          className=""
+          className="c4"
           height="24"
           src="/static/images/opencollective-icon.svg"
           width="24"
         />
         <div
-          className="c4 c2"
+          className="c5 c2"
         >
           <div
-            className="c5"
+            className="c6"
           >
             <img
               height="16px"
@@ -2935,14 +2966,14 @@ exports[`Search Page renders error message 1`] = `
         </div>
       </a>
       <div
-        className="c6 c7 sc-bdVaJa c2"
+        className="c7 c8 sc-bdVaJa c2"
       >
         <div
-          className="c4 c8"
+          className="c5 c9"
           width={1}
         >
           <div
-            className="c9 c10"
+            className="c10 c11"
           >
             <form
               action="/search"
@@ -2950,16 +2981,16 @@ exports[`Search Page renders error message 1`] = `
               onSubmit={[Function]}
             >
               <div
-                className="c11 c12 c13 sc-bdVaJa c2"
+                className="c12 c13 c14 sc-bdVaJa c2"
               >
                 <input
-                  className="c14 c15"
+                  className="c15 c16"
                   name="q"
                   placeholder="Search Open Collective"
                   type="search"
                 />
                 <button
-                  className="c16 c17 c18"
+                  className="c17 c18 c19"
                 >
                   <svg
                     height={16}
@@ -2985,16 +3016,16 @@ exports[`Search Page renders error message 1`] = `
         </div>
       </div>
       <div
-        className="c19 c7 sc-bdVaJa c2"
+        className="c20 c8 sc-bdVaJa c2"
       >
         <div
-          className="c20 c2"
+          className="c21 c2"
         >
           <div
-            className="c21"
+            className="c22"
           >
             <a
-              className="c17 c2"
+              className="c18 c2"
               onClick={[Function]}
             >
               <svg
@@ -3018,18 +3049,18 @@ exports[`Search Page renders error message 1`] = `
           </div>
         </div>
         <div
-          className="c20 c2"
+          className="c21 c2"
         >
           <div
-            className="c21"
+            className="c22"
           >
             <a
-              className="c17 c2"
+              className="c18 c2"
               onClick={[Function]}
             >
               <svg
                 aria-hidden="true"
-                className="c22"
+                className="c23"
                 color="#aaaaaa"
                 fill="currentColor"
                 focusable="false"
@@ -3047,16 +3078,16 @@ exports[`Search Page renders error message 1`] = `
           </div>
         </div>
         <div
-          className="c4 c2"
+          className="c5 c2"
         >
           <ul
-            className="c23 c24 c25"
+            className="c24 c25 c26"
           >
             <li
-              className="c26"
+              className="c27"
             >
               <a
-                className="c27"
+                className="c28"
                 href="/discover"
                 onClick={[Function]}
               >
@@ -3066,10 +3097,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c26"
+              className="c27"
             >
               <a
-                className="c27"
+                className="c28"
                 href="/learn-more"
               >
                 <span>
@@ -3078,10 +3109,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c26"
+              className="c27"
             >
               <a
-                className="c27"
+                className="c28"
                 href="https://medium.com/open-collective"
               >
                 <span>
@@ -3095,7 +3126,7 @@ exports[`Search Page renders error message 1`] = `
           className="LoginTopBarProfileButton"
         >
           <a
-            className="c28"
+            className="c29"
             href="/signin?next=%2F"
             onClick={[Function]}
           >
@@ -3125,17 +3156,17 @@ exports[`Search Page renders error message 1`] = `
     </div>
   </main>
   <div
-    className="c29"
+    className="c30"
     id="footer"
   >
     <div
-      className="c30 c31 sc-bdVaJa c2"
+      className="c31 c32 sc-bdVaJa c2"
     >
       <div
-        className="c32"
+        className="c33"
       >
         <div
-          className="c33 c2 sc-bdVaJa c2"
+          className="c34 c2 sc-bdVaJa c2"
         >
           <object
             data="/static/images/opencollectivelogo-footer.svg"
@@ -3144,21 +3175,21 @@ exports[`Search Page renders error message 1`] = `
           />
         </div>
         <p
-          className="c34"
+          className="c35"
         >
           An organization for your community, transparent by design.
         </p>
       </div>
       <div
-        className="c35"
+        className="c36"
       >
         <a
-          className="c36"
+          className="c37"
           href="https://medium.com/open-collective"
         >
           <svg
             aria-hidden="true"
-            className="c37"
+            className="c38"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -3174,12 +3205,12 @@ exports[`Search Page renders error message 1`] = `
           </svg>
         </a>
         <a
-          className="c36"
+          className="c37"
           href="https://twitter.com/opencollect"
         >
           <svg
             aria-hidden="true"
-            className="c38"
+            className="c39"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -3195,12 +3226,12 @@ exports[`Search Page renders error message 1`] = `
           </svg>
         </a>
         <a
-          className="c36"
+          className="c37"
           href="https://github.com/opencollective"
         >
           <svg
             aria-hidden="true"
-            className="c39"
+            className="c40"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -3216,12 +3247,12 @@ exports[`Search Page renders error message 1`] = `
           </svg>
         </a>
         <a
-          className="c36"
+          className="c37"
           href="https://slack.opencollective.com"
         >
           <svg
             aria-hidden="true"
-            className="c40"
+            className="c41"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -3237,12 +3268,12 @@ exports[`Search Page renders error message 1`] = `
           </svg>
         </a>
         <a
-          className="c36"
+          className="c37"
           href="mailto:info@opencollective.com"
         >
           <svg
             aria-hidden="true"
-            className="c41"
+            className="c42"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -3258,24 +3289,24 @@ exports[`Search Page renders error message 1`] = `
         </a>
       </div>
       <nav
-        className="c42 c43"
+        className="c43 c44"
       >
         <div
-          className="c44"
+          className="c45"
         >
           <p
-            className="c45"
+            className="c46"
           >
             PLATFORM
           </p>
           <ul
-            className="c46"
+            className="c47"
           >
             <li
-              className="c47"
+              className="c48"
             >
               <a
-                className="c48 "
+                className="c49 "
                 href="/discover"
                 onClick={[Function]}
               >
@@ -3283,20 +3314,20 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c47"
+              className="c48"
             >
               <a
-                className="c48 "
+                className="c49 "
                 href="/learn-more"
               >
                 How it Works
               </a>
             </li>
             <li
-              className="c47"
+              className="c48"
             >
               <a
-                className="c48 "
+                className="c49 "
                 href="/signin"
                 onClick={[Function]}
               >
@@ -3304,10 +3335,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c47"
+              className="c48"
             >
               <a
-                className="c48 "
+                className="c49 "
                 href="/signin"
                 onClick={[Function]}
               >
@@ -3317,21 +3348,21 @@ exports[`Search Page renders error message 1`] = `
           </ul>
         </div>
         <div
-          className="c44"
+          className="c45"
         >
           <p
-            className="c45"
+            className="c46"
           >
             JOIN THE MOVEMENT
           </p>
           <ul
-            className="c46"
+            className="c47"
           >
             <li
-              className="c47"
+              className="c48"
             >
               <a
-                className="c48 "
+                className="c49 "
                 href="/create"
                 onClick={[Function]}
               >
@@ -3339,10 +3370,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c47"
+              className="c48"
             >
               <a
-                className="c48 "
+                className="c49 "
                 href="/become-a-sponsor"
                 onClick={[Function]}
               >
@@ -3350,10 +3381,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c47"
+              className="c48"
             >
               <a
-                className="c48 "
+                className="c49 "
                 href="/chapters"
                 onClick={[Function]}
               >
@@ -3363,21 +3394,21 @@ exports[`Search Page renders error message 1`] = `
           </ul>
         </div>
         <div
-          className="c44"
+          className="c45"
         >
           <p
-            className="c45"
+            className="c46"
           >
             COMMUNITY
           </p>
           <ul
-            className="c46"
+            className="c47"
           >
             <li
-              className="c47"
+              className="c48"
             >
               <a
-                className="c48 "
+                className="c49 "
                 href="/opensource"
                 onClick={[Function]}
               >
@@ -3385,10 +3416,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c47"
+              className="c48"
             >
               <a
-                className="c48 "
+                className="c49 "
                 href="https://github.com/opencollective/opencollective/issues"
                 onClick={[Function]}
               >
@@ -3396,10 +3427,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c47"
+              className="c48"
             >
               <a
-                className="c48 "
+                className="c49 "
                 href="https://slack.opencollective.com"
                 onClick={[Function]}
               >
@@ -3407,10 +3438,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c47"
+              className="c48"
             >
               <a
-                className="c48 "
+                className="c49 "
                 href="https://github.com/opencollective/opencollective/wiki"
                 onClick={[Function]}
               >
@@ -3418,10 +3449,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c47"
+              className="c48"
             >
               <a
-                className="c48 "
+                className="c49 "
                 href="mailto:support@opencollective.com"
                 onClick={[Function]}
               >
@@ -3431,21 +3462,21 @@ exports[`Search Page renders error message 1`] = `
           </ul>
         </div>
         <div
-          className="c44"
+          className="c45"
         >
           <p
-            className="c45"
+            className="c46"
           >
             COMPANY
           </p>
           <ul
-            className="c46"
+            className="c47"
           >
             <li
-              className="c47"
+              className="c48"
             >
               <a
-                className="c48 "
+                className="c49 "
                 href="/about"
                 onClick={[Function]}
               >
@@ -3453,10 +3484,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c47"
+              className="c48"
             >
               <a
-                className="c48 "
+                className="c49 "
                 href="/faq"
                 onClick={[Function]}
               >
@@ -3464,10 +3495,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c47"
+              className="c48"
             >
               <a
-                className="c48 "
+                className="c49 "
                 href="https://medium.com/open-collective"
                 onClick={[Function]}
               >
@@ -3475,10 +3506,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c47"
+              className="c48"
             >
               <a
-                className="c48 "
+                className="c49 "
                 href="/tos"
                 onClick={[Function]}
               >
@@ -3486,10 +3517,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c47"
+              className="c48"
             >
               <a
-                className="c48 "
+                className="c49 "
                 href="/privacypolicy"
                 onClick={[Function]}
               >
@@ -3505,7 +3536,8 @@ exports[`Search Page renders error message 1`] = `
 `;
 
 exports[`Search Page renders loading grid SVG 1`] = `
-.c1 {
+Array [
+  .c1 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
@@ -3517,79 +3549,36 @@ exports[`Search Page renders loading grid SVG 1`] = `
   box-sizing: border-box;
 }
 
-.c5 {
+.c6 {
   box-sizing: border-box;
   margin-left: 8px;
   margin-right: 8px;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
 }
 
-.c9 {
+.c10 {
   box-sizing: border-box;
   margin-left: 16px;
   margin-right: 16px;
 }
 
-.c14 {
+.c15 {
   margin: 0;
   box-sizing: border-box;
   margin: 0px;
   padding: 0px;
 }
 
-.c15 {
+.c16 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
-}
-
-.c19 {
-  box-sizing: border-box;
-  width: 100%;
-}
-
-.c21 {
-  box-sizing: border-box;
-  margin-top: 16px;
-  margin-bottom: 16px;
-}
-
-.c26 {
-  box-sizing: border-box;
-  width: 100%;
-  padding-top: 16px;
-  padding-bottom: 16px;
-}
-
-.c29 {
-  max-width: 1300px;
-  box-sizing: border-box;
-  margin-left: auto;
-  margin-right: auto;
-  padding: 8px;
-}
-
-.c41 {
-  box-sizing: border-box;
-  margin-top: 16px;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c42 {
-  box-sizing: border-box;
-  width: 50%;
-  margin-bottom: 16px;
 }
 
 .c0 {
@@ -3621,7 +3610,7 @@ exports[`Search Page renders loading grid SVG 1`] = `
   align-items: center;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3636,14 +3625,14 @@ exports[`Search Page renders loading grid SVG 1`] = `
   justify-content: flex-end;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c13 {
+.c14 {
   margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3655,173 +3644,13 @@ exports[`Search Page renders loading grid SVG 1`] = `
   justify-content: space-around;
 }
 
-.c20 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-}
-
-.c24 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c25 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c28 {
-  max-width: 1300px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c31 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c40 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c32 {
-  color: #6E747A;
-  font-size: 1.4rem;
-  line-height: Paragraph;
-  -webkit-letter-spacing: -0.2px;
-  -moz-letter-spacing: -0.2px;
-  -ms-letter-spacing: -0.2px;
-  letter-spacing: -0.2px;
-  margin: 0px;
-  padding-top: 8px;
-  padding-bottom: 8px;
-  text-align: center;
-}
-
-.c43 {
-  color: #C2C6CC;
-  font-size: 1.2rem;
-  line-height: Paragraph;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  margin: 0px;
-  padding-bottom: 16px;
-  text-align: center;
-}
-
-.c11 {
+.c12 {
   display: inline-block;
   vertical-align: -.125em;
   overflow: hidden;
 }
 
 .c18 {
-  max-width: 1200px;
-  margin-left: auto;
-  margin-right: auto;
-  padding-left: 16px;
-  padding-right: 16px;
-  width: 100%;
-}
-
-.c27 {
-  border-top: 1px solid #aaaaaa;
-  bottom: 0px;
-  background-color: white;
-  min-height: 7.5rem;
-  padding: 1rem;
-  width: 100%;
-}
-
-.c30 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  max-width: 300px;
-  margin-top: 16px;
-  width: 100%;
-}
-
-.c33 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: space-evenly;
-  -webkit-justify-content: space-evenly;
-  -ms-flex-pack: space-evenly;
-  justify-content: space-evenly;
-  max-width: 300px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-  margin-top: 16px;
-  margin-bottom: 16px;
-  width: 100%;
-}
-
-.c17 {
   border: 1px solid #D5DAE0;
   border-radius: 20px;
   color: #3385FF;
@@ -3833,240 +3662,47 @@ exports[`Search Page renders loading grid SVG 1`] = `
   padding-bottom: 8px;
 }
 
-.c45 {
-  list-style: none;
-  margin-bottom: 8px;
-  text-align: center;
+.c4 {
+  -webkit-animation: iECmZH 0.8s infinite linear;
+  animation: iECmZH 0.8s infinite linear;
 }
 
-.c12 {
+.c13 {
   list-style: none;
   min-width: 20rem;
   text-align: right;
 }
 
-.c16 {
+.c17 {
   color: #777777;
   font-size: 1.4rem;
 }
 
-.c37 {
-  display: inline-block;
-  vertical-align: -.125em;
-  overflow: hidden;
-}
-
-.c35 {
-  display: inline-block;
-  vertical-align: -.125em;
-  overflow: hidden;
-}
-
-.c38 {
-  display: inline-block;
-  vertical-align: -.125em;
-  overflow: hidden;
-}
-
-.c36 {
-  display: inline-block;
-  vertical-align: -.125em;
-  overflow: hidden;
-}
-
-.c39 {
-  display: inline-block;
-  vertical-align: middle;
-  overflow: hidden;
-}
-
-.c34 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 1px solid #9399a3;
-  border-radius: 50%;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  height: 48px;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  opacity: 0.6;
-  width: 48px;
-}
-
-.c34:hover,
-.c34:focus {
-  opacity: 1;
-}
-
-.c46 {
-  color: #6e747a;
-  display: block;
-  fontsize: 1.4rem;
-  fontweight: 400;
-  margin: 0;
-  padding: 0;
-}
-
-.c44 {
-  box-sizing: border-box;
-  padding-left: 0px;
-  padding-right: 8px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c22.c22.c22 {
-  border: none;
-  border-bottom: 2px solid #3385FF;
-  border-radius: 0;
-  box-shadow: none;
-  display: block;
-  height: 3.4rem;
-  padding: 0;
-}
-
-.c23.c23 {
-  padding: 0 2rem;
-}
-
-@media screen and (min-width:52em) {
-  .c41 {
-    -webkit-order: 2;
-    -ms-flex-order: 2;
-    order: 2;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c42 {
-    width: 25%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c24 {
-    -webkit-box-pack: center;
-    -webkit-justify-content: center;
-    -ms-flex-pack: center;
-    justify-content: center;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c24 {
-    -webkit-box-pack: start;
-    -webkit-justify-content: flex-start;
-    -ms-flex-pack: start;
-    justify-content: flex-start;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c28 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c28 {
-    -webkit-align-items: flex-start;
-    -webkit-box-align: flex-start;
-    -ms-flex-align: flex-start;
-    align-items: flex-start;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c31 {
-    -webkit-box-pack: start;
-    -webkit-justify-content: flex-start;
-    -ms-flex-pack: start;
-    justify-content: flex-start;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c32 {
-    text-align: left;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c43 {
-    text-align: left;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c18 {
-    width: 85%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c30 {
-    width: 33.33333333333333%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c33 {
-    -webkit-order: 3;
-    -ms-flex-order: 3;
-    order: 3;
-  }
-}
-
 @media screen and (max-width:40em) {
-  .c4 {
+  .c5 {
     display: none;
   }
 }
 
 @media screen and (min-width:40em) and (max-width:52em) {
-  .c8 {
+  .c9 {
     display: none;
   }
 }
 
 @media screen and (min-width:52em) and (max-width:64em) {
-  .c8 {
+  .c9 {
     display: none;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c8 {
+  .c9 {
     display: none;
   }
 }
 
-@media screen and (min-width:52em) {
-  .c45 {
-    text-align: left;
-  }
-}
-
-<div>
-  <header>
+<header>
     <div
       id="top"
     />
@@ -4080,16 +3716,16 @@ exports[`Search Page renders loading grid SVG 1`] = `
       >
         <img
           alt="Open Collective logo"
-          className=""
+          className="c4"
           height="24"
           src="/static/images/opencollective-icon.svg"
           width="24"
         />
         <div
-          className="c4 c2"
+          className="c5 c2"
         >
           <div
-            className="c5"
+            className="c6"
           >
             <img
               height="16px"
@@ -4099,16 +3735,16 @@ exports[`Search Page renders loading grid SVG 1`] = `
         </div>
       </a>
       <div
-        className="c6 c7 sc-bdVaJa c2"
+        className="c7 c8 sc-bdVaJa c2"
       >
         <div
-          className="c8 c2"
+          className="c9 c2"
         >
           <div
-            className="c9"
+            className="c10"
           >
             <a
-              className="c10 c2"
+              className="c11 c2"
               onClick={[Function]}
             >
               <svg
@@ -4132,18 +3768,18 @@ exports[`Search Page renders loading grid SVG 1`] = `
           </div>
         </div>
         <div
-          className="c8 c2"
+          className="c9 c2"
         >
           <div
-            className="c9"
+            className="c10"
           >
             <a
-              className="c10 c2"
+              className="c11 c2"
               onClick={[Function]}
             >
               <svg
                 aria-hidden="true"
-                className="c11"
+                className="c12"
                 color="#aaaaaa"
                 fill="currentColor"
                 focusable="false"
@@ -4161,16 +3797,16 @@ exports[`Search Page renders loading grid SVG 1`] = `
           </div>
         </div>
         <div
-          className="c4 c2"
+          className="c5 c2"
         >
           <ul
-            className="c12 c13 c14"
+            className="c13 c14 c15"
           >
             <li
-              className="c15"
+              className="c16"
             >
               <a
-                className="c16"
+                className="c17"
                 href="/discover"
                 onClick={[Function]}
               >
@@ -4180,10 +3816,10 @@ exports[`Search Page renders loading grid SVG 1`] = `
               </a>
             </li>
             <li
-              className="c15"
+              className="c16"
             >
               <a
-                className="c16"
+                className="c17"
                 href="/learn-more"
               >
                 <span>
@@ -4192,10 +3828,10 @@ exports[`Search Page renders loading grid SVG 1`] = `
               </a>
             </li>
             <li
-              className="c15"
+              className="c16"
             >
               <a
-                className="c16"
+                className="c17"
                 href="https://medium.com/open-collective"
               >
                 <span>
@@ -4209,7 +3845,7 @@ exports[`Search Page renders loading grid SVG 1`] = `
           className="LoginTopBarProfileButton"
         >
           <a
-            className="c17"
+            className="c18"
             href="/signin?next=%2F"
             onClick={[Function]}
           >
@@ -4220,15 +3856,120 @@ exports[`Search Page renders loading grid SVG 1`] = `
         </div>
       </div>
     </div>
-  </header>
-  <main
+  </header>,
+  .c4 {
+  box-sizing: border-box;
+}
+
+.c1 {
+  box-sizing: border-box;
+  width: 100%;
+}
+
+.c3 {
+  box-sizing: border-box;
+  margin-top: 16px;
+  margin-bottom: 16px;
+}
+
+.c9 {
+  box-sizing: border-box;
+  width: 100%;
+  padding-top: 16px;
+  padding-bottom: 16px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c0 {
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 16px;
+  padding-right: 16px;
+  width: 100%;
+}
+
+.c5.c5.c5 {
+  border: none;
+  border-bottom: 2px solid #3385FF;
+  border-radius: 0;
+  box-shadow: none;
+  display: block;
+  height: 3.4rem;
+  padding: 0;
+}
+
+.c6.c6 {
+  padding: 0 2rem;
+}
+
+@media screen and (min-width:40em) {
+  .c7 {
+    -webkit-box-pack: center;
+    -webkit-justify-content: center;
+    -ms-flex-pack: center;
+    justify-content: center;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c7 {
+    -webkit-box-pack: start;
+    -webkit-justify-content: flex-start;
+    -ms-flex-pack: start;
+    justify-content: flex-start;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c0 {
+    width: 85%;
+  }
+}
+
+<main
     className="jsx-916984404"
   >
     <div
-      className="c18"
+      className="c0"
     >
       <div
-        className="c19"
+        className="c1"
       >
         <form
           method="GET"
@@ -4244,10 +3985,10 @@ exports[`Search Page renders loading grid SVG 1`] = `
               Search Open Collective
             </label>
             <div
-              className="c20 c21 sc-bdVaJa c2"
+              className="c2 c3 sc-bdVaJa c4"
             >
               <input
-                className="c22 form-control"
+                className="c5 form-control"
                 defaultValue=""
                 id="search"
                 name="q"
@@ -4255,7 +3996,7 @@ exports[`Search Page renders loading grid SVG 1`] = `
                 type="search"
               />
               <button
-                className="jsx-1144918383 jsx-3101740563 Button blue c23"
+                className="jsx-1144918383 jsx-3101740563 Button blue c6"
                 onClick={[Function]}
                 type="submit"
               >
@@ -4268,10 +4009,10 @@ exports[`Search Page renders loading grid SVG 1`] = `
         </form>
       </div>
       <div
-        className="c24 c2 sc-bdVaJa c2"
+        className="c7 c4 sc-bdVaJa c4"
       >
         <div
-          className="c25 c26 sc-bdVaJa c2"
+          className="c8 c9 sc-bdVaJa c4"
         >
           <svg
             fill="#3385FF"
@@ -4411,19 +4152,322 @@ exports[`Search Page renders loading grid SVG 1`] = `
         </div>
       </div>
     </div>
-  </main>
-  <div
-    className="c27"
+  </main>,
+  .c3 {
+  box-sizing: border-box;
+}
+
+.c2 {
+  max-width: 1300px;
+  box-sizing: border-box;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 8px;
+}
+
+.c15 {
+  box-sizing: border-box;
+  margin-top: 16px;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c16 {
+  box-sizing: border-box;
+  width: 50%;
+  margin-bottom: 16px;
+}
+
+.c1 {
+  max-width: 1300px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c0 {
+  border-top: 1px solid #aaaaaa;
+  bottom: 0px;
+  background-color: white;
+  min-height: 7.5rem;
+  padding: 1rem;
+  width: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  max-width: 300px;
+  margin-top: 16px;
+  width: 100%;
+}
+
+.c7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: space-evenly;
+  -webkit-justify-content: space-evenly;
+  -ms-flex-pack: space-evenly;
+  justify-content: space-evenly;
+  max-width: 300px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+  margin-top: 16px;
+  margin-bottom: 16px;
+  width: 100%;
+}
+
+.c6 {
+  color: #6E747A;
+  font-size: 1.4rem;
+  line-height: Paragraph;
+  -webkit-letter-spacing: -0.2px;
+  -moz-letter-spacing: -0.2px;
+  -ms-letter-spacing: -0.2px;
+  letter-spacing: -0.2px;
+  margin: 0px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  text-align: center;
+}
+
+.c17 {
+  color: #C2C6CC;
+  font-size: 1.2rem;
+  line-height: Paragraph;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  margin: 0px;
+  padding-bottom: 16px;
+  text-align: center;
+}
+
+.c19 {
+  list-style: none;
+  margin-bottom: 8px;
+  text-align: center;
+}
+
+.c11 {
+  display: inline-block;
+  vertical-align: -.125em;
+  overflow: hidden;
+}
+
+.c9 {
+  display: inline-block;
+  vertical-align: -.125em;
+  overflow: hidden;
+}
+
+.c12 {
+  display: inline-block;
+  vertical-align: -.125em;
+  overflow: hidden;
+}
+
+.c10 {
+  display: inline-block;
+  vertical-align: -.125em;
+  overflow: hidden;
+}
+
+.c13 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+}
+
+.c8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #9399a3;
+  border-radius: 50%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 48px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  opacity: 0.6;
+  width: 48px;
+}
+
+.c8:hover,
+.c8:focus {
+  opacity: 1;
+}
+
+.c20 {
+  color: #6e747a;
+  display: block;
+  fontsize: 1.4rem;
+  fontweight: 400;
+  margin: 0;
+  padding: 0;
+}
+
+.c18 {
+  box-sizing: border-box;
+  padding-left: 0px;
+  padding-right: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+@media screen and (min-width:52em) {
+  .c15 {
+    -webkit-order: 2;
+    -ms-flex-order: 2;
+    order: 2;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c16 {
+    width: 25%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c1 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c1 {
+    -webkit-align-items: flex-start;
+    -webkit-box-align: flex-start;
+    -ms-flex-align: flex-start;
+    align-items: flex-start;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c5 {
+    -webkit-box-pack: start;
+    -webkit-justify-content: flex-start;
+    -ms-flex-pack: start;
+    justify-content: flex-start;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c4 {
+    width: 33.33333333333333%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c7 {
+    -webkit-order: 3;
+    -ms-flex-order: 3;
+    order: 3;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c6 {
+    text-align: left;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c17 {
+    text-align: left;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c19 {
+    text-align: left;
+  }
+}
+
+<div
+    className="c0"
     id="footer"
   >
     <div
-      className="c28 c29 sc-bdVaJa c2"
+      className="c1 c2 sc-bdVaJa c3"
     >
       <div
-        className="c30"
+        className="c4"
       >
         <div
-          className="c31 c2 sc-bdVaJa c2"
+          className="c5 c3 sc-bdVaJa c3"
         >
           <object
             data="/static/images/opencollectivelogo-footer.svg"
@@ -4432,21 +4476,21 @@ exports[`Search Page renders loading grid SVG 1`] = `
           />
         </div>
         <p
-          className="c32"
+          className="c6"
         >
           An organization for your community, transparent by design.
         </p>
       </div>
       <div
-        className="c33"
+        className="c7"
       >
         <a
-          className="c34"
+          className="c8"
           href="https://medium.com/open-collective"
         >
           <svg
             aria-hidden="true"
-            className="c35"
+            className="c9"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -4462,12 +4506,12 @@ exports[`Search Page renders loading grid SVG 1`] = `
           </svg>
         </a>
         <a
-          className="c34"
+          className="c8"
           href="https://twitter.com/opencollect"
         >
           <svg
             aria-hidden="true"
-            className="c36"
+            className="c10"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -4483,12 +4527,12 @@ exports[`Search Page renders loading grid SVG 1`] = `
           </svg>
         </a>
         <a
-          className="c34"
+          className="c8"
           href="https://github.com/opencollective"
         >
           <svg
             aria-hidden="true"
-            className="c37"
+            className="c11"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -4504,12 +4548,12 @@ exports[`Search Page renders loading grid SVG 1`] = `
           </svg>
         </a>
         <a
-          className="c34"
+          className="c8"
           href="https://slack.opencollective.com"
         >
           <svg
             aria-hidden="true"
-            className="c38"
+            className="c12"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -4525,12 +4569,12 @@ exports[`Search Page renders loading grid SVG 1`] = `
           </svg>
         </a>
         <a
-          className="c34"
+          className="c8"
           href="mailto:info@opencollective.com"
         >
           <svg
             aria-hidden="true"
-            className="c39"
+            className="c13"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -4546,24 +4590,24 @@ exports[`Search Page renders loading grid SVG 1`] = `
         </a>
       </div>
       <nav
-        className="c40 c41"
+        className="c14 c15"
       >
         <div
-          className="c42"
+          className="c16"
         >
           <p
-            className="c43"
+            className="c17"
           >
             PLATFORM
           </p>
           <ul
-            className="c44"
+            className="c18"
           >
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/discover"
                 onClick={[Function]}
               >
@@ -4571,20 +4615,20 @@ exports[`Search Page renders loading grid SVG 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/learn-more"
               >
                 How it Works
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/signin"
                 onClick={[Function]}
               >
@@ -4592,10 +4636,10 @@ exports[`Search Page renders loading grid SVG 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/signin"
                 onClick={[Function]}
               >
@@ -4605,21 +4649,21 @@ exports[`Search Page renders loading grid SVG 1`] = `
           </ul>
         </div>
         <div
-          className="c42"
+          className="c16"
         >
           <p
-            className="c43"
+            className="c17"
           >
             JOIN THE MOVEMENT
           </p>
           <ul
-            className="c44"
+            className="c18"
           >
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/create"
                 onClick={[Function]}
               >
@@ -4627,10 +4671,10 @@ exports[`Search Page renders loading grid SVG 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/become-a-sponsor"
                 onClick={[Function]}
               >
@@ -4638,10 +4682,10 @@ exports[`Search Page renders loading grid SVG 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/chapters"
                 onClick={[Function]}
               >
@@ -4651,21 +4695,21 @@ exports[`Search Page renders loading grid SVG 1`] = `
           </ul>
         </div>
         <div
-          className="c42"
+          className="c16"
         >
           <p
-            className="c43"
+            className="c17"
           >
             COMMUNITY
           </p>
           <ul
-            className="c44"
+            className="c18"
           >
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/opensource"
                 onClick={[Function]}
               >
@@ -4673,10 +4717,10 @@ exports[`Search Page renders loading grid SVG 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="https://github.com/opencollective/opencollective/issues"
                 onClick={[Function]}
               >
@@ -4684,10 +4728,10 @@ exports[`Search Page renders loading grid SVG 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="https://slack.opencollective.com"
                 onClick={[Function]}
               >
@@ -4695,10 +4739,10 @@ exports[`Search Page renders loading grid SVG 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="https://github.com/opencollective/opencollective/wiki"
                 onClick={[Function]}
               >
@@ -4706,10 +4750,10 @@ exports[`Search Page renders loading grid SVG 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="mailto:support@opencollective.com"
                 onClick={[Function]}
               >
@@ -4719,21 +4763,21 @@ exports[`Search Page renders loading grid SVG 1`] = `
           </ul>
         </div>
         <div
-          className="c42"
+          className="c16"
         >
           <p
-            className="c43"
+            className="c17"
           >
             COMPANY
           </p>
           <ul
-            className="c44"
+            className="c18"
           >
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/about"
                 onClick={[Function]}
               >
@@ -4741,10 +4785,10 @@ exports[`Search Page renders loading grid SVG 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/faq"
                 onClick={[Function]}
               >
@@ -4752,10 +4796,10 @@ exports[`Search Page renders loading grid SVG 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="https://medium.com/open-collective"
                 onClick={[Function]}
               >
@@ -4763,10 +4807,10 @@ exports[`Search Page renders loading grid SVG 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/tos"
                 onClick={[Function]}
               >
@@ -4774,10 +4818,10 @@ exports[`Search Page renders loading grid SVG 1`] = `
               </a>
             </li>
             <li
-              className="c45"
+              className="c19"
             >
               <a
-                className="c46 "
+                className="c20 "
                 href="/privacypolicy"
                 onClick={[Function]}
               >
@@ -4788,12 +4832,13 @@ exports[`Search Page renders loading grid SVG 1`] = `
         </div>
       </nav>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`Search Page renders search results with pagination 1`] = `
-.c1 {
+Array [
+  .c1 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
@@ -4805,87 +4850,36 @@ exports[`Search Page renders search results with pagination 1`] = `
   box-sizing: border-box;
 }
 
-.c5 {
+.c6 {
   box-sizing: border-box;
   margin-left: 8px;
   margin-right: 8px;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
 }
 
-.c9 {
+.c10 {
   box-sizing: border-box;
   margin-left: 16px;
   margin-right: 16px;
 }
 
-.c14 {
+.c15 {
   margin: 0;
   box-sizing: border-box;
   margin: 0px;
   padding: 0px;
 }
 
-.c15 {
+.c16 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
-}
-
-.c19 {
-  box-sizing: border-box;
-  width: 100%;
-}
-
-.c21 {
-  box-sizing: border-box;
-  margin-top: 16px;
-  margin-bottom: 16px;
-}
-
-.c30 {
-  box-sizing: border-box;
-  width: 100%;
-  padding-top: 16px;
-  padding-bottom: 16px;
-}
-
-.c33 {
-  max-width: 1300px;
-  box-sizing: border-box;
-  margin-left: auto;
-  margin-right: auto;
-  padding: 8px;
-}
-
-.c45 {
-  box-sizing: border-box;
-  margin-top: 16px;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c46 {
-  box-sizing: border-box;
-  width: 50%;
-  margin-bottom: 16px;
-}
-
-.c25 {
-  box-sizing: border-box;
-  margin-left: 8px;
-  margin-right: 8px;
-  margin-top: 16px;
-  margin-bottom: 16px;
 }
 
 .c0 {
@@ -4917,7 +4911,7 @@ exports[`Search Page renders search results with pagination 1`] = `
   align-items: center;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4932,14 +4926,14 @@ exports[`Search Page renders search results with pagination 1`] = `
   justify-content: flex-end;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c13 {
+.c14 {
   margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4951,204 +4945,13 @@ exports[`Search Page renders search results with pagination 1`] = `
   justify-content: space-around;
 }
 
-.c20 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-}
-
-.c24 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c32 {
-  max-width: 1300px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c35 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c44 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c36 {
-  color: #6E747A;
-  font-size: 1.4rem;
-  line-height: Paragraph;
-  -webkit-letter-spacing: -0.2px;
-  -moz-letter-spacing: -0.2px;
-  -ms-letter-spacing: -0.2px;
-  letter-spacing: -0.2px;
-  margin: 0px;
-  padding-top: 8px;
-  padding-bottom: 8px;
-  text-align: center;
-}
-
-.c47 {
-  color: #C2C6CC;
-  font-size: 1.2rem;
-  line-height: Paragraph;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  margin: 0px;
-  padding-bottom: 16px;
-  text-align: center;
-}
-
-.c27 {
-  font-size: inherit;
-  line-height: inherit;
-  -webkit-letter-spacing: -0.2px;
-  -moz-letter-spacing: -0.2px;
-  -ms-letter-spacing: -0.2px;
-  letter-spacing: -0.2px;
-  margin: 0px;
-}
-
-.c11 {
+.c12 {
   display: inline-block;
   vertical-align: -.125em;
   overflow: hidden;
 }
 
 .c18 {
-  max-width: 1200px;
-  margin-left: auto;
-  margin-right: auto;
-  padding-left: 16px;
-  padding-right: 16px;
-  width: 100%;
-}
-
-.c31 {
-  border-top: 1px solid #aaaaaa;
-  bottom: 0px;
-  background-color: white;
-  min-height: 7.5rem;
-  padding: 1rem;
-  width: 100%;
-}
-
-.c34 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  max-width: 300px;
-  margin-top: 16px;
-  width: 100%;
-}
-
-.c37 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: space-evenly;
-  -webkit-justify-content: space-evenly;
-  -ms-flex-pack: space-evenly;
-  justify-content: space-evenly;
-  max-width: 300px;
-  -webkit-order: 2;
-  -ms-flex-order: 2;
-  order: 2;
-  margin-top: 16px;
-  margin-bottom: 16px;
-  width: 100%;
-}
-
-.c26 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-size: Paragraph;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  margin-top: 16px;
-  margin-bottom: 16px;
-}
-
-.c17 {
   border: 1px solid #D5DAE0;
   border-radius: 20px;
   color: #3385FF;
@@ -5160,254 +4963,47 @@ exports[`Search Page renders search results with pagination 1`] = `
   padding-bottom: 8px;
 }
 
-.c49 {
-  list-style: none;
-  margin-bottom: 8px;
-  text-align: center;
+.c4 {
+  -webkit-animation: iECmZH 0.8s infinite linear;
+  animation: iECmZH 0.8s infinite linear;
 }
 
-.c12 {
+.c13 {
   list-style: none;
   min-width: 20rem;
   text-align: right;
 }
 
-.c16 {
+.c17 {
   color: #777777;
   font-size: 1.4rem;
 }
 
-.c41 {
-  display: inline-block;
-  vertical-align: -.125em;
-  overflow: hidden;
-}
-
-.c39 {
-  display: inline-block;
-  vertical-align: -.125em;
-  overflow: hidden;
-}
-
-.c42 {
-  display: inline-block;
-  vertical-align: -.125em;
-  overflow: hidden;
-}
-
-.c40 {
-  display: inline-block;
-  vertical-align: -.125em;
-  overflow: hidden;
-}
-
-.c43 {
-  display: inline-block;
-  vertical-align: middle;
-  overflow: hidden;
-}
-
-.c38 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: 1px solid #9399a3;
-  border-radius: 50%;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  height: 48px;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  opacity: 0.6;
-  width: 48px;
-}
-
-.c38:hover,
-.c38:focus {
-  opacity: 1;
-}
-
-.c50 {
-  color: #6e747a;
-  display: block;
-  fontsize: 1.4rem;
-  fontweight: 400;
-  margin: 0;
-  padding: 0;
-}
-
-.c48 {
-  box-sizing: border-box;
-  padding-left: 0px;
-  padding-right: 8px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c28 {
-  border: 1px solid #cccccc;
-  border-radius: 4px;
-  font-size: 14px;
-  margin-left: 4px;
-  margin-right: 4px;
-  padding-left: 4px;
-  padding-right: 4px;
-  padding-top: 4px;
-  padding-bottom: 4px;
-  text-align: center;
-  width: 30px;
-}
-
-.c22.c22.c22 {
-  border: none;
-  border-bottom: 2px solid #3385FF;
-  border-radius: 0;
-  box-shadow: none;
-  display: block;
-  height: 3.4rem;
-  padding: 0;
-}
-
-.c23.c23 {
-  padding: 0 2rem;
-}
-
-@media screen and (min-width:52em) {
-  .c45 {
-    -webkit-order: 2;
-    -ms-flex-order: 2;
-    order: 2;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c46 {
-    width: 25%;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c24 {
-    -webkit-box-pack: center;
-    -webkit-justify-content: center;
-    -ms-flex-pack: center;
-    justify-content: center;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c24 {
-    -webkit-box-pack: start;
-    -webkit-justify-content: flex-start;
-    -ms-flex-pack: start;
-    justify-content: flex-start;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c32 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c32 {
-    -webkit-align-items: flex-start;
-    -webkit-box-align: flex-start;
-    -ms-flex-align: flex-start;
-    align-items: flex-start;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c35 {
-    -webkit-box-pack: start;
-    -webkit-justify-content: flex-start;
-    -ms-flex-pack: start;
-    justify-content: flex-start;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c36 {
-    text-align: left;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c47 {
-    text-align: left;
-  }
-}
-
-@media screen and (min-width:40em) {
-  .c18 {
-    width: 85%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c34 {
-    width: 33.33333333333333%;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c37 {
-    -webkit-order: 3;
-    -ms-flex-order: 3;
-    order: 3;
-  }
-}
-
 @media screen and (max-width:40em) {
-  .c4 {
+  .c5 {
     display: none;
   }
 }
 
 @media screen and (min-width:40em) and (max-width:52em) {
-  .c8 {
+  .c9 {
     display: none;
   }
 }
 
 @media screen and (min-width:52em) and (max-width:64em) {
-  .c8 {
+  .c9 {
     display: none;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c8 {
+  .c9 {
     display: none;
   }
 }
 
-@media screen and (min-width:52em) {
-  .c49 {
-    text-align: left;
-  }
-}
-
-<div>
-  <header>
+<header>
     <div
       id="top"
     />
@@ -5421,16 +5017,16 @@ exports[`Search Page renders search results with pagination 1`] = `
       >
         <img
           alt="Open Collective logo"
-          className=""
+          className="c4"
           height="24"
           src="/static/images/opencollective-icon.svg"
           width="24"
         />
         <div
-          className="c4 c2"
+          className="c5 c2"
         >
           <div
-            className="c5"
+            className="c6"
           >
             <img
               height="16px"
@@ -5440,16 +5036,16 @@ exports[`Search Page renders search results with pagination 1`] = `
         </div>
       </a>
       <div
-        className="c6 c7 sc-bdVaJa c2"
+        className="c7 c8 sc-bdVaJa c2"
       >
         <div
-          className="c8 c2"
+          className="c9 c2"
         >
           <div
-            className="c9"
+            className="c10"
           >
             <a
-              className="c10 c2"
+              className="c11 c2"
               onClick={[Function]}
             >
               <svg
@@ -5473,18 +5069,18 @@ exports[`Search Page renders search results with pagination 1`] = `
           </div>
         </div>
         <div
-          className="c8 c2"
+          className="c9 c2"
         >
           <div
-            className="c9"
+            className="c10"
           >
             <a
-              className="c10 c2"
+              className="c11 c2"
               onClick={[Function]}
             >
               <svg
                 aria-hidden="true"
-                className="c11"
+                className="c12"
                 color="#aaaaaa"
                 fill="currentColor"
                 focusable="false"
@@ -5502,16 +5098,16 @@ exports[`Search Page renders search results with pagination 1`] = `
           </div>
         </div>
         <div
-          className="c4 c2"
+          className="c5 c2"
         >
           <ul
-            className="c12 c13 c14"
+            className="c13 c14 c15"
           >
             <li
-              className="c15"
+              className="c16"
             >
               <a
-                className="c16"
+                className="c17"
                 href="/discover"
                 onClick={[Function]}
               >
@@ -5521,10 +5117,10 @@ exports[`Search Page renders search results with pagination 1`] = `
               </a>
             </li>
             <li
-              className="c15"
+              className="c16"
             >
               <a
-                className="c16"
+                className="c17"
                 href="/learn-more"
               >
                 <span>
@@ -5533,10 +5129,10 @@ exports[`Search Page renders search results with pagination 1`] = `
               </a>
             </li>
             <li
-              className="c15"
+              className="c16"
             >
               <a
-                className="c16"
+                className="c17"
                 href="https://medium.com/open-collective"
               >
                 <span>
@@ -5550,7 +5146,7 @@ exports[`Search Page renders search results with pagination 1`] = `
           className="LoginTopBarProfileButton"
         >
           <a
-            className="c17"
+            className="c18"
             href="/signin?next=%2F"
             onClick={[Function]}
           >
@@ -5561,15 +5157,197 @@ exports[`Search Page renders search results with pagination 1`] = `
         </div>
       </div>
     </div>
-  </header>
-  <main
+  </header>,
+  .c4 {
+  box-sizing: border-box;
+}
+
+.c12 {
+  box-sizing: border-box;
+  margin-left: 8px;
+  margin-right: 8px;
+}
+
+.c1 {
+  box-sizing: border-box;
+  width: 100%;
+}
+
+.c3 {
+  box-sizing: border-box;
+  margin-top: 16px;
+  margin-bottom: 16px;
+}
+
+.c16 {
+  box-sizing: border-box;
+  width: 100%;
+  padding-top: 16px;
+  padding-bottom: 16px;
+}
+
+.c9 {
+  box-sizing: border-box;
+  margin-left: 8px;
+  margin-right: 8px;
+  margin-top: 16px;
+  margin-bottom: 16px;
+}
+
+.c11 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c0 {
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 16px;
+  padding-right: 16px;
+  width: 100%;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: Paragraph;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-top: 16px;
+  margin-bottom: 16px;
+}
+
+.c13 {
+  font-size: inherit;
+  line-height: inherit;
+  -webkit-letter-spacing: -0.2px;
+  -moz-letter-spacing: -0.2px;
+  -ms-letter-spacing: -0.2px;
+  letter-spacing: -0.2px;
+  margin: 0px;
+}
+
+.c14 {
+  border: 1px solid #cccccc;
+  border-radius: 4px;
+  font-size: 14px;
+  margin-left: 4px;
+  margin-right: 4px;
+  padding-left: 4px;
+  padding-right: 4px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  text-align: center;
+  width: 30px;
+}
+
+.c5.c5.c5 {
+  border: none;
+  border-bottom: 2px solid #3385FF;
+  border-radius: 0;
+  box-shadow: none;
+  display: block;
+  height: 3.4rem;
+  padding: 0;
+}
+
+.c6.c6 {
+  padding: 0 2rem;
+}
+
+@media screen and (min-width:40em) {
+  .c7 {
+    -webkit-box-pack: center;
+    -webkit-justify-content: center;
+    -ms-flex-pack: center;
+    justify-content: center;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c7 {
+    -webkit-box-pack: start;
+    -webkit-justify-content: flex-start;
+    -ms-flex-pack: start;
+    justify-content: flex-start;
+  }
+}
+
+@media screen and (min-width:40em) {
+  .c0 {
+    width: 85%;
+  }
+}
+
+<main
     className="jsx-916984404"
   >
     <div
-      className="c18"
+      className="c0"
     >
       <div
-        className="c19"
+        className="c1"
       >
         <form
           method="GET"
@@ -5585,10 +5363,10 @@ exports[`Search Page renders search results with pagination 1`] = `
               Search Open Collective
             </label>
             <div
-              className="c20 c21 sc-bdVaJa c2"
+              className="c2 c3 sc-bdVaJa c4"
             >
               <input
-                className="c22 form-control"
+                className="c5 form-control"
                 defaultValue="Test"
                 id="search"
                 name="q"
@@ -5596,7 +5374,7 @@ exports[`Search Page renders search results with pagination 1`] = `
                 type="search"
               />
               <button
-                className="jsx-1144918383 jsx-3101740563 Button blue c23"
+                className="jsx-1144918383 jsx-3101740563 Button blue c6"
                 onClick={[Function]}
                 type="submit"
               >
@@ -5609,10 +5387,10 @@ exports[`Search Page renders search results with pagination 1`] = `
         </form>
       </div>
       <div
-        className="c24 c2 sc-bdVaJa c2"
+        className="c7 c4 sc-bdVaJa c4"
       >
         <div
-          className="c10 c25 sc-bdVaJa c2"
+          className="c8 c9 sc-bdVaJa c4"
         >
           <a
             href="/test-collective"
@@ -5675,28 +5453,28 @@ exports[`Search Page renders search results with pagination 1`] = `
         </div>
       </div>
       <div
-        className="c26"
+        className="c10"
       >
         <div
-          className="c3 c2 sc-bdVaJa c2"
+          className="c11 c4 sc-bdVaJa c4"
         >
           <div
-            className="c3 c5 sc-bdVaJa c2"
+            className="c11 c12 sc-bdVaJa c4"
           >
             <span
-              className="-Clean-span c27"
+              className="-Clean-span c13"
             >
               Page 
             </span>
             <input
-              className="c28"
+              className="c14"
               defaultValue={1}
               onBlur={[Function]}
               onKeyPress={[Function]}
               type="text"
             />
             <span
-              className="-Clean-span c27"
+              className="-Clean-span c13"
             >
               of 
               5
@@ -5712,74 +5490,7 @@ exports[`Search Page renders search results with pagination 1`] = `
         </div>
       </div>
       <div
-        className="c29 c30 sc-bdVaJa c2"
-      >
-        <p>
-          <em>
-            If you don't see the collective you're searching for:
-          </em>
-        </p>
-      </div>
-      <div
-        className="c27 c2 sc-bdVaJa c2"
-      >
-        <ul
-          className="pagination"
-        >
-          <li
-            className="active"
-          >
-            <a
-              href="?limit=20&offset=0&q=Test"
-              onClick={[Function]}
-            >
-              1
-            </a>
-          </li>
-          <li
-            className=""
-          >
-            <a
-              href="?limit=20&offset=20&q=Test"
-              onClick={[Function]}
-            >
-              2
-            </a>
-          </li>
-          <li
-            className=""
-          >
-            <a
-              href="?limit=20&offset=40&q=Test"
-              onClick={[Function]}
-            >
-              3
-            </a>
-          </li>
-          <li
-            className=""
-          >
-            <a
-              href="?limit=20&offset=60&q=Test"
-              onClick={[Function]}
-            >
-              4
-            </a>
-          </li>
-          <li
-            className=""
-          >
-            <a
-              href="?limit=20&offset=80&q=Test"
-              onClick={[Function]}
-            >
-              5
-            </a>
-          </li>
-        </ul>
-      </div>
-      <div
-        className="c28 c29 sc-bdVaJa c2"
+        className="c15 c16 sc-bdVaJa c4"
       >
         <p>
           <em>
@@ -5788,19 +5499,322 @@ exports[`Search Page renders search results with pagination 1`] = `
         </p>
       </div>
     </div>
-  </main>
-  <div
-    className="c31"
+  </main>,
+  .c3 {
+  box-sizing: border-box;
+}
+
+.c2 {
+  max-width: 1300px;
+  box-sizing: border-box;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 8px;
+}
+
+.c15 {
+  box-sizing: border-box;
+  margin-top: 16px;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
+}
+
+.c16 {
+  box-sizing: border-box;
+  width: 50%;
+  margin-bottom: 16px;
+}
+
+.c1 {
+  max-width: 1300px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c0 {
+  border-top: 1px solid #aaaaaa;
+  bottom: 0px;
+  background-color: white;
+  min-height: 7.5rem;
+  padding: 1rem;
+  width: 100%;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  max-width: 300px;
+  margin-top: 16px;
+  width: 100%;
+}
+
+.c7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: space-evenly;
+  -webkit-justify-content: space-evenly;
+  -ms-flex-pack: space-evenly;
+  justify-content: space-evenly;
+  max-width: 300px;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+  margin-top: 16px;
+  margin-bottom: 16px;
+  width: 100%;
+}
+
+.c6 {
+  color: #6E747A;
+  font-size: 1.4rem;
+  line-height: Paragraph;
+  -webkit-letter-spacing: -0.2px;
+  -moz-letter-spacing: -0.2px;
+  -ms-letter-spacing: -0.2px;
+  letter-spacing: -0.2px;
+  margin: 0px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  text-align: center;
+}
+
+.c17 {
+  color: #C2C6CC;
+  font-size: 1.2rem;
+  line-height: Paragraph;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  margin: 0px;
+  padding-bottom: 16px;
+  text-align: center;
+}
+
+.c19 {
+  list-style: none;
+  margin-bottom: 8px;
+  text-align: center;
+}
+
+.c11 {
+  display: inline-block;
+  vertical-align: -.125em;
+  overflow: hidden;
+}
+
+.c9 {
+  display: inline-block;
+  vertical-align: -.125em;
+  overflow: hidden;
+}
+
+.c12 {
+  display: inline-block;
+  vertical-align: -.125em;
+  overflow: hidden;
+}
+
+.c10 {
+  display: inline-block;
+  vertical-align: -.125em;
+  overflow: hidden;
+}
+
+.c13 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+}
+
+.c8 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: 1px solid #9399a3;
+  border-radius: 50%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 48px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  opacity: 0.6;
+  width: 48px;
+}
+
+.c8:hover,
+.c8:focus {
+  opacity: 1;
+}
+
+.c20 {
+  color: #6e747a;
+  display: block;
+  fontsize: 1.4rem;
+  fontweight: 400;
+  margin: 0;
+  padding: 0;
+}
+
+.c18 {
+  box-sizing: border-box;
+  padding-left: 0px;
+  padding-right: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+@media screen and (min-width:52em) {
+  .c15 {
+    -webkit-order: 2;
+    -ms-flex-order: 2;
+    order: 2;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c16 {
+    width: 25%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c1 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c1 {
+    -webkit-align-items: flex-start;
+    -webkit-box-align: flex-start;
+    -ms-flex-align: flex-start;
+    align-items: flex-start;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c5 {
+    -webkit-box-pack: start;
+    -webkit-justify-content: flex-start;
+    -ms-flex-pack: start;
+    justify-content: flex-start;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c4 {
+    width: 33.33333333333333%;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c7 {
+    -webkit-order: 3;
+    -ms-flex-order: 3;
+    order: 3;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c6 {
+    text-align: left;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c17 {
+    text-align: left;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c19 {
+    text-align: left;
+  }
+}
+
+<div
+    className="c0"
     id="footer"
   >
     <div
-      className="c32 c33 sc-bdVaJa c2"
+      className="c1 c2 sc-bdVaJa c3"
     >
       <div
-        className="c34"
+        className="c4"
       >
         <div
-          className="c35 c2 sc-bdVaJa c2"
+          className="c5 c3 sc-bdVaJa c3"
         >
           <object
             data="/static/images/opencollectivelogo-footer.svg"
@@ -5809,21 +5823,21 @@ exports[`Search Page renders search results with pagination 1`] = `
           />
         </div>
         <p
-          className="c36"
+          className="c6"
         >
           An organization for your community, transparent by design.
         </p>
       </div>
       <div
-        className="c37"
+        className="c7"
       >
         <a
-          className="c38"
+          className="c8"
           href="https://medium.com/open-collective"
         >
           <svg
             aria-hidden="true"
-            className="c39"
+            className="c9"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -5839,12 +5853,12 @@ exports[`Search Page renders search results with pagination 1`] = `
           </svg>
         </a>
         <a
-          className="c38"
+          className="c8"
           href="https://twitter.com/opencollect"
         >
           <svg
             aria-hidden="true"
-            className="c40"
+            className="c10"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -5860,12 +5874,12 @@ exports[`Search Page renders search results with pagination 1`] = `
           </svg>
         </a>
         <a
-          className="c38"
+          className="c8"
           href="https://github.com/opencollective"
         >
           <svg
             aria-hidden="true"
-            className="c41"
+            className="c11"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -5881,12 +5895,12 @@ exports[`Search Page renders search results with pagination 1`] = `
           </svg>
         </a>
         <a
-          className="c38"
+          className="c8"
           href="https://slack.opencollective.com"
         >
           <svg
             aria-hidden="true"
-            className="c42"
+            className="c12"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -5902,12 +5916,12 @@ exports[`Search Page renders search results with pagination 1`] = `
           </svg>
         </a>
         <a
-          className="c38"
+          className="c8"
           href="mailto:info@opencollective.com"
         >
           <svg
             aria-hidden="true"
-            className="c43"
+            className="c13"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -5923,24 +5937,24 @@ exports[`Search Page renders search results with pagination 1`] = `
         </a>
       </div>
       <nav
-        className="c44 c45"
+        className="c14 c15"
       >
         <div
-          className="c46"
+          className="c16"
         >
           <p
-            className="c47"
+            className="c17"
           >
             PLATFORM
           </p>
           <ul
-            className="c48"
+            className="c18"
           >
             <li
-              className="c49"
+              className="c19"
             >
               <a
-                className="c50 "
+                className="c20 "
                 href="/discover"
                 onClick={[Function]}
               >
@@ -5948,20 +5962,20 @@ exports[`Search Page renders search results with pagination 1`] = `
               </a>
             </li>
             <li
-              className="c49"
+              className="c19"
             >
               <a
-                className="c50 "
+                className="c20 "
                 href="/learn-more"
               >
                 How it Works
               </a>
             </li>
             <li
-              className="c49"
+              className="c19"
             >
               <a
-                className="c50 "
+                className="c20 "
                 href="/signin"
                 onClick={[Function]}
               >
@@ -5969,10 +5983,10 @@ exports[`Search Page renders search results with pagination 1`] = `
               </a>
             </li>
             <li
-              className="c49"
+              className="c19"
             >
               <a
-                className="c50 "
+                className="c20 "
                 href="/signin"
                 onClick={[Function]}
               >
@@ -5982,21 +5996,21 @@ exports[`Search Page renders search results with pagination 1`] = `
           </ul>
         </div>
         <div
-          className="c46"
+          className="c16"
         >
           <p
-            className="c47"
+            className="c17"
           >
             JOIN THE MOVEMENT
           </p>
           <ul
-            className="c48"
+            className="c18"
           >
             <li
-              className="c49"
+              className="c19"
             >
               <a
-                className="c50 "
+                className="c20 "
                 href="/create"
                 onClick={[Function]}
               >
@@ -6004,10 +6018,10 @@ exports[`Search Page renders search results with pagination 1`] = `
               </a>
             </li>
             <li
-              className="c49"
+              className="c19"
             >
               <a
-                className="c50 "
+                className="c20 "
                 href="/become-a-sponsor"
                 onClick={[Function]}
               >
@@ -6015,10 +6029,10 @@ exports[`Search Page renders search results with pagination 1`] = `
               </a>
             </li>
             <li
-              className="c49"
+              className="c19"
             >
               <a
-                className="c50 "
+                className="c20 "
                 href="/chapters"
                 onClick={[Function]}
               >
@@ -6028,21 +6042,21 @@ exports[`Search Page renders search results with pagination 1`] = `
           </ul>
         </div>
         <div
-          className="c46"
+          className="c16"
         >
           <p
-            className="c47"
+            className="c17"
           >
             COMMUNITY
           </p>
           <ul
-            className="c48"
+            className="c18"
           >
             <li
-              className="c49"
+              className="c19"
             >
               <a
-                className="c50 "
+                className="c20 "
                 href="/opensource"
                 onClick={[Function]}
               >
@@ -6050,10 +6064,10 @@ exports[`Search Page renders search results with pagination 1`] = `
               </a>
             </li>
             <li
-              className="c49"
+              className="c19"
             >
               <a
-                className="c50 "
+                className="c20 "
                 href="https://github.com/opencollective/opencollective/issues"
                 onClick={[Function]}
               >
@@ -6061,10 +6075,10 @@ exports[`Search Page renders search results with pagination 1`] = `
               </a>
             </li>
             <li
-              className="c49"
+              className="c19"
             >
               <a
-                className="c50 "
+                className="c20 "
                 href="https://slack.opencollective.com"
                 onClick={[Function]}
               >
@@ -6072,10 +6086,10 @@ exports[`Search Page renders search results with pagination 1`] = `
               </a>
             </li>
             <li
-              className="c49"
+              className="c19"
             >
               <a
-                className="c50 "
+                className="c20 "
                 href="https://github.com/opencollective/opencollective/wiki"
                 onClick={[Function]}
               >
@@ -6083,10 +6097,10 @@ exports[`Search Page renders search results with pagination 1`] = `
               </a>
             </li>
             <li
-              className="c49"
+              className="c19"
             >
               <a
-                className="c50 "
+                className="c20 "
                 href="mailto:support@opencollective.com"
                 onClick={[Function]}
               >
@@ -6096,21 +6110,21 @@ exports[`Search Page renders search results with pagination 1`] = `
           </ul>
         </div>
         <div
-          className="c46"
+          className="c16"
         >
           <p
-            className="c47"
+            className="c17"
           >
             COMPANY
           </p>
           <ul
-            className="c48"
+            className="c18"
           >
             <li
-              className="c49"
+              className="c19"
             >
               <a
-                className="c50 "
+                className="c20 "
                 href="/about"
                 onClick={[Function]}
               >
@@ -6118,10 +6132,10 @@ exports[`Search Page renders search results with pagination 1`] = `
               </a>
             </li>
             <li
-              className="c49"
+              className="c19"
             >
               <a
-                className="c50 "
+                className="c20 "
                 href="/faq"
                 onClick={[Function]}
               >
@@ -6129,10 +6143,10 @@ exports[`Search Page renders search results with pagination 1`] = `
               </a>
             </li>
             <li
-              className="c49"
+              className="c19"
             >
               <a
-                className="c50 "
+                className="c20 "
                 href="https://medium.com/open-collective"
                 onClick={[Function]}
               >
@@ -6140,10 +6154,10 @@ exports[`Search Page renders search results with pagination 1`] = `
               </a>
             </li>
             <li
-              className="c49"
+              className="c19"
             >
               <a
-                className="c50 "
+                className="c20 "
                 href="/tos"
                 onClick={[Function]}
               >
@@ -6151,10 +6165,10 @@ exports[`Search Page renders search results with pagination 1`] = `
               </a>
             </li>
             <li
-              className="c49"
+              className="c19"
             >
               <a
-                className="c50 "
+                className="c20 "
                 href="/privacypolicy"
                 onClick={[Function]}
               >
@@ -6165,6 +6179,6 @@ exports[`Search Page renders search results with pagination 1`] = `
         </div>
       </nav>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;

--- a/src/pages/__tests__/__snapshots__/search.test.js.snap
+++ b/src/pages/__tests__/__snapshots__/search.test.js.snap
@@ -5720,6 +5720,73 @@ exports[`Search Page renders search results with pagination 1`] = `
           </em>
         </p>
       </div>
+      <div
+        className="c27 c2 sc-bdVaJa c2"
+      >
+        <ul
+          className="pagination"
+        >
+          <li
+            className="active"
+          >
+            <a
+              href="?limit=20&offset=0&q=Test"
+              onClick={[Function]}
+            >
+              1
+            </a>
+          </li>
+          <li
+            className=""
+          >
+            <a
+              href="?limit=20&offset=20&q=Test"
+              onClick={[Function]}
+            >
+              2
+            </a>
+          </li>
+          <li
+            className=""
+          >
+            <a
+              href="?limit=20&offset=40&q=Test"
+              onClick={[Function]}
+            >
+              3
+            </a>
+          </li>
+          <li
+            className=""
+          >
+            <a
+              href="?limit=20&offset=60&q=Test"
+              onClick={[Function]}
+            >
+              4
+            </a>
+          </li>
+          <li
+            className=""
+          >
+            <a
+              href="?limit=20&offset=80&q=Test"
+              onClick={[Function]}
+            >
+              5
+            </a>
+          </li>
+        </ul>
+      </div>
+      <div
+        className="c28 c29 sc-bdVaJa c2"
+      >
+        <p>
+          <em>
+            If you don't see the collective you're searching for:
+          </em>
+        </p>
+      </div>
     </div>
   </main>
   <div

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -3,6 +3,9 @@ import App, { Container } from 'next/app';
 import Router from 'next/router';
 import NProgress from 'nprogress';
 import { ThemeProvider } from 'styled-components';
+import { ApolloProvider } from 'react-apollo';
+import UserProvider from '../components/UserProvider';
+import withData from '../lib/withData';
 
 import theme from '../constants/theme';
 
@@ -18,7 +21,7 @@ Router.onRouteChangeError = () => NProgress.done();
 
 import { getGoogleMapsScriptUrl, loadGoogleMaps } from '../lib/google-maps';
 
-export default class OpenCollectiveFrontendApp extends App {
+class OpenCollectiveFrontendApp extends App {
   static async getInitialProps({ Component, ctx }) {
     let pageProps = {};
 
@@ -42,13 +45,17 @@ export default class OpenCollectiveFrontendApp extends App {
   }
 
   render() {
-    const { Component, pageProps, scripts } = this.props;
+    const { client, Component, pageProps, scripts } = this.props;
 
     return (
       <Container>
-        <ThemeProvider theme={theme}>
-          <Component {...pageProps} />
-        </ThemeProvider>
+        <ApolloProvider client={client}>
+          <ThemeProvider theme={theme}>
+            <UserProvider>
+              <Component {...pageProps} />
+            </UserProvider>
+          </ThemeProvider>
+        </ApolloProvider>
         {Object.keys(scripts).map(key => (
           <script key={key} type="text/javascript" src={scripts[key]} />
         ))}
@@ -56,3 +63,5 @@ export default class OpenCollectiveFrontendApp extends App {
     );
   }
 }
+
+export default withData(OpenCollectiveFrontendApp);

--- a/src/pages/collective.js
+++ b/src/pages/collective.js
@@ -8,10 +8,9 @@ import PledgedCollective from '../components/PledgedCollective';
 
 import { addCollectiveData } from '../graphql/queries';
 
-import withData from '../lib/withData';
 import withIntl from '../lib/withIntl';
-import withLoggedInUser from '../lib/withLoggedInUser';
 import { ssrNotFoundError } from '../lib/nextjs_utils';
+import { withUser } from '../components/UserProvider';
 
 class CollectivePage extends React.Component {
   static getInitialProps({ req, res, query }) {
@@ -26,7 +25,6 @@ class CollectivePage extends React.Component {
     slug: PropTypes.string, // from getInitialProps, for addCollectiveData
     query: PropTypes.object, // from getInitialProps
     data: PropTypes.object.isRequired, // from withData
-    getLoggedInUser: PropTypes.func.isRequired, // from withLoggedInUser
   };
 
   constructor(props) {
@@ -35,9 +33,7 @@ class CollectivePage extends React.Component {
   }
 
   async componentDidMount() {
-    const { getLoggedInUser, query, data = {} } = this.props;
-    const LoggedInUser = await getLoggedInUser();
-    this.setState({ LoggedInUser });
+    const { LoggedInUser, query, data = {} } = this.props;
     window.OC = window.OC || {};
     window.OC.LoggedInUser = LoggedInUser;
 
@@ -57,8 +53,7 @@ class CollectivePage extends React.Component {
   }
 
   render() {
-    const { data, query } = this.props;
-    const { LoggedInUser } = this.state;
+    const { data, query, LoggedInUser } = this.props;
 
     if (!data.Collective) {
       ssrNotFoundError(data);
@@ -86,4 +81,4 @@ class CollectivePage extends React.Component {
   }
 }
 
-export default withData(withIntl(withLoggedInUser(addCollectiveData(CollectivePage))));
+export default withIntl(withUser(addCollectiveData(CollectivePage)));

--- a/src/pages/collective.js
+++ b/src/pages/collective.js
@@ -55,9 +55,8 @@ class CollectivePage extends React.Component {
   render() {
     const { data, query, LoggedInUser } = this.props;
 
-    if (!data.Collective) {
+    if (!data.Collective && !data.loading) {
       ssrNotFoundError(data);
-      return <ErrorPage LoggedInUser={LoggedInUser} data={data} />;
     }
 
     const collective = data.Collective;
@@ -71,13 +70,15 @@ class CollectivePage extends React.Component {
       return <PledgedCollective {...props} />;
     }
 
-    if (collective.type === 'COLLECTIVE') {
+    if (collective && collective.type === 'COLLECTIVE') {
       return <Collective {...props} />;
     }
 
-    if (['USER', 'ORGANIZATION'].includes(collective.type)) {
+    if (collective && ['USER', 'ORGANIZATION'].includes(collective.type)) {
       return <UserCollective {...props} />;
     }
+
+    return <ErrorPage LoggedInUser={LoggedInUser} data={data} />;
   }
 }
 

--- a/src/pages/collective.js
+++ b/src/pages/collective.js
@@ -55,7 +55,7 @@ class CollectivePage extends React.Component {
   render() {
     const { data, query, LoggedInUser } = this.props;
 
-    if (!data.Collective && !data.loading) {
+    if (!data.Collective) {
       ssrNotFoundError(data);
     }
 

--- a/src/pages/createExpense.js
+++ b/src/pages/createExpense.js
@@ -91,6 +91,7 @@ class CreateExpensePage extends React.Component {
 
         <Body>
           <CollectiveCover
+            key={collective.slug}
             collective={collective}
             href={`/${collective.slug}`}
             cta={{

--- a/src/pages/createOrder.js
+++ b/src/pages/createOrder.js
@@ -291,6 +291,7 @@ class CreateOrderPage extends React.Component {
 
         <Body>
           <CollectiveCover
+            key={collective.slug}
             collective={collective}
             href={collective.path}
             LoggedInUser={LoggedInUser}

--- a/src/pages/createPledge.js
+++ b/src/pages/createPledge.js
@@ -8,9 +8,8 @@ import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 import { themeGet } from 'styled-system';
 
-import withData from '../lib/withData';
-import withLoggedInUser from '../lib/withLoggedInUser';
 import withIntl from '../lib/withIntl';
+import { withUser } from '../components/UserProvider';
 import { addCreateOrderMutation } from '../graphql/mutations';
 import { Link, Router } from '../server/pages';
 import { imagePreview } from '../lib/utils';
@@ -127,19 +126,6 @@ class CreatePledgePage extends React.Component {
     submitting: false,
   };
 
-  async componentDidMount() {
-    const { getLoggedInUser } = this.props;
-    try {
-      const LoggedInUser = getLoggedInUser && (await getLoggedInUser());
-      this.setState({
-        loadingUserLogin: false,
-        LoggedInUser,
-      });
-    } catch (error) {
-      this.setState({ loadingUserLogin: false });
-    }
-  }
-
   async createOrder(event) {
     event.preventDefault();
     const {
@@ -196,8 +182,8 @@ class CreatePledgePage extends React.Component {
   }
 
   render() {
-    const { errorMessage, loadingUserLogin, LoggedInUser, submitting } = this.state;
-    const { data = {}, name, slug } = this.props;
+    const { errorMessage, submitting } = this.state;
+    const { data = {}, name, slug, LoggedInUser, loadingLoggedInUser } = this.props;
 
     const profiles =
       LoggedInUser &&
@@ -221,7 +207,7 @@ class CreatePledgePage extends React.Component {
 
     return (
       <Fragment>
-        <Header title="Make a Pledge" className={loadingUserLogin ? 'loading' : ''} LoggedInUser={LoggedInUser} />
+        <Header title="Make a Pledge" className={loadingLoggedInUser ? 'loading' : ''} LoggedInUser={LoggedInUser} />
         <Body>
           <Container
             mx="auto"
@@ -255,13 +241,13 @@ class CreatePledgePage extends React.Component {
                 email to ask you to fulfill your pledge.
               </P>
 
-              {loadingUserLogin && (
+              {loadingLoggedInUser && (
                 <P my={3} color="black.500">
                   Loading profile...
                 </P>
               )}
 
-              {!loadingUserLogin && !LoggedInUser && (
+              {!loadingLoggedInUser && !LoggedInUser && (
                 <P mt={[5, null, 4]} color="black.700" fontSize="LeadParagraph" lineHeight="LeadParagraph">
                   <Link
                     route="signin"
@@ -275,7 +261,7 @@ class CreatePledgePage extends React.Component {
                 </P>
               )}
 
-              {!loadingUserLogin && LoggedInUser && (
+              {!loadingLoggedInUser && LoggedInUser && (
                 <form onSubmit={this.createOrder.bind(this)}>
                   {!slug && (
                     <Box mb={3}>
@@ -317,7 +303,7 @@ class CreatePledgePage extends React.Component {
                             prepend="https://opencollective.com/"
                             id="slug"
                             name="slug"
-                            defaultValue={slugify(name)}
+                            defaultValue={slugify(name || '')}
                           />
                         </Flex>
                       </Flex>
@@ -586,4 +572,4 @@ const addGraphQL = compose(
 );
 
 export { CreatePledgePage as MockCreatePledgePage };
-export default withIntl(withData(withLoggedInUser(addGraphQL(CreatePledgePage))));
+export default withIntl(withUser(addGraphQL(CreatePledgePage)));

--- a/src/pages/createUpdate.js
+++ b/src/pages/createUpdate.js
@@ -98,6 +98,7 @@ class CreateUpdatePage extends React.Component {
 
         <Body>
           <CollectiveCover
+            key={collective.slug}
             collective={collective}
             href={`/${collective.slug}`}
             title={<FormattedMessage id="updates.new.title" defaultMessage="New update" />}

--- a/src/pages/expense.js
+++ b/src/pages/expense.js
@@ -97,6 +97,7 @@ class ExpensePage extends React.Component {
 
         <Body>
           <CollectiveCover
+            key={collective.slug}
             collective={collective}
             cta={{
               href: `/${collective.slug}#contribute`,

--- a/src/pages/expenses.js
+++ b/src/pages/expenses.js
@@ -116,6 +116,7 @@ class ExpensesPage extends React.Component {
 
         <Body>
           <CollectiveCover
+            key={collective.slug}
             collective={collective}
             cta={{
               href: `/${collective.slug}#contribute`,

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -31,9 +31,7 @@ import Carousel from '../components/Carousel';
 import Currency from '../components/Currency';
 import ErrorPage from '../components/ErrorPage';
 
-import withData from '../lib/withData';
 import withIntl from '../lib/withIntl';
-import withLoggedInUser from '../lib/withLoggedInUser';
 
 const carouselContent = [
   {
@@ -150,7 +148,6 @@ class HomePage extends React.Component {
 
   static propTypes = {
     data: PropTypes.object.isRequired, // from withData
-    getLoggedInUser: PropTypes.func.isRequired, // from withLoggedInUser
   };
 
   state = {
@@ -158,9 +155,6 @@ class HomePage extends React.Component {
   };
 
   async componentDidMount() {
-    const LoggedInUser = await this.props.getLoggedInUser();
-    this.setState({ LoggedInUser });
-
     // separate request to not block showing LoggedInUser
     const { stats } = await fetch(`${getBaseApiUrl()}/homepage`).then(response => response.json());
     this.setState({ stats });
@@ -171,6 +165,7 @@ class HomePage extends React.Component {
       return <ErrorPage data={this.props.data} />;
     }
 
+    const { LoggedInUser } = this.props;
     const {
       topSpenders: { collectives: topSpenders },
       backers: { collectives: backers },
@@ -184,7 +179,6 @@ class HomePage extends React.Component {
       transactions: { transactions },
     } = this.props.data;
     const {
-      LoggedInUser,
       stats: { totalAnnualBudget, totalCollectives, totalDonors },
     } = this.state;
 
@@ -876,4 +870,4 @@ const addHomeData = graphql(query);
 
 export { HomePage as MockHomePage };
 
-export default withData(withLoggedInUser(addHomeData(withIntl(HomePage))));
+export default addHomeData(withIntl(HomePage));

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -7,12 +7,10 @@ import styled from 'styled-components';
 
 import { Link, Router } from '../server/pages';
 
-import Body from '../components/Body';
+import Page from '../components/Page';
 import Button from '../components/Button';
 import CollectiveCard from '../components/CollectiveCard';
 import ErrorPage from '../components/ErrorPage';
-import Footer from '../components/Footer';
-import Header from '../components/Header';
 import LoadingGrid from '../components/LoadingGrid';
 import StyledLink from '../components/StyledLink';
 import Pagination from '../components/Pagination';
@@ -68,11 +66,6 @@ class SearchPage extends React.Component {
     usePledges: false,
   };
 
-  state = {
-    loadingUserLogin: true,
-    LoggedInUser: undefined,
-  };
-
   refetch = event => {
     event.preventDefault();
 
@@ -93,8 +86,6 @@ class SearchPage extends React.Component {
       data: { error, loading, search },
       term = '',
       usePledges,
-      loadingLoggedInUser,
-      LoggedInUser,
     } = this.props;
 
     if (error) {
@@ -102,160 +93,97 @@ class SearchPage extends React.Component {
     }
 
     const { collectives, limit = 20, offset, total = 0 } = search || {};
-
-    const showCollectives = !loading && term.trim() !== '' && !!collectives;
+    const showCollectives = term.trim() !== '' && !!collectives;
 
     return (
-      <div>
-        <Header
-          title="Search"
-          className={loadingLoggedInUser ? 'loading' : ''}
-          LoggedInUser={LoggedInUser}
-          showSearch={false}
-        />
-        <Body>
-          <Container mx="auto" px={3} width={[1, 0.85]} maxWidth={1200}>
-            <Box width={1}>
-              <form method="GET" onSubmit={this.refetch}>
-                <FormGroup controlId="search" bsSize="large">
-                  <ControlLabel className="h1">Search Open Collective</ControlLabel>
-                  <Flex alignItems="flex-end" my={3}>
-                    <SearchInput type="search" name="q" placeholder="open source" defaultValue={term} />
-                    <SearchButton type="submit">
-                      <span className="fa fa-search" />
-                    </SearchButton>
-                  </Flex>
-                </FormGroup>
-              </form>
-            </Box>
-            <Flex justifyContent={['center', 'center', 'flex-start']} flexWrap="wrap">
-              {loading && (
-                <Flex py={3} width={1} justifyContent="center">
-                  <LoadingGrid />
+      <Page title="Search" showSearch={false}>
+        <Container mx="auto" px={3} width={[1, 0.85]} maxWidth={1200}>
+          <Box width={1}>
+            <form method="GET" onSubmit={this.refetch}>
+              <FormGroup controlId="search" bsSize="large">
+                <ControlLabel className="h1">Search Open Collective</ControlLabel>
+                <Flex alignItems="flex-end" my={3}>
+                  <SearchInput type="search" name="q" placeholder="open source" defaultValue={term} />
+                  <SearchButton type="submit">
+                    <span className="fa fa-search" />
+                  </SearchButton>
                 </Flex>
-              )}
-              {showCollectives &&
-                collectives.map(collective => (
-                  <Flex key={collective.slug} my={3} mx={2}>
-                    <CollectiveCard collective={collective} />
-                  </Flex>
-                ))}
+              </FormGroup>
+            </form>
+          </Box>
+          <Flex justifyContent={['center', 'center', 'flex-start']} flexWrap="wrap">
+            {loading && !collectives && (
+              <Flex py={3} width={1} justifyContent="center">
+                <LoadingGrid />
+              </Flex>
+            )}
+            {showCollectives &&
+              collectives.map(collective => (
+                <Flex key={collective.slug} my={3} mx={2}>
+                  <CollectiveCard collective={collective} />
+                </Flex>
+              ))}
 
-              {/* TODO: add suggested collectives when the result is empty */}
-              {showCollectives && collectives.length === 0 && (
-                <Flex py={3} width={1} justifyContent="center" flexDirection="column" alignItems="center">
-                  <p>
-                    <em>
-                      No collectives found matching your query: &quot;
-                      {term}
-                      &quot;
-                    </em>
-                  </p>
-                  {usePledges && (
-                    <Link route="createPledge" params={{ name: term }} passHref>
-                      <StyledLink
-                        display="block"
-                        fontSize="Paragraph"
-                        fontWeight="bold"
-                        maxWidth="220px"
-                        py={2}
-                        px={4}
-                        textAlign="center"
-                        buttonStyle="primary"
-                      >
-                        Make a pledge
-                      </StyledLink>
-                    </Link>
-                  )}
-                </Flex>
+            {/* TODO: add suggested collectives when the result is empty */}
+            {showCollectives && collectives.length === 0 && (
+              <Flex py={3} width={1} justifyContent="center" flexDirection="column" alignItems="center">
+                <p>
+                  <em>
+                    No collectives found matching your query: &quot;
+                    {term}
+                    &quot;
+                  </em>
+                </p>
+                {usePledges && (
+                  <Link route="createPledge" params={{ name: term }} passHref>
+                    <StyledLink
+                      display="block"
+                      fontSize="Paragraph"
+                      fontWeight="bold"
+                      maxWidth="220px"
+                      py={2}
+                      px={4}
+                      textAlign="center"
+                      buttonStyle="primary"
+                    >
+                      Make a pledge
+                    </StyledLink>
+                  </Link>
+                )}
+              </Flex>
+            )}
+          </Flex>
+          {showCollectives && collectives.length !== 0 && total > limit && (
+            <Container display="flex" justifyContent="center" fontSize="Paragraph" my={3}>
+              <Pagination offset={offset} total={total} limit={limit} />
+            </Container>
+          )}
+
+          {showCollectives && collectives.length !== 0 && (
+            <Flex py={3} width={1} justifyContent="center" flexDirection="column" alignItems="center">
+              <p>
+                <em>If you don&apos;t see the collective you&apos;re searching for:</em>
+              </p>
+              {usePledges && (
+                <Link route="createPledge" params={{ name: term }} passHref>
+                  <StyledLink
+                    display="block"
+                    fontSize="Paragraph"
+                    fontWeight="bold"
+                    maxWidth="220px"
+                    py={2}
+                    px={4}
+                    textAlign="center"
+                    buttonStyle="primary"
+                  >
+                    Make a pledge
+                  </StyledLink>
+                </Link>
               )}
             </Flex>
-            {showCollectives && collectives.length !== 0 && total > limit && (
-              <Container display="flex" justifyContent="center" fontSize="Paragraph" my={3}>
-                <Pagination offset={offset} total={total} limit={limit} />
-              </Container>
-            )}
-
-            {showCollectives && collectives.length !== 0 && (
-              <Flex py={3} width={1} justifyContent="center" flexDirection="column" alignItems="center">
-                <p>
-                  <em>If you don&apos;t see the collective you&apos;re searching for:</em>
-                </p>
-                {usePledges && (
-                  <Link route="createPledge" params={{ name: term }} passHref>
-                    <StyledLink
-                      display="block"
-                      fontSize="Paragraph"
-                      fontWeight="bold"
-                      maxWidth="220px"
-                      py={2}
-                      px={4}
-                      textAlign="center"
-                      buttonStyle="primary"
-                    >
-                      Make a pledge
-                    </StyledLink>
-                  </Link>
-                )}
-              </Flex>
-            )}
-            {showCollectives && collectives.length !== 0 && total > limit && (
-              <Flex justifyContent="center">
-                <ul className="pagination">
-                  {Array(Math.ceil(total / limit))
-                    .fill(1)
-                    .map((n, i) => (
-                      <li
-                        key={i * limit}
-                        className={classNames({
-                          active: i * limit === offset,
-                        })}
-                      >
-                        <Link
-                          href={{
-                            query: {
-                              limit,
-                              offset: i * limit,
-                              q: term,
-                            },
-                          }}
-                        >
-                          <a>{`${n + i}`}</a>
-                        </Link>
-                      </li>
-                    ))}
-                </ul>
-              </Flex>
-            )}
-
-            {showCollectives && collectives.length !== 0 && (
-              <Flex py={3} width={1} justifyContent="center" flexDirection="column" alignItems="center">
-                <p>
-                  <em>If you don&apos;t see the collective you&apos;re searching for:</em>
-                </p>
-
-                {usePledges && (
-                  <Link route="createPledge" params={{ name: term }} passHref>
-                    <StyledLink
-                      display="block"
-                      fontSize="Paragraph"
-                      fontWeight="bold"
-                      maxWidth="220px"
-                      py={2}
-                      px={4}
-                      textAlign="center"
-                      buttonStyle="primary"
-                    >
-                      Make a pledge
-                    </StyledLink>
-                  </Link>
-                )}
-              </Flex>
-            )}
-          </Container>
-        </Body>
-        <Footer />
-      </div>
+          )}
+        </Container>
+      </Page>
     );
   }
 }

--- a/src/pages/signin.js
+++ b/src/pages/signin.js
@@ -2,16 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
+import { Router } from '../server/pages';
+
 import Header from '../components/Header';
 import Body from '../components/Body';
 import Footer from '../components/Footer';
 import ErrorPage from '../components/ErrorPage';
 import SignInForm from '../components/SignInForm';
 
-import * as api from '../lib/api';
 import { isValidUrl } from '../lib/utils';
 
 import withIntl from '../lib/withIntl';
+import { withUser } from '../components/UserProvider';
 
 class SigninPage extends React.Component {
   static getInitialProps({ query: { token, next } }) {
@@ -32,14 +34,9 @@ class SigninPage extends React.Component {
 
   async componentDidMount() {
     if (this.props.token) {
-      const { error, token } = await api.refreshToken(this.props.token);
-      if (error) {
-        this.setState({ error });
-        console.log(error);
-      } else {
-        window.localStorage.setItem('accessToken', token);
-        window.location.replace(this.props.next || '/');
-      }
+      window.localStorage.setItem('accessToken', this.props.token);
+      await this.props.login();
+      Router.replaceRoute(this.props.next || '/');
     }
   }
 
@@ -82,4 +79,4 @@ class SigninPage extends React.Component {
   }
 }
 
-export default withIntl(SigninPage);
+export default withIntl(withUser(SigninPage));

--- a/src/pages/transactions.js
+++ b/src/pages/transactions.js
@@ -61,7 +61,13 @@ class TransactionsPage extends React.Component {
         />
 
         <Body>
-          <CollectiveCover collective={collective} href={`/${collective.slug}`} cta={cta} LoggedInUser={LoggedInUser} />
+          <CollectiveCover
+            collective={collective}
+            href={`/${collective.slug}`}
+            cta={cta}
+            LoggedInUser={LoggedInUser}
+            key={collective.slug}
+          />
 
           <div className="content">
             <TransactionsWithData

--- a/src/pages/update.js
+++ b/src/pages/update.js
@@ -69,6 +69,7 @@ class UpdatePage extends React.Component {
         <Body>
           <CollectiveCover
             collective={collective}
+            key={collective.slug}
             cta={{
               href: '#contribute',
               label: intl.formatMessage(this.messages['collective.contribute']),

--- a/src/pages/updates.js
+++ b/src/pages/updates.js
@@ -64,6 +64,7 @@ class UpdatesPage extends React.Component {
               href: `/${collective.slug}#contribute`,
               label: 'contribute',
             }}
+            key={collective.slug}
           />
 
           <div className="content">


### PR DESCRIPTION
A work-in-progress feature and refactor to reduce the boilerplate necessary to authenticate and share the current `LoggedInUser` state among pages and components. 

With this PR,  the [React Context API](https://reactjs.org/docs/context.html) is used to create some global state with the LoggedInUser object and some helper methods like `logout` and `login`. A `withUser` higher-order-component is exported from the `UserProvider` module to pass the LoggedInUser context to any component that needs it, rather than passing it through many layers of parent components. 

This pattern allows the app to keeps the LoggedInUser state in memory between route changes and not checking `localStorage` for the cached object on each page. The app can instantly `logout` and remove LoggedInUser state without doing a full page reload (as is the current implementation). The app can also listen for changes in the localStorage state in one place and update the LoggedInUser between any open tab, which is mostly a convenience but demonstrates the advantage of managing that global state in one place. 

As part of the refactor, it was necessary to wrap the `_app.js` page component in the `ApolloProvider`. This has a bonus advantage of not wrapping every individual page and component in the `withData` helper as the Apollo client context is available at the root of the app. (I'd like to do the same with the `IntlProvider` in a future update as well). 

Overall, it's an extensive refactor but will result in an improvement in user and developer experience of this project.

Tracking issue for continued work: https://github.com/opencollective/opencollective/issues/1484

Footnotes:

- I learned about using the `apollo-link-context` package from this helpful tutorial -> https://www.howtographql.com/react-apollo/5-authentication/
- The use of `resetStore` on the Apollo client is explained here -> https://www.apollographql.com/docs/react/recipes/authentication.html#login-logout