### PR TITLE
Disable fetches in withFallbackImage

### DIFF
--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -40,15 +40,13 @@ StyledAvatar.defaultProps = {
 };
 
 const Avatar = ({ src, type = 'USER', radius, name, ...styleProps }) => {
+  const style = {};
+  // Avoid setting null/undefined background images
+  if (src) {
+    style.backgroundImage = `url(${src})`;
+  }
   return (
-    <StyledAvatar
-      size={radius}
-      type={type}
-      style={{
-        backgroundImage: `url(${src})`,
-      }}
-      {...styleProps}
-    >
+    <StyledAvatar size={radius} type={type} style={style} {...styleProps}>
       {!src && type === 'USER' && name && <span>{getInitials(name)}</span>}
     </StyledAvatar>
   );

--- a/src/lib/withFallbackImage.js
+++ b/src/lib/withFallbackImage.js
@@ -3,6 +3,8 @@ import fetch from 'cross-fetch';
 import { defaultImage } from '../constants/collectives';
 import { getDomain, imagePreview } from './utils';
 
+const fallbackFetchEnabled = false;
+
 export default ChildComponent =>
   withState('src', 'setSrc', ({ src }) => src)(
     ({
@@ -25,7 +27,7 @@ export default ChildComponent =>
         src = `https://logo.clearbit.com/${getDomain(website)}`;
       }
 
-      if (src && src !== fallback) {
+      if (fallbackFetchEnabled && src && src !== fallback) {
         // due to CORS issues, we should use the Image error event in the browser
         if (process.browser) {
           const img = new Image();
@@ -46,10 +48,16 @@ export default ChildComponent =>
         }
       }
 
-      const image = imagePreview(src, fallback, {
-        width: radius,
-        height,
-      });
+      let image;
+      if (!src) {
+        image = fallback;
+      } else {
+        image = imagePreview(src, fallback, {
+          width: radius,
+          height,
+        });
+      }
+
       const childProps = {
         ...props,
         src: image,

--- a/src/pages/__tests__/__snapshots__/search.test.js.snap
+++ b/src/pages/__tests__/__snapshots__/search.test.js.snap
@@ -5898,7 +5898,6 @@ exports[`Search Page renders search results with pagination 1`] = `
                   >
                     <img
                       className="jsx-3454192051 logo"
-                      src={null}
                       style={
                         Object {
                           "maxHeight": 65,


### PR DESCRIPTION
- on the backend: we're fetching for each page, each avatar in high res from its origin, this is too much networking (at least) and memory usage (perhaps)
- on the frontend: we're fetching each images in high res, which is ruining all past performance improvements regarding images

We need to come up with a better solution.