### PR TITLE
List all organization gift cards

### DIFF
--- a/cypress/integration/21-collective.create.test.js
+++ b/cypress/integration/21-collective.create.test.js
@@ -1,20 +1,8 @@
 const collectiveName = 'New collective';
 
-const init = (skip_signin = false) => {
-  if (skip_signin) {
-    cy.visit(
-      '/signin/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzY29wZSI6ImxvZ2luIiwiaWQiOjk0NzQsImVtYWlsIjoidGVzdHVzZXIrYWRtaW5Ab3BlbmNvbGxlY3RpdmUuY29tIiwiaWF0IjoxNTE3NzgzMTkwLCJleHAiOjE1MTc4Njk1OTAsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzA2MCIsInN1YiI6OTQ3NH0.RZojXMJVzznInDr5LyVhzsO5Dcq3qzRsKooPoeJQAEQ?next=/opencollective-host/apply',
-    );
-  } else {
-    cy.visit('/create');
-    cy.fillInputField('email', 'testuser@opencollective.com');
-    cy.get('.LoginForm button').click();
-  }
-};
-
 describe('create a collective', () => {
   it('edit info', () => {
-    init();
+    cy.login({ email: 'testuser@opencollective.com', redirect: '/create' });
     cy.get('.CollectiveCategoryPicker .category')
       .first()
       .click();

--- a/cypress/integration/22-collective.edit.test.js
+++ b/cypress/integration/22-collective.edit.test.js
@@ -103,7 +103,7 @@ describe('edit collective', () => {
     cy.get('.OrderForm', { timeout: 20000 });
     cy.get('.tier .selectPreset label').contains('Select monthly amount');
     cy.get('.tier .presetBtn', { timeout: 5000 }).should('have.length', 3);
-    cy.visit('/testcollective/edit#tiers');
+    cy.visit('/testcollective/edit/tiers');
     cy.get('.EditTiers .tier')
       .first()
       .find('._amountType select')

--- a/src/apps/expenses/components/CreateExpenseForm.js
+++ b/src/apps/expenses/components/CreateExpenseForm.js
@@ -309,7 +309,7 @@ class CreateExpenseForm extends React.Component {
                   defaultMessage="It can be daunting for the community to file an expense. Help them by providing a clear expense policy to explain what they can expense."
                 />
               </p>
-              <Button className="blue" href={`/${collective.slug}/edit#expenses`}>
+              <Button className="blue" href={`/${collective.slug}/edit/expenses`}>
                 <FormattedMessage id="expense.expensePolicy.add" defaultMessage="add an expense policy" />
               </Button>
             </div>

--- a/src/components/Collective.js
+++ b/src/components/Collective.js
@@ -311,7 +311,7 @@ class Collective extends React.Component {
                       )}
                       action={{
                         label: intl.formatMessage(this.messages['collective.addHostBtn']),
-                        href: `/${collective.slug}/edit#host`,
+                        href: `/${collective.slug}/edit/host`,
                       }}
                     />
                   )}

--- a/src/components/CreateCollective.js
+++ b/src/components/CreateCollective.js
@@ -104,22 +104,24 @@ class CreateCollective extends React.Component {
       const successParams = {
         slug: collective.slug,
       };
-      let route = 'collective';
-
-      if (CollectiveInputType.HostCollectiveId) {
-        successParams.status = 'collectiveCreated';
-        successParams.CollectiveId = collective.id;
-        successParams.collectiveSlug = collective.slug;
-      } else {
-        route = `/${collective.slug}/edit#host`;
-      }
-
       this.setState({
         status: 'idle',
         result: { success: 'Collective created successfully' },
       });
 
-      Router.pushRoute(route, successParams);
+      if (CollectiveInputType.HostCollectiveId) {
+        successParams.status = 'collectiveCreated';
+        successParams.CollectiveId = collective.id;
+        successParams.collectiveSlug = collective.slug;
+        Router.pushRoute('collective', {
+          slug: collective.slug,
+          status: 'collectiveCreated',
+          CollectiveId: collective.id,
+          CollectiveSlug: collective.slug,
+        });
+      } else {
+        Router.pushRoute(`/${collective.slug}/edit#host`, { slug: collective.slug });
+      }
     } catch (err) {
       console.error('>>> createCollective error: ', JSON.stringify(err));
       const errorMsg = err.graphQLErrors && err.graphQLErrors[0] ? err.graphQLErrors[0].message : err.message;

--- a/src/components/EditCollectiveForm.js
+++ b/src/components/EditCollectiveForm.js
@@ -16,6 +16,7 @@ import { Link } from '../server/pages';
 import { get } from 'lodash';
 import styled, { css } from 'styled-components';
 import { Flex, Box } from '@rebass/grid';
+import EditVirtualCards from './EditVirtualCards';
 
 const selectedStyle = css`
   background-color: #eee;
@@ -68,6 +69,7 @@ class EditCollectiveForm extends React.Component {
     this.defaultTierType = collective.type === 'EVENT' ? 'TICKET' : 'TIER';
     this.showEditMembers = ['COLLECTIVE', 'ORGANIZATION'].includes(collective.type);
     this.showPaymentMethods = ['USER', 'ORGANIZATION'].includes(collective.type);
+    this.showVirtualCards = collective.canCreateVirtualCards;
     this.members = collective.members && collective.members.filter(m => ['ADMIN', 'MEMBER'].includes(m.role));
 
     this.messages = defineMessages({
@@ -512,6 +514,15 @@ class EditCollectiveForm extends React.Component {
                 <FormattedMessage id="editCollective.menu.paymentMethods" defaultMessage="Payment Methods" />
               </MenuItem>
             )}
+            {this.showVirtualCards && (
+              <MenuItem
+                selected={this.state.section === 'virtualCards'}
+                onClick={() => this.showSection('virtualCards')}
+                className="MenuItem virtualCards"
+              >
+                <FormattedMessage id="editCollective.menu.virtualCards" defaultMessage="Gift Cards" />
+              </MenuItem>
+            )}
             <MenuItem
               selected={this.state.section === 'connectedAccounts'}
               onClick={() => this.showSection('connectedAccounts')}
@@ -609,6 +620,7 @@ class EditCollectiveForm extends React.Component {
                   onChange={this.handleObjectChange}
                 />
               )}
+              {this.state.section === 'virtualCards' && <EditVirtualCards collective={collective} />}
               {this.state.section === 'connectedAccounts' && (
                 <EditConnectedAccounts collective={collective} connectedAccounts={collective.connectedAccounts} />
               )}

--- a/src/components/EditConnectedAccount.js
+++ b/src/components/EditConnectedAccount.js
@@ -69,7 +69,9 @@ class EditConnectedAccount extends React.Component {
     const { collective, options } = this.props;
 
     if (service === 'github' || service === 'twitter') {
-      const redirect = `${window.location.protocol}//${window.location.host}/${collective.slug}/edit#connectedAccounts`;
+      const redirect = `${window.location.protocol}//${window.location.host}/${
+        collective.slug
+      }/edit/connected-accounts`;
       return window.location.replace(
         `/api/connected-accounts/${service}/oauthUrl?CollectiveId=${collective.id}&redirect=${encodeURIComponent(
           redirect,

--- a/src/components/EditHost.js
+++ b/src/components/EditHost.js
@@ -71,7 +71,7 @@ class EditHost extends React.Component {
     if (!newHost.id) {
       this.setState({ selectedOption: 'noHost' });
       if (window.location.search.length > 0) {
-        window.location.replace(`/${collective.slug}/edit#host`); // make sure we clean the query params if any
+        window.location.replace(`/${collective.slug}/edit/host`); // make sure we clean the query params if any
       }
     }
   }

--- a/src/components/EditVirtualCards.js
+++ b/src/components/EditVirtualCards.js
@@ -1,9 +1,146 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { graphql } from 'react-apollo';
+import { ButtonGroup } from 'react-bootstrap';
+import { Flex } from '@rebass/grid';
+import { get, last } from 'lodash';
+import { withRouter } from 'next/router';
 
+import { getCollectiveVirtualCards } from '../graphql/queries';
+import VirtualCardDetails from './VirtualCardDetails';
+import Loading from './Loading';
+import Pagination from './Pagination';
+import Link from './Link';
+
+/**
+ * A filterable list of virtual cards meant to be displayed for organization
+ * admins.
+ */
 class EditVirtualCards extends React.Component {
+  static propTypes = {
+    collectiveId: PropTypes.number.isRequired,
+    /** Max number of items to display */
+    limit: PropTypes.number,
+    /** Provided by graphql */
+    data: PropTypes.object,
+    /** Provided by withRouter */
+    router: PropTypes.object,
+    /** Provided by addTransactionsData */
+    setConfirmedFilter: PropTypes.func,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = { claimedFilter: 'all' };
+  }
+
+  renderFilterLink(onlyConfirmed, paymentMethods, filterName, label) {
+    let btnClassName = 'btn-default';
+    if (
+      (filterName === 'all' && (onlyConfirmed === undefined || onlyConfirmed === 'all')) ||
+      (filterName === 'claimed' && onlyConfirmed) ||
+      (filterName === 'unclaimed' && onlyConfirmed === false)
+    ) {
+      btnClassName = 'btn-primary';
+    } else if (onlyConfirmed === undefined && (!paymentMethods || paymentMethods.length === 0)) {
+      btnClassName += ' disabled';
+    }
+
+    return (
+      <Link
+        route="editCollective"
+        className={`filterBtn btn ${btnClassName}`}
+        params={{ ...this.props.router.query, filter: filterName, offset: 0 }}
+      >
+        {label}
+      </Link>
+    );
+  }
+
+  renderFilters(onlyConfirmed, paymentMethods) {
+    return (
+      <div className="filter">
+        <ButtonGroup>
+          {this.renderFilterLink(
+            onlyConfirmed,
+            paymentMethods,
+            'all',
+            <FormattedMessage id="virtualCards.filterAll" defaultMessage="All" />,
+          )}
+          {this.renderFilterLink(
+            onlyConfirmed,
+            paymentMethods,
+            'claimed',
+            <FormattedMessage id="virtualCards.filterClaimed" defaultMessage="Claimed" />,
+          )}
+          {this.renderFilterLink(
+            onlyConfirmed,
+            paymentMethods,
+            'unclaimed',
+            <FormattedMessage id="virtualCards.filterUnclaimed" defaultMessage="Unclaimed" />,
+          )}
+        </ButtonGroup>
+      </div>
+    );
+  }
+
   render() {
-    return <div />;
+    const { loading } = this.props.data;
+    const queryResult = get(this.props, 'data.Collective.createdVirtualCards', {});
+    const onlyConfirmed = get(this.props, 'data.variables.isConfirmed');
+    const { offset, limit, total, paymentMethods } = queryResult;
+    const lastVirtualCard = last(paymentMethods);
+
+    return (
+      <div>
+        <Flex mb={4} justifyContent="center">
+          {this.renderFilters(onlyConfirmed, paymentMethods)}
+        </Flex>
+        {loading ? (
+          <Loading />
+        ) : (
+          <div>
+            {paymentMethods.map(v => (
+              <div key={v.id}>
+                <VirtualCardDetails virtualCard={v} />
+                {v !== lastVirtualCard && <hr />}
+              </div>
+            ))}
+            {total > limit && (
+              <Flex justifyContent="center" mt={4}>
+                <Pagination offset={offset} total={total} limit={limit} />
+              </Flex>
+            )}
+          </div>
+        )}
+      </div>
+    );
   }
 }
 
-export default EditVirtualCards;
+const VIRTUALCARDS_PER_PAGE = 15;
+
+const getIsConfirmedFromFilter = filter => {
+  if (filter === undefined || filter === 'all') {
+    return undefined;
+  }
+  return filter === 'claimed';
+};
+
+const getGraphQLVariablesFromProps = props => ({
+  CollectiveId: props.collectiveId,
+  isConfirmed: getIsConfirmedFromFilter(props.router.query.filter),
+  offset: props.router.query.offset || 0,
+  limit: props.limit || VIRTUALCARDS_PER_PAGE,
+});
+
+export const addTransactionsData = graphql(getCollectiveVirtualCards, {
+  options: props => ({ variables: getGraphQLVariablesFromProps(props) }),
+  props: ({ data }) => ({
+    data,
+    setConfirmedFilter: isConfirmed => data.refetch({ ...data.variables, isConfirmed: isConfirmed }),
+  }),
+});
+
+export default withRouter(addTransactionsData(EditVirtualCards));

--- a/src/components/EditVirtualCards.js
+++ b/src/components/EditVirtualCards.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+class EditVirtualCards extends React.Component {
+  render() {
+    return <div />;
+  }
+}
+
+export default EditVirtualCards;

--- a/src/components/Event.js
+++ b/src/components/Event.js
@@ -319,7 +319,7 @@ class Event extends React.Component {
                         LoggedInUser && LoggedInUser.canEditCollective(event)
                           ? {
                               label: intl.formatMessage(this.messages['event.tickets.edit']),
-                              href: `${event.path}/edit#tiers`,
+                              href: `${event.path}/edit/tiers`,
                             }
                           : null
                       }

--- a/src/components/TeamSection.js
+++ b/src/components/TeamSection.js
@@ -21,7 +21,7 @@ class TeamSection extends React.Component {
     let action;
     if (LoggedInUser && LoggedInUser.canEditCollective(collective)) {
       action = {
-        href: `/${collective.slug}/edit#members`,
+        href: `/${collective.slug}/edit/members`,
         label: <FormattedMessage id="sections.team.edit" defaultMessage="Edit team members" />,
       };
     }

--- a/src/components/VirtualCardDetails.js
+++ b/src/components/VirtualCardDetails.js
@@ -1,0 +1,167 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { Flex, Box } from '@rebass/grid';
+import { get } from 'lodash';
+import moment from 'moment';
+import styled, { withTheme } from 'styled-components';
+
+import { CardGiftcard as GiftCardIcon } from 'styled-icons/material/CardGiftcard.cjs';
+
+import Link from './Link';
+import Avatar from './Avatar';
+import { formatCurrency } from '../lib/utils';
+import Moment from './Moment';
+
+const DetailsColumnHeader = styled.span`
+  text-transform: uppercase;
+  color: ${props => props.theme.colors.black[500]};
+  font-weight: 300;
+  white-space: nowrap;
+`;
+
+/** Render a text status to indicate if virtual card is claimed, and by whom */
+const VirtualCardStatus = ({ isConfirmed, collective, data }) => {
+  if (isConfirmed) {
+    return (
+      <FormattedMessage
+        id="virtualCards.claimedBy"
+        defaultMessage="claimed by {user}"
+        values={{
+          user: (
+            <Link route="collective" params={{ slug: collective.slug }}>
+              {collective.name}
+            </Link>
+          ),
+        }}
+      />
+    );
+  } else if (get(data, 'email')) {
+    return (
+      <FormattedMessage
+        id="virtualCards.sentTo"
+        defaultMessage="sent to {email}"
+        values={{ email: <a href={`mailto:${data.email}`}>{data.email}</a> }}
+      />
+    );
+  } else {
+    return <FormattedMessage id="virtualCards.notYetClaimed" defaultMessage="not yet claimed" />;
+  }
+};
+
+/**
+ * Render a VirtualCard details like its status (claimed or not), who claimed it,
+ * when was it created... It is not meant to be show to all users, but just to
+ * the organizations that create the virtual cards.
+ */
+class VirtualCardDetails extends React.Component {
+  static propTypes = {
+    /** The virtual card, which is actually a PaymentMethod */
+    virtualCard: PropTypes.object.isRequired,
+    /** Provided by styled-component withTheme(...) */
+    theme: PropTypes.object,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = { expended: false };
+  }
+
+  toggleExpended() {
+    this.setState(state => ({ expended: !state.expended }));
+  }
+
+  getStatusColor(isConfirmed, balance) {
+    const { colors } = this.props.theme;
+    return balance === 0 ? colors.yellow[500] : isConfirmed ? colors.green[500] : colors.black[200];
+  }
+
+  renderDetails() {
+    const redeemCode = this.props.virtualCard.uuid.split('-')[0];
+    return (
+      <Flex mt="0.75em" fontSize="0.8em">
+        <Flex flexDirection="column" mr="1.5em">
+          <DetailsColumnHeader>
+            <FormattedMessage id="virtualCards.redeemCode" defaultMessage="Redeem code" />
+          </DetailsColumnHeader>
+          <Link route="redeem" params={{ code: redeemCode }}>
+            {redeemCode}
+          </Link>
+        </Flex>
+        <Flex flexDirection="column" mr="1.5em">
+          <DetailsColumnHeader>
+            <FormattedMessage id="virtualCards.expiryDate" defaultMessage="Expiry date" />
+          </DetailsColumnHeader>
+          <span>{moment(this.props.virtualCard.expiryDate).format('MM/Y')}</span>
+        </Flex>
+        <Flex flexDirection="column" mr="1.5em">
+          <DetailsColumnHeader>
+            <FormattedMessage id="virtualCards.customMessage" defaultMessage="Custom message" />
+          </DetailsColumnHeader>
+          <span>{this.props.virtualCard.description}</span>
+        </Flex>
+      </Flex>
+    );
+  }
+
+  render() {
+    const { isConfirmed, collective, initialBalance, balance, currency, createdAt, data } = this.props.virtualCard;
+
+    return (
+      <Flex>
+        {/* Avatar column */}
+        <Box mr="20px">
+          {isConfirmed ? (
+            <Link route="collective" params={{ slug: collective.slug }} title={collective.name} passHref>
+              <GiftCardIcon alignSelf="center" size="2.5em" color={this.getStatusColor(isConfirmed, balance)} />
+              <Avatar
+                radius={24}
+                mt="-1em"
+                ml="1em"
+                css={{ position: 'absolute' }}
+                src={collective.image}
+                type={collective.type}
+                name={collective.name}
+              />
+            </Link>
+          ) : (
+            <GiftCardIcon alignSelf="center" size="2.5em" color={this.getStatusColor(isConfirmed, balance)} />
+          )}
+        </Box>
+        {/* Infos + details column */}
+        <Flex flexDirection="column" p="0.1em">
+          <Box>
+            <strong>{formatCurrency(initialBalance, currency)}</strong>{' '}
+            <VirtualCardStatus isConfirmed={isConfirmed} collective={collective} data={data} />
+          </Box>
+          <Box color={this.props.theme.colors.black[500]} fontSize="0.9em">
+            <Flex>
+              <FormattedMessage
+                id="virtualCards.balance"
+                defaultMessage="Balance: {balance}"
+                values={{ balance: formatCurrency(balance, currency) }}
+              />
+              <Box mx={1}>|</Box>
+              <FormattedMessage
+                id="virtualCards.emmitedSince"
+                defaultMessage="Emmited {since}"
+                values={{ since: <Moment relative value={createdAt} /> }}
+              />
+              <Box mx={1}>|</Box>
+              <a onClick={() => this.toggleExpended()}>
+                {this.state.expended ? (
+                  <FormattedMessage id="virtualCards.closeDetails" defaultMessage="Close Details" />
+                ) : (
+                  <FormattedMessage id="virtualCards.viewDetails" defaultMessage="View Details" />
+                )}
+              </a>
+            </Flex>
+          </Box>
+          {this.state.expended && this.renderDetails()}
+        </Flex>
+      </Flex>
+    );
+  }
+}
+
+export default withTheme(VirtualCardDetails);

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -741,6 +741,43 @@ export const getSubscriptionsQuery = gql`
   }
 `;
 
+/** A query to get the virtual cards created by a collective. Must be authenticated. */
+export const getCollectiveVirtualCards = gql`
+  query CollectiveVirtualCards($CollectiveId: Int, $isConfirmed: Boolean, $limit: Int, $offset: Int) {
+    Collective(id: $CollectiveId) {
+      createdVirtualCards(isConfirmed: $isConfirmed, limit: $limit, offset: $offset) {
+        offset
+        limit
+        total
+        paymentMethods {
+          id
+          uuid
+          currency
+          name
+          service
+          type
+          data
+          initialBalance
+          balance
+          expiryDate
+          isConfirmed
+          data
+          createdAt
+          expiryDate
+          description
+          collective {
+            id
+            slug
+            image
+            type
+            name
+          }
+        }
+      }
+    }
+  }
+`;
+
 export const searchCollectivesQuery = gql`
   query search($term: String!, $limit: Int, $offset: Int) {
     search(term: $term, limit: $limit, offset: $offset) {

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -203,6 +203,7 @@ const getCollectiveToEditQuery = gql`
       isActive
       isHost
       expensePolicy
+      canCreateVirtualCards
       stats {
         id
         yearlyBudget

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:3000/api/graphql
-# timestamp: Fri Nov 30 2018 10:46:32 GMT+0100 (Central European Standard Time)
+# timestamp: Mon Dec 10 2018 09:46:19 GMT+0100 (Central European Standard Time)
 
 """Application model"""
 type Application {
@@ -72,6 +72,9 @@ type Collective implements CollectiveInterface {
   backgroundImage: String
   settings: JSON
   data: JSON
+
+  """Specify if collective is allowed to create new VirtualCards"""
+  canCreateVirtualCards: Boolean
   slug: String
   path: String
 
@@ -125,6 +128,17 @@ type Collective implements CollectiveInterface {
   updates(limit: Int, offset: Int): [Event]
   events(limit: Int, offset: Int): [Event]
   paymentMethods(service: String, limit: Int, hasBalanceAboveZero: Boolean, isConfirmed: Boolean = true, types: [String], orderBy: PaymenMethodOrderField = type): [PaymentMethodType]
+
+  """
+  Get the virtual cards created by this collective. RemoteUser must be a collective admin.
+  """
+  createdVirtualCards(
+    limit: Int
+    offset: Int
+
+    """Wether the virtual card has been claimed or not"""
+    isConfirmed: Boolean
+  ): PaginatedPaymentMethod
   connectedAccounts: [ConnectedAccountType]
   stats: CollectiveStatsType
 }
@@ -217,6 +231,9 @@ interface CollectiveInterface {
   backgroundImage: String
   settings: JSON
   data: JSON
+
+  """Specify if collective is allowed to create new VirtualCards"""
+  canCreateVirtualCards: Boolean
   slug: String
   path: String
   isHost: Boolean
@@ -287,6 +304,13 @@ interface CollectiveInterface {
     """Order entries based on given column. Set to null for no ordering."""
     orderBy: PaymenMethodOrderField
   ): [PaymentMethodType]
+  createdVirtualCards(
+    limit: Int
+    offset: Int
+
+    """Wether the virtual card has been claimed or not"""
+    isConfirmed: Boolean
+  ): PaginatedPaymentMethod
   connectedAccounts: [ConnectedAccountType]
 }
 
@@ -475,6 +499,9 @@ type Event implements CollectiveInterface {
   backgroundImage: String
   settings: JSON
   data: JSON
+
+  """Specify if collective is allowed to create new VirtualCards"""
+  canCreateVirtualCards: Boolean
   slug: String
   path: String
 
@@ -528,6 +555,17 @@ type Event implements CollectiveInterface {
   updates(limit: Int, offset: Int): [Event]
   events(limit: Int, offset: Int): [Event]
   paymentMethods(service: String, limit: Int, hasBalanceAboveZero: Boolean, isConfirmed: Boolean = true, types: [String], orderBy: PaymenMethodOrderField = type): [PaymentMethodType]
+
+  """
+  Get the virtual cards created by this collective. RemoteUser must be a collective admin.
+  """
+  createdVirtualCards(
+    limit: Int
+    offset: Int
+
+    """Wether the virtual card has been claimed or not"""
+    isConfirmed: Boolean
+  ): PaginatedPaymentMethod
   connectedAccounts: [ConnectedAccountType]
   stats: CollectiveStatsType
 }
@@ -675,6 +713,7 @@ type InvoiceType {
   title: String
   year: Int
   month: Int
+  day: Int
   totalAmount: Int
   currency: String
   host: CollectiveInterface
@@ -785,6 +824,9 @@ type Mutation {
     PaymentMethodId: Int
     description: String
     expiryDate: String
+
+    """The data attached to this PaymentMethod"""
+    data: PaymentMethodDataVirtualCardInputType
   ): PaymentMethodType
   claimPaymentMethod(code: String!, user: UserInputType): PaymentMethodType
 }
@@ -1007,6 +1049,9 @@ type Organization implements CollectiveInterface {
   backgroundImage: String
   settings: JSON
   data: JSON
+
+  """Specify if collective is allowed to create new VirtualCards"""
+  canCreateVirtualCards: Boolean
   slug: String
   path: String
 
@@ -1060,6 +1105,17 @@ type Organization implements CollectiveInterface {
   updates(limit: Int, offset: Int): [Event]
   events(limit: Int, offset: Int): [Event]
   paymentMethods(service: String, limit: Int, hasBalanceAboveZero: Boolean, isConfirmed: Boolean = true, types: [String], orderBy: PaymenMethodOrderField = type): [PaymentMethodType]
+
+  """
+  Get the virtual cards created by this collective. RemoteUser must be a collective admin.
+  """
+  createdVirtualCards(
+    limit: Int
+    offset: Int
+
+    """Wether the virtual card has been claimed or not"""
+    isConfirmed: Boolean
+  ): PaginatedPaymentMethod
   connectedAccounts: [ConnectedAccountType]
   stats: CollectiveStatsType
   email: String
@@ -1071,6 +1127,14 @@ type PaginatedExpenses {
   limit: Int
   offset: Int
   total: Int
+}
+
+"""A list of PaymentMethod with pagination info"""
+type PaginatedPaymentMethod {
+  paymentMethods: [PaymentMethodType]
+  total: Int
+  limit: Int
+  offset: Int
 }
 
 """List of transactions with pagination data"""
@@ -1085,6 +1149,12 @@ type PaginatedTransactions {
 enum PaymenMethodOrderField {
   """Order payment methods by type (creditcard, virtualcard...)"""
   type
+}
+
+"""Input for virtual card (meta)data"""
+input PaymentMethodDataVirtualCardInputType {
+  """The email virtual card is generated for"""
+  email: String
 }
 
 """Input type for PaymentMethod (paypal/stripe)"""
@@ -1164,10 +1234,23 @@ type Query {
   allInvoices(fromCollectiveSlug: String!): [InvoiceType]
   Invoice(
     """
-    Slug of the invoice. Format: :year:2digitMonth-:hostSlug-:fromCollectiveSlug
+    Slug of the invoice. Format: :year:2digitMonth.:hostSlug.:fromCollectiveSlug
     """
     invoiceSlug: String!
   ): InvoiceType
+  TransactionInvoice(
+    """Slug of the transaction."""
+    transactionUuid: String!
+  ): InvoiceType
+
+  """
+  
+      Given a collective, returns all its transactions:
+      - Debit transactions made by collective without using a virtual card
+      - Debit transactions made using a virtual card from collective
+      - Credit transactions made to collective
+      
+  """
   allTransactions(CollectiveId: Int, collectiveSlug: String, type: String, limit: Int, offset: Int, dateFrom: String, dateTo: String, includeVirtualCards: Boolean): [Transaction]
   transactions(
     """Defaults to 100"""
@@ -1180,7 +1263,7 @@ type Query {
   ): PaginatedTransactions
   Update(collectiveSlug: String, updateSlug: String, id: Int): UpdateType
   Application(id: Int): Application
-  allComments(ExpenseId: Int, OrderId: Int, UpdateId: Int, limit: Int, offset: Int): [CommentType]
+  allComments(ExpenseId: Int, UpdateId: Int, limit: Int, offset: Int): [UpdateType]
   allUpdates(CollectiveId: Int!, includeHostedCollectives: Boolean, limit: Int, offset: Int): [UpdateType]
   allOrders(
     CollectiveId: Int
@@ -1547,6 +1630,9 @@ type User implements CollectiveInterface {
   backgroundImage: String
   settings: JSON
   data: JSON
+
+  """Specify if collective is allowed to create new VirtualCards"""
+  canCreateVirtualCards: Boolean
   slug: String
   path: String
 
@@ -1600,6 +1686,17 @@ type User implements CollectiveInterface {
   updates(limit: Int, offset: Int): [Event]
   events(limit: Int, offset: Int): [Event]
   paymentMethods(service: String, limit: Int, hasBalanceAboveZero: Boolean, isConfirmed: Boolean = true, types: [String], orderBy: PaymenMethodOrderField = type): [PaymentMethodType]
+
+  """
+  Get the virtual cards created by this collective. RemoteUser must be a collective admin.
+  """
+  createdVirtualCards(
+    limit: Int
+    offset: Int
+
+    """Wether the virtual card has been claimed or not"""
+    isConfirmed: Boolean
+  ): PaginatedPaymentMethod
   connectedAccounts: [ConnectedAccountType]
   stats: CollectiveStatsType
   firstName: String

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -264,7 +264,7 @@
   "editCollective.menu.tiers": "Tiers",
   "editCollective.menu.expenses": "Expenses",
   "editCollective.menu.paymentMethods": "Payment Methods",
-  "editCollective.menu.virtualCards": "Vritual Cards",
+  "editCollective.menu.virtualCards": "Gift Cards",
   "editCollective.menu.connectedAccounts": "Connected Accounts",
   "editCollective.menu.export": "Export",
   "editCollective.menu.advanced": "Advanced",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -264,6 +264,7 @@
   "editCollective.menu.tiers": "Tiers",
   "editCollective.menu.expenses": "Expenses",
   "editCollective.menu.paymentMethods": "Payment Methods",
+  "editCollective.menu.virtualCards": "Vritual Cards",
   "editCollective.menu.connectedAccounts": "Connected Accounts",
   "editCollective.menu.export": "Export",
   "editCollective.menu.advanced": "Advanced",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -264,6 +264,7 @@
   "editCollective.menu.tiers": "Tiers",
   "editCollective.menu.expenses": "Dépenses",
   "editCollective.menu.paymentMethods": "Méthodes de paiement",
+  "editCollective.menu.virtualCards": "Chèques Cadeaux",
   "editCollective.menu.connectedAccounts": "Comptes connectés",
   "editCollective.menu.export": "Exporter",
   "editCollective.menu.advanced": "Avancé",

--- a/src/server/pages.js
+++ b/src/server/pages.js
@@ -77,7 +77,10 @@ pages.add('marketing', '/:pageSlug(become-a-sponsor|how-it-works)', 'marketingPa
 
 // Collective
 
-pages.add('collective', '/:slug').add('editCollective', '/:slug/edit');
+pages
+  .add('collective', '/:slug')
+  .add('editCollective', '/:slug/edit')
+  .add('editCollectiveSection', '/:slug/edit/:section', 'editCollective');
 
 export default pages;
 


### PR DESCRIPTION
Add a menu entry for gift cards in `Edit collective` that list all the gift cards emitted by the collective with the ability to filter them (claimed / unclaimed) and with pagination (only displayed if necessary).

![Preview](https://user-images.githubusercontent.com/1556356/49719450-78952b00-fc5d-11e8-8a34-23e86a04c8af.png)

## Important changes

I had to change the way edit collective routes work. Sections used to be assigned to URLs looking like `/collective/edit#paymentMethods`. This didn't play nice with the `Pagination` component. Routes now look like `/collective/edit/payment-methods` and I've added a function to redirect old schemes so we don't break the links we've sent by email in the past.

---

:information_source: Resolve https://github.com/opencollective/opencollective/issues/1511
:information_source: Resolve https://github.com/opencollective/opencollective/issues/1512