### PR TITLE
Change PaymentMethod label to remove last credit card digits

### DIFF
--- a/src/apps/expenses/components/TransactionDetails.js
+++ b/src/apps/expenses/components/TransactionDetails.js
@@ -71,7 +71,7 @@ class TransactionDetails extends React.Component {
     if (pm.type === 'virtualcard') {
       return pm.name.replace('card from', 'Gift Card from');
     } else if (pm.type === 'creditcard') {
-      return `${get(pm, 'data.brand', get(pm, 'type'))} ${pm.name}`;
+      return <FormattedMessage id="creditcard.label" defaultMessage="Credit Card" />;
     } else {
       return capitalize(pm.service);
     }


### PR DESCRIPTION
We now show "Credit Card" instead of showing the last digits

![Preview](https://user-images.githubusercontent.com/1556356/49390229-a7c10f00-f728-11e8-9546-0a113df10cbd.png)
