### PR TITLE
Pin babel-plugin-styled-components to 1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "babel-eslint": "^10.0.1",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-react-intl": "^3.0.1",
-    "babel-plugin-styled-components": "^1.8.0",
+    "babel-plugin-styled-components": "1.8.0",
     "commitizen": "^3.0.4",
     "cypress": "3.1.2",
     "cz-conventional-changelog": "^2.1.0",


### PR DESCRIPTION
Fix: https://github.com/opencollective/opencollective-frontend/issues/1099