### PR TITLE
withFallbackImage: only check broken images in browser

### DIFF
--- a/src/components/UserCollective.js
+++ b/src/components/UserCollective.js
@@ -306,7 +306,7 @@ class UserCollective extends React.Component {
 
             {this.props.message && <MessageModal message={this.props.message} />}
 
-            <CollectiveCover collective={collective} cta={cta} LoggedInUser={LoggedInUser} />
+            <CollectiveCover collective={collective} cta={cta} LoggedInUser={LoggedInUser} key={collective.slug} />
 
             <div>
               {get(query, 'OrderId') && (

--- a/src/lib/withFallbackImage.js
+++ b/src/lib/withFallbackImage.js
@@ -1,9 +1,6 @@
 import { withState } from 'recompose';
-import fetch from 'cross-fetch';
 import { defaultImage } from '../constants/collectives';
 import { getDomain, imagePreview } from './utils';
-
-const fallbackFetchEnabled = false;
 
 export default ChildComponent =>
   withState('src', 'setSrc', ({ src }) => src)(
@@ -18,27 +15,6 @@ export default ChildComponent =>
         src = `https://logo.clearbit.com/${getDomain(website)}`;
       }
 
-      if (fallbackFetchEnabled && src && src !== fallback) {
-        // due to CORS issues, we should use the Image error event in the browser
-        if (process.browser) {
-          const img = new Image();
-          img.src = src;
-          img.addEventListener('error', () => {
-            setSrc(fallback);
-          });
-        } else {
-          fetch(src)
-            .then(({ status }) => {
-              if (status >= 400) {
-                setSrc(fallback);
-              }
-            })
-            .catch(() => {
-              setSrc(fallback);
-            });
-        }
-      }
-
       let image;
       if (!src) {
         image = fallback;
@@ -47,6 +23,16 @@ export default ChildComponent =>
           width: radius,
           height,
         });
+      }
+
+      if (image && image !== fallback) {
+        if (process.browser) {
+          const img = new Image();
+          img.src = image;
+          img.addEventListener('error', () => {
+            setSrc(fallback);
+          });
+        }
       }
 
       const childProps = {


### PR DESCRIPTION
After it was found that the initial fallback image logic used too much memory on the frontend server (https://github.com/opencollective/opencollective-frontend/pull/1071), this PR only checks for broken images in the browser. This should also take advantage of the browser / service-worker caching for successful images to reduce network load. 