### PR TITLE
Don't show download invoice link if transaction uuid is null

### DIFF
--- a/src/apps/expenses/components/TransactionDetails.js
+++ b/src/apps/expenses/components/TransactionDetails.js
@@ -23,7 +23,7 @@ class TransactionDetails extends React.Component {
     canRefund: PropTypes.bool,
     currency: PropTypes.string.isRequired,
     attachment: PropTypes.string,
-    uuid: PropTypes.number,
+    uuid: PropTypes.string,
     netAmountInCollectiveCurrency: PropTypes.number,
     platformFeeInHostCurrency: PropTypes.number,
     paymentProcessorFeeInHostCurrency: PropTypes.number,
@@ -256,7 +256,7 @@ class TransactionDetails extends React.Component {
           </div>
         )}
 
-        {type === 'DEBIT' && canDownloadInvoice && !isRefund && (
+        {type === 'DEBIT' && canDownloadInvoice && !isRefund && uuid && (
           <div className="col invoice">
             <label>
               <FormattedMessage id="transaction.invoice" defaultMessage="invoice" />


### PR DESCRIPTION
If user doesn't have permission to access transaction, API will return a null uuid. This ensure we don't show the download link if this is the case.

Also fixed the propTypes that was improperly set to number instead of string for uuid.