### PR TITLE
Design system input fields

### DIFF
--- a/src/components/NewsletterContainer.js
+++ b/src/components/NewsletterContainer.js
@@ -34,6 +34,7 @@ class NewsletterContainer extends React.Component {
               width={300}
             >
               <StyledInput
+                bare
                 fontSize="Paragraph"
                 name="EMAIL"
                 px={3}

--- a/src/components/StyledInput.js
+++ b/src/components/StyledInput.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import {
   background,
@@ -13,34 +14,106 @@ import {
   minWidth,
   space,
   textAlign,
+  themeGet,
   width,
 } from 'styled-system';
 import tag from 'clean-tag';
 import { overflow } from './Container';
 import { buttonSize, buttonStyle } from '../constants/theme';
 
-const StyledInput = styled(tag.input)(
-  [],
-  background,
-  borders,
-  borderColor,
-  borderRadius,
-  color,
-  display,
-  flex,
-  fontSize,
-  fontWeight,
-  maxWidth,
-  minWidth,
-  overflow,
-  space,
-  textAlign,
-  width,
-);
+const getBorderColor = ({ error, success }) => {
+  if (error) {
+    return themeGet('colors.red.500');
+  }
+
+  if (success) {
+    return themeGet('colors.green.300');
+  }
+
+  return themeGet('colors.black.300');
+};
+
+/**
+ * styled-component input tag using styled-system
+ *
+ * @see See [styled-system docs](https://github.com/jxnblk/styled-system/blob/master/docs/api.md) for usage of those props
+ */
+const StyledInput = styled(tag.input)`
+  ${background}
+  ${borders}
+  ${borderColor}
+  ${borderRadius}
+  ${color}
+  ${display}
+  ${flex}
+  ${fontSize}
+  ${fontWeight}
+  ${maxWidth}
+  ${minWidth}
+  ${overflow}
+  ${space}
+  ${textAlign}
+  ${width}
+
+  border-color: ${getBorderColor};
+  border-style: ${props => (props.bare ? 'none' : 'solid')};
+
+  &:disabled {
+    background-color: ${themeGet('colors.black.50')};
+  }
+
+  &:focus, &:hover:not(:disabled) {
+    border-color: ${themeGet('colors.primary.300')};
+  }
+
+  &::placeholder {
+    color: ${themeGet('colors.black.400')};
+  }
+`;
+
+StyledInput.propTypes = {
+  /** @ignore */
+  blacklist: PropTypes.arrayOf(PropTypes.string),
+  /** true to hide styled borders */
+  bare: PropTypes.bool,
+  /** styled-system prop: accepts any css 'border' value */
+  border: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
+  /** styled-system prop: accepts any css 'border-color' value */
+  borderColor: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
+  /** styled-system prop: accepts any css 'border-radius' value */
+  borderRadius: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
+  /** Show disabled state for field */
+  disabled: PropTypes.bool,
+  /** Show error state for field */
+  error: PropTypes.bool,
+  /** styled-system prop: accepts any css 'font-size' value */
+  fontSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
+  /** styled-system prop: accepts any css 'min-width' value */
+  maxWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
+  /** styled-system prop: accepts any css 'max-width' value */
+  minWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
+  /** @ignore */
+  px: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
+  /** @ignore */
+  py: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
+  /**
+   * styled-system prop: adds margin & padding props
+   * see: https://github.com/jxnblk/styled-system/blob/master/docs/api.md#space
+   */
+  space: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
+  /** Show success state for field */
+  success: PropTypes.bool,
+  /** styled-system prop: accepts any css 'width' value */
+  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
+};
 
 StyledInput.defaultProps = {
   blacklist: tag.defaultProps.blacklist.concat('buttonStyle', 'buttonSize'),
-  border: 'none',
+  border: '1px solid',
+  borderColor: 'black.300',
+  borderRadius: '4px',
+  px: 3,
+  py: 2,
 };
 
 export const TextInput = styled(StyledInput)``;
@@ -66,4 +139,5 @@ SubmitInput.defaultProps = {
   type: 'submit',
 };
 
+/** @component */
 export default StyledInput;

--- a/src/components/StyledInputField.js
+++ b/src/components/StyledInputField.js
@@ -1,0 +1,39 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { P, Span } from './Text';
+
+/**
+ * Form field to display an input element with a label and errors. Uses [renderProps](https://reactjs.org/docs/render-props.html#using-props-other-than-render) to pass field props like 'name' and 'id' to child input.
+ */
+const StyledInputField = ({ children, label, htmlFor, error, success, disabled }) => (
+  <Fragment>
+    {label && (
+      <P as="label" htmlFor={htmlFor} display="block" color="black.500" mb={1}>
+        {label}
+      </P>
+    )}
+    {children({ name: htmlFor, id: htmlFor, error: Boolean(error), success, disabled })}
+    {error && (
+      <Span display="block" color="red.500" pt={2} fontSize="Tiny">
+        {error}
+      </Span>
+    )}
+  </Fragment>
+);
+
+StyledInputField.propTypes = {
+  /** React component to wrap with the label and errors */
+  children: PropTypes.func.isRequired,
+  /** Show disabled state for field */
+  disabled: PropTypes.bool,
+  /** text to display below the input */
+  error: PropTypes.string,
+  /** the label's 'for' attribute to be used as the 'name' and 'id' for the input */
+  htmlFor: PropTypes.string,
+  /** text to display above the input */
+  label: PropTypes.string,
+  /** Show success state for field */
+  success: PropTypes.bool,
+};
+
+export default StyledInputField;

--- a/src/components/StyledInputGroup.js
+++ b/src/components/StyledInputGroup.js
@@ -1,16 +1,112 @@
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import { themeGet } from 'styled-system';
+import { withState } from 'recompose';
+
 import Container from './Container';
 import { Span } from './Text';
 import StyledInput from './StyledInput';
 
-const StyledInputGroup = ({ prepend, ...inputProps }) => (
-  <Container border="1px solid #D5DAE0" borderRadius="4px" display="flex" alignItems="center">
-    <Container bg="#F7F8FA" borderRadius="4px 0 0 4px" py={2} px={3} mr={1}>
-      <Span color="#C2C6CC" fontSize="14px">
-        {prepend}
-      </Span>
-    </Container>
-    <StyledInput type="text" overflow="scroll" fontSize="14px" flex="1 1 auto" {...inputProps} />
-  </Container>
+const InputContainer = styled(Container)`
+  &:hover {
+    border-color: ${themeGet('colors.primary.300')};
+  }
+`;
+
+const getColor = ({ error, focused, success }) => {
+  if (error) {
+    return 'red.300';
+  }
+
+  if (success) {
+    return 'green.300';
+  }
+
+  if (focused) {
+    return 'primary.300';
+  }
+
+  return 'black.400';
+};
+
+const getBgColor = ({ error, focused, success }) => {
+  if (error) {
+    return 'red.100';
+  }
+
+  if (success) {
+    return 'green.100';
+  }
+
+  if (focused) {
+    return 'primary.100';
+  }
+
+  return 'black.50';
+};
+
+const getBorderColor = ({ error, focused, success }) => {
+  if (error) {
+    return 'red.500';
+  }
+
+  if (success) {
+    return 'green.300';
+  }
+
+  if (focused) {
+    return 'primary.300';
+  }
+
+  return 'black.300';
+};
+
+/**
+ * A styled input with a prepended field element.
+ * @see See [StyledInput](/#!/StyledInput) for details about props passed to it
+ */
+const StyledInputGroup = withState('focused', 'setFocus', false)(
+  ({ prepend, focused, setFocus, disabled, success, error, ...inputProps }) => (
+    <InputContainer
+      bg={disabled ? 'black.50' : 'white.full'}
+      border="1px solid"
+      borderColor={getBorderColor({ error, focused, success })}
+      borderRadius="4px"
+      display="flex"
+      alignItems="center"
+    >
+      <Container bg={getBgColor({ error, focused, success })} borderRadius="4px 0 0 4px" py={2} px={3}>
+        <Span color={getColor({ error, focused, success })} fontSize="Paragraph">
+          {prepend}
+        </Span>
+      </Container>
+      <StyledInput
+        bare
+        color="black.800"
+        type="text"
+        overflow="scroll"
+        fontSize="Paragraph"
+        flex="1 1 auto"
+        disabled={disabled}
+        {...inputProps}
+        onFocus={() => setFocus(true)}
+        onBlur={() => setFocus(false)}
+      />
+    </InputContainer>
+  ),
 );
+
+StyledInputGroup.propTypes = {
+  /** Text shown before input */
+  prepend: PropTypes.string.isRequired,
+  /** Show disabled state for field */
+  disabled: PropTypes.bool,
+  /** Show error state for field */
+  error: PropTypes.bool,
+  /** Show success state for field */
+  success: PropTypes.bool,
+  /** Passed to internal StyledInput */
+  type: PropTypes.string,
+};
 
 export default StyledInputGroup;

--- a/src/pages/__tests__/__snapshots__/search.test.js.snap
+++ b/src/pages/__tests__/__snapshots__/search.test.js.snap
@@ -5457,6 +5457,52 @@ Array [
   padding-bottom: 4px;
   text-align: center;
   width: 30px;
+  border-style: solid;
+}
+
+.c12 {
+  border: 1px solid #cccccc;
+  border-radius: 4px;
+  font-size: 14px;
+  margin-left: 4px;
+  margin-right: 4px;
+  padding-left: 4px;
+  padding-right: 4px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  text-align: center;
+  width: 30px;
+  border-style: solid;
+}
+
+.c12 {
+  border: 1px solid #cccccc;
+  border-radius: 4px;
+  font-size: 14px;
+  margin-left: 4px;
+  margin-right: 4px;
+  padding-left: 4px;
+  padding-right: 4px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  text-align: center;
+  width: 30px;
+  border-style: solid;
+}
+
+.c12 {
+  border: 1px solid #cccccc;
+  border-radius: 4px;
+  font-size: 14px;
+  margin-left: 4px;
+  margin-right: 4px;
+  padding-left: 4px;
+  padding-right: 4px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  text-align: center;
+  width: 30px;
+  border-style: solid;
 }
 
 .c5 {

--- a/styleguide/examples/StyledInput.md
+++ b/styleguide/examples/StyledInput.md
@@ -1,0 +1,23 @@
+Default state:
+
+```js
+<StyledInput type="text" placeholder="Default" />
+```
+
+Disabled state:
+
+```js
+<StyledInput type="text" placeholder="Disabled" disabled />
+```
+
+Success state:
+
+```js
+<StyledInput type="text" placeholder="Success!" success />
+```
+
+Error state:
+
+```js
+<StyledInput type="text" placeholder="Error!" error />
+```

--- a/styleguide/examples/StyledInputField.md
+++ b/styleguide/examples/StyledInputField.md
@@ -1,0 +1,41 @@
+Using [renderProps](https://reactjs.org/docs/render-props.html#using-props-other-than-render) allows this component to focus on just the label and error styles, leaving the input logic independent as a separate concern.
+
+Default state:
+
+```js
+<StyledInputField label="Component with Label" htmlFor="example">
+  {(inputProps) => (
+    <StyledInput type="text" placeholder="sample text" {...inputProps} />
+  )}
+</StyledInputField>
+```
+
+Disabled state:
+
+```js
+<StyledInputField label="Disabled Component with Label" htmlFor="disabled" disabled>
+  {(inputProps) => (
+    <StyledInput type="text" placeholder="sample text" {...inputProps} />
+  )}
+</StyledInputField>
+```
+
+Success state:
+
+```js
+<StyledInputField label="Success Component with Label" htmlFor="success" success>
+  {(inputProps) => (
+    <StyledInput type="text" placeholder="sample text" {...inputProps} />
+  )}
+</StyledInputField>
+```
+
+Error state:
+
+```js
+<StyledInputField label="Component with Error" htmlFor="error-example" error="Error message goes here">
+  {(inputProps) => (
+    <StyledInput type="text" placeholder="sample text" {...inputProps} />
+  )}
+</StyledInputField>
+```

--- a/styleguide/examples/StyledInputGroup.md
+++ b/styleguide/examples/StyledInputGroup.md
@@ -1,0 +1,23 @@
+Default state:
+
+```js
+<StyledInputGroup prepend="http://" type="url" placeholder="Default" />
+```
+
+Disabled state:
+
+```js
+<StyledInputGroup prepend="http://" type="url" placeholder="Disabled" disabled />
+```
+
+Success state:
+
+```js
+<StyledInputGroup prepend="https://" type="url" placeholder="Success!" success />
+```
+
+Error state:
+
+```js
+<StyledInputGroup prepend="https://" type="url" placeholder="Error!" error />
+```


### PR DESCRIPTION
Implements the [design system input fields](https://www.figma.com/file/N4Xbl652BhzOutXmzhcrLGch/01.-Design-System-(Atoms)?node-id=32%3A192)

Adds the following components to the styleguide:

- `StyledInput`
- `StyledInputGroup`
- `StyledInputField`

Staging styleguide preview:
https://opencollective-styleguide.now.sh/