### PR TITLE
Transactions: show net amount (fix)

### DIFF
--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -23,6 +23,7 @@ export const transactionFields = `
   }
   collective {
     slug
+    type
     name
   }
   fromCollective {


### PR DESCRIPTION
https://github.com/opencollective/opencollective-frontend/pull/993 intoduced the nice change of showing the net amount on transactions but somehow the updated graphql query didn't get updated.

## Before
![selection_818](https://user-images.githubusercontent.com/1556356/49237549-b5ac2280-f3fe-11e8-87a6-f4c3001bdb44.png)

## After
![selection_819](https://user-images.githubusercontent.com/1556356/49237556-ba70d680-f3fe-11e8-9f71-864768895882.png)

