### PR TITLE
Use new PaymentMethod labels on Subscription cards

### DIFF
--- a/src/components/__tests__/PaymentMethodChooser.test.js
+++ b/src/components/__tests__/PaymentMethodChooser.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { IntlProvider } from 'react-intl';
+import { merge } from 'lodash';
 
 import PaymentMethodChooser from '../PaymentMethodChooser';
 
@@ -14,6 +15,7 @@ describe('PaymentMethodChooser.test.js', () => {
 
   const defaultPaymentMethod = {
     service: 'stripe',
+    type: 'creditcard',
     name: '4242',
     data: { brand: 'VISA', expMonth: '01', expYear: '2020' },
   };
@@ -21,6 +23,7 @@ describe('PaymentMethodChooser.test.js', () => {
   const defaultValues = {
     paymentMethodInUse: {
       service: 'stripe',
+      type: 'creditcard',
       name: '5555',
       data: { brand: 'VISA', expMonth: '02', expYear: '2021' },
     },
@@ -41,7 +44,7 @@ describe('PaymentMethodChooser.test.js', () => {
     const component = mountComponent(values);
 
     expect(component.find('.paymentmethod-info').text()).toContain(
-      '(credit card info not available)',
+      '(payment method info not available)',
     );
   });
 
@@ -49,7 +52,35 @@ describe('PaymentMethodChooser.test.js', () => {
     const component = mountComponent(defaultValues);
 
     expect(component.find('.paymentmethod-info').text()).toContain(
-      '💳   VISA ***5555 (Exp: 02/2021)',
+      '💳\xA0\xA0VISA **** 5555 - exp 02/2021',
+    );
+  });
+
+  it('displays American Express cards with an abbreviated label', () => {
+    const component = mountComponent(
+      merge(defaultValues, {
+        paymentMethodInUse: { data: { brand: 'American Express' } },
+      }),
+    );
+
+    expect(component.find('.paymentmethod-info').text()).toContain(
+      '💳\xA0\xA0AMEX **** 5555 - exp 02/2021',
+    );
+  });
+
+  it('truncate brand if too long', () => {
+    const component = mountComponent(
+      merge(defaultValues, {
+        paymentMethodInUse: {
+          data: {
+            brand: 'The bank of the people who like long descriptions',
+          },
+        },
+      }),
+    );
+
+    expect(component.find('.paymentmethod-info').text()).toContain(
+      '💳\xA0\xA0THE BANK... **** 5555 - exp 02/2021',
     );
   });
 

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -685,19 +685,25 @@ export const getSubscriptionsQuery = gql`
         paymentMethod {
           id
           uuid
-          data
+          currency
           name
           service
           type
+          data
+          balance
+          expiryDate
         }
       }
       paymentMethods {
         id
         uuid
+        currency
+        name
         service
         type
         data
-        name
+        balance
+        expiryDate
       }
       ... on User {
         memberOf(limit: 60) {

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -506,7 +506,7 @@
   "tier.order.contribution": "Contribution",
   "tier.order.ticket": "Ticket",
   "order.error.hostRequired": "This collective doesn't have a host that can receive money on their behalf",
-  "paymentMethod.add": "Add credit card",
+  "paymentMethod.add": "New credit card",
   "paymentMethod.cancel": "Cancel",
   "paymentMethod.success": "Successfully added!",
   "paymentMethod.expire": "Exp",


### PR DESCRIPTION
I've also imported two improvements to PM made in this component:
1. Show abbreviated names for brand if too long
2. Show `****` before name for CC so we properly understand they're the last digits of CC number

![Preview](https://user-images.githubusercontent.com/1556356/48904925-5c714b80-ee60-11e8-903e-cc711c396fb6.png)

---

:information_source: Resolve https://github.com/opencollective/opencollective/issues/1462