### PR TITLE
Return a 404 error when fetching a collective that don't exists

### DIFF
--- a/cypress/integration/0-ssr-errors.js
+++ b/cypress/integration/0-ssr-errors.js
@@ -1,0 +1,53 @@
+const WEBSITE_URL =
+  process.env.WEBSITE_URL ||
+  'http://localhost:3000' ||
+  'https://staging.opencollective.com';
+
+const notFoundSlug = 'a-collective-that-does-not-exist';
+const notFoundURL = `${WEBSITE_URL}/${notFoundSlug}`;
+
+it("fetching a collective page that doesn't exist returns a 404", () => {
+  cy.request({ url: notFoundURL, failOnStatusCode: false }).then(resp => {
+    expect(resp.status).to.eq(404);
+  });
+});
+
+describe('the NotFound page when logged out', () => {
+  before(() => {
+    cy.visit(notFoundURL, { failOnStatusCode: false });
+  });
+
+  it('show the proper error message', () => {
+    cy.get('.NotFound').contains('Not found');
+  });
+
+  it('has a nice comforting little buddy', () => {
+    cy.get('.NotFound .shrug').should('contain', '¯\\\\_(ツ)_/¯');
+  });
+
+  it('includes a button to search for the collective', () => {
+    cy.contains('search for')
+      .should('contain', notFoundSlug)
+      .click();
+
+    // Search page shows an error in tests and dev so we don't have an
+    // observable element to watch, fallback on cy.wait
+    cy.wait(1000);
+    cy.location().should(location => {
+      expect(location.pathname).to.equal('/search');
+      expect(location.search).to.equal(`?q=${notFoundSlug}`);
+    });
+  });
+});
+
+describe('the NotFound page when logged in', () => {
+  before(() => {
+    cy.visit(`${WEBSITE_URL}/signin?next=/${notFoundSlug}`);
+    cy.get('.inputField.email input').type('testuser+admin@opencollective.com');
+    cy.get('.LoginForm button').click();
+  });
+
+  it('has the user properly logged in', () => {
+    cy.get('.LoginTopBarProfileButton-name').should('contain', 'testuseradmin');
+  });
+});

--- a/src/lib/nextjs_utils.js
+++ b/src/lib/nextjs_utils.js
@@ -1,0 +1,22 @@
+/**
+ * Define some helpers to deal with NextJS.
+ */
+
+/**
+ * When called from server-side code, this function throws an error that
+ * NextJS will translate to a 404, rendering the `src/page/_error.js` with
+ * the proper status code set.
+ *
+ * When called from client-side, this function does nothing.
+ *
+ * Check [this link](https://github.com/zeit/next.js/issues/4451#issuecomment-391116035)
+ * for more information.
+ *
+ */
+export const ssrNotFoundError = () => {
+  if (!process.browser) {
+    const err = new Error('NOT_FOUND');
+    err.code = 'ENOENT';
+    throw err;
+  }
+};

--- a/src/pages/_error.js
+++ b/src/pages/_error.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import withData from '../lib/withData';
+import withLoggedInUser from '../lib/withLoggedInUser';
+import withIntl from '../lib/withIntl';
+import ErrorPage from '../components/ErrorPage';
+
+/**
+ * This page is shown when NextJS triggers a critical error during server-side
+ * rendering, typically 404 errors.
+ */
+class Error extends React.Component {
+  static propTypes = {
+    statusCode: PropTypes.number.isRequired,
+    url: PropTypes.string,
+    err: PropTypes.object,
+  };
+
+  static getInitialProps({ res, err, req }) {
+    const statusCode = res ? res.statusCode : err ? err.statusCode : null;
+    return { statusCode, err, url: req && req.originalUrl };
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  async componentDidMount() {
+    const { getLoggedInUser } = this.props;
+    const LoggedInUser = await getLoggedInUser();
+    this.setState({ LoggedInUser });
+  }
+
+  render() {
+    const { statusCode, url } = this.props;
+    const { LoggedInUser } = this.state;
+
+    if (statusCode === 404 && url) {
+      const slugRegex = /^\/([^/?]+)/;
+      const parsedUrl = slugRegex.exec(url);
+      const errorData = parsedUrl && {
+        error: { message: 'No collective found' },
+        variables: { slug: parsedUrl[1] },
+      };
+
+      return <ErrorPage LoggedInUser={LoggedInUser} data={errorData} />;
+    }
+    return <ErrorPage LoggedInUser={LoggedInUser} />;
+  }
+}
+
+export default withData(withIntl(withLoggedInUser(Error)));

--- a/src/pages/collective.js
+++ b/src/pages/collective.js
@@ -11,6 +11,7 @@ import { addCollectiveData } from '../graphql/queries';
 import withData from '../lib/withData';
 import withIntl from '../lib/withIntl';
 import withLoggedInUser from '../lib/withLoggedInUser';
+import { ssrNotFoundError } from '../lib/nextjs_utils';
 
 class CollectivePage extends React.Component {
   static getInitialProps({ req, res, query }) {
@@ -60,6 +61,7 @@ class CollectivePage extends React.Component {
     const { LoggedInUser } = this.state;
 
     if (!data.Collective) {
+      ssrNotFoundError(data);
       return <ErrorPage LoggedInUser={LoggedInUser} data={data} />;
     }
 


### PR DESCRIPTION
Return a proper 404 error by implementing the (undocumented) solution proposed [here](https://github.com/zeit/next.js/issues/4451#issuecomment-391336668).

* It works with curl:
```
curl -I http://localhost:3000/the-truth
HTTP/1.1 404 Not Found
```

* And the error page mimics the behaviour we would have if navigating to the route client-side:

![Browser preview](https://user-images.githubusercontent.com/1556356/48648573-37a84e80-e9f0-11e8-9b9c-544bfe540875.png)

---
:information_source: Fix https://github.com/opencollective/opencollective/issues/1369