### PR TITLE
Disable errors logging in Error component for collectives not found

### DIFF
--- a/src/components/ErrorPage.js
+++ b/src/components/ErrorPage.js
@@ -16,6 +16,8 @@ class ErrorPage extends React.Component {
     data: PropTypes.object, // we can pass the data object of Apollo to detect and handle GraphQL errors
     intl: PropTypes.object.isRequired,
     LoggedInUser: PropTypes.object,
+    /** Define if error should be logged to console. Default: true */
+    log: PropTypes.bool,
   };
 
   constructor(props) {
@@ -50,9 +52,9 @@ class ErrorPage extends React.Component {
   }
 
   getErrorComponent() {
-    const { message, data, loading } = this.props;
+    const { message, data, loading, log = true } = this.props;
 
-    if (get(data, 'error')) {
+    if (log && get(data, 'error')) {
       if (data.error.message !== 'Test error') {
         // That might not be the right place to log the error. Remove?
         console.error(data.error);

--- a/src/pages/_error.js
+++ b/src/pages/_error.js
@@ -45,7 +45,9 @@ class Error extends React.Component {
         variables: { slug: parsedUrl[1] },
       };
 
-      return <ErrorPage LoggedInUser={LoggedInUser} data={errorData} />;
+      return (
+        <ErrorPage LoggedInUser={LoggedInUser} data={errorData} log={false} />
+      );
     }
     return <ErrorPage LoggedInUser={LoggedInUser} />;
   }


### PR DESCRIPTION
This error is already logged in the browser by default (like any 404) so there's no need for manually logging.