### PR TITLE
CreateOrder Page: refactor to use withUser + Page component

### DIFF
--- a/src/components/CollectiveCover.js
+++ b/src/components/CollectiveCover.js
@@ -6,6 +6,7 @@ import { Github } from 'styled-icons/fa-brands/Github.cjs';
 import { Twitter } from 'styled-icons/fa-brands/Twitter.cjs';
 import { ExternalLinkAlt } from 'styled-icons/fa-solid/ExternalLinkAlt.cjs';
 import { get, pick } from 'lodash';
+import { withUser } from './UserProvider';
 import { prettyUrl, imagePreview } from '../lib/utils';
 import Currency from './Currency';
 import Avatar from './Avatar';
@@ -457,4 +458,4 @@ ${description}`;
   }
 }
 
-export default withIntl(CollectiveCover);
+export default withIntl(withUser(CollectiveCover));

--- a/src/components/MenuBar.js
+++ b/src/components/MenuBar.js
@@ -494,6 +494,9 @@ class MenuBar extends React.Component {
               overflow: hidden;
               background-color: #17181a;
             }
+            #nprogress .bar {
+              z-index: 2001;
+            }
             .active .sticky-inner-wrapper {
               z-index: 2000;
               overflow: hidden;

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -8,7 +8,17 @@ import ErrorPage from '../components/ErrorPage';
 import Footer from '../components/Footer';
 import Header from '../components/Header';
 
-const Page = ({ children, data = {}, loadingLoggedInUser, LoggedInUser, title, showSearch }) => {
+const Page = ({
+  children,
+  data = {},
+  description,
+  image,
+  loadingLoggedInUser,
+  LoggedInUser,
+  title,
+  twitterHandle,
+  showSearch,
+}) => {
   if (data.error) {
     return <ErrorPage data={data} LoggedInUser={LoggedInUser} />;
   }
@@ -17,7 +27,13 @@ const Page = ({ children, data = {}, loadingLoggedInUser, LoggedInUser, title, s
 
   return (
     <Fragment>
-      <Header showSearch={showSearch} title={title} />
+      <Header
+        showSearch={showSearch}
+        title={title}
+        twitterHandle={twitterHandle}
+        description={description}
+        image={image}
+      />
       <Body>{typeof children === 'function' ? children(childProps) : children}</Body>
       <Footer />
     </Fragment>
@@ -30,10 +46,13 @@ Page.propTypes = {
   data: PropTypes.shape({
     error: PropTypes.shape({}),
   }),
+  description: PropTypes.string,
+  image: PropTypes.string,
   loadingLoggedInUser: PropTypes.bool,
   LoggedInUser: PropTypes.shape({}),
   showSearch: PropTypes.bool,
   title: PropTypes.string,
+  twitterHandle: PropTypes.string,
 };
 
 Page.defaultProps = {


### PR DESCRIPTION
Working on the new contribution flow and wanted to get this quick refactor out of the way to clean up the CreateOrder page to use the new `withUser` helper for passing User Context around and the new `Page` component to reduce the repetitive boilerplate for app pages. No functionality has changed for this page. 

Also includes:

- fix to the progress bar to show about the sticky MenuBar
- add `withUser` to the `CollectiveCover` component so LoggedInUser does not need to be passed in by the parent component. 