### PR TITLE
Add missing external link icon on pledged collective

### DIFF
--- a/src/components/PledgedCollective.js
+++ b/src/components/PledgedCollective.js
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import { ExternalLinkAlt } from 'styled-icons/fa-solid/ExternalLinkAlt.cjs';
 
 import { Link } from '../server/pages';
 
@@ -61,7 +62,7 @@ class PledgedCollective extends React.Component {
 
               <Box mb={4} mt={3}>
                 <StyledLink href={collective.website} color="primary.500" fontSize="Caption">
-                  <img src="/static/icons/external-link.svg" alt="link icon" /> {collective.website}
+                  <ExternalLinkAlt size="1em" /> {collective.website}
                 </StyledLink>
               </Box>
             </Flex>


### PR DESCRIPTION
Not sure how I missed this one, but better later than never.

![selection_811](https://user-images.githubusercontent.com/1556356/49172998-c5663100-f342-11e8-840e-2b305896a259.png)