### PR TITLE
Update styled-components && grid-styled

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,11 +12,7 @@
     ["react-intl", {
       "messagesDir": "./build/messages/"
     }],
-    ["styled-components", {
-      "ssr": true,
-      "displayName": true,
-      "preprocess": false
-    }]
+    "styled-components"
   ],
   "env": {
     "development" : {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1273,6 +1273,24 @@
         }
       }
     },
+    "@emotion/is-prop-valid": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.6.8.tgz",
+      "integrity": "sha512-IMSL7ekYhmFlILXcouA6ket3vV7u9BqStlXzbKOF9HBtpUPMMlHU+bBxrLOa2NvleVwNIxeq/zL8LafLbeUXcA==",
+      "requires": {
+        "@emotion/memoize": "^0.6.6"
+      }
+    },
+    "@emotion/memoize": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
+      "integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ=="
+    },
+    "@emotion/unitless": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.3.tgz",
+      "integrity": "sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg=="
+    },
     "@iamstarkov/listr-update-renderer": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@iamstarkov/listr-update-renderer/-/listr-update-renderer-0.4.1.tgz",
@@ -1291,7 +1309,7 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
           "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
           "dev": true
         },
@@ -1303,7 +1321,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -1370,7 +1388,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -1532,6 +1550,14 @@
       "integrity": "sha512-TK5JytA7qk2ZejklCBKCZ8iRe9/8oPtW5xRK5d9pNnXeFZlXXlQ+Pf48q7sdI7vSL9k3EGU1xWI+kQVkIGgI8A==",
       "requires": {
         "methods": "^1.1.2"
+      }
+    },
+    "@rebass/grid": {
+      "version": "6.0.0-4",
+      "resolved": "https://registry.npmjs.org/@rebass/grid/-/grid-6.0.0-4.tgz",
+      "integrity": "sha512-a+bnjwNLoborCUtzHPo8KAJKFq/f1zREA1X61sF53229st3eifZ/51dwzmEPSJV+K/BVkH9N/8G5W8JjHcgQ4A==",
+      "requires": {
+        "styled-system": "^3.1.6"
       }
     },
     "@samverschueren/stream-to-observable": {
@@ -2872,7 +2898,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.8.0.tgz",
       "integrity": "sha512-PcrdbXFO/9Plo9JURIj8G0Dsz+Ct8r+NvjoLh6qPt8Y/3EIAj1gHGW1ocPY1IkQbXZLBEZZSRBAxJem1KFdBXg==",
-      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "lodash": "^4.17.10"
@@ -3430,7 +3455,7 @@
       "dependencies": {
         "callsites": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         }
@@ -6567,13 +6592,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6586,18 +6609,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6700,8 +6720,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6711,7 +6730,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6724,20 +6742,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6754,7 +6769,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6827,8 +6841,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6838,7 +6851,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6944,7 +6956,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7256,14 +7267,6 @@
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.0.tgz",
       "integrity": "sha512-9FD6cw976TLLf9WYIUPCaaTpniawIjHWZSwIRZSjrfufJamcXbVVYfN2TWvJYbw0Xf2JjYbl1/f2+wDnBVw3/w=="
     },
-    "grid-styled": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/grid-styled/-/grid-styled-5.0.2.tgz",
-      "integrity": "sha512-kM3kewM77sBifQLZUZD9meoMSXOZE9ArxxM9XZ6qtwb4B2ylHYHH9Ylkt96hDMHA32J+LoEeYoHAvn6+j4fn9Q==",
-      "requires": {
-        "system-components": "^3.0.0"
-      }
-    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -7352,7 +7355,8 @@
     "has-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -9642,7 +9646,7 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
           "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
           "dev": true
         },
@@ -10056,7 +10060,7 @@
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
@@ -10179,7 +10183,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -10820,6 +10824,11 @@
       "requires": {
         "mimic-fn": "^1.0.0"
       }
+    },
+    "memoize-one": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
+      "integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -16653,6 +16662,11 @@
           "version": "2.5.5",
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
           "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
         }
       }
     },
@@ -18326,34 +18340,39 @@
       }
     },
     "styled-components": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-3.4.10.tgz",
-      "integrity": "sha512-TA8ip8LoILgmSAFd3r326pKtXytUUGu5YWuqZcOQVwVVwB6XqUMn4MHW2IuYJ/HAD81jLrdQed8YWfLSG1LX4Q==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.1.1.tgz",
+      "integrity": "sha512-UzT/qyoOyKpYooeLdwKrPHZ85R8KWl8i0fbyH9I3z6B2WT9uGDCV7J4kbfKsBeSWFD9EytBriEODOkybcUFD/Q==",
       "requires": {
-        "buffer": "^5.0.3",
-        "css-to-react-native": "^2.0.3",
-        "fbjs": "^0.8.16",
-        "hoist-non-react-statics": "^2.5.0",
+        "@emotion/is-prop-valid": "^0.6.8",
+        "@emotion/unitless": "^0.7.0",
+        "babel-plugin-styled-components": ">= 1",
+        "css-to-react-native": "^2.2.2",
+        "memoize-one": "^4.0.0",
         "prop-types": "^15.5.4",
-        "react-is": "^16.3.1",
+        "react-is": "^16.6.0",
         "stylis": "^3.5.0",
         "stylis-rule-sheet": "^0.0.10",
-        "supports-color": "^3.2.3"
+        "supports-color": "^5.5.0"
       },
       "dependencies": {
-        "buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
-        "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        "react-is": {
+          "version": "16.6.3",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.3.tgz",
+          "integrity": "sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA=="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },
@@ -18439,6 +18458,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
       "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+      "dev": true,
       "requires": {
         "has-flag": "^1.0.0"
       }
@@ -18453,14 +18473,6 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
       "dev": true
-    },
-    "system-components": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/system-components/-/system-components-3.0.0.tgz",
-      "integrity": "sha512-97jmSbZlDE6BBygRz72bU4hlSaJH15ypm7ZRWvdRp6c19XJFlnxswKfuaEMx0OKJdRkueF2DRF/rjA/wJ7V/IQ==",
-      "requires": {
-        "styled-system": "^3.0.1"
-      }
     },
     "table": {
       "version": "4.0.3",
@@ -19606,7 +19618,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "graphql": "14.0.2",
     "graphql-request": "1.8.2",
     "graphql-tag": "2.10.0",
-    "grid-styled": "5.0.2",
+    "@rebass/grid": "6.0.0-4",
     "html-pdf": "2.2.0",
     "intl": "1.2.5",
     "jsonwebtoken": "8.4.0",
@@ -84,7 +84,7 @@
     "sanitize-html": "1.19.1",
     "showdown": "1.9.0",
     "slugify": "1.3.3",
-    "styled-components": "3.4.10",
+    "styled-components": "4.1.1",
     "styled-icons": "3.7.0",
     "styled-jsx": "3.1.0",
     "styled-system": "3.1.11",
@@ -170,7 +170,9 @@
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/test/mocks/fileMock.js",
       "\\.(css|less)$": "<rootDir>/test/mocks/styleMock.js"
     },
-    "setupFiles": ["<rootDir>/test/setup.js"]
+    "setupFiles": [
+      "<rootDir>/test/setup.js"
+    ]
   },
   "config": {
     "commitizen": {
@@ -195,7 +197,13 @@
     }
   },
   "lint-staged": {
-    "*.js": ["prettier --write", "git add"]
+    "*.js": [
+      "prettier --write",
+      "git add"
+    ]
   },
-  "cacheDirectories": [".cache", "node_modules"]
+  "cacheDirectories": [
+    ".cache",
+    "node_modules"
+  ]
 }

--- a/src/apps/expenses/components/AmountCurrency.js
+++ b/src/apps/expenses/components/AmountCurrency.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Span } from '../../../components/Text';
-import { Box, Flex } from 'grid-styled';
+import { Box, Flex } from '@rebass/grid';
 import Currency from '../../../components/Currency';
 
 const AmountCurrency = ({ abbreviate = false, currency, precision = 0, amount, ...styles }) => (

--- a/src/apps/expenses/components/Transaction.js
+++ b/src/apps/expenses/components/Transaction.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Flex } from 'grid-styled';
+import { Flex } from '@rebass/grid';
 import { FormattedMessage } from 'react-intl';
 
 import Avatar from '../../../components/Avatar';

--- a/src/apps/expenses/components/Transactions.js
+++ b/src/apps/expenses/components/Transactions.js
@@ -10,7 +10,7 @@ import Transaction from './Transaction';
 import TransactionsExportPopoverAndButton from './TransactionsExportPopoverAndButton';
 import DownloadInvoicesPopOver from './DownloadInvoicesPopOver';
 
-import { Box } from 'grid-styled';
+import { Box } from '@rebass/grid';
 
 class Transactions extends React.Component {
   static propTypes = {

--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { backgroundImage, borders, borderColor, size, themeGet } from 'styled-system';
 import tag from 'clean-tag';
-import { Flex } from 'grid-styled';
+import { Flex } from '@rebass/grid';
 import withFallbackImage from '../lib/withFallbackImage';
 
 const getInitials = name => name.split(' ').reduce((result, value) => (result += value.slice(0, 1).toUpperCase()), '');

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { borders, borderRadius } from 'styled-system';
-import { Flex } from 'grid-styled';
+import { Flex } from '@rebass/grid';
 
 const computeBorderRadius = ({ index, itemCount }) => {
   if (index === 0) {

--- a/src/components/CollectiveStatsCard.js
+++ b/src/components/CollectiveStatsCard.js
@@ -6,7 +6,7 @@ import { defaultImage, defaultBackgroundImage } from '../constants/collectives';
 
 import { imagePreview } from '../lib/utils';
 
-import { Flex } from 'grid-styled';
+import { Flex } from '@rebass/grid';
 import Container from './Container';
 import { P, Span } from './Text';
 import { Link } from '../server/pages';

--- a/src/components/CreateHostForm.js
+++ b/src/components/CreateHostForm.js
@@ -7,7 +7,7 @@ import { groupBy } from 'lodash';
 import { capitalize } from '../lib/utils';
 import InputField from './InputField';
 import colors from '../constants/colors';
-import { Flex, Box } from 'grid-styled';
+import { Flex, Box } from '@rebass/grid';
 import CreateOrganizationForm from './CreateOrganizationForm';
 import { Button } from 'react-bootstrap';
 

--- a/src/components/CreateHostFormWithData.js
+++ b/src/components/CreateHostFormWithData.js
@@ -6,7 +6,7 @@ import { graphql, compose } from 'react-apollo';
 import gql from 'graphql-tag';
 import LoadingGrid from './LoadingGrid';
 import CreateHostForm from './CreateHostForm';
-import { Flex } from 'grid-styled';
+import { Flex } from '@rebass/grid';
 
 class CreateHostFormWithData extends React.Component {
   static propTypes = {

--- a/src/components/EditCollectiveForm.js
+++ b/src/components/EditCollectiveForm.js
@@ -15,7 +15,7 @@ import { Button } from 'react-bootstrap';
 import { Link } from '../server/pages';
 import { get } from 'lodash';
 import styled, { css } from 'styled-components';
-import { Flex, Box } from 'grid-styled';
+import { Flex, Box } from '@rebass/grid';
 
 const selectedStyle = css`
   background-color: #eee;

--- a/src/components/EditHost.js
+++ b/src/components/EditHost.js
@@ -5,7 +5,7 @@ import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import withIntl from '../lib/withIntl';
 import styled from 'styled-components';
-import { Flex, Box } from 'grid-styled';
+import { Flex, Box } from '@rebass/grid';
 import { Radio } from '@material-ui/core';
 import CreateHostFormWithData from './CreateHostFormWithData';
 import HostsWithData from './HostsWithData';

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Box, Flex } from 'grid-styled';
+import { Box, Flex } from '@rebass/grid';
 import { Github } from 'styled-icons/fa-brands/Github.cjs';
 import { MediumM } from 'styled-icons/fa-brands/MediumM.cjs';
 import { Slack } from 'styled-icons/fa-brands/Slack.cjs';
@@ -121,7 +121,7 @@ class Footer extends React.Component {
               <Mail size={19} color="#9399A3" />
             </SocialLink>
           </Container>
-          <Flex is="nav" flexWrap="wrap" justifyContent="center" mt={3} flex="1 1 auto" order={['3', null, '2']}>
+          <Flex as="nav" flexWrap="wrap" justifyContent="center" mt={3} flex="1 1 auto" order={['3', null, '2']}>
             {Object.keys(navigation).map(key => (
               <Box key={key} width={[0.5, null, 0.25]} mb={3}>
                 <P textAlign={['center', null, 'left']} fontSize="1.2rem" color="#C2C6CC" letterSpacing="1px" pb={3}>

--- a/src/components/GiftCard.js
+++ b/src/components/GiftCard.js
@@ -6,7 +6,7 @@ import Container from './Container';
 import { Span } from './Text';
 import Currency from './Currency';
 import Link from './Link';
-import { Flex, Box } from 'grid-styled';
+import { Flex, Box } from '@rebass/grid';
 import styled from 'styled-components';
 import { FormattedMessage } from 'react-intl';
 import { width, height, fontSize } from 'styled-system';

--- a/src/components/Hide.js
+++ b/src/components/Hide.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { Box } from 'grid-styled';
+import { Box } from '@rebass/grid';
 import { bottom, height, left, position, right, top } from 'styled-system';
 import PropTypes from 'prop-types';
 

--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import LoadingGrid from '../components/LoadingGrid';
-import { Flex } from 'grid-styled';
+import { Flex } from '@rebass/grid';
 
 const Loading = () => {
   return (

--- a/src/components/NewsletterContainer.js
+++ b/src/components/NewsletterContainer.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { H5 } from './Text';
 import Container from './Container';
-import { Flex } from 'grid-styled';
+import { Flex } from '@rebass/grid';
 import StyledInput, { SubmitInput } from '../components/StyledInput';
 
 class NewsletterContainer extends React.Component {

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { withRouter } from 'next/router';
 import { Link } from '../server/pages';
 
-import { Flex } from 'grid-styled';
+import { Flex } from '@rebass/grid';
 import StyledLink from './StyledLink';
 import { TextInput } from './StyledInput';
 import { Span } from './Text';

--- a/src/components/PledgedCollective.js
+++ b/src/components/PledgedCollective.js
@@ -8,7 +8,7 @@ import Header from './Header';
 import Body from './Body';
 import Footer from './Footer';
 import Container from './Container';
-import { Box, Flex } from 'grid-styled';
+import { Box, Flex } from '@rebass/grid';
 import { H2, H3, H5, P } from './Text';
 import PledgeCard from './PledgeCard';
 import StyledLink from './StyledLink';
@@ -57,7 +57,7 @@ class PledgedCollective extends React.Component {
             <Flex alignItems="center" flexDirection="column">
               <img src={defaultPledgedLogo} alt="Pledged Collective" />
 
-              <H2 is="h1">{collective.name}</H2>
+              <H2 as="h1">{collective.name}</H2>
 
               <Box mb={4} mt={3}>
                 <StyledLink href={collective.website} color="primary.500" fontSize="Caption">

--- a/src/components/RedeemForm.js
+++ b/src/components/RedeemForm.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import withIntl from '../lib/withIntl';
 
-import { Flex } from 'grid-styled';
+import { Flex } from '@rebass/grid';
 import { FormattedMessage, defineMessages } from 'react-intl';
 import { P } from './Text';
 import InputField from './InputField';

--- a/src/components/RedeemSuccess.js
+++ b/src/components/RedeemSuccess.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import withIntl from '../lib/withIntl';
 
-import { Flex, Box } from 'grid-styled';
+import { Flex, Box } from '@rebass/grid';
 import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 import { Check } from 'styled-icons/fa-solid/Check.cjs';

--- a/src/components/SearchForm.js
+++ b/src/components/SearchForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box, Flex } from 'grid-styled';
+import { Box, Flex } from '@rebass/grid';
 import { fontSize } from 'styled-system';
 import styled from 'styled-components';
 
@@ -42,7 +42,7 @@ const SearchForm = ({ fontSize, onSubmit = handleSubmit }) => (
   <form action="/search" method="GET" onSubmit={onSubmit}>
     <SearchInputContainer alignItems="center" justifyContent="space-between" p={1}>
       <SearchInput
-        is="input"
+        as="input"
         type="search"
         name="q"
         placeholder="Search Open Collective"
@@ -51,7 +51,7 @@ const SearchForm = ({ fontSize, onSubmit = handleSubmit }) => (
         width={1}
         fontSize={fontSize}
       />
-      <SearchButton is="button" mr={1} p={1}>
+      <SearchButton as="button" mr={1} p={1}>
         <SearchIcon size={16} fill="#aaaaaa" />
       </SearchButton>
     </SearchInputContainer>

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -9,7 +9,7 @@ import withIntl from '../lib/withIntl';
 import { Link } from '../server/pages';
 
 import Hide from './Hide';
-import { Box, Flex } from 'grid-styled';
+import { Box, Flex } from '@rebass/grid';
 import styled from 'styled-components';
 
 import { rotateMixin } from '../constants/animations';
@@ -67,7 +67,7 @@ class TopBar extends React.Component {
     return (
       <Flex px={3} py={showSearch ? 2 : 3} alignItems="center" flexDirection="row" justifyContent="space-around">
         <Link route="home" passHref>
-          <Flex is="a" alignItems="center">
+          <Flex as="a" alignItems="center">
             <Logo width="24" height="24" animate={shouldAnimate} />
             <Hide xs>
               <Box mx={2}>
@@ -91,7 +91,7 @@ class TopBar extends React.Component {
           <Hide sm md lg>
             <Box mx={3}>
               <Link href="/search">
-                <Flex is="a">
+                <Flex as="a">
                   <SearchIcon fill="#aaaaaa" size={24} />
                 </Flex>
               </Link>
@@ -101,7 +101,7 @@ class TopBar extends React.Component {
           <Hide sm md lg>
             <Box mx={3}>
               <Link href="#footer">
-                <Flex is="a">
+                <Flex as="a">
                   <MenuIcon color="#aaaaaa" size={24} />
                 </Flex>
               </Link>
@@ -109,20 +109,20 @@ class TopBar extends React.Component {
           </Hide>
 
           <Hide xs>
-            <NavList is="ul" p={0} m={0} justifyContent="space-around" css="margin: 0;">
-              <Box is="li" px={3}>
+            <NavList as="ul" p={0} m={0} justifyContent="space-around" css="margin: 0;">
+              <Box as="li" px={3}>
                 <Link route="discover" passHref>
                   <NavLink>
                     <FormattedMessage id="menu.discover" defaultMessage="Discover" />
                   </NavLink>
                 </Link>
               </Box>
-              <Box is="li" px={3}>
+              <Box as="li" px={3}>
                 <NavLink href="/learn-more">
                   <FormattedMessage id="menu.howItWorks" defaultMessage="How it Works" />
                 </NavLink>
               </Box>
-              <Box is="li" px={3}>
+              <Box as="li" px={3}>
                 <NavLink href="https://medium.com/open-collective">
                   <FormattedMessage id="menu.blog" defaultMessage="Blog" />
                 </NavLink>

--- a/src/components/TopBarProfileMenu.js
+++ b/src/components/TopBarProfileMenu.js
@@ -7,7 +7,7 @@ import { withUser } from './UserProvider';
 import { formatCurrency, capitalize } from '../lib/utils';
 import { Badge } from 'react-bootstrap';
 import { get, uniqBy } from 'lodash';
-import { Box, Flex } from 'grid-styled';
+import { Box, Flex } from '@rebass/grid';
 import Avatar from './Avatar';
 import Hide from './Hide';
 import { P } from './Text';
@@ -152,7 +152,7 @@ class TopBarProfileMenu extends React.Component {
               </StyledLink>
             </Link>
           </Flex>
-          <Box is="ul" p={0} my={2}>
+          <Box as="ul" p={0} my={2}>
             {collectives.map(membership => (
               <ListItem py={1} key={`LoggedInMenu-Collective-${get(membership, 'collective.slug')}`}>
                 <Link route={`/${get(membership, 'collective.slug')}`} passHref>
@@ -202,7 +202,7 @@ class TopBarProfileMenu extends React.Component {
               </StyledLink>
             </Link>
           </Flex>
-          <Box is="ul" p={0} my={2}>
+          <Box as="ul" p={0} my={2}>
             {orgs.map(membership => (
               <ListItem py={1} key={`LoggedInMenu-Collective-${get(membership, 'collective.slug')}`}>
                 <Link route={`/${get(membership, 'collective.slug')}`} passHref>
@@ -251,7 +251,7 @@ class TopBarProfileMenu extends React.Component {
           >
             <FormattedMessage id="menu.myAccount" defaultMessage="My account" />
           </P>
-          <Box is="ul" p={0} my={2}>
+          <Box as="ul" p={0} my={2}>
             <ListItem py={1}>
               <Link route="collective" params={{ slug: LoggedInUser.username }} passHref>
                 <StyledLink color="#494D52" fontSize="1.2rem" fontFamily="montserratlight, arial">

--- a/src/pages/__tests__/__snapshots__/search.test.js.snap
+++ b/src/pages/__tests__/__snapshots__/search.test.js.snap
@@ -2,51 +2,30 @@
 
 exports[`Search Page renders "Make pledge" button with empty results 1`] = `
 Array [
-  .c1 {
-  box-sizing: border-box;
-  padding-left: 16px;
-  padding-right: 16px;
-  padding-top: 16px;
-  padding-bottom: 16px;
-}
-
-.c2 {
-  box-sizing: border-box;
-}
-
-.c6 {
+  .c4 {
   box-sizing: border-box;
   margin-left: 8px;
   margin-right: 8px;
 }
 
-.c8 {
-  box-sizing: border-box;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c10 {
+.c7 {
   box-sizing: border-box;
   margin-left: 16px;
   margin-right: 16px;
 }
 
-.c15 {
-  margin: 0;
-  box-sizing: border-box;
-  margin: 0px;
-  padding: 0px;
-}
-
-.c16 {
+.c11 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
 }
 
 .c0 {
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-top: 16px;
+  padding-bottom: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -64,7 +43,8 @@ Array [
   justify-content: space-around;
 }
 
-.c3 {
+.c1 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -75,7 +55,11 @@ Array [
   align-items: center;
 }
 
-.c7 {
+.c5 {
+  box-sizing: border-box;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -90,32 +74,29 @@ Array [
   justify-content: flex-end;
 }
 
-.c11 {
+.c8 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c14 {
-  margin: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: space-around;
-  -webkit-justify-content: space-around;
-  -ms-flex-pack: space-around;
-  justify-content: space-around;
-}
-
-.c12 {
+.c9 {
   display: inline-block;
   vertical-align: -.125em;
   overflow: hidden;
 }
 
-.c18 {
+.c3 {
+  box-sizing: border-box;
+}
+
+.c6 {
+  box-sizing: border-box;
+}
+
+.c13 {
   border: 1px solid #D5DAE0;
   border-radius: 20px;
   color: #3385FF;
@@ -127,42 +108,54 @@ Array [
   padding-bottom: 8px;
 }
 
-.c4 {
+.c2 {
   -webkit-animation: iECmZH 0.8s infinite linear;
   animation: iECmZH 0.8s infinite linear;
 }
 
-.c13 {
+.c10 {
+  box-sizing: border-box;
+  margin: 0px;
+  padding: 0px;
+  margin: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
   list-style: none;
   min-width: 20rem;
   text-align: right;
 }
 
-.c17 {
+.c12 {
   color: #777777;
   font-size: 1.4rem;
 }
 
 @media screen and (max-width:40em) {
-  .c5 {
+  .c3 {
     display: none;
   }
 }
 
 @media screen and (min-width:40em) and (max-width:52em) {
-  .c9 {
+  .c6 {
     display: none;
   }
 }
 
 @media screen and (min-width:52em) and (max-width:64em) {
-  .c9 {
+  .c6 {
     display: none;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c9 {
+  .c6 {
     display: none;
   }
 }
@@ -172,25 +165,25 @@ Array [
       id="top"
     />
     <div
-      className="c0 c1 sc-bdVaJa c2"
+      className="c0"
     >
       <a
-        className="c3 c2"
+        className="c1"
         href="/"
         onClick={[Function]}
       >
         <img
           alt="Open Collective logo"
-          className="c4"
+          className="c2"
           height="24"
           src="/static/images/opencollective-icon.svg"
           width="24"
         />
         <div
-          className="c5 c2"
+          className="c3"
         >
           <div
-            className="c6"
+            className="c4"
           >
             <img
               height="16px"
@@ -200,16 +193,16 @@ Array [
         </div>
       </a>
       <div
-        className="c7 c8 sc-bdVaJa c2"
+        className="c5"
       >
         <div
-          className="c9 c2"
+          className="c6"
         >
           <div
-            className="c10"
+            className="c7"
           >
             <a
-              className="c11 c2"
+              className="c8"
               onClick={[Function]}
             >
               <svg
@@ -233,18 +226,18 @@ Array [
           </div>
         </div>
         <div
-          className="c9 c2"
+          className="c6"
         >
           <div
-            className="c10"
+            className="c7"
           >
             <a
-              className="c11 c2"
+              className="c8"
               onClick={[Function]}
             >
               <svg
                 aria-hidden="true"
-                className="c12"
+                className="c9"
                 color="#aaaaaa"
                 fill="currentColor"
                 focusable="false"
@@ -262,16 +255,16 @@ Array [
           </div>
         </div>
         <div
-          className="c5 c2"
+          className="c3"
         >
           <ul
-            className="c13 c14 c15"
+            className="c10"
           >
             <li
-              className="c16"
+              className="c11"
             >
               <a
-                className="c17"
+                className="c12"
                 href="/discover"
                 onClick={[Function]}
               >
@@ -281,10 +274,10 @@ Array [
               </a>
             </li>
             <li
-              className="c16"
+              className="c11"
             >
               <a
-                className="c17"
+                className="c12"
                 href="/learn-more"
               >
                 <span>
@@ -293,10 +286,10 @@ Array [
               </a>
             </li>
             <li
-              className="c16"
+              className="c11"
             >
               <a
-                className="c17"
+                className="c12"
                 href="https://medium.com/open-collective"
               >
                 <span>
@@ -310,7 +303,7 @@ Array [
           className="LoginTopBarProfileButton"
         >
           <a
-            className="c18"
+            className="c13"
             href="/signin?next=%2F"
             onClick={[Function]}
           >
@@ -322,29 +315,15 @@ Array [
       </div>
     </div>
   </header>,
-  .c4 {
-  box-sizing: border-box;
-}
-
-.c1 {
+  .c1 {
   box-sizing: border-box;
   width: 100%;
-}
-
-.c3 {
-  box-sizing: border-box;
-  margin-top: 16px;
-  margin-bottom: 16px;
-}
-
-.c9 {
-  box-sizing: border-box;
-  width: 100%;
-  padding-top: 16px;
-  padding-bottom: 16px;
 }
 
 .c2 {
+  box-sizing: border-box;
+  margin-top: 16px;
+  margin-bottom: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -355,7 +334,8 @@ Array [
   align-items: flex-end;
 }
 
-.c7 {
+.c5 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -369,7 +349,11 @@ Array [
   justify-content: center;
 }
 
-.c8 {
+.c6 {
+  box-sizing: border-box;
+  padding-top: 16px;
+  padding-bottom: 16px;
+  width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -396,7 +380,7 @@ Array [
   width: 100%;
 }
 
-.c10 {
+.c7 {
   display: block;
   font-size: Paragraph;
   font-weight: bold;
@@ -408,7 +392,7 @@ Array [
   text-align: center;
 }
 
-.c5.c5.c5 {
+.c3.c3.c3 {
   border: none;
   border-bottom: 2px solid #3385FF;
   border-radius: 0;
@@ -418,12 +402,12 @@ Array [
   padding: 0;
 }
 
-.c6.c6 {
+.c4.c4 {
   padding: 0 2rem;
 }
 
 @media screen and (min-width:40em) {
-  .c7 {
+  .c5 {
     -webkit-box-pack: center;
     -webkit-justify-content: center;
     -ms-flex-pack: center;
@@ -432,7 +416,7 @@ Array [
 }
 
 @media screen and (min-width:52em) {
-  .c7 {
+  .c5 {
     -webkit-box-pack: start;
     -webkit-justify-content: flex-start;
     -ms-flex-pack: start;
@@ -454,6 +438,7 @@ Array [
     >
       <div
         className="c1"
+        width={1}
       >
         <form
           method="GET"
@@ -469,10 +454,10 @@ Array [
               Search Open Collective
             </label>
             <div
-              className="c2 c3 sc-bdVaJa c4"
+              className="c2"
             >
               <input
-                className="c5 form-control"
+                className="c3 form-control"
                 defaultValue="test"
                 id="search"
                 name="q"
@@ -480,7 +465,7 @@ Array [
                 type="search"
               />
               <button
-                className="jsx-1144918383 jsx-3101740563 Button blue c6"
+                className="jsx-1144918383 jsx-3101740563 Button blue c4"
                 onClick={[Function]}
                 type="submit"
               >
@@ -493,10 +478,11 @@ Array [
         </form>
       </div>
       <div
-        className="c7 c4 sc-bdVaJa c4"
+        className="c5"
       >
         <div
-          className="c8 c9 sc-bdVaJa c4"
+          className="c6"
+          width={1}
         >
           <p>
             <em>
@@ -506,7 +492,7 @@ Array [
             </em>
           </p>
           <a
-            className="c10"
+            className="c7"
             href="createPledge"
             onClick={[Function]}
           >
@@ -516,36 +502,17 @@ Array [
       </div>
     </div>
   </main>,
-  .c3 {
+  .c13 {
   box-sizing: border-box;
+  margin-bottom: 16px;
+  width: 50%;
 }
 
-.c2 {
-  max-width: 1300px;
+.c1 {
   box-sizing: border-box;
   margin-left: auto;
   margin-right: auto;
   padding: 8px;
-}
-
-.c15 {
-  box-sizing: border-box;
-  margin-top: 16px;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c16 {
-  box-sizing: border-box;
-  width: 50%;
-  margin-bottom: 16px;
-}
-
-.c1 {
   max-width: 1300px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -564,7 +531,8 @@ Array [
   justify-content: space-between;
 }
 
-.c5 {
+.c3 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -575,7 +543,15 @@ Array [
   justify-content: center;
 }
 
-.c14 {
+.c12 {
+  box-sizing: border-box;
+  margin-top: 16px;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -598,7 +574,7 @@ Array [
   width: 100%;
 }
 
-.c4 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -611,7 +587,7 @@ Array [
   width: 100%;
 }
 
-.c7 {
+.c5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -633,7 +609,7 @@ Array [
   width: 100%;
 }
 
-.c6 {
+.c4 {
   color: #6E747A;
   font-size: 1.4rem;
   line-height: Paragraph;
@@ -647,7 +623,7 @@ Array [
   text-align: center;
 }
 
-.c17 {
+.c14 {
   color: #C2C6CC;
   font-size: 1.2rem;
   line-height: Paragraph;
@@ -660,16 +636,10 @@ Array [
   text-align: center;
 }
 
-.c19 {
+.c16 {
   list-style: none;
   margin-bottom: 8px;
   text-align: center;
-}
-
-.c11 {
-  display: inline-block;
-  vertical-align: -.125em;
-  overflow: hidden;
 }
 
 .c9 {
@@ -678,7 +648,7 @@ Array [
   overflow: hidden;
 }
 
-.c12 {
+.c7 {
   display: inline-block;
   vertical-align: -.125em;
   overflow: hidden;
@@ -690,13 +660,19 @@ Array [
   overflow: hidden;
 }
 
-.c13 {
+.c8 {
+  display: inline-block;
+  vertical-align: -.125em;
+  overflow: hidden;
+}
+
+.c11 {
   display: inline-block;
   vertical-align: middle;
   overflow: hidden;
 }
 
-.c8 {
+.c6 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -716,12 +692,12 @@ Array [
   width: 48px;
 }
 
-.c8:hover,
-.c8:focus {
+.c6:hover,
+.c6:focus {
   opacity: 1;
 }
 
-.c20 {
+.c17 {
   color: #6e747a;
   display: block;
   fontsize: 1.4rem;
@@ -730,7 +706,10 @@ Array [
   padding: 0;
 }
 
-.c18 {
+.c15 {
+  box-sizing: border-box;
+  padding-left: 0px;
+  padding-right: 8px;
   box-sizing: border-box;
   padding-left: 0px;
   padding-right: 8px;
@@ -748,15 +727,7 @@ Array [
 }
 
 @media screen and (min-width:52em) {
-  .c15 {
-    -webkit-order: 2;
-    -ms-flex-order: 2;
-    order: 2;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c16 {
+  .c13 {
     width: 25%;
   }
 }
@@ -779,7 +750,7 @@ Array [
 }
 
 @media screen and (min-width:52em) {
-  .c5 {
+  .c3 {
     -webkit-box-pack: start;
     -webkit-justify-content: flex-start;
     -ms-flex-pack: start;
@@ -788,13 +759,21 @@ Array [
 }
 
 @media screen and (min-width:52em) {
-  .c4 {
+  .c12 {
+    -webkit-order: 2;
+    -ms-flex-order: 2;
+    order: 2;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c2 {
     width: 33.33333333333333%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c7 {
+  .c5 {
     -webkit-order: 3;
     -ms-flex-order: 3;
     order: 3;
@@ -802,19 +781,19 @@ Array [
 }
 
 @media screen and (min-width:52em) {
-  .c6 {
+  .c4 {
     text-align: left;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c17 {
+  .c14 {
     text-align: left;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c19 {
+  .c16 {
     text-align: left;
   }
 }
@@ -824,13 +803,13 @@ Array [
     id="footer"
   >
     <div
-      className="c1 c2 sc-bdVaJa c3"
+      className="c1"
     >
       <div
-        className="c4"
+        className="c2"
       >
         <div
-          className="c5 c3 sc-bdVaJa c3"
+          className="c3"
         >
           <object
             data="/static/images/opencollectivelogo-footer.svg"
@@ -839,21 +818,21 @@ Array [
           />
         </div>
         <p
-          className="c6"
+          className="c4"
         >
           An organization for your community, transparent by design.
         </p>
       </div>
       <div
-        className="c7"
+        className="c5"
       >
         <a
-          className="c8"
+          className="c6"
           href="https://medium.com/open-collective"
         >
           <svg
             aria-hidden="true"
-            className="c9"
+            className="c7"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -869,12 +848,12 @@ Array [
           </svg>
         </a>
         <a
-          className="c8"
+          className="c6"
           href="https://twitter.com/opencollect"
         >
           <svg
             aria-hidden="true"
-            className="c10"
+            className="c8"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -890,12 +869,12 @@ Array [
           </svg>
         </a>
         <a
-          className="c8"
+          className="c6"
           href="https://github.com/opencollective"
         >
           <svg
             aria-hidden="true"
-            className="c11"
+            className="c9"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -911,12 +890,12 @@ Array [
           </svg>
         </a>
         <a
-          className="c8"
+          className="c6"
           href="https://slack.opencollective.com"
         >
           <svg
             aria-hidden="true"
-            className="c12"
+            className="c10"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -932,12 +911,12 @@ Array [
           </svg>
         </a>
         <a
-          className="c8"
+          className="c6"
           href="mailto:info@opencollective.com"
         >
           <svg
             aria-hidden="true"
-            className="c13"
+            className="c11"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -953,24 +932,38 @@ Array [
         </a>
       </div>
       <nav
-        className="c14 c15"
+        className="c12"
+        order={
+          Array [
+            "3",
+            null,
+            "2",
+          ]
+        }
       >
         <div
-          className="c16"
+          className="c13"
+          width={
+            Array [
+              0.5,
+              null,
+              0.25,
+            ]
+          }
         >
           <p
-            className="c17"
+            className="c14"
           >
             PLATFORM
           </p>
           <ul
-            className="c18"
+            className="c15"
           >
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/discover"
                 onClick={[Function]}
               >
@@ -978,20 +971,20 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/learn-more"
               >
                 How it Works
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/signin"
                 onClick={[Function]}
               >
@@ -999,10 +992,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/signin"
                 onClick={[Function]}
               >
@@ -1012,21 +1005,28 @@ Array [
           </ul>
         </div>
         <div
-          className="c16"
+          className="c13"
+          width={
+            Array [
+              0.5,
+              null,
+              0.25,
+            ]
+          }
         >
           <p
-            className="c17"
+            className="c14"
           >
             JOIN THE MOVEMENT
           </p>
           <ul
-            className="c18"
+            className="c15"
           >
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/create"
                 onClick={[Function]}
               >
@@ -1034,10 +1034,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/become-a-sponsor"
                 onClick={[Function]}
               >
@@ -1045,10 +1045,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/chapters"
                 onClick={[Function]}
               >
@@ -1058,21 +1058,28 @@ Array [
           </ul>
         </div>
         <div
-          className="c16"
+          className="c13"
+          width={
+            Array [
+              0.5,
+              null,
+              0.25,
+            ]
+          }
         >
           <p
-            className="c17"
+            className="c14"
           >
             COMMUNITY
           </p>
           <ul
-            className="c18"
+            className="c15"
           >
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/opensource"
                 onClick={[Function]}
               >
@@ -1080,10 +1087,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="https://github.com/opencollective/opencollective/issues"
                 onClick={[Function]}
               >
@@ -1091,10 +1098,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="https://slack.opencollective.com"
                 onClick={[Function]}
               >
@@ -1102,10 +1109,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="https://github.com/opencollective/opencollective/wiki"
                 onClick={[Function]}
               >
@@ -1113,10 +1120,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="mailto:support@opencollective.com"
                 onClick={[Function]}
               >
@@ -1126,21 +1133,28 @@ Array [
           </ul>
         </div>
         <div
-          className="c16"
+          className="c13"
+          width={
+            Array [
+              0.5,
+              null,
+              0.25,
+            ]
+          }
         >
           <p
-            className="c17"
+            className="c14"
           >
             COMPANY
           </p>
           <ul
-            className="c18"
+            className="c15"
           >
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/about"
                 onClick={[Function]}
               >
@@ -1148,10 +1162,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/faq"
                 onClick={[Function]}
               >
@@ -1159,10 +1173,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="https://medium.com/open-collective"
                 onClick={[Function]}
               >
@@ -1170,10 +1184,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/tos"
                 onClick={[Function]}
               >
@@ -1181,10 +1195,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/privacypolicy"
                 onClick={[Function]}
               >
@@ -1201,51 +1215,30 @@ Array [
 
 exports[`Search Page renders empty results message 1`] = `
 Array [
-  .c1 {
-  box-sizing: border-box;
-  padding-left: 16px;
-  padding-right: 16px;
-  padding-top: 16px;
-  padding-bottom: 16px;
-}
-
-.c2 {
-  box-sizing: border-box;
-}
-
-.c6 {
+  .c4 {
   box-sizing: border-box;
   margin-left: 8px;
   margin-right: 8px;
 }
 
-.c8 {
-  box-sizing: border-box;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c10 {
+.c7 {
   box-sizing: border-box;
   margin-left: 16px;
   margin-right: 16px;
 }
 
-.c15 {
-  margin: 0;
-  box-sizing: border-box;
-  margin: 0px;
-  padding: 0px;
-}
-
-.c16 {
+.c11 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
 }
 
 .c0 {
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-top: 16px;
+  padding-bottom: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1263,7 +1256,8 @@ Array [
   justify-content: space-around;
 }
 
-.c3 {
+.c1 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1274,7 +1268,11 @@ Array [
   align-items: center;
 }
 
-.c7 {
+.c5 {
+  box-sizing: border-box;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1289,32 +1287,29 @@ Array [
   justify-content: flex-end;
 }
 
-.c11 {
+.c8 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c14 {
-  margin: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: space-around;
-  -webkit-justify-content: space-around;
-  -ms-flex-pack: space-around;
-  justify-content: space-around;
-}
-
-.c12 {
+.c9 {
   display: inline-block;
   vertical-align: -.125em;
   overflow: hidden;
 }
 
-.c18 {
+.c3 {
+  box-sizing: border-box;
+}
+
+.c6 {
+  box-sizing: border-box;
+}
+
+.c13 {
   border: 1px solid #D5DAE0;
   border-radius: 20px;
   color: #3385FF;
@@ -1326,42 +1321,54 @@ Array [
   padding-bottom: 8px;
 }
 
-.c4 {
+.c2 {
   -webkit-animation: iECmZH 0.8s infinite linear;
   animation: iECmZH 0.8s infinite linear;
 }
 
-.c13 {
+.c10 {
+  box-sizing: border-box;
+  margin: 0px;
+  padding: 0px;
+  margin: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
   list-style: none;
   min-width: 20rem;
   text-align: right;
 }
 
-.c17 {
+.c12 {
   color: #777777;
   font-size: 1.4rem;
 }
 
 @media screen and (max-width:40em) {
-  .c5 {
+  .c3 {
     display: none;
   }
 }
 
 @media screen and (min-width:40em) and (max-width:52em) {
-  .c9 {
+  .c6 {
     display: none;
   }
 }
 
 @media screen and (min-width:52em) and (max-width:64em) {
-  .c9 {
+  .c6 {
     display: none;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c9 {
+  .c6 {
     display: none;
   }
 }
@@ -1371,25 +1378,25 @@ Array [
       id="top"
     />
     <div
-      className="c0 c1 sc-bdVaJa c2"
+      className="c0"
     >
       <a
-        className="c3 c2"
+        className="c1"
         href="/"
         onClick={[Function]}
       >
         <img
           alt="Open Collective logo"
-          className="c4"
+          className="c2"
           height="24"
           src="/static/images/opencollective-icon.svg"
           width="24"
         />
         <div
-          className="c5 c2"
+          className="c3"
         >
           <div
-            className="c6"
+            className="c4"
           >
             <img
               height="16px"
@@ -1399,16 +1406,16 @@ Array [
         </div>
       </a>
       <div
-        className="c7 c8 sc-bdVaJa c2"
+        className="c5"
       >
         <div
-          className="c9 c2"
+          className="c6"
         >
           <div
-            className="c10"
+            className="c7"
           >
             <a
-              className="c11 c2"
+              className="c8"
               onClick={[Function]}
             >
               <svg
@@ -1432,18 +1439,18 @@ Array [
           </div>
         </div>
         <div
-          className="c9 c2"
+          className="c6"
         >
           <div
-            className="c10"
+            className="c7"
           >
             <a
-              className="c11 c2"
+              className="c8"
               onClick={[Function]}
             >
               <svg
                 aria-hidden="true"
-                className="c12"
+                className="c9"
                 color="#aaaaaa"
                 fill="currentColor"
                 focusable="false"
@@ -1461,16 +1468,16 @@ Array [
           </div>
         </div>
         <div
-          className="c5 c2"
+          className="c3"
         >
           <ul
-            className="c13 c14 c15"
+            className="c10"
           >
             <li
-              className="c16"
+              className="c11"
             >
               <a
-                className="c17"
+                className="c12"
                 href="/discover"
                 onClick={[Function]}
               >
@@ -1480,10 +1487,10 @@ Array [
               </a>
             </li>
             <li
-              className="c16"
+              className="c11"
             >
               <a
-                className="c17"
+                className="c12"
                 href="/learn-more"
               >
                 <span>
@@ -1492,10 +1499,10 @@ Array [
               </a>
             </li>
             <li
-              className="c16"
+              className="c11"
             >
               <a
-                className="c17"
+                className="c12"
                 href="https://medium.com/open-collective"
               >
                 <span>
@@ -1509,7 +1516,7 @@ Array [
           className="LoginTopBarProfileButton"
         >
           <a
-            className="c18"
+            className="c13"
             href="/signin?next=%2F"
             onClick={[Function]}
           >
@@ -1521,29 +1528,15 @@ Array [
       </div>
     </div>
   </header>,
-  .c4 {
-  box-sizing: border-box;
-}
-
-.c1 {
+  .c1 {
   box-sizing: border-box;
   width: 100%;
-}
-
-.c3 {
-  box-sizing: border-box;
-  margin-top: 16px;
-  margin-bottom: 16px;
-}
-
-.c9 {
-  box-sizing: border-box;
-  width: 100%;
-  padding-top: 16px;
-  padding-bottom: 16px;
 }
 
 .c2 {
+  box-sizing: border-box;
+  margin-top: 16px;
+  margin-bottom: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1554,7 +1547,8 @@ Array [
   align-items: flex-end;
 }
 
-.c7 {
+.c5 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1568,7 +1562,11 @@ Array [
   justify-content: center;
 }
 
-.c8 {
+.c6 {
+  box-sizing: border-box;
+  padding-top: 16px;
+  padding-bottom: 16px;
+  width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1595,7 +1593,7 @@ Array [
   width: 100%;
 }
 
-.c5.c5.c5 {
+.c3.c3.c3 {
   border: none;
   border-bottom: 2px solid #3385FF;
   border-radius: 0;
@@ -1605,12 +1603,12 @@ Array [
   padding: 0;
 }
 
-.c6.c6 {
+.c4.c4 {
   padding: 0 2rem;
 }
 
 @media screen and (min-width:40em) {
-  .c7 {
+  .c5 {
     -webkit-box-pack: center;
     -webkit-justify-content: center;
     -ms-flex-pack: center;
@@ -1619,7 +1617,7 @@ Array [
 }
 
 @media screen and (min-width:52em) {
-  .c7 {
+  .c5 {
     -webkit-box-pack: start;
     -webkit-justify-content: flex-start;
     -ms-flex-pack: start;
@@ -1641,6 +1639,7 @@ Array [
     >
       <div
         className="c1"
+        width={1}
       >
         <form
           method="GET"
@@ -1656,10 +1655,10 @@ Array [
               Search Open Collective
             </label>
             <div
-              className="c2 c3 sc-bdVaJa c4"
+              className="c2"
             >
               <input
-                className="c5 form-control"
+                className="c3 form-control"
                 defaultValue="test"
                 id="search"
                 name="q"
@@ -1667,7 +1666,7 @@ Array [
                 type="search"
               />
               <button
-                className="jsx-1144918383 jsx-3101740563 Button blue c6"
+                className="jsx-1144918383 jsx-3101740563 Button blue c4"
                 onClick={[Function]}
                 type="submit"
               >
@@ -1680,10 +1679,11 @@ Array [
         </form>
       </div>
       <div
-        className="c7 c4 sc-bdVaJa c4"
+        className="c5"
       >
         <div
-          className="c8 c9 sc-bdVaJa c4"
+          className="c6"
+          width={1}
         >
           <p>
             <em>
@@ -1696,36 +1696,17 @@ Array [
       </div>
     </div>
   </main>,
-  .c3 {
+  .c13 {
   box-sizing: border-box;
+  margin-bottom: 16px;
+  width: 50%;
 }
 
-.c2 {
-  max-width: 1300px;
+.c1 {
   box-sizing: border-box;
   margin-left: auto;
   margin-right: auto;
   padding: 8px;
-}
-
-.c15 {
-  box-sizing: border-box;
-  margin-top: 16px;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c16 {
-  box-sizing: border-box;
-  width: 50%;
-  margin-bottom: 16px;
-}
-
-.c1 {
   max-width: 1300px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1744,7 +1725,8 @@ Array [
   justify-content: space-between;
 }
 
-.c5 {
+.c3 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1755,7 +1737,15 @@ Array [
   justify-content: center;
 }
 
-.c14 {
+.c12 {
+  box-sizing: border-box;
+  margin-top: 16px;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1778,7 +1768,7 @@ Array [
   width: 100%;
 }
 
-.c4 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1791,7 +1781,7 @@ Array [
   width: 100%;
 }
 
-.c7 {
+.c5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1813,7 +1803,7 @@ Array [
   width: 100%;
 }
 
-.c6 {
+.c4 {
   color: #6E747A;
   font-size: 1.4rem;
   line-height: Paragraph;
@@ -1827,7 +1817,7 @@ Array [
   text-align: center;
 }
 
-.c17 {
+.c14 {
   color: #C2C6CC;
   font-size: 1.2rem;
   line-height: Paragraph;
@@ -1840,16 +1830,10 @@ Array [
   text-align: center;
 }
 
-.c19 {
+.c16 {
   list-style: none;
   margin-bottom: 8px;
   text-align: center;
-}
-
-.c11 {
-  display: inline-block;
-  vertical-align: -.125em;
-  overflow: hidden;
 }
 
 .c9 {
@@ -1858,7 +1842,7 @@ Array [
   overflow: hidden;
 }
 
-.c12 {
+.c7 {
   display: inline-block;
   vertical-align: -.125em;
   overflow: hidden;
@@ -1870,13 +1854,19 @@ Array [
   overflow: hidden;
 }
 
-.c13 {
+.c8 {
+  display: inline-block;
+  vertical-align: -.125em;
+  overflow: hidden;
+}
+
+.c11 {
   display: inline-block;
   vertical-align: middle;
   overflow: hidden;
 }
 
-.c8 {
+.c6 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1896,12 +1886,12 @@ Array [
   width: 48px;
 }
 
-.c8:hover,
-.c8:focus {
+.c6:hover,
+.c6:focus {
   opacity: 1;
 }
 
-.c20 {
+.c17 {
   color: #6e747a;
   display: block;
   fontsize: 1.4rem;
@@ -1910,7 +1900,10 @@ Array [
   padding: 0;
 }
 
-.c18 {
+.c15 {
+  box-sizing: border-box;
+  padding-left: 0px;
+  padding-right: 8px;
   box-sizing: border-box;
   padding-left: 0px;
   padding-right: 8px;
@@ -1928,15 +1921,7 @@ Array [
 }
 
 @media screen and (min-width:52em) {
-  .c15 {
-    -webkit-order: 2;
-    -ms-flex-order: 2;
-    order: 2;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c16 {
+  .c13 {
     width: 25%;
   }
 }
@@ -1959,7 +1944,7 @@ Array [
 }
 
 @media screen and (min-width:52em) {
-  .c5 {
+  .c3 {
     -webkit-box-pack: start;
     -webkit-justify-content: flex-start;
     -ms-flex-pack: start;
@@ -1968,13 +1953,21 @@ Array [
 }
 
 @media screen and (min-width:52em) {
-  .c4 {
+  .c12 {
+    -webkit-order: 2;
+    -ms-flex-order: 2;
+    order: 2;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c2 {
     width: 33.33333333333333%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c7 {
+  .c5 {
     -webkit-order: 3;
     -ms-flex-order: 3;
     order: 3;
@@ -1982,19 +1975,19 @@ Array [
 }
 
 @media screen and (min-width:52em) {
-  .c6 {
+  .c4 {
     text-align: left;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c17 {
+  .c14 {
     text-align: left;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c19 {
+  .c16 {
     text-align: left;
   }
 }
@@ -2004,13 +1997,13 @@ Array [
     id="footer"
   >
     <div
-      className="c1 c2 sc-bdVaJa c3"
+      className="c1"
     >
       <div
-        className="c4"
+        className="c2"
       >
         <div
-          className="c5 c3 sc-bdVaJa c3"
+          className="c3"
         >
           <object
             data="/static/images/opencollectivelogo-footer.svg"
@@ -2019,21 +2012,21 @@ Array [
           />
         </div>
         <p
-          className="c6"
+          className="c4"
         >
           An organization for your community, transparent by design.
         </p>
       </div>
       <div
-        className="c7"
+        className="c5"
       >
         <a
-          className="c8"
+          className="c6"
           href="https://medium.com/open-collective"
         >
           <svg
             aria-hidden="true"
-            className="c9"
+            className="c7"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -2049,12 +2042,12 @@ Array [
           </svg>
         </a>
         <a
-          className="c8"
+          className="c6"
           href="https://twitter.com/opencollect"
         >
           <svg
             aria-hidden="true"
-            className="c10"
+            className="c8"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -2070,12 +2063,12 @@ Array [
           </svg>
         </a>
         <a
-          className="c8"
+          className="c6"
           href="https://github.com/opencollective"
         >
           <svg
             aria-hidden="true"
-            className="c11"
+            className="c9"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -2091,12 +2084,12 @@ Array [
           </svg>
         </a>
         <a
-          className="c8"
+          className="c6"
           href="https://slack.opencollective.com"
         >
           <svg
             aria-hidden="true"
-            className="c12"
+            className="c10"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -2112,12 +2105,12 @@ Array [
           </svg>
         </a>
         <a
-          className="c8"
+          className="c6"
           href="mailto:info@opencollective.com"
         >
           <svg
             aria-hidden="true"
-            className="c13"
+            className="c11"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -2133,24 +2126,38 @@ Array [
         </a>
       </div>
       <nav
-        className="c14 c15"
+        className="c12"
+        order={
+          Array [
+            "3",
+            null,
+            "2",
+          ]
+        }
       >
         <div
-          className="c16"
+          className="c13"
+          width={
+            Array [
+              0.5,
+              null,
+              0.25,
+            ]
+          }
         >
           <p
-            className="c17"
+            className="c14"
           >
             PLATFORM
           </p>
           <ul
-            className="c18"
+            className="c15"
           >
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/discover"
                 onClick={[Function]}
               >
@@ -2158,20 +2165,20 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/learn-more"
               >
                 How it Works
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/signin"
                 onClick={[Function]}
               >
@@ -2179,10 +2186,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/signin"
                 onClick={[Function]}
               >
@@ -2192,21 +2199,28 @@ Array [
           </ul>
         </div>
         <div
-          className="c16"
+          className="c13"
+          width={
+            Array [
+              0.5,
+              null,
+              0.25,
+            ]
+          }
         >
           <p
-            className="c17"
+            className="c14"
           >
             JOIN THE MOVEMENT
           </p>
           <ul
-            className="c18"
+            className="c15"
           >
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/create"
                 onClick={[Function]}
               >
@@ -2214,10 +2228,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/become-a-sponsor"
                 onClick={[Function]}
               >
@@ -2225,10 +2239,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/chapters"
                 onClick={[Function]}
               >
@@ -2238,21 +2252,28 @@ Array [
           </ul>
         </div>
         <div
-          className="c16"
+          className="c13"
+          width={
+            Array [
+              0.5,
+              null,
+              0.25,
+            ]
+          }
         >
           <p
-            className="c17"
+            className="c14"
           >
             COMMUNITY
           </p>
           <ul
-            className="c18"
+            className="c15"
           >
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/opensource"
                 onClick={[Function]}
               >
@@ -2260,10 +2281,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="https://github.com/opencollective/opencollective/issues"
                 onClick={[Function]}
               >
@@ -2271,10 +2292,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="https://slack.opencollective.com"
                 onClick={[Function]}
               >
@@ -2282,10 +2303,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="https://github.com/opencollective/opencollective/wiki"
                 onClick={[Function]}
               >
@@ -2293,10 +2314,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="mailto:support@opencollective.com"
                 onClick={[Function]}
               >
@@ -2306,21 +2327,28 @@ Array [
           </ul>
         </div>
         <div
-          className="c16"
+          className="c13"
+          width={
+            Array [
+              0.5,
+              null,
+              0.25,
+            ]
+          }
         >
           <p
-            className="c17"
+            className="c14"
           >
             COMPANY
           </p>
           <ul
-            className="c18"
+            className="c15"
           >
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/about"
                 onClick={[Function]}
               >
@@ -2328,10 +2356,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/faq"
                 onClick={[Function]}
               >
@@ -2339,10 +2367,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="https://medium.com/open-collective"
                 onClick={[Function]}
               >
@@ -2350,10 +2378,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/tos"
                 onClick={[Function]}
               >
@@ -2361,10 +2389,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/privacypolicy"
                 onClick={[Function]}
               >
@@ -2380,56 +2408,105 @@ Array [
 `;
 
 exports[`Search Page renders error message 1`] = `
-.c2 {
-  box-sizing: border-box;
-}
-
-.c6 {
+.c4 {
   box-sizing: border-box;
   margin-left: 8px;
   margin-right: 8px;
 }
 
-.c8 {
-  box-sizing: border-box;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c22 {
+.c13 {
   box-sizing: border-box;
   margin-left: 16px;
   margin-right: 16px;
 }
 
-.c26 {
-  margin: 0;
-  box-sizing: border-box;
-  margin: 0px;
-  padding: 0px;
-}
-
-.c27 {
+.c17 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
 }
 
-.c9 {
+.c33 {
   box-sizing: border-box;
-  width: 100%;
+  margin-bottom: 16px;
+  width: 50%;
 }
 
-.c32 {
-  max-width: 1300px;
+.c1 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c11 {
+  box-sizing: border-box;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c14 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c21 {
   box-sizing: border-box;
   margin-left: auto;
   margin-right: auto;
   padding: 8px;
+  max-width: 1300px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
 }
 
-.c44 {
+.c23 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c32 {
   box-sizing: border-box;
   margin-top: 16px;
   -webkit-flex: 1 1 auto;
@@ -2438,47 +2515,25 @@ exports[`Search Page renders error message 1`] = `
   -webkit-order: 3;
   -ms-flex-order: 3;
   order: 3;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
-.c45 {
-  box-sizing: border-box;
-  width: 50%;
-  margin-bottom: 16px;
-}
-
-.c1 {
+.c0 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
   padding-top: 8px;
   padding-bottom: 8px;
-}
-
-.c11 {
-  box-sizing: border-box;
-  padding: 8px;
-}
-
-.c14 {
-  box-sizing: border-box;
-  padding: 4px;
-}
-
-.c16 {
-  box-sizing: border-box;
-  width: 100%;
-  padding-left: 16px;
-  padding-top: 4px;
-  padding-bottom: 4px;
-}
-
-.c19 {
-  box-sizing: border-box;
-  margin-right: 4px;
-  padding: 4px;
-}
-
-.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2496,52 +2551,11 @@ exports[`Search Page renders error message 1`] = `
   justify-content: space-around;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c20 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
-.c18 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c25 {
-  margin: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: space-around;
-  -webkit-justify-content: space-around;
-  -ms-flex-pack: space-around;
-  justify-content: space-around;
-}
-
-.c7 {
+.c5 {
+  box-sizing: border-box;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2552,72 +2566,13 @@ exports[`Search Page renders error message 1`] = `
   justify-content: center;
 }
 
-.c31 {
-  max-width: 1300px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c34 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c43 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c13 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c23 {
+.c15 {
   display: inline-block;
   vertical-align: -.125em;
   overflow: hidden;
 }
 
-.c30 {
+.c20 {
   border-top: 1px solid #aaaaaa;
   bottom: 0px;
   background-color: white;
@@ -2626,7 +2581,7 @@ exports[`Search Page renders error message 1`] = `
   width: 100%;
 }
 
-.c33 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2639,7 +2594,7 @@ exports[`Search Page renders error message 1`] = `
   width: 100%;
 }
 
-.c36 {
+.c25 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2661,7 +2616,20 @@ exports[`Search Page renders error message 1`] = `
   width: 100%;
 }
 
-.c35 {
+.c3 {
+  box-sizing: border-box;
+}
+
+.c12 {
+  box-sizing: border-box;
+}
+
+.c6 {
+  box-sizing: border-box;
+  width: 100%;
+}
+
+.c24 {
   color: #6E747A;
   font-size: 1.4rem;
   line-height: Paragraph;
@@ -2675,7 +2643,7 @@ exports[`Search Page renders error message 1`] = `
   text-align: center;
 }
 
-.c46 {
+.c34 {
   color: #C2C6CC;
   font-size: 1.2rem;
   line-height: Paragraph;
@@ -2688,7 +2656,7 @@ exports[`Search Page renders error message 1`] = `
   text-align: center;
 }
 
-.c29 {
+.c19 {
   border: 1px solid #D5DAE0;
   border-radius: 20px;
   color: #3385FF;
@@ -2700,18 +2668,40 @@ exports[`Search Page renders error message 1`] = `
   padding-bottom: 8px;
 }
 
-.c48 {
+.c36 {
   list-style: none;
   margin-bottom: 8px;
   text-align: center;
 }
 
-.c12 {
+.c8 {
+  box-sizing: border-box;
+  padding: 4px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   border: solid 1px var(--silver-four);
   border-radius: 20px;
 }
 
-.c15.c15 {
+.c9 {
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  width: 100%;
+}
+
+.c9.c9 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -2724,7 +2714,17 @@ exports[`Search Page renders error message 1`] = `
   letter-spacing: 0.1rem;
 }
 
-.c17.c17 {
+.c10 {
+  box-sizing: border-box;
+  margin-right: 4px;
+  padding: 4px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c10.c10 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -2732,58 +2732,72 @@ exports[`Search Page renders error message 1`] = `
   border: none;
 }
 
-.c4 {
+.c2 {
   -webkit-animation: iECmZH 0.8s infinite linear;
   animation: iECmZH 0.8s infinite linear;
 }
 
-.c10 {
+.c7 {
+  box-sizing: border-box;
+  padding: 8px;
   max-width: 30rem;
   min-width: 10rem;
 }
 
-.c24 {
+.c16 {
+  box-sizing: border-box;
+  margin: 0px;
+  padding: 0px;
+  margin: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
   list-style: none;
   min-width: 20rem;
   text-align: right;
 }
 
-.c28 {
+.c18 {
   color: #777777;
   font-size: 1.4rem;
 }
 
-.c40 {
+.c29 {
   display: inline-block;
   vertical-align: -.125em;
   overflow: hidden;
 }
 
-.c38 {
+.c27 {
   display: inline-block;
   vertical-align: -.125em;
   overflow: hidden;
 }
 
-.c41 {
+.c30 {
   display: inline-block;
   vertical-align: -.125em;
   overflow: hidden;
 }
 
-.c39 {
+.c28 {
   display: inline-block;
   vertical-align: -.125em;
   overflow: hidden;
 }
 
-.c42 {
+.c31 {
   display: inline-block;
   vertical-align: middle;
   overflow: hidden;
 }
 
-.c37 {
+.c26 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2803,12 +2817,12 @@ exports[`Search Page renders error message 1`] = `
   width: 48px;
 }
 
-.c37:hover,
-.c37:focus {
+.c26:hover,
+.c26:focus {
   opacity: 1;
 }
 
-.c49 {
+.c37 {
   color: #6e747a;
   display: block;
   fontsize: 1.4rem;
@@ -2817,7 +2831,10 @@ exports[`Search Page renders error message 1`] = `
   padding: 0;
 }
 
-.c47 {
+.c35 {
+  box-sizing: border-box;
+  padding-left: 0px;
+  padding-right: 8px;
   box-sizing: border-box;
   padding-left: 0px;
   padding-right: 8px;
@@ -2835,21 +2852,13 @@ exports[`Search Page renders error message 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c44 {
-    -webkit-order: 2;
-    -ms-flex-order: 2;
-    order: 2;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c45 {
+  .c33 {
     width: 25%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c31 {
+  .c21 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -2857,7 +2866,7 @@ exports[`Search Page renders error message 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c31 {
+  .c21 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -2866,7 +2875,7 @@ exports[`Search Page renders error message 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c34 {
+  .c23 {
     -webkit-box-pack: start;
     -webkit-justify-content: flex-start;
     -ms-flex-pack: start;
@@ -2875,13 +2884,21 @@ exports[`Search Page renders error message 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c33 {
+  .c32 {
+    -webkit-order: 2;
+    -ms-flex-order: 2;
+    order: 2;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c22 {
     width: 33.33333333333333%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c36 {
+  .c25 {
     -webkit-order: 3;
     -ms-flex-order: 3;
     order: 3;
@@ -2889,43 +2906,49 @@ exports[`Search Page renders error message 1`] = `
 }
 
 @media screen and (max-width:40em) {
-  .c5 {
+  .c3 {
     display: none;
   }
 }
 
 @media screen and (min-width:40em) and (max-width:52em) {
-  .c21 {
+  .c12 {
     display: none;
   }
 }
 
 @media screen and (min-width:52em) and (max-width:64em) {
-  .c21 {
+  .c12 {
     display: none;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c21 {
+  .c12 {
+    display: none;
+  }
+}
+
+@media screen and (max-width:40em) {
+  .c6 {
     display: none;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c35 {
+  .c24 {
     text-align: left;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c46 {
+  .c34 {
     text-align: left;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c48 {
+  .c36 {
     text-align: left;
   }
 }
@@ -2938,25 +2961,25 @@ exports[`Search Page renders error message 1`] = `
       id="top"
     />
     <div
-      className="c0 c1 sc-bdVaJa c2"
+      className="c0"
     >
       <a
-        className="c3 c2"
+        className="c1"
         href="/"
         onClick={[Function]}
       >
         <img
           alt="Open Collective logo"
-          className="c4"
+          className="c2"
           height="24"
           src="/static/images/opencollective-icon.svg"
           width="24"
         />
         <div
-          className="c5 c2"
+          className="c3"
         >
           <div
-            className="c6"
+            className="c4"
           >
             <img
               height="16px"
@@ -2966,14 +2989,14 @@ exports[`Search Page renders error message 1`] = `
         </div>
       </a>
       <div
-        className="c7 c8 sc-bdVaJa c2"
+        className="c5"
       >
         <div
-          className="c5 c9"
+          className="c6"
           width={1}
         >
           <div
-            className="c10 c11"
+            className="c7"
           >
             <form
               action="/search"
@@ -2981,16 +3004,17 @@ exports[`Search Page renders error message 1`] = `
               onSubmit={[Function]}
             >
               <div
-                className="c12 c13 c14 sc-bdVaJa c2"
+                className="c8"
               >
                 <input
-                  className="c15 c16"
+                  className="c9"
                   name="q"
                   placeholder="Search Open Collective"
                   type="search"
+                  width={1}
                 />
                 <button
-                  className="c17 c18 c19"
+                  className="c10"
                 >
                   <svg
                     height={16}
@@ -3016,16 +3040,16 @@ exports[`Search Page renders error message 1`] = `
         </div>
       </div>
       <div
-        className="c20 c8 sc-bdVaJa c2"
+        className="c11"
       >
         <div
-          className="c21 c2"
+          className="c12"
         >
           <div
-            className="c22"
+            className="c13"
           >
             <a
-              className="c18 c2"
+              className="c14"
               onClick={[Function]}
             >
               <svg
@@ -3049,18 +3073,18 @@ exports[`Search Page renders error message 1`] = `
           </div>
         </div>
         <div
-          className="c21 c2"
+          className="c12"
         >
           <div
-            className="c22"
+            className="c13"
           >
             <a
-              className="c18 c2"
+              className="c14"
               onClick={[Function]}
             >
               <svg
                 aria-hidden="true"
-                className="c23"
+                className="c15"
                 color="#aaaaaa"
                 fill="currentColor"
                 focusable="false"
@@ -3078,16 +3102,16 @@ exports[`Search Page renders error message 1`] = `
           </div>
         </div>
         <div
-          className="c5 c2"
+          className="c3"
         >
           <ul
-            className="c24 c25 c26"
+            className="c16"
           >
             <li
-              className="c27"
+              className="c17"
             >
               <a
-                className="c28"
+                className="c18"
                 href="/discover"
                 onClick={[Function]}
               >
@@ -3097,10 +3121,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c27"
+              className="c17"
             >
               <a
-                className="c28"
+                className="c18"
                 href="/learn-more"
               >
                 <span>
@@ -3109,10 +3133,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c27"
+              className="c17"
             >
               <a
-                className="c28"
+                className="c18"
                 href="https://medium.com/open-collective"
               >
                 <span>
@@ -3126,7 +3150,7 @@ exports[`Search Page renders error message 1`] = `
           className="LoginTopBarProfileButton"
         >
           <a
-            className="c29"
+            className="c19"
             href="/signin?next=%2F"
             onClick={[Function]}
           >
@@ -3156,17 +3180,17 @@ exports[`Search Page renders error message 1`] = `
     </div>
   </main>
   <div
-    className="c30"
+    className="c20"
     id="footer"
   >
     <div
-      className="c31 c32 sc-bdVaJa c2"
+      className="c21"
     >
       <div
-        className="c33"
+        className="c22"
       >
         <div
-          className="c34 c2 sc-bdVaJa c2"
+          className="c23"
         >
           <object
             data="/static/images/opencollectivelogo-footer.svg"
@@ -3175,21 +3199,21 @@ exports[`Search Page renders error message 1`] = `
           />
         </div>
         <p
-          className="c35"
+          className="c24"
         >
           An organization for your community, transparent by design.
         </p>
       </div>
       <div
-        className="c36"
+        className="c25"
       >
         <a
-          className="c37"
+          className="c26"
           href="https://medium.com/open-collective"
         >
           <svg
             aria-hidden="true"
-            className="c38"
+            className="c27"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -3205,12 +3229,12 @@ exports[`Search Page renders error message 1`] = `
           </svg>
         </a>
         <a
-          className="c37"
+          className="c26"
           href="https://twitter.com/opencollect"
         >
           <svg
             aria-hidden="true"
-            className="c39"
+            className="c28"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -3226,12 +3250,12 @@ exports[`Search Page renders error message 1`] = `
           </svg>
         </a>
         <a
-          className="c37"
+          className="c26"
           href="https://github.com/opencollective"
         >
           <svg
             aria-hidden="true"
-            className="c40"
+            className="c29"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -3247,12 +3271,12 @@ exports[`Search Page renders error message 1`] = `
           </svg>
         </a>
         <a
-          className="c37"
+          className="c26"
           href="https://slack.opencollective.com"
         >
           <svg
             aria-hidden="true"
-            className="c41"
+            className="c30"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -3268,12 +3292,12 @@ exports[`Search Page renders error message 1`] = `
           </svg>
         </a>
         <a
-          className="c37"
+          className="c26"
           href="mailto:info@opencollective.com"
         >
           <svg
             aria-hidden="true"
-            className="c42"
+            className="c31"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -3289,24 +3313,38 @@ exports[`Search Page renders error message 1`] = `
         </a>
       </div>
       <nav
-        className="c43 c44"
+        className="c32"
+        order={
+          Array [
+            "3",
+            null,
+            "2",
+          ]
+        }
       >
         <div
-          className="c45"
+          className="c33"
+          width={
+            Array [
+              0.5,
+              null,
+              0.25,
+            ]
+          }
         >
           <p
-            className="c46"
+            className="c34"
           >
             PLATFORM
           </p>
           <ul
-            className="c47"
+            className="c35"
           >
             <li
-              className="c48"
+              className="c36"
             >
               <a
-                className="c49 "
+                className="c37"
                 href="/discover"
                 onClick={[Function]}
               >
@@ -3314,20 +3352,20 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c48"
+              className="c36"
             >
               <a
-                className="c49 "
+                className="c37"
                 href="/learn-more"
               >
                 How it Works
               </a>
             </li>
             <li
-              className="c48"
+              className="c36"
             >
               <a
-                className="c49 "
+                className="c37"
                 href="/signin"
                 onClick={[Function]}
               >
@@ -3335,10 +3373,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c48"
+              className="c36"
             >
               <a
-                className="c49 "
+                className="c37"
                 href="/signin"
                 onClick={[Function]}
               >
@@ -3348,21 +3386,28 @@ exports[`Search Page renders error message 1`] = `
           </ul>
         </div>
         <div
-          className="c45"
+          className="c33"
+          width={
+            Array [
+              0.5,
+              null,
+              0.25,
+            ]
+          }
         >
           <p
-            className="c46"
+            className="c34"
           >
             JOIN THE MOVEMENT
           </p>
           <ul
-            className="c47"
+            className="c35"
           >
             <li
-              className="c48"
+              className="c36"
             >
               <a
-                className="c49 "
+                className="c37"
                 href="/create"
                 onClick={[Function]}
               >
@@ -3370,10 +3415,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c48"
+              className="c36"
             >
               <a
-                className="c49 "
+                className="c37"
                 href="/become-a-sponsor"
                 onClick={[Function]}
               >
@@ -3381,10 +3426,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c48"
+              className="c36"
             >
               <a
-                className="c49 "
+                className="c37"
                 href="/chapters"
                 onClick={[Function]}
               >
@@ -3394,21 +3439,28 @@ exports[`Search Page renders error message 1`] = `
           </ul>
         </div>
         <div
-          className="c45"
+          className="c33"
+          width={
+            Array [
+              0.5,
+              null,
+              0.25,
+            ]
+          }
         >
           <p
-            className="c46"
+            className="c34"
           >
             COMMUNITY
           </p>
           <ul
-            className="c47"
+            className="c35"
           >
             <li
-              className="c48"
+              className="c36"
             >
               <a
-                className="c49 "
+                className="c37"
                 href="/opensource"
                 onClick={[Function]}
               >
@@ -3416,10 +3468,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c48"
+              className="c36"
             >
               <a
-                className="c49 "
+                className="c37"
                 href="https://github.com/opencollective/opencollective/issues"
                 onClick={[Function]}
               >
@@ -3427,10 +3479,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c48"
+              className="c36"
             >
               <a
-                className="c49 "
+                className="c37"
                 href="https://slack.opencollective.com"
                 onClick={[Function]}
               >
@@ -3438,10 +3490,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c48"
+              className="c36"
             >
               <a
-                className="c49 "
+                className="c37"
                 href="https://github.com/opencollective/opencollective/wiki"
                 onClick={[Function]}
               >
@@ -3449,10 +3501,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c48"
+              className="c36"
             >
               <a
-                className="c49 "
+                className="c37"
                 href="mailto:support@opencollective.com"
                 onClick={[Function]}
               >
@@ -3462,21 +3514,28 @@ exports[`Search Page renders error message 1`] = `
           </ul>
         </div>
         <div
-          className="c45"
+          className="c33"
+          width={
+            Array [
+              0.5,
+              null,
+              0.25,
+            ]
+          }
         >
           <p
-            className="c46"
+            className="c34"
           >
             COMPANY
           </p>
           <ul
-            className="c47"
+            className="c35"
           >
             <li
-              className="c48"
+              className="c36"
             >
               <a
-                className="c49 "
+                className="c37"
                 href="/about"
                 onClick={[Function]}
               >
@@ -3484,10 +3543,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c48"
+              className="c36"
             >
               <a
-                className="c49 "
+                className="c37"
                 href="/faq"
                 onClick={[Function]}
               >
@@ -3495,10 +3554,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c48"
+              className="c36"
             >
               <a
-                className="c49 "
+                className="c37"
                 href="https://medium.com/open-collective"
                 onClick={[Function]}
               >
@@ -3506,10 +3565,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c48"
+              className="c36"
             >
               <a
-                className="c49 "
+                className="c37"
                 href="/tos"
                 onClick={[Function]}
               >
@@ -3517,10 +3576,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c48"
+              className="c36"
             >
               <a
-                className="c49 "
+                className="c37"
                 href="/privacypolicy"
                 onClick={[Function]}
               >
@@ -3537,51 +3596,30 @@ exports[`Search Page renders error message 1`] = `
 
 exports[`Search Page renders loading grid SVG 1`] = `
 Array [
-  .c1 {
-  box-sizing: border-box;
-  padding-left: 16px;
-  padding-right: 16px;
-  padding-top: 16px;
-  padding-bottom: 16px;
-}
-
-.c2 {
-  box-sizing: border-box;
-}
-
-.c6 {
+  .c4 {
   box-sizing: border-box;
   margin-left: 8px;
   margin-right: 8px;
 }
 
-.c8 {
-  box-sizing: border-box;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c10 {
+.c7 {
   box-sizing: border-box;
   margin-left: 16px;
   margin-right: 16px;
 }
 
-.c15 {
-  margin: 0;
-  box-sizing: border-box;
-  margin: 0px;
-  padding: 0px;
-}
-
-.c16 {
+.c11 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
 }
 
 .c0 {
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-top: 16px;
+  padding-bottom: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3599,7 +3637,8 @@ Array [
   justify-content: space-around;
 }
 
-.c3 {
+.c1 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3610,7 +3649,11 @@ Array [
   align-items: center;
 }
 
-.c7 {
+.c5 {
+  box-sizing: border-box;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3625,32 +3668,29 @@ Array [
   justify-content: flex-end;
 }
 
-.c11 {
+.c8 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c14 {
-  margin: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: space-around;
-  -webkit-justify-content: space-around;
-  -ms-flex-pack: space-around;
-  justify-content: space-around;
-}
-
-.c12 {
+.c9 {
   display: inline-block;
   vertical-align: -.125em;
   overflow: hidden;
 }
 
-.c18 {
+.c3 {
+  box-sizing: border-box;
+}
+
+.c6 {
+  box-sizing: border-box;
+}
+
+.c13 {
   border: 1px solid #D5DAE0;
   border-radius: 20px;
   color: #3385FF;
@@ -3662,42 +3702,54 @@ Array [
   padding-bottom: 8px;
 }
 
-.c4 {
+.c2 {
   -webkit-animation: iECmZH 0.8s infinite linear;
   animation: iECmZH 0.8s infinite linear;
 }
 
-.c13 {
+.c10 {
+  box-sizing: border-box;
+  margin: 0px;
+  padding: 0px;
+  margin: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
   list-style: none;
   min-width: 20rem;
   text-align: right;
 }
 
-.c17 {
+.c12 {
   color: #777777;
   font-size: 1.4rem;
 }
 
 @media screen and (max-width:40em) {
-  .c5 {
+  .c3 {
     display: none;
   }
 }
 
 @media screen and (min-width:40em) and (max-width:52em) {
-  .c9 {
+  .c6 {
     display: none;
   }
 }
 
 @media screen and (min-width:52em) and (max-width:64em) {
-  .c9 {
+  .c6 {
     display: none;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c9 {
+  .c6 {
     display: none;
   }
 }
@@ -3707,25 +3759,25 @@ Array [
       id="top"
     />
     <div
-      className="c0 c1 sc-bdVaJa c2"
+      className="c0"
     >
       <a
-        className="c3 c2"
+        className="c1"
         href="/"
         onClick={[Function]}
       >
         <img
           alt="Open Collective logo"
-          className="c4"
+          className="c2"
           height="24"
           src="/static/images/opencollective-icon.svg"
           width="24"
         />
         <div
-          className="c5 c2"
+          className="c3"
         >
           <div
-            className="c6"
+            className="c4"
           >
             <img
               height="16px"
@@ -3735,16 +3787,16 @@ Array [
         </div>
       </a>
       <div
-        className="c7 c8 sc-bdVaJa c2"
+        className="c5"
       >
         <div
-          className="c9 c2"
+          className="c6"
         >
           <div
-            className="c10"
+            className="c7"
           >
             <a
-              className="c11 c2"
+              className="c8"
               onClick={[Function]}
             >
               <svg
@@ -3768,18 +3820,18 @@ Array [
           </div>
         </div>
         <div
-          className="c9 c2"
+          className="c6"
         >
           <div
-            className="c10"
+            className="c7"
           >
             <a
-              className="c11 c2"
+              className="c8"
               onClick={[Function]}
             >
               <svg
                 aria-hidden="true"
-                className="c12"
+                className="c9"
                 color="#aaaaaa"
                 fill="currentColor"
                 focusable="false"
@@ -3797,16 +3849,16 @@ Array [
           </div>
         </div>
         <div
-          className="c5 c2"
+          className="c3"
         >
           <ul
-            className="c13 c14 c15"
+            className="c10"
           >
             <li
-              className="c16"
+              className="c11"
             >
               <a
-                className="c17"
+                className="c12"
                 href="/discover"
                 onClick={[Function]}
               >
@@ -3816,10 +3868,10 @@ Array [
               </a>
             </li>
             <li
-              className="c16"
+              className="c11"
             >
               <a
-                className="c17"
+                className="c12"
                 href="/learn-more"
               >
                 <span>
@@ -3828,10 +3880,10 @@ Array [
               </a>
             </li>
             <li
-              className="c16"
+              className="c11"
             >
               <a
-                className="c17"
+                className="c12"
                 href="https://medium.com/open-collective"
               >
                 <span>
@@ -3845,7 +3897,7 @@ Array [
           className="LoginTopBarProfileButton"
         >
           <a
-            className="c18"
+            className="c13"
             href="/signin?next=%2F"
             onClick={[Function]}
           >
@@ -3857,29 +3909,15 @@ Array [
       </div>
     </div>
   </header>,
-  .c4 {
-  box-sizing: border-box;
-}
-
-.c1 {
+  .c1 {
   box-sizing: border-box;
   width: 100%;
-}
-
-.c3 {
-  box-sizing: border-box;
-  margin-top: 16px;
-  margin-bottom: 16px;
-}
-
-.c9 {
-  box-sizing: border-box;
-  width: 100%;
-  padding-top: 16px;
-  padding-bottom: 16px;
 }
 
 .c2 {
+  box-sizing: border-box;
+  margin-top: 16px;
+  margin-bottom: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3890,7 +3928,8 @@ Array [
   align-items: flex-end;
 }
 
-.c7 {
+.c5 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3904,7 +3943,11 @@ Array [
   justify-content: center;
 }
 
-.c8 {
+.c6 {
+  box-sizing: border-box;
+  padding-top: 16px;
+  padding-bottom: 16px;
+  width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3924,7 +3967,7 @@ Array [
   width: 100%;
 }
 
-.c5.c5.c5 {
+.c3.c3.c3 {
   border: none;
   border-bottom: 2px solid #3385FF;
   border-radius: 0;
@@ -3934,12 +3977,12 @@ Array [
   padding: 0;
 }
 
-.c6.c6 {
+.c4.c4 {
   padding: 0 2rem;
 }
 
 @media screen and (min-width:40em) {
-  .c7 {
+  .c5 {
     -webkit-box-pack: center;
     -webkit-justify-content: center;
     -ms-flex-pack: center;
@@ -3948,7 +3991,7 @@ Array [
 }
 
 @media screen and (min-width:52em) {
-  .c7 {
+  .c5 {
     -webkit-box-pack: start;
     -webkit-justify-content: flex-start;
     -ms-flex-pack: start;
@@ -3970,6 +4013,7 @@ Array [
     >
       <div
         className="c1"
+        width={1}
       >
         <form
           method="GET"
@@ -3985,10 +4029,10 @@ Array [
               Search Open Collective
             </label>
             <div
-              className="c2 c3 sc-bdVaJa c4"
+              className="c2"
             >
               <input
-                className="c5 form-control"
+                className="c3 form-control"
                 defaultValue=""
                 id="search"
                 name="q"
@@ -3996,7 +4040,7 @@ Array [
                 type="search"
               />
               <button
-                className="jsx-1144918383 jsx-3101740563 Button blue c6"
+                className="jsx-1144918383 jsx-3101740563 Button blue c4"
                 onClick={[Function]}
                 type="submit"
               >
@@ -4009,10 +4053,11 @@ Array [
         </form>
       </div>
       <div
-        className="c7 c4 sc-bdVaJa c4"
+        className="c5"
       >
         <div
-          className="c8 c9 sc-bdVaJa c4"
+          className="c6"
+          width={1}
         >
           <svg
             fill="#3385FF"
@@ -4153,36 +4198,17 @@ Array [
       </div>
     </div>
   </main>,
-  .c3 {
+  .c13 {
   box-sizing: border-box;
+  margin-bottom: 16px;
+  width: 50%;
 }
 
-.c2 {
-  max-width: 1300px;
+.c1 {
   box-sizing: border-box;
   margin-left: auto;
   margin-right: auto;
   padding: 8px;
-}
-
-.c15 {
-  box-sizing: border-box;
-  margin-top: 16px;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c16 {
-  box-sizing: border-box;
-  width: 50%;
-  margin-bottom: 16px;
-}
-
-.c1 {
   max-width: 1300px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -4201,7 +4227,8 @@ Array [
   justify-content: space-between;
 }
 
-.c5 {
+.c3 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4212,7 +4239,15 @@ Array [
   justify-content: center;
 }
 
-.c14 {
+.c12 {
+  box-sizing: border-box;
+  margin-top: 16px;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4235,7 +4270,7 @@ Array [
   width: 100%;
 }
 
-.c4 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4248,7 +4283,7 @@ Array [
   width: 100%;
 }
 
-.c7 {
+.c5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4270,7 +4305,7 @@ Array [
   width: 100%;
 }
 
-.c6 {
+.c4 {
   color: #6E747A;
   font-size: 1.4rem;
   line-height: Paragraph;
@@ -4284,7 +4319,7 @@ Array [
   text-align: center;
 }
 
-.c17 {
+.c14 {
   color: #C2C6CC;
   font-size: 1.2rem;
   line-height: Paragraph;
@@ -4297,16 +4332,10 @@ Array [
   text-align: center;
 }
 
-.c19 {
+.c16 {
   list-style: none;
   margin-bottom: 8px;
   text-align: center;
-}
-
-.c11 {
-  display: inline-block;
-  vertical-align: -.125em;
-  overflow: hidden;
 }
 
 .c9 {
@@ -4315,7 +4344,7 @@ Array [
   overflow: hidden;
 }
 
-.c12 {
+.c7 {
   display: inline-block;
   vertical-align: -.125em;
   overflow: hidden;
@@ -4327,13 +4356,19 @@ Array [
   overflow: hidden;
 }
 
-.c13 {
+.c8 {
+  display: inline-block;
+  vertical-align: -.125em;
+  overflow: hidden;
+}
+
+.c11 {
   display: inline-block;
   vertical-align: middle;
   overflow: hidden;
 }
 
-.c8 {
+.c6 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4353,12 +4388,12 @@ Array [
   width: 48px;
 }
 
-.c8:hover,
-.c8:focus {
+.c6:hover,
+.c6:focus {
   opacity: 1;
 }
 
-.c20 {
+.c17 {
   color: #6e747a;
   display: block;
   fontsize: 1.4rem;
@@ -4367,7 +4402,10 @@ Array [
   padding: 0;
 }
 
-.c18 {
+.c15 {
+  box-sizing: border-box;
+  padding-left: 0px;
+  padding-right: 8px;
   box-sizing: border-box;
   padding-left: 0px;
   padding-right: 8px;
@@ -4385,15 +4423,7 @@ Array [
 }
 
 @media screen and (min-width:52em) {
-  .c15 {
-    -webkit-order: 2;
-    -ms-flex-order: 2;
-    order: 2;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c16 {
+  .c13 {
     width: 25%;
   }
 }
@@ -4416,7 +4446,7 @@ Array [
 }
 
 @media screen and (min-width:52em) {
-  .c5 {
+  .c3 {
     -webkit-box-pack: start;
     -webkit-justify-content: flex-start;
     -ms-flex-pack: start;
@@ -4425,13 +4455,21 @@ Array [
 }
 
 @media screen and (min-width:52em) {
-  .c4 {
+  .c12 {
+    -webkit-order: 2;
+    -ms-flex-order: 2;
+    order: 2;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c2 {
     width: 33.33333333333333%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c7 {
+  .c5 {
     -webkit-order: 3;
     -ms-flex-order: 3;
     order: 3;
@@ -4439,19 +4477,19 @@ Array [
 }
 
 @media screen and (min-width:52em) {
-  .c6 {
+  .c4 {
     text-align: left;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c17 {
+  .c14 {
     text-align: left;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c19 {
+  .c16 {
     text-align: left;
   }
 }
@@ -4461,13 +4499,13 @@ Array [
     id="footer"
   >
     <div
-      className="c1 c2 sc-bdVaJa c3"
+      className="c1"
     >
       <div
-        className="c4"
+        className="c2"
       >
         <div
-          className="c5 c3 sc-bdVaJa c3"
+          className="c3"
         >
           <object
             data="/static/images/opencollectivelogo-footer.svg"
@@ -4476,21 +4514,21 @@ Array [
           />
         </div>
         <p
-          className="c6"
+          className="c4"
         >
           An organization for your community, transparent by design.
         </p>
       </div>
       <div
-        className="c7"
+        className="c5"
       >
         <a
-          className="c8"
+          className="c6"
           href="https://medium.com/open-collective"
         >
           <svg
             aria-hidden="true"
-            className="c9"
+            className="c7"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -4506,12 +4544,12 @@ Array [
           </svg>
         </a>
         <a
-          className="c8"
+          className="c6"
           href="https://twitter.com/opencollect"
         >
           <svg
             aria-hidden="true"
-            className="c10"
+            className="c8"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -4527,12 +4565,12 @@ Array [
           </svg>
         </a>
         <a
-          className="c8"
+          className="c6"
           href="https://github.com/opencollective"
         >
           <svg
             aria-hidden="true"
-            className="c11"
+            className="c9"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -4548,12 +4586,12 @@ Array [
           </svg>
         </a>
         <a
-          className="c8"
+          className="c6"
           href="https://slack.opencollective.com"
         >
           <svg
             aria-hidden="true"
-            className="c12"
+            className="c10"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -4569,12 +4607,12 @@ Array [
           </svg>
         </a>
         <a
-          className="c8"
+          className="c6"
           href="mailto:info@opencollective.com"
         >
           <svg
             aria-hidden="true"
-            className="c13"
+            className="c11"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -4590,24 +4628,38 @@ Array [
         </a>
       </div>
       <nav
-        className="c14 c15"
+        className="c12"
+        order={
+          Array [
+            "3",
+            null,
+            "2",
+          ]
+        }
       >
         <div
-          className="c16"
+          className="c13"
+          width={
+            Array [
+              0.5,
+              null,
+              0.25,
+            ]
+          }
         >
           <p
-            className="c17"
+            className="c14"
           >
             PLATFORM
           </p>
           <ul
-            className="c18"
+            className="c15"
           >
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/discover"
                 onClick={[Function]}
               >
@@ -4615,20 +4667,20 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/learn-more"
               >
                 How it Works
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/signin"
                 onClick={[Function]}
               >
@@ -4636,10 +4688,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/signin"
                 onClick={[Function]}
               >
@@ -4649,21 +4701,28 @@ Array [
           </ul>
         </div>
         <div
-          className="c16"
+          className="c13"
+          width={
+            Array [
+              0.5,
+              null,
+              0.25,
+            ]
+          }
         >
           <p
-            className="c17"
+            className="c14"
           >
             JOIN THE MOVEMENT
           </p>
           <ul
-            className="c18"
+            className="c15"
           >
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/create"
                 onClick={[Function]}
               >
@@ -4671,10 +4730,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/become-a-sponsor"
                 onClick={[Function]}
               >
@@ -4682,10 +4741,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/chapters"
                 onClick={[Function]}
               >
@@ -4695,21 +4754,28 @@ Array [
           </ul>
         </div>
         <div
-          className="c16"
+          className="c13"
+          width={
+            Array [
+              0.5,
+              null,
+              0.25,
+            ]
+          }
         >
           <p
-            className="c17"
+            className="c14"
           >
             COMMUNITY
           </p>
           <ul
-            className="c18"
+            className="c15"
           >
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/opensource"
                 onClick={[Function]}
               >
@@ -4717,10 +4783,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="https://github.com/opencollective/opencollective/issues"
                 onClick={[Function]}
               >
@@ -4728,10 +4794,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="https://slack.opencollective.com"
                 onClick={[Function]}
               >
@@ -4739,10 +4805,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="https://github.com/opencollective/opencollective/wiki"
                 onClick={[Function]}
               >
@@ -4750,10 +4816,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="mailto:support@opencollective.com"
                 onClick={[Function]}
               >
@@ -4763,21 +4829,28 @@ Array [
           </ul>
         </div>
         <div
-          className="c16"
+          className="c13"
+          width={
+            Array [
+              0.5,
+              null,
+              0.25,
+            ]
+          }
         >
           <p
-            className="c17"
+            className="c14"
           >
             COMPANY
           </p>
           <ul
-            className="c18"
+            className="c15"
           >
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/about"
                 onClick={[Function]}
               >
@@ -4785,10 +4858,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/faq"
                 onClick={[Function]}
               >
@@ -4796,10 +4869,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="https://medium.com/open-collective"
                 onClick={[Function]}
               >
@@ -4807,10 +4880,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/tos"
                 onClick={[Function]}
               >
@@ -4818,10 +4891,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/privacypolicy"
                 onClick={[Function]}
               >
@@ -4838,51 +4911,30 @@ Array [
 
 exports[`Search Page renders search results with pagination 1`] = `
 Array [
-  .c1 {
-  box-sizing: border-box;
-  padding-left: 16px;
-  padding-right: 16px;
-  padding-top: 16px;
-  padding-bottom: 16px;
-}
-
-.c2 {
-  box-sizing: border-box;
-}
-
-.c6 {
+  .c4 {
   box-sizing: border-box;
   margin-left: 8px;
   margin-right: 8px;
 }
 
-.c8 {
-  box-sizing: border-box;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-}
-
-.c10 {
+.c7 {
   box-sizing: border-box;
   margin-left: 16px;
   margin-right: 16px;
 }
 
-.c15 {
-  margin: 0;
-  box-sizing: border-box;
-  margin: 0px;
-  padding: 0px;
-}
-
-.c16 {
+.c11 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
 }
 
 .c0 {
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-top: 16px;
+  padding-bottom: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4900,7 +4952,8 @@ Array [
   justify-content: space-around;
 }
 
-.c3 {
+.c1 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4911,7 +4964,11 @@ Array [
   align-items: center;
 }
 
-.c7 {
+.c5 {
+  box-sizing: border-box;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4926,32 +4983,29 @@ Array [
   justify-content: flex-end;
 }
 
-.c11 {
+.c8 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c14 {
-  margin: 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: space-around;
-  -webkit-justify-content: space-around;
-  -ms-flex-pack: space-around;
-  justify-content: space-around;
-}
-
-.c12 {
+.c9 {
   display: inline-block;
   vertical-align: -.125em;
   overflow: hidden;
 }
 
-.c18 {
+.c3 {
+  box-sizing: border-box;
+}
+
+.c6 {
+  box-sizing: border-box;
+}
+
+.c13 {
   border: 1px solid #D5DAE0;
   border-radius: 20px;
   color: #3385FF;
@@ -4963,42 +5017,54 @@ Array [
   padding-bottom: 8px;
 }
 
-.c4 {
+.c2 {
   -webkit-animation: iECmZH 0.8s infinite linear;
   animation: iECmZH 0.8s infinite linear;
 }
 
-.c13 {
+.c10 {
+  box-sizing: border-box;
+  margin: 0px;
+  padding: 0px;
+  margin: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: space-around;
+  -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
+  justify-content: space-around;
   list-style: none;
   min-width: 20rem;
   text-align: right;
 }
 
-.c17 {
+.c12 {
   color: #777777;
   font-size: 1.4rem;
 }
 
 @media screen and (max-width:40em) {
-  .c5 {
+  .c3 {
     display: none;
   }
 }
 
 @media screen and (min-width:40em) and (max-width:52em) {
-  .c9 {
+  .c6 {
     display: none;
   }
 }
 
 @media screen and (min-width:52em) and (max-width:64em) {
-  .c9 {
+  .c6 {
     display: none;
   }
 }
 
 @media screen and (min-width:64em) {
-  .c9 {
+  .c6 {
     display: none;
   }
 }
@@ -5008,25 +5074,25 @@ Array [
       id="top"
     />
     <div
-      className="c0 c1 sc-bdVaJa c2"
+      className="c0"
     >
       <a
-        className="c3 c2"
+        className="c1"
         href="/"
         onClick={[Function]}
       >
         <img
           alt="Open Collective logo"
-          className="c4"
+          className="c2"
           height="24"
           src="/static/images/opencollective-icon.svg"
           width="24"
         />
         <div
-          className="c5 c2"
+          className="c3"
         >
           <div
-            className="c6"
+            className="c4"
           >
             <img
               height="16px"
@@ -5036,16 +5102,16 @@ Array [
         </div>
       </a>
       <div
-        className="c7 c8 sc-bdVaJa c2"
+        className="c5"
       >
         <div
-          className="c9 c2"
+          className="c6"
         >
           <div
-            className="c10"
+            className="c7"
           >
             <a
-              className="c11 c2"
+              className="c8"
               onClick={[Function]}
             >
               <svg
@@ -5069,18 +5135,18 @@ Array [
           </div>
         </div>
         <div
-          className="c9 c2"
+          className="c6"
         >
           <div
-            className="c10"
+            className="c7"
           >
             <a
-              className="c11 c2"
+              className="c8"
               onClick={[Function]}
             >
               <svg
                 aria-hidden="true"
-                className="c12"
+                className="c9"
                 color="#aaaaaa"
                 fill="currentColor"
                 focusable="false"
@@ -5098,16 +5164,16 @@ Array [
           </div>
         </div>
         <div
-          className="c5 c2"
+          className="c3"
         >
           <ul
-            className="c13 c14 c15"
+            className="c10"
           >
             <li
-              className="c16"
+              className="c11"
             >
               <a
-                className="c17"
+                className="c12"
                 href="/discover"
                 onClick={[Function]}
               >
@@ -5117,10 +5183,10 @@ Array [
               </a>
             </li>
             <li
-              className="c16"
+              className="c11"
             >
               <a
-                className="c17"
+                className="c12"
                 href="/learn-more"
               >
                 <span>
@@ -5129,10 +5195,10 @@ Array [
               </a>
             </li>
             <li
-              className="c16"
+              className="c11"
             >
               <a
-                className="c17"
+                className="c12"
                 href="https://medium.com/open-collective"
               >
                 <span>
@@ -5146,7 +5212,7 @@ Array [
           className="LoginTopBarProfileButton"
         >
           <a
-            className="c18"
+            className="c13"
             href="/signin?next=%2F"
             onClick={[Function]}
           >
@@ -5158,43 +5224,13 @@ Array [
       </div>
     </div>
   </header>,
-  .c4 {
-  box-sizing: border-box;
-}
-
-.c12 {
-  box-sizing: border-box;
-  margin-left: 8px;
-  margin-right: 8px;
-}
-
-.c1 {
+  .c1 {
   box-sizing: border-box;
   width: 100%;
 }
 
-.c3 {
+.c8 {
   box-sizing: border-box;
-  margin-top: 16px;
-  margin-bottom: 16px;
-}
-
-.c16 {
-  box-sizing: border-box;
-  width: 100%;
-  padding-top: 16px;
-  padding-bottom: 16px;
-}
-
-.c9 {
-  box-sizing: border-box;
-  margin-left: 8px;
-  margin-right: 8px;
-  margin-top: 16px;
-  margin-bottom: 16px;
-}
-
-.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5205,14 +5241,10 @@ Array [
   align-items: center;
 }
 
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
 .c2 {
+  box-sizing: border-box;
+  margin-top: 16px;
+  margin-bottom: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5223,7 +5255,8 @@ Array [
   align-items: flex-end;
 }
 
-.c7 {
+.c5 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5237,7 +5270,11 @@ Array [
   justify-content: center;
 }
 
-.c15 {
+.c12 {
+  box-sizing: border-box;
+  padding-top: 16px;
+  padding-bottom: 16px;
+  width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5255,6 +5292,32 @@ Array [
   justify-content: center;
 }
 
+.c6 {
+  box-sizing: border-box;
+  margin-left: 8px;
+  margin-right: 8px;
+  margin-top: 16px;
+  margin-bottom: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c9 {
+  box-sizing: border-box;
+  margin-left: 8px;
+  margin-right: 8px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
 .c0 {
   max-width: 1200px;
   margin-left: auto;
@@ -5264,7 +5327,7 @@ Array [
   width: 100%;
 }
 
-.c10 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5278,7 +5341,7 @@ Array [
   margin-bottom: 16px;
 }
 
-.c13 {
+.c10 {
   font-size: inherit;
   line-height: inherit;
   -webkit-letter-spacing: -0.2px;
@@ -5288,7 +5351,7 @@ Array [
   margin: 0px;
 }
 
-.c14 {
+.c11 {
   border: 1px solid #cccccc;
   border-radius: 4px;
   font-size: 14px;
@@ -5302,7 +5365,7 @@ Array [
   width: 30px;
 }
 
-.c5.c5.c5 {
+.c3.c3.c3 {
   border: none;
   border-bottom: 2px solid #3385FF;
   border-radius: 0;
@@ -5312,12 +5375,12 @@ Array [
   padding: 0;
 }
 
-.c6.c6 {
+.c4.c4 {
   padding: 0 2rem;
 }
 
 @media screen and (min-width:40em) {
-  .c7 {
+  .c5 {
     -webkit-box-pack: center;
     -webkit-justify-content: center;
     -ms-flex-pack: center;
@@ -5326,7 +5389,7 @@ Array [
 }
 
 @media screen and (min-width:52em) {
-  .c7 {
+  .c5 {
     -webkit-box-pack: start;
     -webkit-justify-content: flex-start;
     -ms-flex-pack: start;
@@ -5348,6 +5411,7 @@ Array [
     >
       <div
         className="c1"
+        width={1}
       >
         <form
           method="GET"
@@ -5363,10 +5427,10 @@ Array [
               Search Open Collective
             </label>
             <div
-              className="c2 c3 sc-bdVaJa c4"
+              className="c2"
             >
               <input
-                className="c5 form-control"
+                className="c3 form-control"
                 defaultValue="Test"
                 id="search"
                 name="q"
@@ -5374,7 +5438,7 @@ Array [
                 type="search"
               />
               <button
-                className="jsx-1144918383 jsx-3101740563 Button blue c6"
+                className="jsx-1144918383 jsx-3101740563 Button blue c4"
                 onClick={[Function]}
                 type="submit"
               >
@@ -5387,10 +5451,10 @@ Array [
         </form>
       </div>
       <div
-        className="c7 c4 sc-bdVaJa c4"
+        className="c5"
       >
         <div
-          className="c8 c9 sc-bdVaJa c4"
+          className="c6"
         >
           <a
             href="/test-collective"
@@ -5453,28 +5517,28 @@ Array [
         </div>
       </div>
       <div
-        className="c10"
+        className="c7"
       >
         <div
-          className="c11 c4 sc-bdVaJa c4"
+          className="c8"
         >
           <div
-            className="c11 c12 sc-bdVaJa c4"
+            className="c9"
           >
             <span
-              className="-Clean-span c13"
+              className="-Clean-span c10"
             >
               Page 
             </span>
             <input
-              className="c14"
+              className="c11"
               defaultValue={1}
               onBlur={[Function]}
               onKeyPress={[Function]}
               type="text"
             />
             <span
-              className="-Clean-span c13"
+              className="-Clean-span c10"
             >
               of 
               5
@@ -5490,7 +5554,8 @@ Array [
         </div>
       </div>
       <div
-        className="c15 c16 sc-bdVaJa c4"
+        className="c12"
+        width={1}
       >
         <p>
           <em>
@@ -5500,36 +5565,17 @@ Array [
       </div>
     </div>
   </main>,
-  .c3 {
+  .c13 {
   box-sizing: border-box;
+  margin-bottom: 16px;
+  width: 50%;
 }
 
-.c2 {
-  max-width: 1300px;
+.c1 {
   box-sizing: border-box;
   margin-left: auto;
   margin-right: auto;
   padding: 8px;
-}
-
-.c15 {
-  box-sizing: border-box;
-  margin-top: 16px;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  -webkit-order: 3;
-  -ms-flex-order: 3;
-  order: 3;
-}
-
-.c16 {
-  box-sizing: border-box;
-  width: 50%;
-  margin-bottom: 16px;
-}
-
-.c1 {
   max-width: 1300px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -5548,7 +5594,8 @@ Array [
   justify-content: space-between;
 }
 
-.c5 {
+.c3 {
+  box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5559,7 +5606,15 @@ Array [
   justify-content: center;
 }
 
-.c14 {
+.c12 {
+  box-sizing: border-box;
+  margin-top: 16px;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  -webkit-order: 3;
+  -ms-flex-order: 3;
+  order: 3;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5582,7 +5637,7 @@ Array [
   width: 100%;
 }
 
-.c4 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5595,7 +5650,7 @@ Array [
   width: 100%;
 }
 
-.c7 {
+.c5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5617,7 +5672,7 @@ Array [
   width: 100%;
 }
 
-.c6 {
+.c4 {
   color: #6E747A;
   font-size: 1.4rem;
   line-height: Paragraph;
@@ -5631,7 +5686,7 @@ Array [
   text-align: center;
 }
 
-.c17 {
+.c14 {
   color: #C2C6CC;
   font-size: 1.2rem;
   line-height: Paragraph;
@@ -5644,16 +5699,10 @@ Array [
   text-align: center;
 }
 
-.c19 {
+.c16 {
   list-style: none;
   margin-bottom: 8px;
   text-align: center;
-}
-
-.c11 {
-  display: inline-block;
-  vertical-align: -.125em;
-  overflow: hidden;
 }
 
 .c9 {
@@ -5662,7 +5711,7 @@ Array [
   overflow: hidden;
 }
 
-.c12 {
+.c7 {
   display: inline-block;
   vertical-align: -.125em;
   overflow: hidden;
@@ -5674,13 +5723,19 @@ Array [
   overflow: hidden;
 }
 
-.c13 {
+.c8 {
+  display: inline-block;
+  vertical-align: -.125em;
+  overflow: hidden;
+}
+
+.c11 {
   display: inline-block;
   vertical-align: middle;
   overflow: hidden;
 }
 
-.c8 {
+.c6 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -5700,12 +5755,12 @@ Array [
   width: 48px;
 }
 
-.c8:hover,
-.c8:focus {
+.c6:hover,
+.c6:focus {
   opacity: 1;
 }
 
-.c20 {
+.c17 {
   color: #6e747a;
   display: block;
   fontsize: 1.4rem;
@@ -5714,7 +5769,10 @@ Array [
   padding: 0;
 }
 
-.c18 {
+.c15 {
+  box-sizing: border-box;
+  padding-left: 0px;
+  padding-right: 8px;
   box-sizing: border-box;
   padding-left: 0px;
   padding-right: 8px;
@@ -5732,15 +5790,7 @@ Array [
 }
 
 @media screen and (min-width:52em) {
-  .c15 {
-    -webkit-order: 2;
-    -ms-flex-order: 2;
-    order: 2;
-  }
-}
-
-@media screen and (min-width:52em) {
-  .c16 {
+  .c13 {
     width: 25%;
   }
 }
@@ -5763,7 +5813,7 @@ Array [
 }
 
 @media screen and (min-width:52em) {
-  .c5 {
+  .c3 {
     -webkit-box-pack: start;
     -webkit-justify-content: flex-start;
     -ms-flex-pack: start;
@@ -5772,13 +5822,21 @@ Array [
 }
 
 @media screen and (min-width:52em) {
-  .c4 {
+  .c12 {
+    -webkit-order: 2;
+    -ms-flex-order: 2;
+    order: 2;
+  }
+}
+
+@media screen and (min-width:52em) {
+  .c2 {
     width: 33.33333333333333%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c7 {
+  .c5 {
     -webkit-order: 3;
     -ms-flex-order: 3;
     order: 3;
@@ -5786,19 +5844,19 @@ Array [
 }
 
 @media screen and (min-width:52em) {
-  .c6 {
+  .c4 {
     text-align: left;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c17 {
+  .c14 {
     text-align: left;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c19 {
+  .c16 {
     text-align: left;
   }
 }
@@ -5808,13 +5866,13 @@ Array [
     id="footer"
   >
     <div
-      className="c1 c2 sc-bdVaJa c3"
+      className="c1"
     >
       <div
-        className="c4"
+        className="c2"
       >
         <div
-          className="c5 c3 sc-bdVaJa c3"
+          className="c3"
         >
           <object
             data="/static/images/opencollectivelogo-footer.svg"
@@ -5823,21 +5881,21 @@ Array [
           />
         </div>
         <p
-          className="c6"
+          className="c4"
         >
           An organization for your community, transparent by design.
         </p>
       </div>
       <div
-        className="c7"
+        className="c5"
       >
         <a
-          className="c8"
+          className="c6"
           href="https://medium.com/open-collective"
         >
           <svg
             aria-hidden="true"
-            className="c9"
+            className="c7"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -5853,12 +5911,12 @@ Array [
           </svg>
         </a>
         <a
-          className="c8"
+          className="c6"
           href="https://twitter.com/opencollect"
         >
           <svg
             aria-hidden="true"
-            className="c10"
+            className="c8"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -5874,12 +5932,12 @@ Array [
           </svg>
         </a>
         <a
-          className="c8"
+          className="c6"
           href="https://github.com/opencollective"
         >
           <svg
             aria-hidden="true"
-            className="c11"
+            className="c9"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -5895,12 +5953,12 @@ Array [
           </svg>
         </a>
         <a
-          className="c8"
+          className="c6"
           href="https://slack.opencollective.com"
         >
           <svg
             aria-hidden="true"
-            className="c12"
+            className="c10"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -5916,12 +5974,12 @@ Array [
           </svg>
         </a>
         <a
-          className="c8"
+          className="c6"
           href="mailto:info@opencollective.com"
         >
           <svg
             aria-hidden="true"
-            className="c13"
+            className="c11"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -5937,24 +5995,38 @@ Array [
         </a>
       </div>
       <nav
-        className="c14 c15"
+        className="c12"
+        order={
+          Array [
+            "3",
+            null,
+            "2",
+          ]
+        }
       >
         <div
-          className="c16"
+          className="c13"
+          width={
+            Array [
+              0.5,
+              null,
+              0.25,
+            ]
+          }
         >
           <p
-            className="c17"
+            className="c14"
           >
             PLATFORM
           </p>
           <ul
-            className="c18"
+            className="c15"
           >
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/discover"
                 onClick={[Function]}
               >
@@ -5962,20 +6034,20 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/learn-more"
               >
                 How it Works
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/signin"
                 onClick={[Function]}
               >
@@ -5983,10 +6055,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/signin"
                 onClick={[Function]}
               >
@@ -5996,21 +6068,28 @@ Array [
           </ul>
         </div>
         <div
-          className="c16"
+          className="c13"
+          width={
+            Array [
+              0.5,
+              null,
+              0.25,
+            ]
+          }
         >
           <p
-            className="c17"
+            className="c14"
           >
             JOIN THE MOVEMENT
           </p>
           <ul
-            className="c18"
+            className="c15"
           >
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/create"
                 onClick={[Function]}
               >
@@ -6018,10 +6097,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/become-a-sponsor"
                 onClick={[Function]}
               >
@@ -6029,10 +6108,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/chapters"
                 onClick={[Function]}
               >
@@ -6042,21 +6121,28 @@ Array [
           </ul>
         </div>
         <div
-          className="c16"
+          className="c13"
+          width={
+            Array [
+              0.5,
+              null,
+              0.25,
+            ]
+          }
         >
           <p
-            className="c17"
+            className="c14"
           >
             COMMUNITY
           </p>
           <ul
-            className="c18"
+            className="c15"
           >
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/opensource"
                 onClick={[Function]}
               >
@@ -6064,10 +6150,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="https://github.com/opencollective/opencollective/issues"
                 onClick={[Function]}
               >
@@ -6075,10 +6161,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="https://slack.opencollective.com"
                 onClick={[Function]}
               >
@@ -6086,10 +6172,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="https://github.com/opencollective/opencollective/wiki"
                 onClick={[Function]}
               >
@@ -6097,10 +6183,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="mailto:support@opencollective.com"
                 onClick={[Function]}
               >
@@ -6110,21 +6196,28 @@ Array [
           </ul>
         </div>
         <div
-          className="c16"
+          className="c13"
+          width={
+            Array [
+              0.5,
+              null,
+              0.25,
+            ]
+          }
         >
           <p
-            className="c17"
+            className="c14"
           >
             COMPANY
           </p>
           <ul
-            className="c18"
+            className="c15"
           >
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/about"
                 onClick={[Function]}
               >
@@ -6132,10 +6225,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/faq"
                 onClick={[Function]}
               >
@@ -6143,10 +6236,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="https://medium.com/open-collective"
                 onClick={[Function]}
               >
@@ -6154,10 +6247,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/tos"
                 onClick={[Function]}
               >
@@ -6165,10 +6258,10 @@ Array [
               </a>
             </li>
             <li
-              className="c19"
+              className="c16"
             >
               <a
-                className="c20 "
+                className="c17"
                 href="/privacypolicy"
                 onClick={[Function]}
               >

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Document, { Head, Main, NextScript } from 'next/document';
 import { ServerStyleSheet } from 'styled-components';
 import flush from 'styled-jsx/server';
-import './global-styles';
+import GlobalStyles from './global-styles';
 
 // The document (which is SSR-only) needs to be customized to expose the locale
 // data for the user's locale for React Intl to work in the browser.
@@ -45,6 +45,7 @@ export default class IntlDocument extends Document {
       <html>
         <Head>{this.props.styleTags}</Head>
         <body>
+          <GlobalStyles />
           <Main />
           <script
             dangerouslySetInnerHTML={{

--- a/src/pages/claimCollective.js
+++ b/src/pages/claimCollective.js
@@ -15,7 +15,7 @@ import Header from '../components/Header';
 import Body from '../components/Body';
 import Footer from '../components/Footer';
 import { H2, H5, P } from '../components/Text';
-import { Flex } from 'grid-styled';
+import { Flex } from '@rebass/grid';
 import Container from '../components/Container';
 import ErrorPage from '../components/ErrorPage';
 import StyledLink from '../components/StyledLink';
@@ -109,7 +109,7 @@ class ClaimCollectivePage extends React.Component {
           <Container background="linear-gradient(180deg, #DBECFF, #FFFFFF)" py={4}>
             <Container display="flex" flexDirection="column" alignItems="center" mx="auto" maxWidth={1200} py={4}>
               <img src={defaultPledgedLogo} alt="Pledged Collective" />
-              <H2 is="h1">{name}</H2>
+              <H2 as="h1">{name}</H2>
 
               <Container
                 bg="white.full"

--- a/src/pages/createExpense.js
+++ b/src/pages/createExpense.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { graphql, compose } from 'react-apollo';
 import gql from 'graphql-tag';
-import { Box, Flex } from 'grid-styled';
+import { Box, Flex } from '@rebass/grid';
 import { pick } from 'lodash';
 
 import ExpensesStatsWithData from '../apps/expenses/components/ExpensesStatsWithData';

--- a/src/pages/createPledge.js
+++ b/src/pages/createPledge.js
@@ -21,7 +21,7 @@ import Footer from '../components/Footer';
 import { H3, H4, H5, P, Span } from '../components/Text';
 import StyledInput, { SubmitInput, TextInput } from '../components/StyledInput';
 import StyledInputGroup from '../components/StyledInputGroup';
-import { Box, Flex } from 'grid-styled';
+import { Box, Flex } from '@rebass/grid';
 import Container from '../components/Container';
 import ButtonGroup from '../components/ButtonGroup';
 import StyledLink from '../components/StyledLink';
@@ -32,7 +32,7 @@ const defaultPledgedLogo = '/static/images/default-pledged-logo.svg';
 const labelStyles = {
   color: 'black.600',
   fontWeight: 400,
-  is: 'label',
+  as: 'label',
   mb: 1,
 };
 
@@ -66,7 +66,7 @@ const WordCountTextarea = withState('wordCount', 'setWordCount', 140)(({ wordCou
       <P {...labelStyles} htmlFor="publicMessage">
         A message for the community <Span fontWeight="200">- Optional</Span>
       </P>
-      <P {...labelStyles} is="p">
+      <P {...labelStyles} as="p">
         {wordCount}
       </P>
     </Flex>
@@ -75,7 +75,7 @@ const WordCountTextarea = withState('wordCount', 'setWordCount', 140)(({ wordCou
       borderColor="black.300"
       borderRadius="4px"
       fontSize="Paragraph"
-      is="textarea"
+      as="textarea"
       id="publicMessage"
       name="publicMessage"
       placeholder="This will be public and it is also optional"
@@ -226,7 +226,7 @@ class CreatePledgePage extends React.Component {
               px={3}
               width={[1, null, 0.5]}
             >
-              <H3 is="h1" color="black.900" textAlign="left" mb={4}>
+              <H3 as="h1" color="black.900" textAlign="left" mb={4}>
                 Make a pledge
               </H3>
 

--- a/src/pages/discover.js
+++ b/src/pages/discover.js
@@ -9,7 +9,7 @@ import withIntl from '../lib/withIntl';
 import { getBaseApiUrl } from '../lib/utils';
 import { queryString } from '../lib/api';
 
-import { Box, Flex } from 'grid-styled';
+import { Box, Flex } from '@rebass/grid';
 import CollectiveCard from '../components/CollectiveCard';
 import Container from '../components/Container';
 import Page from '../components/Page';
@@ -132,7 +132,7 @@ const DiscoverPage = ({ collectives, onChange, offset, total, show, sort, tags =
           >
             <Flex width={[1, 0.8, 0.6]} justifyContent="space-evenly" flexWrap="wrap" mb={4}>
               <Flex width={[1, null, 0.5]} justifyContent="center" alignItems="center" mb={[3, null, 0]}>
-                <P is="label" htmlFor="sort" color="white.full" fontSize="LeadParagraph" pr={2}>
+                <P as="label" htmlFor="sort" color="white.full" fontSize="LeadParagraph" pr={2}>
                   Sort By
                 </P>
                 <select name="sort" id="sort" value={sort} onChange={onChange}>
@@ -142,7 +142,7 @@ const DiscoverPage = ({ collectives, onChange, offset, total, show, sort, tags =
               </Flex>
 
               <Flex width={[1, null, 0.5]} justifyContent="center" alignItems="center">
-                <P is="label" htmlFor="show" color="white.full" fontSize="LeadParagraph" pr={2}>
+                <P as="label" htmlFor="show" color="white.full" fontSize="LeadParagraph" pr={2}>
                   Show
                 </P>
                 <select name="show" id="show" value={show} onChange={onChange}>

--- a/src/pages/global-styles.js
+++ b/src/pages/global-styles.js
@@ -1,7 +1,7 @@
-import { injectGlobal } from 'styled-components';
+import { createGlobalStyle } from 'styled-components';
 import colors from '../constants/colors';
 
-injectGlobal`
+export default createGlobalStyle`
   @font-face {
     font-family: 'Inter UI';
     font-style:  normal;

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { graphql } from 'react-apollo';
 import gql from 'graphql-tag';
 import fetch from 'node-fetch';
-import { Box, Flex } from 'grid-styled';
+import { Box, Flex } from '@rebass/grid';
 import { FormattedNumber } from 'react-intl';
 import { Facebook } from 'styled-icons/fa-brands/Facebook.cjs';
 import { Twitter } from 'styled-icons/fa-brands/Twitter.cjs';
@@ -244,7 +244,7 @@ class HomePage extends React.Component {
 
               <Hide xs sm width={0.4}>
                 <Container maxHeight="50rem" overflow="scroll">
-                  <Box is="ul" p={0}>
+                  <Box as="ul" p={0}>
                     {filteredTransactions.map(transaction => (
                       <ListItem key={transaction.id} mb={1}>
                         <Container
@@ -265,7 +265,7 @@ class HomePage extends React.Component {
           </Container>
 
           <Container maxWidth={1200} mx="auto" px={2}>
-            <H3 is="h2" textAlign={['center', null, 'left']} pb={3}>
+            <H3 as="h2" textAlign={['center', null, 'left']} pb={3}>
               Active collectives
             </H3>
 
@@ -318,7 +318,7 @@ class HomePage extends React.Component {
                 textAlign="center"
                 fontWeight="900"
                 px={2}
-                is="h2"
+                as="h2"
                 fontSize={['H2', null, 'H1']}
                 lineHeight={['H2', null, 'H1']}
               >

--- a/src/pages/redeem.js
+++ b/src/pages/redeem.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import sanitizeHtml from 'sanitize-html';
 import { graphql } from 'react-apollo';
 import { backgroundSize, fontSize, minHeight, maxWidth } from 'styled-system';
-import { Flex, Box } from 'grid-styled';
+import { Flex, Box } from '@rebass/grid';
 import { FormattedMessage, defineMessages } from 'react-intl';
 import { get } from 'lodash';
 

--- a/src/pages/redeemed.js
+++ b/src/pages/redeemed.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import sanitizeHtml from 'sanitize-html';
 import styled from 'styled-components';
 import gql from 'graphql-tag';
-import { Flex, Box } from 'grid-styled';
+import { Flex, Box } from '@rebass/grid';
 import { backgroundSize, fontSize, minHeight, maxWidth } from 'styled-system';
 import { FormattedMessage } from 'react-intl';
 import { get } from 'lodash';

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ControlLabel, FormControl, FormGroup } from 'react-bootstrap';
-import { Box, Flex } from 'grid-styled';
+import { Box, Flex } from '@rebass/grid';
 import { withRouter } from 'next/router';
 import styled from 'styled-components';
 


### PR DESCRIPTION
This PR updates `styled-components` to the latest version (v4.1.1) and updates `grid-styled` to the latest version, which includes renaming it to `@rebass/grid` (v6.0.0-4). 

Includes:
- use of new `createGlobalStyle` API from `styled-components`
- `as` prop from `styled-components` to replace `is` prop from `clean-tag`