### PR TITLE
Fix "button" param name in ExportImages documentation

### DIFF
--- a/src/components/ExportImages.js
+++ b/src/components/ExportImages.js
@@ -76,7 +76,7 @@ class ExportImages extends React.Component {
                 description: 'max height of each avatar / logo',
               },
               {
-                name: 'showBtn',
+                name: 'button',
                 description: 'show "become a backer/sponsor" button',
                 defaultValue: 'true',
               },


### PR DESCRIPTION
Fix parameter name in export documentation: `showBtn` -> `button`

Fix https://github.com/opencollective/opencollective/issues/1425