### PR TITLE
Gift cards admin

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -3,5 +3,6 @@
   "viewportHeight": 1660,
   "projectId": "yt5kwm",
   "defaultCommandTimeout": 8000,
-  "video": false
+  "video": false,
+  "chromeWebSecurity": false
 }

--- a/cypress/integration/21-collective.create.test.js
+++ b/cypress/integration/21-collective.create.test.js
@@ -1,20 +1,8 @@
 const collectiveName = 'New collective';
 
-const init = (skip_signin = false) => {
-  if (skip_signin) {
-    cy.visit(
-      '/signin/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzY29wZSI6ImxvZ2luIiwiaWQiOjk0NzQsImVtYWlsIjoidGVzdHVzZXIrYWRtaW5Ab3BlbmNvbGxlY3RpdmUuY29tIiwiaWF0IjoxNTE3NzgzMTkwLCJleHAiOjE1MTc4Njk1OTAsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzA2MCIsInN1YiI6OTQ3NH0.RZojXMJVzznInDr5LyVhzsO5Dcq3qzRsKooPoeJQAEQ?next=/opencollective-host/apply',
-    );
-  } else {
-    cy.visit('/create');
-    cy.fillInputField('email', 'testuser@opencollective.com');
-    cy.get('.LoginForm button').click();
-  }
-};
-
 describe('create a collective', () => {
   it('edit info', () => {
-    init();
+    cy.login({ email: 'testuser@opencollective.com', redirect: '/create' });
     cy.get('.CollectiveCategoryPicker .category')
       .first()
       .click();

--- a/cypress/integration/22-collective.edit.test.js
+++ b/cypress/integration/22-collective.edit.test.js
@@ -103,7 +103,7 @@ describe('edit collective', () => {
     cy.get('.OrderForm', { timeout: 20000 });
     cy.get('.tier .selectPreset label').contains('Select monthly amount');
     cy.get('.tier .presetBtn', { timeout: 5000 }).should('have.length', 3);
-    cy.visit('/testcollective/edit#tiers');
+    cy.visit('/testcollective/edit/tiers');
     cy.get('.EditTiers .tier')
       .first()
       .find('._amountType select')

--- a/cypress/integration/30-virtualcards-admin.js
+++ b/cypress/integration/30-virtualcards-admin.js
@@ -17,7 +17,7 @@ describe('Virtual cards admin', () => {
     cy.login({ redirect: `/${collectiveSlug}/edit/gift-cards-create` });
     cy.get('#virtualcard-amount').type('42');
     cy.get('#virtualcard-numberOfVirtualCards').type('{selectall}5');
-    cy.get('.field-limitToOpenSourceCollectives .custom-checkbox').click();
+    cy.get('.field-onlyOpensource .custom-checkbox').click();
     cy.get('.FormInputs button[type="submit"]').click();
     cy.contains('Your 5 gift cards are ready!');
   });
@@ -47,7 +47,7 @@ describe('Virtual cards admin', () => {
     );
     cy.get('#virtualcard-amount').type('12');
     checkSubmit(true, 'Create 3 gift cards');
-    cy.get('.field-limitToOpenSourceCollectives .custom-checkbox').click();
+    cy.get('.field-onlyOpensource .custom-checkbox').click();
     cy.get('.FormInputs button[type="submit"]').click();
     cy.contains('Your 3 gift cards have been sent!');
   });

--- a/cypress/integration/30-virtualcards-admin.js
+++ b/cypress/integration/30-virtualcards-admin.js
@@ -1,0 +1,58 @@
+describe('Virtual cards admin', () => {
+  let collectiveSlug = null;
+
+  before(() => {
+    cy.createCollective({ type: 'ORGANIZATION' }).then(collective => {
+      collectiveSlug = collective.slug;
+      cy.addCreditCardToCollective({ collectiveSlug });
+    });
+  });
+
+  it('start with empty gift cards list', () => {
+    cy.login({ redirect: `/${collectiveSlug}/edit/gift-cards` });
+    cy.get('.virtualcards-list').contains('Create your first gift card!');
+  });
+
+  it('create gift card codes', () => {
+    cy.login({ redirect: `/${collectiveSlug}/edit/gift-cards-create` });
+    cy.get('#virtualcard-amount').type('42');
+    cy.get('#virtualcard-numberOfVirtualCards').type('{selectall}5');
+    cy.get('.FormInputs button[type="submit"]').click();
+    cy.contains('Your 5 gift cards are ready!');
+  });
+
+  it('send gift cards by emails', () => {
+    cy.login({ redirect: `/${collectiveSlug}/edit/gift-cards-send` });
+
+    // Button should be disabled untill we add emails
+    checkSubmit(false, 'Create 0 gift cards');
+
+    // Multi-email tests
+    const multiEmailSelector = '.virtualcards-recipients .public-DraftEditor-content';
+    cy.get(multiEmailSelector).type('test1@opencollective.com');
+    checkSubmit(true, 'Create 1 gift cards');
+    // De-duplicate
+    cy.get(multiEmailSelector).type(' test1@opencollective.com');
+    checkSubmit(true, 'Create 1 gift cards');
+    // Show invalid emails
+    cy.get(multiEmailSelector).type(' Everybody Love Cats');
+    cy.get('#virtualcard-amount').focus(); // focus another field to trigger validation
+    cy.get('.multiemails-errors').contains('Invalid emails: Everybody, Love, Cats');
+    checkSubmit(false, 'Create 1 gift cards');
+
+    // Let's complete and submit this form
+    cy.get(multiEmailSelector).type(
+      '{selectall} test1@opencollective.com test2@opencollective.com test3@opencollective.com',
+    );
+    cy.get('#virtualcard-amount').type('12');
+    checkSubmit(true, 'Create 3 gift cards');
+    cy.get('.FormInputs button[type="submit"]').click();
+    cy.contains('Your 3 gift cards have been sent!');
+  });
+});
+
+function checkSubmit(enabled, message) {
+  cy.get('.FormInputs button[type="submit"]')
+    .should(`be.${enabled ? 'enabled' : 'disabled'}`)
+    .contains(message);
+}

--- a/cypress/integration/30-virtualcards-admin.js
+++ b/cypress/integration/30-virtualcards-admin.js
@@ -17,6 +17,7 @@ describe('Virtual cards admin', () => {
     cy.login({ redirect: `/${collectiveSlug}/edit/gift-cards-create` });
     cy.get('#virtualcard-amount').type('42');
     cy.get('#virtualcard-numberOfVirtualCards').type('{selectall}5');
+    cy.get('.field-limitToOpenSourceCollectives .custom-checkbox').click();
     cy.get('.FormInputs button[type="submit"]').click();
     cy.contains('Your 5 gift cards are ready!');
   });
@@ -46,6 +47,7 @@ describe('Virtual cards admin', () => {
     );
     cy.get('#virtualcard-amount').type('12');
     checkSubmit(true, 'Create 3 gift cards');
+    cy.get('.field-limitToOpenSourceCollectives .custom-checkbox').click();
     cy.get('.FormInputs button[type="submit"]').click();
     cy.contains('Your 3 gift cards have been sent!');
   });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -4,24 +4,96 @@ Cypress.Commands.add('login', (params = {}) => {
   const { email = defaultTestUserEmail, redirect = null } = params;
   const user = { email, newsletterOptIn: false };
 
-  return cy
-    .request({
-      url: '/api/users/signin',
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ user, redirect }),
-    })
-    .then(({ body: { redirect } }) => {
-      // Default test user is allowed to signin directly, thus a signin URL
-      // is directly returned by the URL. See singin function in
-      // opencollective-api/server/controllers/users.js for more info
-      cy.visit(redirect);
+  return signinRequest(user, redirect).then(({ body: { redirect } }) => {
+    // Default test user is allowed to signin directly, thus a signin URL
+    // is directly returned by the URL. See singin function in
+    // opencollective-api/server/controllers/users.js for more info
+    cy.visit(redirect);
+  });
+});
+
+Cypress.Commands.add('createCollective', ({ type = 'ORGANIZATION' }) => {
+  const user = { email: defaultTestUserEmail, newsletterOptIn: false };
+  return signinRequest(user, null).then(response => {
+    const token = getTokenFromRedirectUrl(response.body.redirect);
+    return graphqlQuery(token, {
+      operationName: 'createCollective',
+      query: `
+          mutation createCollective($collective: CollectiveInputType!) {
+            createCollective(collective: $collective) {
+              id
+              slug
+            }
+          }
+        `,
+      variables: { collective: { location: {}, name: 'TestOrg', slug: '', tiers: [], type } },
+    }).then(({ body }) => {
+      return body.data.createCollective;
     });
+  });
+});
+
+Cypress.Commands.add('addCreditCardToCollective', ({ collectiveSlug }) => {
+  cy.login({ redirect: `/${collectiveSlug}/edit/payment-methods` });
+  cy.get('.editPaymentMethodsActions button').click();
+  cy.wait(2000);
+  cy.get('.__PrivateStripeElement iframe').then(iframe => {
+    const body = iframe.contents().find('body');
+
+    cy.wrap(body)
+      .find('input:eq(1)')
+      .type('4242424242424242');
+
+    cy.wrap(body)
+      .find('input:eq(2)')
+      .type('1222');
+
+    cy.wrap(body)
+      .find('input:eq(3)')
+      .type('123');
+
+    cy.wrap(body)
+      .find('input:eq(4)')
+      .type('42222');
+
+    cy.wait(1000);
+
+    cy.get('button[type="submit"]').click();
+
+    cy.wait(2000);
+  });
 });
 
 Cypress.Commands.add('fillInputField', (fieldname, value) => {
   return cy.get(`.inputField.${fieldname} input`).type(value);
 });
+
+function signinRequest(user, redirect) {
+  return cy.request({
+    url: '/api/users/signin',
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ user, redirect }),
+  });
+}
+
+function getTokenFromRedirectUrl(url) {
+  const regex = /\/signin\/([^?]+)/;
+  return regex.exec(url)[1];
+}
+
+function graphqlQuery(token, body) {
+  return cy.request({
+    url: '/api/graphql',
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}

--- a/src/apps/expenses/components/CreateExpenseForm.js
+++ b/src/apps/expenses/components/CreateExpenseForm.js
@@ -309,7 +309,7 @@ class CreateExpenseForm extends React.Component {
                   defaultMessage="It can be daunting for the community to file an expense. Help them by providing a clear expense policy to explain what they can expense."
                 />
               </p>
-              <Button className="blue" href={`/${collective.slug}/edit#expenses`}>
+              <Button className="blue" href={`/${collective.slug}/edit/expenses`}>
                 <FormattedMessage id="expense.expensePolicy.add" defaultMessage="add an expense policy" />
               </Button>
             </div>

--- a/src/components/Collective.js
+++ b/src/components/Collective.js
@@ -311,7 +311,7 @@ class Collective extends React.Component {
                       )}
                       action={{
                         label: intl.formatMessage(this.messages['collective.addHostBtn']),
-                        href: `/${collective.slug}/edit#host`,
+                        href: `/${collective.slug}/edit/host`,
                       }}
                     />
                   )}

--- a/src/components/CreateCollective.js
+++ b/src/components/CreateCollective.js
@@ -104,22 +104,24 @@ class CreateCollective extends React.Component {
       const successParams = {
         slug: collective.slug,
       };
-      let route = 'collective';
-
-      if (CollectiveInputType.HostCollectiveId) {
-        successParams.status = 'collectiveCreated';
-        successParams.CollectiveId = collective.id;
-        successParams.collectiveSlug = collective.slug;
-      } else {
-        route = `/${collective.slug}/edit#host`;
-      }
-
       this.setState({
         status: 'idle',
         result: { success: 'Collective created successfully' },
       });
 
-      Router.pushRoute(route, successParams);
+      if (CollectiveInputType.HostCollectiveId) {
+        successParams.status = 'collectiveCreated';
+        successParams.CollectiveId = collective.id;
+        successParams.collectiveSlug = collective.slug;
+        Router.pushRoute('collective', {
+          slug: collective.slug,
+          status: 'collectiveCreated',
+          CollectiveId: collective.id,
+          CollectiveSlug: collective.slug,
+        });
+      } else {
+        Router.pushRoute('editCollectiveSection', { slug: collective.slug, section: 'host' });
+      }
     } catch (err) {
       console.error('>>> createCollective error: ', JSON.stringify(err));
       const errorMsg = err.graphQLErrors && err.graphQLErrors[0] ? err.graphQLErrors[0].message : err.message;

--- a/src/components/CreateCollective.js
+++ b/src/components/CreateCollective.js
@@ -120,7 +120,7 @@ class CreateCollective extends React.Component {
           CollectiveSlug: collective.slug,
         });
       } else {
-        Router.pushRoute('editCollectiveSection', { slug: collective.slug, section: 'host' });
+        Router.pushRoute('editCollective', { slug: collective.slug, section: 'host' });
       }
     } catch (err) {
       console.error('>>> createCollective error: ', JSON.stringify(err));

--- a/src/components/CreateVirtualCardsBulk.js
+++ b/src/components/CreateVirtualCardsBulk.js
@@ -45,6 +45,7 @@ class CreateVirtualCardsBulk extends Component {
       errors: { emails: [] },
       submitting: false,
       createdVirtualCards: null,
+      serverError: null,
     };
   }
 
@@ -84,6 +85,9 @@ class CreateVirtualCardsBulk extends Component {
         })
         .then(({ data }) => {
           this.setState({ createdVirtualCards: data.createVirtualCards, submitting: false });
+        })
+        .catch(e => {
+          this.setState({ serverError: e.message, submitting: false });
         });
     }
   }
@@ -160,7 +164,7 @@ class CreateVirtualCardsBulk extends Component {
     if (loading) return <Loading />;
     if (paymentMethods.length === 0) return this.renderNoPaymentMethodMessage();
 
-    const { submitting, values, createdVirtualCards } = this.state;
+    const { submitting, values, createdVirtualCards, serverError } = this.state;
 
     return createdVirtualCards ? (
       this.renderSuccess(createdVirtualCards)
@@ -211,6 +215,8 @@ class CreateVirtualCardsBulk extends Component {
               onChange={option => this.onChange('paymentMethod', option)}
             />
           </InlineField>
+
+          {serverError && <P color="red.700">{serverError}</P>}
 
           <Box mb="1em" css={{ alignSelf: 'center' }}>
             {this.renderSubmit()}

--- a/src/components/CreateVirtualCardsBulk.js
+++ b/src/components/CreateVirtualCardsBulk.js
@@ -1,0 +1,240 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { Flex, Box } from '@rebass/grid';
+import { get } from 'lodash';
+import { graphql } from 'react-apollo';
+
+import { CheckCircle } from 'styled-icons/fa-regular/CheckCircle.cjs';
+
+import { getCollectiveSourcePaymentMethodsQuery } from '../graphql/queries';
+import { createVirtualCardsMutationQuery } from '../graphql/mutations';
+import StyledInputAmount from './StyledInputAmount';
+import StyledButton from './StyledButton';
+import StyledInput from './StyledInput';
+import StyledPaymentMethodChooser from './StyledPaymentMethodChooser';
+import Loading from './Loading';
+import Link from './Link';
+import { P } from './Text';
+
+const MIN_AMOUNT = 5;
+
+const InlineField = ({ name, children, label }) => (
+  <Flex alignItems="center" mb="2.5em">
+    <Box css={{ flexBasis: '12em' }}>
+      <label htmlFor={`virtualcard-${name}`}>{label}</label>
+    </Box>
+    {children}
+  </Flex>
+);
+
+class CreateVirtualCardsBulk extends Component {
+  static propTypes = {
+    collectiveId: PropTypes.number.isRequired,
+    collectiveSlug: PropTypes.string.isRequired,
+    currency: PropTypes.string.isRequired,
+    createVirtualCards: PropTypes.func,
+  };
+
+  constructor(props) {
+    super(props);
+    this.form = React.createRef();
+    this.onSubmit = this.onSubmit.bind(this);
+    this.state = {
+      values: { amount: '', numberOfVirtualCards: 1 },
+      errors: { emails: [] },
+      submitting: false,
+      createdVirtualCards: null,
+    };
+  }
+
+  onChange(fieldName, value) {
+    if (fieldName === 'amount') {
+      const intAmount = parseInt(value);
+      if (!isNaN(intAmount)) {
+        this.setState(state => ({ ...state, values: { ...state.values, amount: intAmount } }));
+      } else if (this.state.values.amount === undefined) {
+        this.setState(state => ({ ...state, values: { ...state.values, amount: MIN_AMOUNT } }));
+      }
+    } else if (fieldName === 'numberOfVirtualCards') {
+      const intnumberOfVirtualCards = parseInt(value);
+      if (!isNaN(intnumberOfVirtualCards)) {
+        this.setState(state => ({
+          ...state,
+          values: { ...state.values, numberOfVirtualCards: intnumberOfVirtualCards },
+        }));
+      } else if (this.state.values.numberOfVirtualCards === undefined) {
+        this.setState(state => ({ ...state, values: { ...state.values, numberOfVirtualCards: 1 } }));
+      }
+    } else if (fieldName === 'paymentMethod') {
+      this.setState(state => ({ ...state, values: { ...state.values, PaymentMethodId: value.value.id } }));
+    }
+  }
+
+  onSubmit(e) {
+    e.preventDefault();
+    const { values, submitting } = this.state;
+    if (!submitting && this.form.current.reportValidity()) {
+      this.setState({ submitting: true });
+      this.props
+        .createVirtualCards({
+          amount: values.amount * 100,
+          numberOfVirtualCards: values.numberOfVirtualCards,
+          PaymentMethodId: values.PaymentMethodId || this.getDefaultPaymentMethod().id,
+        })
+        .then(({ data }) => {
+          this.setState({ createdVirtualCards: data.createVirtualCards, submitting: false });
+        });
+    }
+  }
+
+  getDefaultPaymentMethod() {
+    return get(this.props, 'data.Collective.paymentMethods', [])[0];
+  }
+
+  getError(fieldName) {
+    return this.state.errors[fieldName];
+  }
+
+  renderSubmit() {
+    const { submitting, values } = this.state;
+    return (
+      <StyledButton
+        type="submit"
+        buttonSize="large"
+        buttonStyle="primary"
+        minWidth="5em"
+        loading={submitting}
+        disabled={values.numberOfVirtualCards === 0}
+      >
+        <FormattedMessage
+          id="virtualCards.generate"
+          defaultMessage="Create {count} gift cards"
+          values={{ count: values.numberOfVirtualCards }}
+        />
+      </StyledButton>
+    );
+  }
+
+  renderNoPaymentMethodMessage() {
+    return (
+      <Flex justifyContent="center">
+        <Link route="editCollective" params={{ slug: this.props.collectiveSlug, section: 'payment-methods' }}>
+          <StyledButton buttonSize="large" mt="2em" justifyContent="center">
+            <FormattedMessage
+              id="virtualCards.create.requirePM"
+              defaultMessage="You must add a payment method to your account to create gift cards"
+            />
+          </StyledButton>
+        </Link>
+      </Flex>
+    );
+  }
+
+  renderSuccess(createdVirtualCards) {
+    return (
+      <Flex flexDirection="column" alignItems="center" justifyContent="center">
+        <P color="green.700">
+          <CheckCircle size="3em" />
+        </P>
+        <FormattedMessage
+          id="virtualCards.create.success"
+          defaultMessage="Your {count} gift cards are ready! Go back to the {link} to see them."
+          values={{
+            count: createdVirtualCards.length,
+            link: (
+              <Link route="editCollective" params={{ slug: this.props.collectiveSlug, section: 'gift-cards' }}>
+                <FormattedMessage id="virtualcards.create.listPage" defaultMessage="gift cards list" />
+              </Link>
+            ),
+          }}
+        />
+      </Flex>
+    );
+  }
+
+  render() {
+    const loading = get(this.props, 'data.loading');
+    const paymentMethods = get(this.props, 'data.Collective.paymentMethods', []);
+
+    if (loading) return <Loading />;
+    if (paymentMethods.length === 0) return this.renderNoPaymentMethodMessage();
+
+    const { submitting, values, createdVirtualCards } = this.state;
+
+    return createdVirtualCards ? (
+      this.renderSuccess(createdVirtualCards)
+    ) : (
+      <form ref={this.form} onSubmit={this.onSubmit}>
+        <Flex flexDirection="column">
+          <InlineField
+            name="amount"
+            label={<FormattedMessage id="virtualCards.create.amount" defaultMessage="Amount" />}
+          >
+            <StyledInputAmount
+              id="virtualcard-amount"
+              currency={this.props.currency}
+              onChange={e => this.onChange('amount', e.target.value)}
+              error={this.getError('amount')}
+              value={values.amount}
+              min={MIN_AMOUNT}
+              disabled={submitting}
+              required
+            />
+          </InlineField>
+
+          <InlineField
+            name="numberOfVirtualCards"
+            label={<FormattedMessage id="virtualCards.create.number" defaultMessage="Number of gift cards" />}
+          >
+            <StyledInput
+              id="virtualcard-numberOfVirtualCards"
+              type="number"
+              step="1"
+              min="1"
+              max="100"
+              maxWidth="8em"
+              onChange={e => this.onChange('numberOfVirtualCards', e.target.value)}
+              value={this.state.values.numberOfVirtualCards}
+              disabled={submitting}
+            />
+          </InlineField>
+
+          <InlineField
+            name="paymentMethod"
+            label={<FormattedMessage id="virtualCards.create.paymentMethod" defaultMessage="Payment Method" />}
+          >
+            <StyledPaymentMethodChooser
+              disabled={submitting}
+              paymentMethods={paymentMethods}
+              defaultPaymentMethod={this.getDefaultPaymentMethod()}
+              onChange={option => this.onChange('paymentMethod', option)}
+            />
+          </InlineField>
+
+          <Box mb="1em" css={{ alignSelf: 'center' }}>
+            {this.renderSubmit()}
+          </Box>
+        </Flex>
+      </form>
+    );
+  }
+}
+
+const addPaymentMethods = graphql(getCollectiveSourcePaymentMethodsQuery, {
+  options: props => ({ variables: { id: props.collectiveId } }),
+});
+
+const addCreateVirtualCardsMutation = graphql(createVirtualCardsMutationQuery, {
+  props: ({ mutate, ownProps }) => ({
+    createVirtualCards: variables =>
+      mutate({
+        variables: {
+          ...variables,
+          CollectiveId: ownProps.collectiveId,
+        },
+      }),
+  }),
+});
+
+export default addPaymentMethods(addCreateVirtualCardsMutation(CreateVirtualCardsBulk));

--- a/src/components/CreateVirtualCardsBulk.js
+++ b/src/components/CreateVirtualCardsBulk.js
@@ -19,11 +19,14 @@ import Link from './Link';
 import { P } from './Text';
 
 const MIN_AMOUNT = 5;
+const MAX_AMOUNT = 10000;
 
-const InlineField = ({ name, children, label }) => (
+const InlineField = ({ name, children, label, isLabelClickable }) => (
   <Flex alignItems="center" mb="2.5em" className={`field-${name}`}>
     <Box css={{ flexBasis: '12em' }}>
-      <label htmlFor={`virtualcard-${name}`}>{label}</label>
+      <label htmlFor={`virtualcard-${name}`} style={isLabelClickable && { cursor: 'pointer' }}>
+        {label}
+      </label>
     </Box>
     <Box>{children}</Box>
   </Flex>
@@ -186,6 +189,7 @@ class CreateVirtualCardsBulk extends Component {
               error={this.getError('amount')}
               value={values.amount}
               min={MIN_AMOUNT}
+              max={MAX_AMOUNT}
               disabled={submitting}
               required
             />
@@ -221,7 +225,8 @@ class CreateVirtualCardsBulk extends Component {
           </InlineField>
 
           <InlineField
-            name="limitToOpenSourceCollectives"
+            name="onlyOpensource"
+            isLabelClickable
             label={
               <FormattedMessage
                 id="virtualCards.create.onlyOpenSource"
@@ -230,15 +235,17 @@ class CreateVirtualCardsBulk extends Component {
             }
           >
             <StyledCheckbox
+              inputId="virtualcard-onlyOpensource"
+              name="onlyOpensource"
               checked={values.onlyOpensource}
-              onChange={checked => this.onChange('onlyOpensource', checked)}
+              onChange={({ checked }) => this.onChange('onlyOpensource', checked)}
               size="25px"
             />
           </InlineField>
 
           {serverError && <P color="red.700">{serverError}</P>}
 
-          <Box mb="1em" css={{ alignSelf: 'center' }}>
+          <Box mb="1em" alignSelf="center">
             {this.renderSubmit()}
           </Box>
         </Flex>

--- a/src/components/CreateVirtualCardsBulk.js
+++ b/src/components/CreateVirtualCardsBulk.js
@@ -11,6 +11,7 @@ import { getCollectiveSourcePaymentMethodsQuery } from '../graphql/queries';
 import { createVirtualCardsMutationQuery } from '../graphql/mutations';
 import StyledInputAmount from './StyledInputAmount';
 import StyledButton from './StyledButton';
+import StyledCheckbox from './StyledCheckbox';
 import StyledInput from './StyledInput';
 import StyledPaymentMethodChooser from './StyledPaymentMethodChooser';
 import Loading from './Loading';
@@ -20,11 +21,11 @@ import { P } from './Text';
 const MIN_AMOUNT = 5;
 
 const InlineField = ({ name, children, label }) => (
-  <Flex alignItems="center" mb="2.5em">
+  <Flex alignItems="center" mb="2.5em" className={`field-${name}`}>
     <Box css={{ flexBasis: '12em' }}>
       <label htmlFor={`virtualcard-${name}`}>{label}</label>
     </Box>
-    {children}
+    <Box>{children}</Box>
   </Flex>
 );
 
@@ -41,7 +42,7 @@ class CreateVirtualCardsBulk extends Component {
     this.form = React.createRef();
     this.onSubmit = this.onSubmit.bind(this);
     this.state = {
-      values: { amount: '', numberOfVirtualCards: 1 },
+      values: { amount: '', numberOfVirtualCards: 1, onlyOpensource: true },
       errors: { emails: [] },
       submitting: false,
       createdVirtualCards: null,
@@ -69,6 +70,8 @@ class CreateVirtualCardsBulk extends Component {
       }
     } else if (fieldName === 'paymentMethod') {
       this.setState(state => ({ ...state, values: { ...state.values, PaymentMethodId: value.value.id } }));
+    } else if (fieldName === 'onlyOpensource') {
+      this.setState(state => ({ ...state, values: { ...state.values, onlyOpensource: value } }));
     }
   }
 
@@ -82,6 +85,7 @@ class CreateVirtualCardsBulk extends Component {
           amount: values.amount * 100,
           numberOfVirtualCards: values.numberOfVirtualCards,
           PaymentMethodId: values.PaymentMethodId || this.getDefaultPaymentMethod().id,
+          limitedToOpenSourceCollectives: values.onlyOpensource,
         })
         .then(({ data }) => {
           this.setState({ createdVirtualCards: data.createVirtualCards, submitting: false });
@@ -213,6 +217,22 @@ class CreateVirtualCardsBulk extends Component {
               paymentMethods={paymentMethods}
               defaultPaymentMethod={this.getDefaultPaymentMethod()}
               onChange={option => this.onChange('paymentMethod', option)}
+            />
+          </InlineField>
+
+          <InlineField
+            name="limitToOpenSourceCollectives"
+            label={
+              <FormattedMessage
+                id="virtualCards.create.onlyOpenSource"
+                defaultMessage="Limit to opensource collectives"
+              />
+            }
+          >
+            <StyledCheckbox
+              checked={values.onlyOpensource}
+              onChange={checked => this.onChange('onlyOpensource', checked)}
+              size="25px"
             />
           </InlineField>
 

--- a/src/components/CreateVirtualCardsFromEmails.js
+++ b/src/components/CreateVirtualCardsFromEmails.js
@@ -13,6 +13,7 @@ import { getCollectiveSourcePaymentMethodsQuery } from '../graphql/queries';
 import { createVirtualCardsMutationQuery } from '../graphql/mutations';
 import StyledInputAmount from './StyledInputAmount';
 import StyledButton from './StyledButton';
+import StyledCheckbox from './StyledCheckbox';
 import StyledPaymentMethodChooser from './StyledPaymentMethodChooser';
 import Loading from './Loading';
 import Link from './Link';
@@ -22,7 +23,7 @@ import { P } from './Text';
 const MIN_AMOUNT = 5;
 
 const InlineField = ({ name, children, label }) => (
-  <Flex alignItems="center" mb="2.5em">
+  <Flex alignItems="center" mb="2.5em" className={`field-${name}`}>
     <Box css={{ flexBasis: '12em' }}>
       <label htmlFor={`virtualcard-${name}`}>{label}</label>
     </Box>
@@ -48,7 +49,7 @@ class CreateVirtualCardsFromEmails extends Component {
     this.form = React.createRef();
     this.onSubmit = this.onSubmit.bind(this);
     this.state = {
-      values: { emails: [], amount: '' },
+      values: { emails: [], amount: '', onlyOpensource: true },
       errors: { emails: [] },
       submitting: false,
       createdVirtualCards: null,
@@ -73,6 +74,8 @@ class CreateVirtualCardsFromEmails extends Component {
       }
     } else if (fieldName === 'paymentMethod') {
       this.setState(state => ({ ...state, values: { ...state.values, PaymentMethodId: value.value.id } }));
+    } else if (fieldName === 'onlyOpensource') {
+      this.setState(state => ({ ...state, values: { ...state.values, onlyOpensource: value } }));
     }
   }
 
@@ -92,6 +95,7 @@ class CreateVirtualCardsFromEmails extends Component {
           amount: values.amount * 100,
           emails: values.emails,
           PaymentMethodId: values.PaymentMethodId || this.getDefaultPaymentMethod().id,
+          limitedToOpenSourceCollectives: values.onlyOpensource,
         })
         .then(({ data }) => {
           this.setState({ createdVirtualCards: data.createVirtualCards, submitting: false });
@@ -204,6 +208,22 @@ class CreateVirtualCardsFromEmails extends Component {
               paymentMethods={paymentMethods}
               defaultPaymentMethod={this.getDefaultPaymentMethod()}
               onChange={option => this.onChange('paymentMethod', option)}
+            />
+          </InlineField>
+
+          <InlineField
+            name="limitToOpenSourceCollectives"
+            label={
+              <FormattedMessage
+                id="virtualCards.create.onlyOpenSource"
+                defaultMessage="Limit to opensource collectives"
+              />
+            }
+          >
+            <StyledCheckbox
+              checked={values.onlyOpensource}
+              onChange={checked => this.onChange('onlyOpensource', checked)}
+              size="25px"
             />
           </InlineField>
 

--- a/src/components/CreateVirtualCardsFromEmails.js
+++ b/src/components/CreateVirtualCardsFromEmails.js
@@ -21,11 +21,14 @@ import StyledMultiEmailInput from './StyledMultiEmailInput';
 import { P } from './Text';
 
 const MIN_AMOUNT = 5;
+const MAX_AMOUNT = 10000;
 
-const InlineField = ({ name, children, label }) => (
+const InlineField = ({ name, children, label, isLabelClickable }) => (
   <Flex alignItems="center" mb="2.5em" className={`field-${name}`}>
     <Box css={{ flexBasis: '12em' }}>
-      <label htmlFor={`virtualcard-${name}`}>{label}</label>
+      <label htmlFor={`virtualcard-${name}`} style={isLabelClickable && { cursor: 'pointer' }}>
+        {label}
+      </label>
     </Box>
     {children}
   </Flex>
@@ -194,6 +197,7 @@ class CreateVirtualCardsFromEmails extends Component {
               error={this.getError('amount')}
               value={values.amount}
               min={MIN_AMOUNT}
+              max={MAX_AMOUNT}
               disabled={submitting}
               required
             />
@@ -212,7 +216,8 @@ class CreateVirtualCardsFromEmails extends Component {
           </InlineField>
 
           <InlineField
-            name="limitToOpenSourceCollectives"
+            name="onlyOpensource"
+            isLabelClickable
             label={
               <FormattedMessage
                 id="virtualCards.create.onlyOpenSource"
@@ -221,8 +226,10 @@ class CreateVirtualCardsFromEmails extends Component {
             }
           >
             <StyledCheckbox
+              inputId="virtualcard-onlyOpensource"
+              name="onlyOpensource"
               checked={values.onlyOpensource}
-              onChange={checked => this.onChange('onlyOpensource', checked)}
+              onChange={({ checked }) => this.onChange('onlyOpensource', checked)}
               size="25px"
             />
           </InlineField>
@@ -250,7 +257,7 @@ class CreateVirtualCardsFromEmails extends Component {
 
           {serverError && <P color="red.700">{serverError}</P>}
 
-          <Box mb="1em" css={{ alignSelf: 'center' }}>
+          <Box mb="1em" alignSelf="center">
             {this.renderSubmit()}
           </Box>
         </Flex>

--- a/src/components/CreateVirtualCardsFromEmails.js
+++ b/src/components/CreateVirtualCardsFromEmails.js
@@ -220,6 +220,7 @@ class CreateVirtualCardsFromEmails extends Component {
               </Flex>
             </label>
             <StyledMultiEmailInput
+              className="virtualcards-recipients"
               mt="0.25em"
               invalids={errors.emails}
               onChange={value => this.onChange('emails', value)}

--- a/src/components/CreateVirtualCardsFromEmails.js
+++ b/src/components/CreateVirtualCardsFromEmails.js
@@ -1,0 +1,273 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { FormattedMessage } from 'react-intl';
+import { Flex, Box } from '@rebass/grid';
+import { get } from 'lodash';
+import { graphql } from 'react-apollo';
+
+import { CheckCircle } from 'styled-icons/fa-regular/CheckCircle.cjs';
+
+import { getCollectiveSourcePaymentMethodsQuery } from '../graphql/queries';
+import { createVirtualCardsMutationQuery } from '../graphql/mutations';
+import StyledInputAmount from './StyledInputAmount';
+import StyledButton from './StyledButton';
+import StyledInput from './StyledInput';
+import StyledPaymentMethodChooser from './StyledPaymentMethodChooser';
+import Loading from './Loading';
+import Link from './Link';
+import StyledMultiEmailInput from './StyledMultiEmailInput';
+import { P } from './Text';
+
+const MIN_AMOUNT = 5;
+
+const InlineField = ({ name, children, label }) => (
+  <Flex alignItems="center" mb="2.5em">
+    <Box css={{ flexBasis: '12em' }}>
+      <label htmlFor={`virtualcard-${name}`}>{label}</label>
+    </Box>
+    {children}
+  </Flex>
+);
+
+const FieldLabelDetails = styled.span`
+  color: ${props => props.theme.colors.black[400]};
+  font-weight: 400;
+`;
+
+class CreateVirtualCardsFromEmails extends Component {
+  static propTypes = {
+    collectiveId: PropTypes.number.isRequired,
+    collectiveSlug: PropTypes.string.isRequired,
+    currency: PropTypes.string.isRequired,
+    createVirtualCards: PropTypes.func.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.form = React.createRef();
+    this.onSubmit = this.onSubmit.bind(this);
+    this.state = {
+      values: { emails: [], amount: '' },
+      errors: { emails: [] },
+      submitting: false,
+      createdVirtualCards: null,
+    };
+  }
+
+  onChange(fieldName, value) {
+    if (fieldName === 'emails') {
+      const { emails, invalids } = value;
+      this.setState(state => ({
+        ...state,
+        values: { ...state.values, emails },
+        errors: { ...state.errors, emails: invalids },
+      }));
+    } else if (fieldName === 'amount') {
+      const intAmount = parseInt(value);
+      if (!isNaN(intAmount)) {
+        this.setState(state => ({ ...state, values: { ...state.values, amount: intAmount } }));
+      } else if (this.state.values.amount === undefined) {
+        this.setState(state => ({ ...state, values: { ...state.values, amount: MIN_AMOUNT } }));
+      }
+    } else if (fieldName === 'paymentMethod') {
+      this.setState(state => ({ ...state, values: { ...state.values, PaymentMethodId: value.value.id } }));
+    }
+  }
+
+  isSubmitEnabled() {
+    // Others fields validity are checked with HTML5 validation (see `onSubmit`)
+    const { values, errors } = this.state;
+    return values.emails.length > 0 && errors.emails.length == 0;
+  }
+
+  onSubmit(e) {
+    e.preventDefault();
+    const { values, submitting } = this.state;
+    if (!submitting && this.form.current.reportValidity()) {
+      this.setState({ submitting: true });
+      this.props
+        .createVirtualCards({
+          amount: values.amount * 100,
+          emails: values.emails,
+          PaymentMethodId: values.PaymentMethodId || this.getDefaultPaymentMethod().id,
+        })
+        .then(({ data }) => {
+          this.setState({ createdVirtualCards: data.createVirtualCards, submitting: false });
+        });
+    }
+  }
+
+  getDefaultPaymentMethod() {
+    return get(this.props, 'data.Collective.paymentMethods', [])[0];
+  }
+
+  getError(fieldName) {
+    return this.state.errors[fieldName];
+  }
+
+  renderSubmit() {
+    const { submitting, values } = this.state;
+    const count = values.emails.length;
+    const enable = this.isSubmitEnabled();
+    return (
+      <StyledButton
+        type="submit"
+        buttonSize="large"
+        buttonStyle="primary"
+        minWidth="16em"
+        disabled={!submitting && !enable}
+        loading={submitting}
+      >
+        <FormattedMessage id="virtualCards.generate" defaultMessage="Create {count} gift cards" values={{ count }} />
+      </StyledButton>
+    );
+  }
+
+  renderNoPaymentMethodMessage() {
+    return (
+      <Flex justifyContent="center">
+        <Link route="editCollective" params={{ slug: this.props.collectiveSlug, section: 'payment-methods' }}>
+          <StyledButton buttonSize="large" mt="2em" justifyContent="center">
+            <FormattedMessage
+              id="virtualCards.create.requirePM"
+              defaultMessage="You must add a payment method to your account to create gift cards"
+            />
+          </StyledButton>
+        </Link>
+      </Flex>
+    );
+  }
+
+  renderSuccess(createdVirtualCards) {
+    return (
+      <Flex flexDirection="column" alignItems="center" justifyContent="center">
+        <P color="green.700">
+          <CheckCircle size="3em" />
+        </P>
+        <FormattedMessage
+          id="virtualCards.create.successSent"
+          defaultMessage="Your {count} gift cards have been sent! Go back to the {link} to see them."
+          values={{
+            count: createdVirtualCards.length,
+            link: (
+              <Link route="editCollective" params={{ slug: this.props.collectiveSlug, section: 'gift-cards' }}>
+                <FormattedMessage id="virtualcards.create.listPage" defaultMessage="gift cards list" />
+              </Link>
+            ),
+          }}
+        />
+      </Flex>
+    );
+  }
+
+  render() {
+    const loading = get(this.props, 'data.loading');
+    const paymentMethods = get(this.props, 'data.Collective.paymentMethods', []);
+
+    if (loading) return <Loading />;
+    if (paymentMethods.length === 0) return this.renderNoPaymentMethodMessage();
+
+    const { submitting, values, errors, createdVirtualCards } = this.state;
+
+    return createdVirtualCards ? (
+      this.renderSuccess(createdVirtualCards)
+    ) : (
+      <form ref={this.form} onSubmit={this.onSubmit}>
+        <Flex flexDirection="column">
+          <InlineField
+            name="amount"
+            label={<FormattedMessage id="virtualCards.create.amount" defaultMessage="Amount" />}
+          >
+            <StyledInputAmount
+              id="virtualcard-amount"
+              currency={this.props.currency}
+              onChange={e => this.onChange('amount', e.target.value)}
+              error={this.getError('amount')}
+              value={values.amount}
+              min={MIN_AMOUNT}
+              disabled={submitting}
+              required
+            />
+          </InlineField>
+
+          <InlineField
+            name="paymentMethod"
+            label={<FormattedMessage id="virtualCards.create.paymentMethod" defaultMessage="Payment Method" />}
+          >
+            <StyledPaymentMethodChooser
+              disabled={submitting}
+              paymentMethods={paymentMethods}
+              defaultPaymentMethod={this.getDefaultPaymentMethod()}
+              onChange={option => this.onChange('paymentMethod', option)}
+            />
+          </InlineField>
+
+          <InlineField
+            name="customMessage"
+            label={
+              <Flex flexDirection="column">
+                <FormattedMessage id="virtualCards.create.customMessage" defaultMessage="Custom message" />
+                <FieldLabelDetails>
+                  <FormattedMessage id="forms.optional" defaultMessage="Optional" />
+                </FieldLabelDetails>
+              </Flex>
+            }
+          >
+            <StyledInput
+              id="virtualcard-customMessage"
+              type="text"
+              maxLength="255"
+              placeholder="Will be sent in the invitation email"
+              onChange={value => this.onChange('customMessage', value)}
+              style={{ flexGrow: 1 }}
+              disabled={submitting}
+            />
+          </InlineField>
+
+          <Flex flexDirection="column" mb="3em">
+            <label style={{ width: '100%' }}>
+              <Flex flexDirection="column">
+                <FormattedMessage id="virtualCards.create.recipients" defaultMessage="Recipients" />
+                <FieldLabelDetails>
+                  <FormattedMessage
+                    id="virtualCards.create.recipientsDetails"
+                    defaultMessage="A list of emails that will receive a gift card"
+                  />
+                </FieldLabelDetails>
+              </Flex>
+            </label>
+            <StyledMultiEmailInput
+              mt="0.25em"
+              invalids={errors.emails}
+              onChange={value => this.onChange('emails', value)}
+              disabled={submitting}
+            />
+          </Flex>
+
+          <Box mb="1em" css={{ alignSelf: 'center' }}>
+            {this.renderSubmit()}
+          </Box>
+        </Flex>
+      </form>
+    );
+  }
+}
+
+const addPaymentMethods = graphql(getCollectiveSourcePaymentMethodsQuery, {
+  options: props => ({ variables: { id: props.collectiveId } }),
+});
+
+const addCreateVirtualCardsMutation = graphql(createVirtualCardsMutationQuery, {
+  props: ({ mutate, ownProps }) => ({
+    createVirtualCards: variables =>
+      mutate({
+        variables: {
+          ...variables,
+          CollectiveId: ownProps.collectiveId,
+        },
+      }),
+  }),
+});
+
+export default addPaymentMethods(addCreateVirtualCardsMutation(CreateVirtualCardsFromEmails));

--- a/src/components/CreateVirtualCardsFromEmails.js
+++ b/src/components/CreateVirtualCardsFromEmails.js
@@ -52,6 +52,7 @@ class CreateVirtualCardsFromEmails extends Component {
       errors: { emails: [] },
       submitting: false,
       createdVirtualCards: null,
+      serverError: null,
     };
   }
 
@@ -94,6 +95,9 @@ class CreateVirtualCardsFromEmails extends Component {
         })
         .then(({ data }) => {
           this.setState({ createdVirtualCards: data.createVirtualCards, submitting: false });
+        })
+        .catch(e => {
+          this.setState({ serverError: e.message, submitting: false });
         });
     }
   }
@@ -168,7 +172,7 @@ class CreateVirtualCardsFromEmails extends Component {
     if (loading) return <Loading />;
     if (paymentMethods.length === 0) return this.renderNoPaymentMethodMessage();
 
-    const { submitting, values, errors, createdVirtualCards } = this.state;
+    const { submitting, values, errors, createdVirtualCards, serverError } = this.state;
 
     return createdVirtualCards ? (
       this.renderSuccess(createdVirtualCards)
@@ -222,6 +226,8 @@ class CreateVirtualCardsFromEmails extends Component {
               disabled={submitting}
             />
           </Flex>
+
+          {serverError && <P color="red.700">{serverError}</P>}
 
           <Box mb="1em" css={{ alignSelf: 'center' }}>
             {this.renderSubmit()}

--- a/src/components/CreateVirtualCardsFromEmails.js
+++ b/src/components/CreateVirtualCardsFromEmails.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { themeGet } from 'styled-system';
 import { FormattedMessage } from 'react-intl';
 import { Flex, Box } from '@rebass/grid';
 import { get } from 'lodash';
@@ -12,7 +13,6 @@ import { getCollectiveSourcePaymentMethodsQuery } from '../graphql/queries';
 import { createVirtualCardsMutationQuery } from '../graphql/mutations';
 import StyledInputAmount from './StyledInputAmount';
 import StyledButton from './StyledButton';
-import StyledInput from './StyledInput';
 import StyledPaymentMethodChooser from './StyledPaymentMethodChooser';
 import Loading from './Loading';
 import Link from './Link';
@@ -31,7 +31,7 @@ const InlineField = ({ name, children, label }) => (
 );
 
 const FieldLabelDetails = styled.span`
-  color: ${props => props.theme.colors.black[400]};
+  color: ${themeGet('colors.black.400')};
   font-weight: 400;
 `;
 
@@ -200,28 +200,6 @@ class CreateVirtualCardsFromEmails extends Component {
               paymentMethods={paymentMethods}
               defaultPaymentMethod={this.getDefaultPaymentMethod()}
               onChange={option => this.onChange('paymentMethod', option)}
-            />
-          </InlineField>
-
-          <InlineField
-            name="customMessage"
-            label={
-              <Flex flexDirection="column">
-                <FormattedMessage id="virtualCards.create.customMessage" defaultMessage="Custom message" />
-                <FieldLabelDetails>
-                  <FormattedMessage id="forms.optional" defaultMessage="Optional" />
-                </FieldLabelDetails>
-              </Flex>
-            }
-          >
-            <StyledInput
-              id="virtualcard-customMessage"
-              type="text"
-              maxLength="255"
-              placeholder="Will be sent in the invitation email"
-              onChange={value => this.onChange('customMessage', value)}
-              style={{ flexGrow: 1 }}
-              disabled={submitting}
             />
           </InlineField>
 

--- a/src/components/EditCollectiveForm.js
+++ b/src/components/EditCollectiveForm.js
@@ -80,7 +80,7 @@ class EditCollectiveForm extends React.Component {
     this.defaultTierType = collective.type === 'EVENT' ? 'TICKET' : 'TIER';
     this.showEditMembers = ['COLLECTIVE', 'ORGANIZATION'].includes(collective.type);
     this.showPaymentMethods = ['USER', 'ORGANIZATION'].includes(collective.type);
-    this.showVirtualCards = true;
+    this.showVirtualCards = collective.type === 'ORGANIZATION';
     this.members = collective.members && collective.members.filter(m => ['ADMIN', 'MEMBER'].includes(m.role));
 
     this.messages = defineMessages({

--- a/src/components/EditCollectiveForm.js
+++ b/src/components/EditCollectiveForm.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'next/router';
+import { ArrowBack } from 'styled-icons/material/ArrowBack.cjs';
+
+import { Router } from '../server/pages';
 import InputField from './InputField';
 import EditTiers from './EditTiers';
 import EditGoals from './EditGoals';
@@ -17,7 +20,10 @@ import Link from './Link';
 import { get } from 'lodash';
 import styled, { css } from 'styled-components';
 import { Flex, Box } from '@rebass/grid';
+import StyledButton from './StyledButton';
 import EditVirtualCards from './EditVirtualCards';
+import CreateVirtualCardsFromEmails from './CreateVirtualCardsFromEmails';
+import CreateVirtualCardsBulk from './CreateVirtualCardsBulk';
 
 const selectedStyle = css`
   background-color: #eee;
@@ -74,7 +80,7 @@ class EditCollectiveForm extends React.Component {
     this.defaultTierType = collective.type === 'EVENT' ? 'TICKET' : 'TIER';
     this.showEditMembers = ['COLLECTIVE', 'ORGANIZATION'].includes(collective.type);
     this.showPaymentMethods = ['USER', 'ORGANIZATION'].includes(collective.type);
-    this.showVirtualCards = collective.canCreateVirtualCards;
+    this.showVirtualCards = true;
     this.members = collective.members && collective.members.filter(m => ['ADMIN', 'MEMBER'].includes(m.role));
 
     this.messages = defineMessages({
@@ -197,19 +203,16 @@ class EditCollectiveForm extends React.Component {
       // routes (like `/collective/edit/payment-methods`) but we keep this
       // legacy redirect for old emails sent with the old URL scheme
       // Deprecated on 2018-12-08
-      const legacySections = [
-        'info',
-        'images',
-        'members',
-        'payment-methods',
-        'gift-cards',
-        'connected-accounts',
-        'advanced',
-      ];
+      const legacySections = ['info', 'images', 'members', 'payment-methods', 'connected-accounts', 'advanced'];
       let section = hash.substr(1);
       if (section === 'connectedAccounts') section = 'connected-accounts';
       else if (section === 'paymentMethods') section = 'payment-methods';
-      if (legacySections.includes(section)) this.props.router.push(`/${this.props.collective.slug}/edit/${section}`);
+      if (legacySections.includes(section))
+        Router.pushRoute('editCollective', {
+          ...this.props.router.query,
+          slug: this.props.collective.slug,
+          section: section,
+        });
     }
   }
 
@@ -470,7 +473,7 @@ class EditCollectiveForm extends React.Component {
           <Box width={1 / 5} mr={4}>
             <MenuItem
               selected={this.state.section === 'info'}
-              route="editCollectiveSection"
+              route="editCollective"
               params={{ slug: collective.slug, section: 'info' }}
               className="MenuItem info"
             >
@@ -478,7 +481,7 @@ class EditCollectiveForm extends React.Component {
             </MenuItem>
             <MenuItem
               selected={this.state.section === 'images'}
-              route="editCollectiveSection"
+              route="editCollective"
               params={{ slug: collective.slug, section: 'images' }}
               className="MenuItem images"
             >
@@ -487,7 +490,7 @@ class EditCollectiveForm extends React.Component {
             {this.showEditMembers && (
               <MenuItem
                 selected={this.state.section === 'members'}
-                route="editCollectiveSection"
+                route="editCollective"
                 params={{ slug: collective.slug, section: 'members' }}
                 className="MenuItem members"
               >
@@ -497,7 +500,7 @@ class EditCollectiveForm extends React.Component {
             {this.showEditGoals && (
               <MenuItem
                 selected={this.state.section === 'goals'}
-                route="editCollectiveSection"
+                route="editCollective"
                 params={{ slug: collective.slug, section: 'goals' }}
                 className="MenuItem goals"
               >
@@ -507,7 +510,7 @@ class EditCollectiveForm extends React.Component {
             {this.showHost && (
               <MenuItem
                 selected={this.state.section === 'host'}
-                route="editCollectiveSection"
+                route="editCollective"
                 params={{ slug: collective.slug, section: 'host' }}
                 className="MenuItem host"
               >
@@ -517,7 +520,7 @@ class EditCollectiveForm extends React.Component {
             {this.showEditTiers && (
               <MenuItem
                 selected={this.state.section === 'tiers'}
-                route="editCollectiveSection"
+                route="editCollective"
                 params={{ slug: collective.slug, section: 'tiers' }}
                 className="MenuItem tiers"
               >
@@ -527,7 +530,7 @@ class EditCollectiveForm extends React.Component {
             {this.showExpenses && (
               <MenuItem
                 selected={this.state.section === 'expenses'}
-                route="editCollectiveSection"
+                route="editCollective"
                 params={{ slug: collective.slug, section: 'expenses' }}
                 className="MenuItem expenses"
               >
@@ -537,7 +540,7 @@ class EditCollectiveForm extends React.Component {
             {this.showPaymentMethods && (
               <MenuItem
                 selected={this.state.section === 'payment-methods'}
-                route="editCollectiveSection"
+                route="editCollective"
                 params={{ slug: collective.slug, section: 'payment-methods' }}
                 className="MenuItem paymentMethods"
               >
@@ -546,8 +549,8 @@ class EditCollectiveForm extends React.Component {
             )}
             {this.showVirtualCards && (
               <MenuItem
-                selected={this.state.section === 'gift-cards'}
-                route="editCollectiveSection"
+                selected={['gift-cards-create', 'gift-cards-send', 'gift-cards'].includes(this.state.section)}
+                route="editCollective"
                 params={{ slug: collective.slug, section: 'gift-cards' }}
                 className="MenuItem gift-cards"
               >
@@ -556,7 +559,7 @@ class EditCollectiveForm extends React.Component {
             )}
             <MenuItem
               selected={this.state.section === 'connected-accounts'}
-              route="editCollectiveSection"
+              route="editCollective"
               params={{ slug: collective.slug, section: 'connected-accounts' }}
               className="MenuItem connectedAccounts"
             >
@@ -565,7 +568,7 @@ class EditCollectiveForm extends React.Component {
             {collective.type === 'COLLECTIVE' && (
               <MenuItem
                 selected={this.state.section === 'export'}
-                route="editCollectiveSection"
+                route="editCollective"
                 params={{ slug: collective.slug, section: 'export' }}
                 className="MenuItem export"
               >
@@ -574,7 +577,7 @@ class EditCollectiveForm extends React.Component {
             )}
             <MenuItem
               selected={this.state.section === 'advanced'}
-              route="editCollectiveSection"
+              route="editCollective"
               params={{ slug: collective.slug, section: 'advanced' }}
               className="MenuItem advanced"
             >
@@ -654,14 +657,44 @@ class EditCollectiveForm extends React.Component {
                   onChange={this.handleObjectChange}
                 />
               )}
-              {this.state.section === 'gift-cards' && <EditVirtualCards collectiveId={collective.id} />}
+              {this.state.section === 'gift-cards' && (
+                <EditVirtualCards collectiveId={collective.id} collectiveSlug={collective.slug} />
+              )}
+              {['gift-cards-create', 'gift-cards-send'].includes(this.state.section) && (
+                <Flex flexDirection="column">
+                  <Box mb="3em">
+                    <Link route="editCollective" params={{ slug: collective.slug, section: 'gift-cards' }}>
+                      <StyledButton>
+                        <ArrowBack size="1em" />{' '}
+                        <FormattedMessage id="virtualCards.returnToEdit" defaultMessage="Go back to gift cards list" />
+                      </StyledButton>
+                    </Link>
+                  </Box>
+                  {this.state.section === 'gift-cards-send' && (
+                    <CreateVirtualCardsFromEmails
+                      collectiveId={collective.id}
+                      collectiveSlug={collective.slug}
+                      currency={collective.currency}
+                    />
+                  )}
+                  {this.state.section === 'gift-cards-create' && (
+                    <CreateVirtualCardsBulk
+                      collectiveId={collective.id}
+                      collectiveSlug={collective.slug}
+                      currency={collective.currency}
+                    />
+                  )}
+                </Flex>
+              )}
               {this.state.section === 'connected-accounts' && (
                 <EditConnectedAccounts collective={collective} connectedAccounts={collective.connectedAccounts} />
               )}
               {this.state.section === 'export' && <ExportData collective={collective} />}
             </div>
 
-            {['export', 'connected-accounts', 'host', 'gift-cards'].indexOf(this.state.section) === -1 && (
+            {['export', 'connected-accounts', 'host', 'gift-cards', 'gift-cards-create', 'gift-cards-send'].indexOf(
+              this.state.section,
+            ) === -1 && (
               <div className="actions">
                 <Button
                   bsStyle="primary"

--- a/src/components/EditCollectiveForm.js
+++ b/src/components/EditCollectiveForm.js
@@ -16,6 +16,7 @@ import { Link } from '../server/pages';
 import { get } from 'lodash';
 import styled, { css } from 'styled-components';
 import { Flex, Box } from '@rebass/grid';
+import EditVirtualCards from './EditVirtualCards';
 
 const selectedStyle = css`
   background-color: #eee;
@@ -68,6 +69,7 @@ class EditCollectiveForm extends React.Component {
     this.defaultTierType = collective.type === 'EVENT' ? 'TICKET' : 'TIER';
     this.showEditMembers = ['COLLECTIVE', 'ORGANIZATION'].includes(collective.type);
     this.showPaymentMethods = ['USER', 'ORGANIZATION'].includes(collective.type);
+    this.showVirtualCards = collective.canCreateVirtualCards;
     this.members = collective.members && collective.members.filter(m => ['ADMIN', 'MEMBER'].includes(m.role));
 
     this.messages = defineMessages({
@@ -512,6 +514,15 @@ class EditCollectiveForm extends React.Component {
                 <FormattedMessage id="editCollective.menu.paymentMethods" defaultMessage="Payment Methods" />
               </MenuItem>
             )}
+            {this.showVirtualCards && (
+              <MenuItem
+                selected={this.state.section === 'virtualCards'}
+                onClick={() => this.showSection('virtualCards')}
+                className="MenuItem virtualCards"
+              >
+                <FormattedMessage id="editCollective.menu.virtualCards" defaultMessage="Gift Cards" />
+              </MenuItem>
+            )}
             <MenuItem
               selected={this.state.section === 'connectedAccounts'}
               onClick={() => this.showSection('connectedAccounts')}
@@ -609,6 +620,7 @@ class EditCollectiveForm extends React.Component {
                   onChange={this.handleObjectChange}
                 />
               )}
+              {this.state.section === 'virtualCards' && <EditVirtualCards collective={collective} />}
               {this.state.section === 'connectedAccounts' && (
                 <EditConnectedAccounts collective={collective} connectedAccounts={collective.connectedAccounts} />
               )}

--- a/src/components/EditCollectiveForm.js
+++ b/src/components/EditCollectiveForm.js
@@ -80,8 +80,10 @@ class EditCollectiveForm extends React.Component {
     this.defaultTierType = collective.type === 'EVENT' ? 'TICKET' : 'TIER';
     this.showEditMembers = ['COLLECTIVE', 'ORGANIZATION'].includes(collective.type);
     this.showPaymentMethods = ['USER', 'ORGANIZATION'].includes(collective.type);
-    this.showVirtualCards = collective.type === 'ORGANIZATION';
     this.members = collective.members && collective.members.filter(m => ['ADMIN', 'MEMBER'].includes(m.role));
+    this.showVirtualCards =
+      collective.type === 'ORGANIZATION' &&
+      (get(collective, 'settings.canCreateVirtualCards') || props.router.query.showGiftCards);
 
     this.messages = defineMessages({
       loading: { id: 'loading', defaultMessage: 'loading' },

--- a/src/components/EditConnectedAccount.js
+++ b/src/components/EditConnectedAccount.js
@@ -69,7 +69,9 @@ class EditConnectedAccount extends React.Component {
     const { collective, options } = this.props;
 
     if (service === 'github' || service === 'twitter') {
-      const redirect = `${window.location.protocol}//${window.location.host}/${collective.slug}/edit#connectedAccounts`;
+      const redirect = `${window.location.protocol}//${window.location.host}/${
+        collective.slug
+      }/edit/connected-accounts`;
       return window.location.replace(
         `/api/connected-accounts/${service}/oauthUrl?CollectiveId=${collective.id}&redirect=${encodeURIComponent(
           redirect,

--- a/src/components/EditHost.js
+++ b/src/components/EditHost.js
@@ -71,7 +71,7 @@ class EditHost extends React.Component {
     if (!newHost.id) {
       this.setState({ selectedOption: 'noHost' });
       if (window.location.search.length > 0) {
-        window.location.replace(`/${collective.slug}/edit#host`); // make sure we clean the query params if any
+        window.location.replace(`/${collective.slug}/edit/host`); // make sure we clean the query params if any
       }
     }
   }

--- a/src/components/EditVirtualCards.js
+++ b/src/components/EditVirtualCards.js
@@ -1,9 +1,146 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { graphql } from 'react-apollo';
+import { ButtonGroup } from 'react-bootstrap';
+import { Flex } from '@rebass/grid';
+import { get, last } from 'lodash';
+import { withRouter } from 'next/router';
 
+import { getCollectiveVirtualCards } from '../graphql/queries';
+import VirtualCardDetails from './VirtualCardDetails';
+import Loading from './Loading';
+import Pagination from './Pagination';
+import Link from './Link';
+
+/**
+ * A filterable list of virtual cards meant to be displayed for organization
+ * admins.
+ */
 class EditVirtualCards extends React.Component {
+  static propTypes = {
+    collectiveId: PropTypes.number.isRequired,
+    /** Max number of items to display */
+    limit: PropTypes.number,
+    /** Provided by graphql */
+    data: PropTypes.object,
+    /** Provided by withRouter */
+    router: PropTypes.object,
+    /** Provided by addTransactionsData */
+    setConfirmedFilter: PropTypes.func,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = { claimedFilter: 'all' };
+  }
+
+  renderFilterLink(onlyConfirmed, paymentMethods, filterName, label) {
+    let btnClassName = 'btn-default';
+    if (
+      (filterName === 'all' && (onlyConfirmed === undefined || onlyConfirmed === 'all')) ||
+      (filterName === 'claimed' && onlyConfirmed) ||
+      (filterName === 'unclaimed' && onlyConfirmed === false)
+    ) {
+      btnClassName = 'btn-primary';
+    } else if (onlyConfirmed === undefined && (!paymentMethods || paymentMethods.length === 0)) {
+      btnClassName += ' disabled';
+    }
+
+    return (
+      <Link
+        route="editCollective"
+        className={`filterBtn btn ${btnClassName}`}
+        params={{ ...this.props.router.query, filter: filterName, offset: 0 }}
+      >
+        {label}
+      </Link>
+    );
+  }
+
+  renderFilters(onlyConfirmed, paymentMethods) {
+    return (
+      <div className="filter">
+        <ButtonGroup>
+          {this.renderFilterLink(
+            onlyConfirmed,
+            paymentMethods,
+            'all',
+            <FormattedMessage id="virtualCards.filterAll" defaultMessage="All" />,
+          )}
+          {this.renderFilterLink(
+            onlyConfirmed,
+            paymentMethods,
+            'claimed',
+            <FormattedMessage id="virtualCards.filterClaimed" defaultMessage="Claimed" />,
+          )}
+          {this.renderFilterLink(
+            onlyConfirmed,
+            paymentMethods,
+            'unclaimed',
+            <FormattedMessage id="virtualCards.filterUnclaimed" defaultMessage="Unclaimed" />,
+          )}
+        </ButtonGroup>
+      </div>
+    );
+  }
+
   render() {
-    return <div />;
+    const { loading } = this.props.data;
+    const queryResult = get(this.props, 'data.Collective.createdVirtualCards', {});
+    const onlyConfirmed = get(this.props, 'data.variables.isConfirmed');
+    const { offset, limit, total, paymentMethods } = queryResult;
+    const lastVirtualCard = last(paymentMethods);
+
+    return (
+      <div>
+        <Flex mb={4} justifyContent="center">
+          {this.renderFilters(onlyConfirmed, paymentMethods)}
+        </Flex>
+        {loading ? (
+          <Loading />
+        ) : (
+          <div>
+            {paymentMethods.map(v => (
+              <div key={v.id}>
+                <VirtualCardDetails virtualCard={v} />
+                {v !== lastVirtualCard && <hr />}
+              </div>
+            ))}
+            {total > limit && (
+              <Flex justifyContent="center" mt={4}>
+                <Pagination offset={offset} total={total} limit={limit} />
+              </Flex>
+            )}
+          </div>
+        )}
+      </div>
+    );
   }
 }
 
-export default EditVirtualCards;
+const VIRTUALCARDS_PER_PAGE = 15;
+
+const getIsConfirmedFromFilter = filter => {
+  if (filter === undefined || filter === 'all') {
+    return undefined;
+  }
+  return filter === 'claimed';
+};
+
+const getGraphQLVariablesFromProps = props => ({
+  CollectiveId: props.collectiveId,
+  isConfirmed: getIsConfirmedFromFilter(props.router.query.filter),
+  offset: props.router.query.offset || 0,
+  limit: props.limit || VIRTUALCARDS_PER_PAGE,
+});
+
+export const addTransactionsData = graphql(getCollectiveVirtualCards, {
+  options: props => ({ variables: getGraphQLVariablesFromProps(props) }),
+  props: ({ data }) => ({
+    data,
+    setConfirmedFilter: isConfirmed => data.refetch({ ...data.variables, isConfirmed: isConfirmed }),
+  }),
+});
+
+export default withRouter(addTransactionsData(EditVirtualCards));

--- a/src/components/EditVirtualCards.js
+++ b/src/components/EditVirtualCards.js
@@ -80,7 +80,7 @@ class EditVirtualCards extends React.Component {
     const { loading } = this.props.data;
     const queryResult = get(this.props, 'data.Collective.createdVirtualCards', {});
     const onlyConfirmed = get(this.props, 'data.variables.isConfirmed');
-    const { offset, limit, total, paymentMethods } = queryResult;
+    const { offset, limit, total, paymentMethods = [] } = queryResult;
     const lastVirtualCard = last(paymentMethods);
 
     return (
@@ -117,12 +117,11 @@ class EditVirtualCards extends React.Component {
           <Loading />
         ) : (
           <div className="virtualcards-list">
-            {!paymentMethods ||
-              (paymentMethods.length === 0 && (
-                <Flex justifyContent="center" mt="4em">
-                  {this.renderNoVirtualCardMessage(onlyConfirmed)}
-                </Flex>
-              ))}
+            {paymentMethods.length === 0 && (
+              <Flex justifyContent="center" mt="4em">
+                {this.renderNoVirtualCardMessage(onlyConfirmed)}
+              </Flex>
+            )}
             {paymentMethods.map(v => (
               <div key={v.id}>
                 <VirtualCardDetails virtualCard={v} />

--- a/src/components/EditVirtualCards.js
+++ b/src/components/EditVirtualCards.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { graphql } from 'react-apollo';
-import { ButtonGroup } from 'react-bootstrap';
 import { Flex, Box } from '@rebass/grid';
 import { get, last } from 'lodash';
 import { withRouter } from 'next/router';
@@ -17,6 +16,8 @@ import Pagination from './Pagination';
 import Link from './Link';
 import { Link as LinkWrapper } from '../server/pages';
 import StyledLink from './StyledLink';
+import StyledButtonSet from './StyledButtonSet';
+import { P } from './Text';
 
 /**
  * A filterable list of virtual cards meant to be displayed for organization
@@ -41,53 +42,23 @@ class EditVirtualCards extends React.Component {
     this.state = { claimedFilter: 'all' };
   }
 
-  renderFilterLink(onlyConfirmed, paymentMethods, filterName, label) {
-    let btnClassName = 'btn-default';
-    if (
-      (filterName === 'all' && (onlyConfirmed === undefined || onlyConfirmed === 'all')) ||
-      (filterName === 'claimed' && onlyConfirmed) ||
-      (filterName === 'unclaimed' && onlyConfirmed === false)
-    ) {
-      btnClassName = 'btn-primary';
-    } else if (onlyConfirmed === undefined && (!paymentMethods || paymentMethods.length === 0)) {
-      btnClassName += ' disabled';
-    }
+  renderFilters(onlyConfirmed) {
+    let selected = 'all';
+    if (onlyConfirmed) selected = 'redeemed';
+    if (onlyConfirmed === false) selected = 'pending';
 
     return (
-      <Link
-        route="editCollective"
-        className={`filterBtn btn ${btnClassName}`}
-        params={{ ...this.props.router.query, filter: filterName, offset: 0 }}
-      >
-        {label}
-      </Link>
-    );
-  }
-
-  renderFilters(onlyConfirmed, paymentMethods) {
-    return (
-      <div className="filter">
-        <ButtonGroup>
-          {this.renderFilterLink(
-            onlyConfirmed,
-            paymentMethods,
-            'all',
-            <FormattedMessage id="virtualCards.filterAll" defaultMessage="All" />,
-          )}
-          {this.renderFilterLink(
-            onlyConfirmed,
-            paymentMethods,
-            'claimed',
-            <FormattedMessage id="virtualCards.filterClaimed" defaultMessage="Claimed" />,
-          )}
-          {this.renderFilterLink(
-            onlyConfirmed,
-            paymentMethods,
-            'unclaimed',
-            <FormattedMessage id="virtualCards.filterUnclaimed" defaultMessage="Unclaimed" />,
-          )}
-        </ButtonGroup>
-      </div>
+      <StyledButtonSet items={['all', 'redeemed', 'pending']} selected={selected} buttonProps={{ p: 0 }}>
+        {({ item, isSelected }) => (
+          <Link route="editCollective" params={{ ...this.props.router.query, filter: item, offset: 0 }}>
+            <P p="0.5em 1em" color={isSelected ? 'white.full' : 'black.800'} style={{ margin: 0 }}>
+              {item === 'all' && <FormattedMessage id="virtualCards.filterAll" defaultMessage="All" />}
+              {item === 'redeemed' && <FormattedMessage id="virtualCards.filterRedeemed" defaultMessage="Redeemed" />}
+              {item === 'pending' && <FormattedMessage id="virtualCards.filterPending" defaultMessage="Pending" />}
+            </P>
+          </Link>
+        )}
+      </StyledButtonSet>
     );
   }
 
@@ -114,8 +85,8 @@ class EditVirtualCards extends React.Component {
 
     return (
       <div>
-        <Flex mb={4} justifyContent="space-between">
-          {this.renderFilters(onlyConfirmed, paymentMethods)}
+        <Flex mb={4} justifyContent="space-between" flexWrap="wrap">
+          {this.renderFilters(onlyConfirmed)}
           <Flex>
             <LinkWrapper
               route="editCollective"
@@ -125,7 +96,7 @@ class EditVirtualCards extends React.Component {
               <StyledLink buttonStyle="standard" buttonSize="medium">
                 <Add size="1em" />
                 {'  '}
-                <FormattedMessage id="virtualCards.createSingle" defaultMessage="Create gift cards" />
+                <FormattedMessage id="virtualCards.createCodes" defaultMessage="Create gift card codes" />
               </StyledLink>
             </LinkWrapper>
             <Box mr="0.5em" />
@@ -137,7 +108,7 @@ class EditVirtualCards extends React.Component {
               <StyledLink buttonStyle="primary" buttonSize="medium">
                 <PaperPlane size="1em" />
                 {'  '}
-                <FormattedMessage id="virtualCards.send" defaultMessage="Send gift cards" />
+                <FormattedMessage id="virtualCards.send" defaultMessage="Send gift cards by email" />
               </StyledLink>
             </LinkWrapper>
           </Flex>
@@ -175,7 +146,7 @@ const getIsConfirmedFromFilter = filter => {
   if (filter === undefined || filter === 'all') {
     return undefined;
   }
-  return filter === 'claimed';
+  return filter === 'redeemed';
 };
 
 const getGraphQLVariablesFromProps = props => ({

--- a/src/components/EditVirtualCards.js
+++ b/src/components/EditVirtualCards.js
@@ -117,11 +117,12 @@ class EditVirtualCards extends React.Component {
           <Loading />
         ) : (
           <div className="virtualcards-list">
-            {paymentMethods.length === 0 && (
-              <Flex justifyContent="center" mt="4em">
-                {this.renderNoVirtualCardMessage(onlyConfirmed)}
-              </Flex>
-            )}
+            {!paymentMethods ||
+              (paymentMethods.length === 0 && (
+                <Flex justifyContent="center" mt="4em">
+                  {this.renderNoVirtualCardMessage(onlyConfirmed)}
+                </Flex>
+              ))}
             {paymentMethods.map(v => (
               <div key={v.id}>
                 <VirtualCardDetails virtualCard={v} />

--- a/src/components/EditVirtualCards.js
+++ b/src/components/EditVirtualCards.js
@@ -116,7 +116,7 @@ class EditVirtualCards extends React.Component {
         {loading ? (
           <Loading />
         ) : (
-          <div>
+          <div className="virtualcards-list">
             {paymentMethods.length === 0 && (
               <Flex justifyContent="center" mt="4em">
                 {this.renderNoVirtualCardMessage(onlyConfirmed)}

--- a/src/components/EditVirtualCards.js
+++ b/src/components/EditVirtualCards.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+class EditVirtualCards extends React.Component {
+  render() {
+    return <div />;
+  }
+}
+
+export default EditVirtualCards;

--- a/src/components/Event.js
+++ b/src/components/Event.js
@@ -319,7 +319,7 @@ class Event extends React.Component {
                         LoggedInUser && LoggedInUser.canEditCollective(event)
                           ? {
                               label: intl.formatMessage(this.messages['event.tickets.edit']),
-                              href: `${event.path}/edit#tiers`,
+                              href: `${event.path}/edit/tiers`,
                             }
                           : null
                       }

--- a/src/components/StyledButton.js
+++ b/src/components/StyledButton.js
@@ -32,6 +32,9 @@ const StyledButtonContent = styled(tag.button)`
   cursor: pointer;
   outline: 0;
 
+  ${buttonStyle}
+  ${buttonSize}
+
   ${bgColor}
   ${border}
   ${borderRadius}
@@ -46,9 +49,6 @@ const StyledButtonContent = styled(tag.button)`
   ${space}
   ${textAlign}
   ${width}
-
-  ${buttonStyle}
-  ${buttonSize}
 `;
 
 const StyledButton = ({ loading, ...props }) =>

--- a/src/components/StyledButton.js
+++ b/src/components/StyledButton.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import tag from 'clean-tag';
@@ -10,6 +11,7 @@ import {
   fontFamily,
   fontSize,
   fontWeight,
+  minWidth,
   maxWidth,
   minWidth,
   space,
@@ -17,16 +19,18 @@ import {
   width,
 } from 'styled-system';
 import { buttonSize, buttonStyle } from '../constants/theme';
+import StyledSpinner from './StyledSpinner';
 
 /**
  * styled-component button using styled-system
  *
  * @see See [styled-system docs](https://github.com/jxnblk/styled-system/blob/master/docs/api.md) for usage of those props
  */
-const StyledButton = styled(tag.button)`
+const StyledButtonContent = styled(tag.button)`
   appearance: none;
   border: none;
   cursor: pointer;
+  outline: 0;
 
   ${bgColor}
   ${border}
@@ -36,6 +40,7 @@ const StyledButton = styled(tag.button)`
   ${fontFamily}
   ${fontSize}
   ${fontWeight}
+  ${minWidth}
   ${maxWidth}
   ${minWidth}
   ${space}
@@ -45,6 +50,15 @@ const StyledButton = styled(tag.button)`
   ${buttonStyle}
   ${buttonSize}
 `;
+
+const StyledButton = ({ loading, ...props }) =>
+  !loading ? (
+    <StyledButtonContent {...props} />
+  ) : (
+    <StyledButtonContent {...props}>
+      <StyledSpinner />
+    </StyledButtonContent>
+  );
 
 StyledButton.propTypes = {
   /** @ignore */
@@ -66,6 +80,10 @@ StyledButton.propTypes = {
    */
   fontWeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
   /**
+   * From styled-system: accepts any css 'min-width' value
+   */
+  minWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
+  /**
    * From styled-system: accepts any css 'max-width' value
    */
   maxWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
@@ -86,12 +104,17 @@ StyledButton.propTypes = {
    * From styled-system: accepts any css 'width' value
    */
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
+  /**
+   * Show a loading spinner on button
+   */
+  loading: PropTypes.bool,
 };
 
 StyledButton.defaultProps = {
   blacklist: tag.defaultProps.blacklist.concat('buttonStyle', 'buttonSize'),
   buttonSize: 'medium',
   buttonStyle: 'standard',
+  loading: false,
 };
 
 /** @component */

--- a/src/components/StyledButton.js
+++ b/src/components/StyledButton.js
@@ -13,7 +13,6 @@ import {
   fontWeight,
   minWidth,
   maxWidth,
-  minWidth,
   space,
   textAlign,
   width,
@@ -45,7 +44,6 @@ const StyledButtonContent = styled(tag.button)`
   ${fontWeight}
   ${minWidth}
   ${maxWidth}
-  ${minWidth}
   ${space}
   ${textAlign}
   ${width}
@@ -87,10 +85,6 @@ StyledButton.propTypes = {
    * From styled-system: accepts any css 'max-width' value
    */
   maxWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
-  /**
-   * From styled-system: accepts any css 'min-width' value
-   */
-  minWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
   /**
    * styled-system prop: adds margin & padding props
    * see: https://github.com/jxnblk/styled-system/blob/master/docs/api.md#space

--- a/src/components/StyledButtonSet.js
+++ b/src/components/StyledButtonSet.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import { Flex } from '@rebass/grid';
+
+import StyledButton from './StyledButton';
+
+const borderRadius = '4px';
+
+const StyledButtonItem = styled(StyledButton)`
+  border-radius: 0;
+  &:active p {
+    color: white;
+  }
+  &:hover {
+    /* Use a higher z-index on hover to get all the borders colored */
+    z-index: 9;
+  }
+  &:first-child {
+    border-radius: ${borderRadius} 0 0 ${borderRadius};
+  }
+  &:not(:first-child) {
+    margin-left: -1px;
+  }
+  &:last-child {
+    border-radius: 0 ${borderRadius} ${borderRadius} 0;
+  }
+`;
+
+const StyledButtonSet = ({ size, items, children, selected, buttonProps, onChange, ...props }) => (
+  <Flex {...props}>
+    {items.map(item => (
+      <StyledButtonItem
+        key={item}
+        buttonSize={size}
+        buttonStyle={item === selected ? 'primary' : 'standard'}
+        onClick={onChange && (() => onChange(item))}
+        {...buttonProps}
+      >
+        {children({ item, isSelected: item === selected })}
+      </StyledButtonItem>
+    ))}
+  </Flex>
+);
+
+StyledButtonSet.propTypes = {
+  /** A list of elements to build buttons uppon */
+  items: PropTypes.arrayOf(PropTypes.any).isRequired,
+  /** Button child content renderer. Get passed an object like { item, isSelected } */
+  children: PropTypes.func.isRequired,
+  /** Based on the design system theme */
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  /** Currently selected item */
+  selected: PropTypes.any,
+  /** An optionnal func called with the new item when option changes */
+  onChange: PropTypes.func,
+};
+
+StyledButtonSet.defaultProps = {
+  size: 'medium',
+};
+
+export default StyledButtonSet;

--- a/src/components/StyledButtonSet.js
+++ b/src/components/StyledButtonSet.js
@@ -16,6 +16,10 @@ const StyledButtonItem = styled(StyledButton)`
     /* Use a higher z-index on hover to get all the borders colored */
     z-index: 9;
   }
+  /* Remove the dotted outline on Firefox */
+  &::-moz-focus-inner {
+    border: 0;
+  }
   &:first-child {
     border-radius: ${borderRadius} 0 0 ${borderRadius};
   }

--- a/src/components/StyledCheckbox.js
+++ b/src/components/StyledCheckbox.js
@@ -1,0 +1,116 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { themeGet, fontSize } from 'styled-system';
+
+const IconCheckmark = () => {
+  return (
+    <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        id="checkmark-tiny"
+        d="M3.30913 8C3.0158 8 2.73358 7.88442 2.52358 7.67438L0.32583 5.47599C-0.10861 5.04257 -0.10861 4.34021 0.32583 3.90569C0.760269 3.47116 1.46248 3.47116 1.89692 3.90569L3.16913 5.17835L5.98574 0.462633C6.34352 -0.0341285 7.03573 -0.149706 7.53683 0.20814C8.03572 0.565985 8.14905 1.26056 7.79128 1.75843L4.21134 7.53769C4.01245 7.81663 3.68357 8 3.30913 8Z"
+      />
+    </svg>
+  );
+};
+
+const CheckboxContainer = styled.div`
+  ${fontSize}
+
+  height: ${props => props.size};
+
+  /* Hide the default checkbox */
+  input {
+    position: absolute;
+    opacity: 0;
+    cursor: pointer;
+    height: 0;
+    width: 0;
+  }
+
+  /* Show our custom checkbox */
+  .custom-checkbox {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: absolute;
+    height: ${props => props.size};
+    width: ${props => props.size};
+    border: 1px solid #dcdee0;
+    border-radius: 4px;
+    background-color: white;
+    cursor: pointer;
+    transition: background-color 0.2s;
+    svg {
+      opacity: 0;
+      height: 0.572em;
+      width: 0.572em;
+      fill: white;
+    }
+  }
+
+  /* Hover label / checkbox */
+  &:hover .custom-checkbox {
+    background: ${themeGet('colors.primary.400')};
+    border-color: ${themeGet('colors.primary.400')};
+    svg {
+      opacity: 1;
+    }
+  }
+
+  /* Checked */
+  input:checked ~ .custom-checkbox {
+    background: ${themeGet('colors.primary.500')};
+    border-color: ${themeGet('colors.primary.500')};
+    svg {
+      opacity: 1;
+    }
+  }
+
+  /* Disabled */
+  input:disabled ~ .custom-checkbox {
+    background: #f7f8fa;
+    border: 1px solid #e8e9eb;
+    cursor: not-allowed;
+    svg {
+      fill: ${themeGet('colors.primary.200')};
+    }
+  }
+`;
+
+const Label = styled.label`
+  margin-left: 1.5em;
+  color: black;
+  z-index: 9;
+`;
+
+const StyledCheckbox = ({ checked, onChange, label, disabled, size }) => {
+  return (
+    <CheckboxContainer fontSize={size} size={size} onClick={() => onChange(!checked)}>
+      <input type="checkbox" checked={checked} disabled={disabled} />
+      <span className="custom-checkbox">
+        <IconCheckmark />
+      </span>
+      {label && <Label>{label}</Label>}
+    </CheckboxContainer>
+  );
+};
+
+StyledCheckbox.defaultProps = {
+  size: '14px',
+};
+
+StyledCheckbox.propTypes = {
+  /** Wether the checkbox is checked */
+  checked: PropTypes.bool.isRequired,
+  /** Called when state change with a bool representing new state */
+  onChange: PropTypes.func.isRequired,
+  /** Wether checkbox should be disabled */
+  disabled: PropTypes.bool,
+  /** An optional label to display next to checkbox */
+  label: PropTypes.string,
+  /** An optional size */
+  size: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
+};
+
+export default StyledCheckbox;

--- a/src/components/StyledCheckbox.js
+++ b/src/components/StyledCheckbox.js
@@ -57,7 +57,7 @@ const CheckboxContainer = styled.div`
 
   /* Hover label / checkbox - only for pointer devices (ignored on touch devices) */
   @media (hover:hover) {
-    &:hover input:not(:disabled) ~ .custom-checkbox {
+    &:hover input:not(:disabled):not(:checked) ~ .custom-checkbox {
       background: ${themeGet('colors.primary.400')};
       border-color: ${themeGet('colors.primary.400')};
       svg {
@@ -73,6 +73,12 @@ const CheckboxContainer = styled.div`
     svg {
       opacity: 1;
     }
+  }
+
+  /* Focused */
+  input:focus ~ .custom-checkbox {
+    background: ${themeGet('colors.primary.400')};
+    border-color: ${themeGet('colors.primary.400')};
   }
 
   /* Disabled */
@@ -91,10 +97,14 @@ const CheckboxContainer = styled.div`
   }
 `;
 
-const StyledCheckbox = ({ checked, onChange, label, disabled, size }) => {
+const StyledCheckbox = ({ name, checked, onChange, label, disabled, size, inputId }) => {
   return (
-    <CheckboxContainer fontSize={size} size={size} onClick={() => !disabled && onChange(!checked)}>
-      <input type="checkbox" checked={checked} disabled={disabled} />
+    <CheckboxContainer
+      onClick={() => !disabled && onChange({ name, checked: !checked, type: 'checkbox' })}
+      fontSize={size}
+      size={size}
+    >
+      <input id={inputId} name={name} type="checkbox" checked={checked} disabled={disabled} readOnly />
       <span className="custom-checkbox">
         <IconCheckmark />
       </span>
@@ -108,10 +118,14 @@ StyledCheckbox.defaultProps = {
 };
 
 StyledCheckbox.propTypes = {
+  /** The name of the input */
+  name: PropTypes.string.isRequired,
   /** Wether the checkbox is checked */
   checked: PropTypes.bool.isRequired,
   /** Called when state change with a bool representing new state */
   onChange: PropTypes.func.isRequired,
+  /* And optional ID for the `<input/>` */
+  inputId: PropTypes.string,
   /** Wether checkbox should be disabled */
   disabled: PropTypes.bool,
   /** An optional label to display next to checkbox */

--- a/src/components/StyledCheckbox.js
+++ b/src/components/StyledCheckbox.js
@@ -23,9 +23,15 @@ const CheckboxContainer = styled.div`
   input {
     position: absolute;
     opacity: 0;
-    cursor: pointer;
     height: 0;
     width: 0;
+  }
+
+  label {
+    cursor: pointer;
+    margin-left: 1.5em;
+    color: black;
+    z-index: 9;
   }
 
   /* Show our custom checkbox */
@@ -34,12 +40,12 @@ const CheckboxContainer = styled.div`
     justify-content: center;
     align-items: center;
     position: absolute;
+    cursor: pointer;
     height: ${props => props.size};
     width: ${props => props.size};
     border: 1px solid #dcdee0;
     border-radius: 4px;
     background-color: white;
-    cursor: pointer;
     transition: background-color 0.2s;
     svg {
       opacity: 0;
@@ -49,12 +55,14 @@ const CheckboxContainer = styled.div`
     }
   }
 
-  /* Hover label / checkbox */
-  &:hover .custom-checkbox {
-    background: ${themeGet('colors.primary.400')};
-    border-color: ${themeGet('colors.primary.400')};
-    svg {
-      opacity: 1;
+  /* Hover label / checkbox - only for pointer devices (ignored on touch devices) */
+  @media (hover:hover) {
+    &:hover input:not(:disabled) ~ .custom-checkbox {
+      background: ${themeGet('colors.primary.400')};
+      border-color: ${themeGet('colors.primary.400')};
+      svg {
+        opacity: 1;
+      }
     }
   }
 
@@ -68,30 +76,29 @@ const CheckboxContainer = styled.div`
   }
 
   /* Disabled */
-  input:disabled ~ .custom-checkbox {
-    background: #f7f8fa;
-    border: 1px solid #e8e9eb;
-    cursor: not-allowed;
-    svg {
-      fill: ${themeGet('colors.primary.200')};
+  input:disabled {
+    & ~ .custom-checkbox {
+      background: #f7f8fa;
+      border: 1px solid #e8e9eb;
+      cursor: not-allowed;
+      svg {
+        fill: ${themeGet('colors.primary.200')};
+      }
+    }
+    & ~ label {
+      cursor: not-allowed;
     }
   }
 `;
 
-const Label = styled.label`
-  margin-left: 1.5em;
-  color: black;
-  z-index: 9;
-`;
-
 const StyledCheckbox = ({ checked, onChange, label, disabled, size }) => {
   return (
-    <CheckboxContainer fontSize={size} size={size} onClick={() => onChange(!checked)}>
+    <CheckboxContainer fontSize={size} size={size} onClick={() => !disabled && onChange(!checked)}>
       <input type="checkbox" checked={checked} disabled={disabled} />
       <span className="custom-checkbox">
         <IconCheckmark />
       </span>
-      {label && <Label>{label}</Label>}
+      {label && <label>{label}</label>}
     </CheckboxContainer>
   );
 };

--- a/src/components/StyledInput.js
+++ b/src/components/StyledInput.js
@@ -61,6 +61,7 @@ const StyledInput = styled(tag.input)`
 
   &:disabled {
     background-color: ${themeGet('colors.black.50')};
+    cursor: not-allowed;
   }
 
   &:focus, &:hover:not(:disabled) {

--- a/src/components/StyledInputAmount.js
+++ b/src/components/StyledInputAmount.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import StyledInputGroup from './StyledInputGroup';
+import { getCurrencySymbol } from '../lib/utils';
+
+/**
+ * An input for amount inputs. Accepts all props from [StyledInputGroup](/#!/StyledInputGroup).
+ */
+const StyledInputAmount = ({ currency, min = 0, ...props }) => {
+  return (
+    <StyledInputGroup
+      name="amount"
+      maxWidth="10em"
+      type="number"
+      step="1"
+      min={min}
+      prepend={getCurrencySymbol(currency)}
+      {...props}
+    />
+  );
+};
+
+StyledInputAmount.propTypes = {
+  /** The currency (eg. `USD`, `EUR`...) */
+  currency: PropTypes.string.isRequired,
+  /** Minimum amount */
+  min: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Accept all PropTypes from `StyledInputGroup` */
+  ...StyledInputGroup.propTypes,
+};
+
+export default StyledInputAmount;

--- a/src/components/StyledInputGroup.js
+++ b/src/components/StyledInputGroup.js
@@ -70,42 +70,51 @@ const getBorderColor = ({ error, focused, success }) => {
  * @see See [StyledInput](/#!/StyledInput) for details about props passed to it
  */
 const StyledInputGroup = withState('focused', 'setFocus', false)(
-  ({ append, prepend, focused, setFocus, disabled, success, error, ...inputProps }) => (
-    <InputContainer
-      bg={disabled ? 'black.50' : 'white.full'}
-      border="1px solid"
-      borderColor={getBorderColor({ error, focused, success })}
-      borderRadius="4px"
-      display="flex"
-      alignItems="center"
-    >
-      {prepend && (
-        <Container bg={getBgColor({ error, focused, success })} borderRadius="4px 0 0 4px" py={2} px={3}>
-          <Span color={getColor({ error, focused, success })} fontSize="Paragraph" lineHeight="Paragraph">
-            {prepend}
-          </Span>
-        </Container>
+  ({ append, prepend, focused, setFocus, disabled, success, error, maxWidth, ...inputProps }) => (
+    <div>
+      <InputContainer
+        bg={disabled ? 'black.50' : 'white.full'}
+        maxWidth={maxWidth}
+        border="1px solid"
+        borderColor={getBorderColor({ error, focused, success })}
+        borderRadius="4px"
+        display="flex"
+        alignItems="center"
+      >
+        {prepend && (
+          <Container bg={getBgColor({ error, focused, success })} borderRadius="4px 0 0 4px" py={2} px={3}>
+            <Span color={getColor({ error, focused, success })} fontSize="Paragraph">
+              {prepend}
+            </Span>
+          </Container>
+        )}
+        <StyledInput
+          bare
+          color="black.800"
+          type="text"
+          overflow="scroll"
+          fontSize="Paragraph"
+          flex="1 1 auto"
+          disabled={disabled}
+          py="0"
+          {...inputProps}
+          onFocus={() => setFocus(true)}
+          onBlur={() => setFocus(false)}
+        />
+        {append && (
+          <Container bg={getBgColor({ error, focused, success })} borderRadius="4px 0 0 4px" p={2}>
+            <Span color={getColor({ error, focused, success })} fontSize="Paragraph">
+              {append}
+            </Span>
+          </Container>
+        )}
+      </InputContainer>
+      {error && (
+        <Span display="block" color="red.500" pt={2} fontSize="Tiny">
+          {error}
+        </Span>
       )}
-      <StyledInput
-        bare
-        color="black.800"
-        type="text"
-        overflow="scroll"
-        fontSize="Paragraph"
-        flex="1 1 auto"
-        disabled={disabled}
-        {...inputProps}
-        onFocus={() => setFocus(true)}
-        onBlur={() => setFocus(false)}
-      />
-      {append && (
-        <Container bg={getBgColor({ error, focused, success })} borderRadius="4px 0 0 4px" p={2}>
-          <Span color={getColor({ error, focused, success })} fontSize="Paragraph" lineHeight="Paragraph">
-            {append}
-          </Span>
-        </Container>
-      )}
-    </InputContainer>
+    </div>
   ),
 );
 
@@ -116,8 +125,8 @@ StyledInputGroup.propTypes = {
   prepend: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.element]),
   /** Show disabled state for field */
   disabled: PropTypes.bool,
-  /** Show error state for field */
-  error: PropTypes.bool,
+  /** Show error state for field, and a message error if given a string */
+  error: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   /** Show success state for field */
   success: PropTypes.bool,
   /** Passed to internal StyledInput */

--- a/src/components/StyledInputGroup.js
+++ b/src/components/StyledInputGroup.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { themeGet } from 'styled-system';
@@ -71,7 +72,7 @@ const getBorderColor = ({ error, focused, success }) => {
  */
 const StyledInputGroup = withState('focused', 'setFocus', false)(
   ({ append, prepend, focused, setFocus, disabled, success, error, maxWidth, ...inputProps }) => (
-    <div>
+    <React.Fragment>
       <InputContainer
         bg={disabled ? 'black.50' : 'white.full'}
         maxWidth={maxWidth}
@@ -97,6 +98,7 @@ const StyledInputGroup = withState('focused', 'setFocus', false)(
           flex="1 1 auto"
           disabled={disabled}
           py="0"
+          error={error}
           {...inputProps}
           onFocus={() => setFocus(true)}
           onBlur={() => setFocus(false)}
@@ -114,7 +116,7 @@ const StyledInputGroup = withState('focused', 'setFocus', false)(
           {error}
         </Span>
       )}
-    </div>
+    </React.Fragment>
   ),
 );
 

--- a/src/components/StyledMultiEmailInput.js
+++ b/src/components/StyledMultiEmailInput.js
@@ -1,0 +1,125 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { themeGet } from 'styled-system';
+import { Editor, EditorState } from 'draft-js';
+import { omit, uniq, debounce } from 'lodash';
+
+import Container from './Container';
+import { Span } from './Text';
+import { getInputBorderColor } from '../lib/styled_components_utils';
+import { FormattedMessage } from 'react-intl';
+
+const InputContainer = styled(Container)`
+  .DraftEditor-root {
+    padding: 0.5em;
+    cursor: text;
+    font-weight: 400;
+    border: 1px solid;
+    border-radius: 4px;
+    border-color: inherit;
+
+    &:hover,
+    &:focus {
+      border-color: ${themeGet('colors.primary.300')};
+    }
+  }
+
+  .public-DraftEditor-content {
+    min-height: 6em;
+    max-height: 18em;
+    overflow-y: auto;
+  }
+
+  .public-DraftEditor-content[contenteditable='false'] {
+    cursor: not-allowed;
+  }
+`;
+
+export default class StyledMultiEmailInput extends Component {
+  static propTypes = {
+    /** Callback for state update like `({emails, invalids}) => void` */
+    onChange: PropTypes.func,
+    /** On array of invalid emails */
+    invalids: PropTypes.arrayOf(PropTypes.string),
+  };
+
+  constructor(props) {
+    super(props);
+    this.onChange = this.onChange.bind(this);
+    this.onChangeParent = debounce(this.onChangeParent.bind(this), 100, { trailing: true });
+    this.onBlur = this.onBlur.bind(this);
+    this.onFocus = this.onFocus.bind(this);
+    this.state = { editorState: EditorState.createEmpty(), showErrors: false };
+  }
+
+  extractEmails(str) {
+    return uniq(str.split(/[\s,;]/gm)).reduce(
+      (result, term) => {
+        if (term.length === 0) {
+          return result;
+        } else if (term.match(/.+@.+\..+/)) {
+          result.emails.push(term);
+        } else {
+          result.invalids.push(term);
+        }
+        return result;
+      },
+      { emails: [], invalids: [] },
+    );
+  }
+
+  onChange(editorState) {
+    this.setState(state => {
+      return { ...state, editorState };
+    });
+    if (this.props.onChange) {
+      this.onChangeParent(editorState);
+    }
+  }
+
+  onChangeParent(editorState) {
+    const stringContent = editorState.getCurrentContent().getPlainText();
+    const returnedState = this.extractEmails(stringContent);
+    this.props.onChange(returnedState);
+  }
+
+  onBlur() {
+    this.setState({ showErrors: true });
+  }
+
+  onFocus() {
+    this.setState({ showErrors: false });
+  }
+
+  render() {
+    const { invalids, disabled } = this.props;
+
+    return (
+      <InputContainer
+        width="100%"
+        bg={disabled ? 'black.50' : 'white.full'}
+        fontSize="Paragraph"
+        borderColor={getInputBorderColor(invalids && invalids.length > 0)}
+        {...omit(this.props, ['invalids', 'onChange'])}
+      >
+        <Editor
+          editorState={this.state.editorState}
+          onChange={this.onChange}
+          onBlur={this.onBlur}
+          onFocus={this.onFocus}
+          readOnly={disabled}
+          stripPastedStyles
+        />
+        {this.state.showErrors && invalids && invalids.length > 0 && (
+          <Span display="block" color="red.500" pt={2} fontSize="Tiny">
+            <strong>
+              <FormattedMessage id="multiemail.invalids" defaultMessage="Invalid emails: " />
+            </strong>
+            {invalids.join(', ')}
+          </Span>
+        )}
+      </InputContainer>
+    );
+  }
+}

--- a/src/components/StyledMultiEmailInput.js
+++ b/src/components/StyledMultiEmailInput.js
@@ -112,7 +112,7 @@ export default class StyledMultiEmailInput extends Component {
           stripPastedStyles
         />
         {this.state.showErrors && invalids && invalids.length > 0 && (
-          <Span display="block" color="red.500" pt={2} fontSize="Tiny">
+          <Span className="multiemails-errors" display="block" color="red.500" pt={2} fontSize="Tiny">
             <strong>
               <FormattedMessage id="multiemail.invalids" defaultMessage="Invalid emails: " />
             </strong>

--- a/src/components/StyledPaymentMethodChooser.js
+++ b/src/components/StyledPaymentMethodChooser.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import StyledSelect from './StyledSelect';
+import { paymentMethodLabelWithIcon } from '../lib/payment_method_label';
+import withIntl from '../lib/withIntl';
+
+const paymentMethodsToOptions = paymentMethods => {
+  return paymentMethods.reduce((options, pm) => {
+    return { ...options, [pm.id]: pm };
+  }, {});
+};
+
+const StyledPaymentMethodChooser = ({ intl, paymentMethods, defaultPaymentMethod, ...props }) => {
+  return (
+    <StyledSelect
+      name="paymentMethod"
+      options={paymentMethodsToOptions(paymentMethods)}
+      defaultValue={defaultPaymentMethod}
+      {...props}
+    >
+      {({ value: pm }) => <div>{paymentMethodLabelWithIcon(intl, pm)}</div>}
+    </StyledSelect>
+  );
+};
+
+StyledPaymentMethodChooser.propTypes = {
+  /** The payment methods to display. **Cannot be empty !** */
+  paymentMethods: PropTypes.arrayOf(PropTypes.object).isRequired,
+  /** The default payment method. Will use the first one if not provided. */
+  defaultPaymentMethod: PropTypes.object,
+  /** @ignore Provided by withIntl */
+  intl: PropTypes.object,
+};
+
+export default withIntl(StyledPaymentMethodChooser);

--- a/src/components/StyledSelect.js
+++ b/src/components/StyledSelect.js
@@ -23,7 +23,7 @@ const getBgColor = ({ highlightedIndex, index, item, selectedItem }) => {
   return 'white.full';
 };
 
-const getItems = options =>
+export const getItems = options =>
   Object.keys(options).reduce(
     (items, key) =>
       items.concat({

--- a/src/components/StyledSelect.js
+++ b/src/components/StyledSelect.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import PropTypes from 'prop-types';
 import Downshift from 'downshift';
 import styled from 'styled-components';
@@ -5,6 +6,7 @@ import { SelectArrows } from 'styled-icons/boxicons-regular/SelectArrows.cjs';
 import { themeGet } from 'styled-system';
 import { Box } from '@rebass/grid';
 
+import { getInputBorderColor } from '../lib/styled_components_utils';
 import Container from './Container';
 
 const matches = (a, b) => JSON.stringify(a) === JSON.stringify(b);
@@ -21,19 +23,7 @@ const getBgColor = ({ highlightedIndex, index, item, selectedItem }) => {
   return 'white.full';
 };
 
-const getBorderColor = ({ error, success }) => {
-  if (error) {
-    return 'red.500';
-  }
-
-  if (success) {
-    return 'green.300';
-  }
-
-  return 'black.300';
-};
-
-export const getItems = options =>
+const getItems = options =>
   Object.keys(options).reduce(
     (items, key) =>
       items.concat({
@@ -48,6 +38,8 @@ export const getItems = options =>
   );
 
 const SelectContainer = styled(Container)`
+  cursor: pointer;
+  ${props => props.disabled && 'cursor: not-allowed;'};
   &:hover,
   &:focus {
     border-color: ${themeGet('colors.primary.300')};
@@ -58,8 +50,17 @@ const SelectContainer = styled(Container)`
   }
 `;
 
+const SelectPopupContainer = styled(Container)`
+  position: absolute;
+  z-index: 10;
+  background: white;
+`;
+
 const ListItem = styled(Container)`
   list-style: none;
+  cursor: pointer;
+  /* We need !important here cause "Body.js" CSS is overriding this :( */
+  margin: 0.2em !important;
 `;
 
 const Icon = styled(SelectArrows)`
@@ -88,10 +89,11 @@ const StyledSelect = ({ children, error, defaultValue, disabled, id, name, onCha
           alignItems="center"
           bg={disabled ? 'black.50' : 'white.full'}
           border="1px solid"
-          borderColor={getBorderColor({ error, success })}
+          borderColor={getInputBorderColor(error, success)}
           borderRadius="4px"
           fontSize="Paragraph"
-          p={2}
+          py={2}
+          px="1em"
           {...getInputProps({
             disabled,
             id,
@@ -100,20 +102,22 @@ const StyledSelect = ({ children, error, defaultValue, disabled, id, name, onCha
             onKeyDown: ({ key }) => key === 'Enter' && !disabled && toggleMenu(),
           })}
         >
-          <Box flex="1 1 auto">{selectedItem && children(selectedItem)}</Box>
-          <Icon size={14} disabled={disabled} error={error} success={success} />
+          <Box flex="1 1 auto" mr={1}>
+            {selectedItem && children(selectedItem)}
+          </Box>
+          <Icon size="1.2em" disabled={disabled} error={error} success={success} />
         </SelectContainer>
         {isOpen && (
-          <Container
+          <SelectPopupContainer
             as="ul"
-            px={1}
-            pt={1}
+            p={1}
             mt={2}
             border="1px solid"
             borderColor="black.300"
             borderRadius="4px"
             maxHeight={200}
-            overflow="scroll"
+            overflow="auto"
+            fontSize="Paragraph"
             {...getMenuProps()}
           >
             {getItems(options).map((item, index) => (
@@ -133,7 +137,7 @@ const StyledSelect = ({ children, error, defaultValue, disabled, id, name, onCha
                 {children(item)}
               </ListItem>
             ))}
-          </Container>
+          </SelectPopupContainer>
         )}
       </div>
     )}
@@ -145,7 +149,7 @@ StyledSelect.propTypes = {
   children: PropTypes.func,
   defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.shape()]),
   /** disable selecion */
-  disabled: PropTypes.func,
+  disabled: PropTypes.bool,
   /** show error state */
   error: PropTypes.bool,
   /** element id for forms */

--- a/src/components/StyledSpinner.js
+++ b/src/components/StyledSpinner.js
@@ -1,0 +1,32 @@
+import PropTypes from 'prop-types';
+import { LoaderAlt } from 'styled-icons/boxicons-regular/LoaderAlt.cjs';
+import styled from 'styled-components';
+
+/** A loading spinner using SVG + css animation. */
+const StyledSpinner = styled(LoaderAlt)`
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  animation: spin 1s linear infinite;
+`;
+
+StyledSpinner.defaultProps = {
+  title: 'Loading',
+  size: '1em',
+};
+
+StyledSpinner.propTypes = {
+  /** From styled-icons, this is a convenience for setting both width and height to the same value */
+  size: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /** A title for accessibility */
+  title: PropTypes.string,
+};
+
+/** @component */
+export default StyledSpinner;

--- a/src/components/StyledSpinner.js
+++ b/src/components/StyledSpinner.js
@@ -1,19 +1,19 @@
 import PropTypes from 'prop-types';
 import { LoaderAlt } from 'styled-icons/boxicons-regular/LoaderAlt.cjs';
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
+
+const spin = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+`;
 
 /** A loading spinner using SVG + css animation. */
 const StyledSpinner = styled(LoaderAlt)`
-  @keyframes spin {
-    from {
-      transform: rotate(0deg);
-    }
-    to {
-      transform: rotate(360deg);
-    }
-  }
-
-  animation: spin 1s linear infinite;
+  animation: ${spin} 1s linear infinite;
 `;
 
 StyledSpinner.defaultProps = {

--- a/src/components/TeamSection.js
+++ b/src/components/TeamSection.js
@@ -21,7 +21,7 @@ class TeamSection extends React.Component {
     let action;
     if (LoggedInUser && LoggedInUser.canEditCollective(collective)) {
       action = {
-        href: `/${collective.slug}/edit#members`,
+        href: `/${collective.slug}/edit/members`,
         label: <FormattedMessage id="sections.team.edit" defaultMessage="Edit team members" />,
       };
     }

--- a/src/components/VirtualCardDetails.js
+++ b/src/components/VirtualCardDetails.js
@@ -1,0 +1,167 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { Flex, Box } from '@rebass/grid';
+import { get } from 'lodash';
+import moment from 'moment';
+import styled, { withTheme } from 'styled-components';
+
+import { CardGiftcard as GiftCardIcon } from 'styled-icons/material/CardGiftcard.cjs';
+
+import Link from './Link';
+import Avatar from './Avatar';
+import { formatCurrency } from '../lib/utils';
+import Moment from './Moment';
+
+const DetailsColumnHeader = styled.span`
+  text-transform: uppercase;
+  color: ${props => props.theme.colors.black[500]};
+  font-weight: 300;
+  white-space: nowrap;
+`;
+
+/** Render a text status to indicate if virtual card is claimed, and by whom */
+const VirtualCardStatus = ({ isConfirmed, collective, data }) => {
+  if (isConfirmed) {
+    return (
+      <FormattedMessage
+        id="virtualCards.claimedBy"
+        defaultMessage="claimed by {user}"
+        values={{
+          user: (
+            <Link route="collective" params={{ slug: collective.slug }}>
+              {collective.name}
+            </Link>
+          ),
+        }}
+      />
+    );
+  } else if (get(data, 'email')) {
+    return (
+      <FormattedMessage
+        id="virtualCards.sentTo"
+        defaultMessage="sent to {email}"
+        values={{ email: <a href={`mailto:${data.email}`}>{data.email}</a> }}
+      />
+    );
+  } else {
+    return <FormattedMessage id="virtualCards.notYetClaimed" defaultMessage="not yet claimed" />;
+  }
+};
+
+/**
+ * Render a VirtualCard details like its status (claimed or not), who claimed it,
+ * when was it created... It is not meant to be show to all users, but just to
+ * the organizations that create the virtual cards.
+ */
+class VirtualCardDetails extends React.Component {
+  static propTypes = {
+    /** The virtual card, which is actually a PaymentMethod */
+    virtualCard: PropTypes.object.isRequired,
+    /** Provided by styled-component withTheme(...) */
+    theme: PropTypes.object,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = { expended: false };
+  }
+
+  toggleExpended() {
+    this.setState(state => ({ expended: !state.expended }));
+  }
+
+  getStatusColor(isConfirmed, balance) {
+    const { colors } = this.props.theme;
+    return balance === 0 ? colors.yellow[500] : isConfirmed ? colors.green[500] : colors.black[200];
+  }
+
+  renderDetails() {
+    const redeemCode = this.props.virtualCard.uuid.split('-')[0];
+    return (
+      <Flex mt="0.75em" fontSize="0.8em">
+        <Flex flexDirection="column" mr="1.5em">
+          <DetailsColumnHeader>
+            <FormattedMessage id="virtualCards.redeemCode" defaultMessage="Redeem code" />
+          </DetailsColumnHeader>
+          <Link route="redeem" params={{ code: redeemCode }}>
+            {redeemCode}
+          </Link>
+        </Flex>
+        <Flex flexDirection="column" mr="1.5em">
+          <DetailsColumnHeader>
+            <FormattedMessage id="virtualCards.expiryDate" defaultMessage="Expiry date" />
+          </DetailsColumnHeader>
+          <span>{moment(this.props.virtualCard.expiryDate).format('MM/Y')}</span>
+        </Flex>
+        <Flex flexDirection="column" mr="1.5em">
+          <DetailsColumnHeader>
+            <FormattedMessage id="virtualCards.customMessage" defaultMessage="Custom message" />
+          </DetailsColumnHeader>
+          <span>{this.props.virtualCard.description}</span>
+        </Flex>
+      </Flex>
+    );
+  }
+
+  render() {
+    const { isConfirmed, collective, initialBalance, balance, currency, createdAt, data } = this.props.virtualCard;
+
+    return (
+      <Flex>
+        {/* Avatar column */}
+        <Box mr="20px">
+          {isConfirmed ? (
+            <Link route="collective" params={{ slug: collective.slug }} title={collective.name} passHref>
+              <GiftCardIcon alignSelf="center" size="2.5em" color={this.getStatusColor(isConfirmed, balance)} />
+              <Avatar
+                radius={24}
+                mt="-1em"
+                ml="1em"
+                css={{ position: 'absolute' }}
+                src={collective.image}
+                type={collective.type}
+                name={collective.name}
+              />
+            </Link>
+          ) : (
+            <GiftCardIcon alignSelf="center" size="2.5em" color={this.getStatusColor(isConfirmed, balance)} />
+          )}
+        </Box>
+        {/* Infos + details column */}
+        <Flex flexDirection="column" p="0.1em">
+          <Box>
+            <strong>{formatCurrency(initialBalance, currency)}</strong>{' '}
+            <VirtualCardStatus isConfirmed={isConfirmed} collective={collective} data={data} />
+          </Box>
+          <Box color={this.props.theme.colors.black[500]} fontSize="0.9em">
+            <Flex>
+              <FormattedMessage
+                id="virtualCards.balance"
+                defaultMessage="Balance: {balance}"
+                values={{ balance: formatCurrency(balance, currency) }}
+              />
+              <Box mx={1}>|</Box>
+              <FormattedMessage
+                id="virtualCards.emmitedSince"
+                defaultMessage="Emmited {since}"
+                values={{ since: <Moment relative value={createdAt} /> }}
+              />
+              <Box mx={1}>|</Box>
+              <a onClick={() => this.toggleExpended()}>
+                {this.state.expended ? (
+                  <FormattedMessage id="virtualCards.closeDetails" defaultMessage="Close Details" />
+                ) : (
+                  <FormattedMessage id="virtualCards.viewDetails" defaultMessage="View Details" />
+                )}
+              </a>
+            </Flex>
+          </Box>
+          {this.state.expended && this.renderDetails()}
+        </Flex>
+      </Flex>
+    );
+  }
+}
+
+export default withTheme(VirtualCardDetails);

--- a/src/components/VirtualCardDetails.js
+++ b/src/components/VirtualCardDetails.js
@@ -78,25 +78,28 @@ class VirtualCardDetails extends React.Component {
 
   renderDetails() {
     const redeemCode = this.props.virtualCard.uuid.split('-')[0];
+    const email = get(this.props.virtualCard, 'data.email');
+    const linkParams = email ? { code: redeemCode, email } : { code: redeemCode };
+
     return (
       <Flex mt="0.75em" fontSize="0.8em">
         <Flex flexDirection="column" mr="1.5em">
           <DetailsColumnHeader>
-            <FormattedMessage id="virtualCards.redeemCode" defaultMessage="Redeem code" />
+            <FormattedMessage id="virtualCards.redeemCode" defaultMessage="REDEEM CODE" />
           </DetailsColumnHeader>
-          <Link route="redeem" params={{ code: redeemCode }}>
+          <Link route="redeem" params={linkParams}>
             {redeemCode}
           </Link>
         </Flex>
         <Flex flexDirection="column" mr="1.5em">
           <DetailsColumnHeader>
-            <FormattedMessage id="virtualCards.expiryDate" defaultMessage="Expiry date" />
+            <FormattedMessage id="virtualCards.expiryDate" defaultMessage="EXPIRY DATE" />
           </DetailsColumnHeader>
           <span>{moment(this.props.virtualCard.expiryDate).format('MM/Y')}</span>
         </Flex>
         <Flex flexDirection="column" mr="1.5em">
           <DetailsColumnHeader>
-            <FormattedMessage id="virtualCards.customMessage" defaultMessage="Custom message" />
+            <FormattedMessage id="virtualCards.customMessage" defaultMessage="CUSTOM MESSAGE" />
           </DetailsColumnHeader>
           <span>{this.props.virtualCard.description}</span>
         </Flex>

--- a/src/components/VirtualCardDetails.js
+++ b/src/components/VirtualCardDetails.js
@@ -5,6 +5,7 @@ import { Flex, Box } from '@rebass/grid';
 import { get } from 'lodash';
 import moment from 'moment';
 import styled, { withTheme } from 'styled-components';
+import { themeGet } from 'styled-system';
 
 import { CardGiftcard as GiftCardIcon } from 'styled-icons/material/CardGiftcard.cjs';
 
@@ -15,7 +16,7 @@ import Moment from './Moment';
 
 const DetailsColumnHeader = styled.span`
   text-transform: uppercase;
-  color: ${props => props.theme.colors.black[500]};
+  color: ${themeGet('colors.black.500')};
   font-weight: 300;
   white-space: nowrap;
 `;
@@ -73,35 +74,42 @@ class VirtualCardDetails extends React.Component {
 
   getStatusColor(isConfirmed, balance) {
     const { colors } = this.props.theme;
-    return balance === 0 ? colors.yellow[500] : isConfirmed ? colors.green[500] : colors.black[200];
+    if (balance === 0) {
+      return colors.black[200];
+    }
+
+    return isConfirmed ? colors.green[500] : colors.yellow[500];
   }
 
   renderDetails() {
-    const redeemCode = this.props.virtualCard.uuid.split('-')[0];
-    const email = get(this.props.virtualCard, 'data.email');
+    const { virtualCard } = this.props;
+    const redeemCode = virtualCard.uuid.split('-')[0];
+    const email = get(virtualCard, 'data.email');
     const linkParams = email ? { code: redeemCode, email } : { code: redeemCode };
 
     return (
       <Flex mt="0.75em" fontSize="0.8em">
-        <Flex flexDirection="column" mr="1.5em">
-          <DetailsColumnHeader>
-            <FormattedMessage id="virtualCards.redeemCode" defaultMessage="REDEEM CODE" />
-          </DetailsColumnHeader>
-          <Link route="redeem" params={linkParams}>
-            {redeemCode}
-          </Link>
-        </Flex>
+        {!virtualCard.isConfirmed && (
+          <Flex flexDirection="column" mr="1.5em">
+            <DetailsColumnHeader>
+              <FormattedMessage id="virtualCards.redeemCode" defaultMessage="REDEEM CODE" />
+            </DetailsColumnHeader>
+            <Link route="redeem" params={linkParams}>
+              {redeemCode}
+            </Link>
+          </Flex>
+        )}
         <Flex flexDirection="column" mr="1.5em">
           <DetailsColumnHeader>
             <FormattedMessage id="virtualCards.expiryDate" defaultMessage="EXPIRY DATE" />
           </DetailsColumnHeader>
-          <span>{moment(this.props.virtualCard.expiryDate).format('MM/Y')}</span>
+          <span>{moment(virtualCard.expiryDate).format('MM/Y')}</span>
         </Flex>
         <Flex flexDirection="column" mr="1.5em">
           <DetailsColumnHeader>
-            <FormattedMessage id="virtualCards.customMessage" defaultMessage="CUSTOM MESSAGE" />
+            <FormattedMessage id="virtualCards.description" defaultMessage="DESCRIPTION" />
           </DetailsColumnHeader>
-          <span>{this.props.virtualCard.description}</span>
+          <span>{virtualCard.description}</span>
         </Flex>
       </Flex>
     );

--- a/src/constants/theme.js
+++ b/src/constants/theme.js
@@ -118,6 +118,7 @@ const theme = {
         backgroundColor: colors.black[50],
         borderColor: colors.black[200],
         color: colors.black[300],
+        cursor: 'not-allowed',
       },
     },
 
@@ -138,6 +139,7 @@ const theme = {
 
       '&:disabled': {
         backgroundColor: colors.primary[200],
+        cursor: 'not-allowed',
       },
     },
   },

--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -197,6 +197,48 @@ export const deleteApplicationMutation = gql`
   }
 `;
 
+export const createVirtualCardsMutationQuery = gql`
+  mutation createPaymentMethod(
+    $CollectiveId: Int!
+    $numberOfVirtualCards: Int
+    $emails: [String]
+    $PaymentMethodId: Int
+    $amount: Int
+    $monthlyLimitPerMember: Int
+    $description: String
+    $expiryDate: String
+    $currency: String
+    $limitedToTags: [String]
+    $limitedToCollectiveIds: [Int]
+    $limitedToHostCollectiveIds: [Int]
+  ) {
+    createVirtualCards(
+      amount: $amount
+      monthlyLimitPerMember: $monthlyLimitPerMember
+      CollectiveId: $CollectiveId
+      PaymentMethodId: $PaymentMethodId
+      description: $description
+      expiryDate: $expiryDate
+      currency: $currency
+      limitedToTags: $limitedToTags
+      limitedToCollectiveIds: $limitedToCollectiveIds
+      limitedToHostCollectiveIds: $limitedToHostCollectiveIds
+      numberOfVirtualCards: $numberOfVirtualCards
+      emails: $emails
+    ) {
+      id
+      name
+      uuid
+      description
+      initialBalance
+      monthlyLimitPerMember
+      expiryDate
+      currency
+      data
+    }
+  }
+`;
+
 export const addCreateOrderMutation = graphql(createOrderQuery, {
   props: ({ mutate }) => ({
     createOrder: order => mutate({ variables: { order } }),

--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -211,6 +211,7 @@ export const createVirtualCardsMutationQuery = gql`
     $limitedToTags: [String]
     $limitedToCollectiveIds: [Int]
     $limitedToHostCollectiveIds: [Int]
+    $limitedToOpenSourceCollectives: Boolean
   ) {
     createVirtualCards(
       amount: $amount
@@ -225,6 +226,7 @@ export const createVirtualCardsMutationQuery = gql`
       limitedToHostCollectiveIds: $limitedToHostCollectiveIds
       numberOfVirtualCards: $numberOfVirtualCards
       emails: $emails
+      limitedToOpenSourceCollectives: $limitedToOpenSourceCollectives
     ) {
       id
       name

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -741,6 +741,43 @@ export const getSubscriptionsQuery = gql`
   }
 `;
 
+/** A query to get the virtual cards created by a collective. Must be authenticated. */
+export const getCollectiveVirtualCards = gql`
+  query CollectiveVirtualCards($CollectiveId: Int, $isConfirmed: Boolean, $limit: Int, $offset: Int) {
+    Collective(id: $CollectiveId) {
+      createdVirtualCards(isConfirmed: $isConfirmed, limit: $limit, offset: $offset) {
+        offset
+        limit
+        total
+        paymentMethods {
+          id
+          uuid
+          currency
+          name
+          service
+          type
+          data
+          initialBalance
+          balance
+          expiryDate
+          isConfirmed
+          data
+          createdAt
+          expiryDate
+          description
+          collective {
+            id
+            slug
+            image
+            type
+            name
+          }
+        }
+      }
+    }
+  }
+`;
+
 export const searchCollectivesQuery = gql`
   query search($term: String!, $limit: Int, $offset: Int) {
     search(term: $term, limit: $limit, offset: $offset) {

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -835,6 +835,31 @@ export const getCollectiveApplicationsQuery = gql`
   }
 `;
 
+/**
+ * A query to get a collective source payment methods. This will not return
+ * virtual cards, as a virtual card cannot be used as a source payment method
+ * for another payment method.
+ */
+export const getCollectiveSourcePaymentMethodsQuery = gql`
+  query Collective($id: Int) {
+    Collective(id: $id) {
+      id
+      paymentMethods(types: ["creditcard"], hasBalanceAboveZero: true) {
+        id
+        uuid
+        name
+        data
+        monthlyLimitPerMember
+        service
+        type
+        balance
+        currency
+        expiryDate
+      }
+    }
+  }
+`;
+
 export const addCollectiveData = graphql(getCollectiveQuery);
 export const addCollectiveCoverData = (component, options) => {
   return graphql(getCollectiveCoverQuery, options)(component);

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -203,7 +203,6 @@ const getCollectiveToEditQuery = gql`
       isActive
       isHost
       expensePolicy
-      canCreateVirtualCards
       stats {
         id
         yearlyBudget

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -203,6 +203,7 @@ const getCollectiveToEditQuery = gql`
       isActive
       isHost
       expensePolicy
+      canCreateVirtualCards
       stats {
         id
         yearlyBudget

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:3000/api/graphql
-# timestamp: Fri Nov 30 2018 10:46:32 GMT+0100 (Central European Standard Time)
+# timestamp: Mon Dec 10 2018 09:46:19 GMT+0100 (Central European Standard Time)
 
 """Application model"""
 type Application {
@@ -72,6 +72,9 @@ type Collective implements CollectiveInterface {
   backgroundImage: String
   settings: JSON
   data: JSON
+
+  """Specify if collective is allowed to create new VirtualCards"""
+  canCreateVirtualCards: Boolean
   slug: String
   path: String
 
@@ -125,6 +128,17 @@ type Collective implements CollectiveInterface {
   updates(limit: Int, offset: Int): [Event]
   events(limit: Int, offset: Int): [Event]
   paymentMethods(service: String, limit: Int, hasBalanceAboveZero: Boolean, isConfirmed: Boolean = true, types: [String], orderBy: PaymenMethodOrderField = type): [PaymentMethodType]
+
+  """
+  Get the virtual cards created by this collective. RemoteUser must be a collective admin.
+  """
+  createdVirtualCards(
+    limit: Int
+    offset: Int
+
+    """Wether the virtual card has been claimed or not"""
+    isConfirmed: Boolean
+  ): PaginatedPaymentMethod
   connectedAccounts: [ConnectedAccountType]
   stats: CollectiveStatsType
 }
@@ -217,6 +231,9 @@ interface CollectiveInterface {
   backgroundImage: String
   settings: JSON
   data: JSON
+
+  """Specify if collective is allowed to create new VirtualCards"""
+  canCreateVirtualCards: Boolean
   slug: String
   path: String
   isHost: Boolean
@@ -287,6 +304,13 @@ interface CollectiveInterface {
     """Order entries based on given column. Set to null for no ordering."""
     orderBy: PaymenMethodOrderField
   ): [PaymentMethodType]
+  createdVirtualCards(
+    limit: Int
+    offset: Int
+
+    """Wether the virtual card has been claimed or not"""
+    isConfirmed: Boolean
+  ): PaginatedPaymentMethod
   connectedAccounts: [ConnectedAccountType]
 }
 
@@ -475,6 +499,9 @@ type Event implements CollectiveInterface {
   backgroundImage: String
   settings: JSON
   data: JSON
+
+  """Specify if collective is allowed to create new VirtualCards"""
+  canCreateVirtualCards: Boolean
   slug: String
   path: String
 
@@ -528,6 +555,17 @@ type Event implements CollectiveInterface {
   updates(limit: Int, offset: Int): [Event]
   events(limit: Int, offset: Int): [Event]
   paymentMethods(service: String, limit: Int, hasBalanceAboveZero: Boolean, isConfirmed: Boolean = true, types: [String], orderBy: PaymenMethodOrderField = type): [PaymentMethodType]
+
+  """
+  Get the virtual cards created by this collective. RemoteUser must be a collective admin.
+  """
+  createdVirtualCards(
+    limit: Int
+    offset: Int
+
+    """Wether the virtual card has been claimed or not"""
+    isConfirmed: Boolean
+  ): PaginatedPaymentMethod
   connectedAccounts: [ConnectedAccountType]
   stats: CollectiveStatsType
 }
@@ -675,6 +713,7 @@ type InvoiceType {
   title: String
   year: Int
   month: Int
+  day: Int
   totalAmount: Int
   currency: String
   host: CollectiveInterface
@@ -785,6 +824,9 @@ type Mutation {
     PaymentMethodId: Int
     description: String
     expiryDate: String
+
+    """The data attached to this PaymentMethod"""
+    data: PaymentMethodDataVirtualCardInputType
   ): PaymentMethodType
   claimPaymentMethod(code: String!, user: UserInputType): PaymentMethodType
 }
@@ -1007,6 +1049,9 @@ type Organization implements CollectiveInterface {
   backgroundImage: String
   settings: JSON
   data: JSON
+
+  """Specify if collective is allowed to create new VirtualCards"""
+  canCreateVirtualCards: Boolean
   slug: String
   path: String
 
@@ -1060,6 +1105,17 @@ type Organization implements CollectiveInterface {
   updates(limit: Int, offset: Int): [Event]
   events(limit: Int, offset: Int): [Event]
   paymentMethods(service: String, limit: Int, hasBalanceAboveZero: Boolean, isConfirmed: Boolean = true, types: [String], orderBy: PaymenMethodOrderField = type): [PaymentMethodType]
+
+  """
+  Get the virtual cards created by this collective. RemoteUser must be a collective admin.
+  """
+  createdVirtualCards(
+    limit: Int
+    offset: Int
+
+    """Wether the virtual card has been claimed or not"""
+    isConfirmed: Boolean
+  ): PaginatedPaymentMethod
   connectedAccounts: [ConnectedAccountType]
   stats: CollectiveStatsType
   email: String
@@ -1071,6 +1127,14 @@ type PaginatedExpenses {
   limit: Int
   offset: Int
   total: Int
+}
+
+"""A list of PaymentMethod with pagination info"""
+type PaginatedPaymentMethod {
+  paymentMethods: [PaymentMethodType]
+  total: Int
+  limit: Int
+  offset: Int
 }
 
 """List of transactions with pagination data"""
@@ -1085,6 +1149,12 @@ type PaginatedTransactions {
 enum PaymenMethodOrderField {
   """Order payment methods by type (creditcard, virtualcard...)"""
   type
+}
+
+"""Input for virtual card (meta)data"""
+input PaymentMethodDataVirtualCardInputType {
+  """The email virtual card is generated for"""
+  email: String
 }
 
 """Input type for PaymentMethod (paypal/stripe)"""
@@ -1164,10 +1234,23 @@ type Query {
   allInvoices(fromCollectiveSlug: String!): [InvoiceType]
   Invoice(
     """
-    Slug of the invoice. Format: :year:2digitMonth-:hostSlug-:fromCollectiveSlug
+    Slug of the invoice. Format: :year:2digitMonth.:hostSlug.:fromCollectiveSlug
     """
     invoiceSlug: String!
   ): InvoiceType
+  TransactionInvoice(
+    """Slug of the transaction."""
+    transactionUuid: String!
+  ): InvoiceType
+
+  """
+  
+      Given a collective, returns all its transactions:
+      - Debit transactions made by collective without using a virtual card
+      - Debit transactions made using a virtual card from collective
+      - Credit transactions made to collective
+      
+  """
   allTransactions(CollectiveId: Int, collectiveSlug: String, type: String, limit: Int, offset: Int, dateFrom: String, dateTo: String, includeVirtualCards: Boolean): [Transaction]
   transactions(
     """Defaults to 100"""
@@ -1180,7 +1263,7 @@ type Query {
   ): PaginatedTransactions
   Update(collectiveSlug: String, updateSlug: String, id: Int): UpdateType
   Application(id: Int): Application
-  allComments(ExpenseId: Int, OrderId: Int, UpdateId: Int, limit: Int, offset: Int): [CommentType]
+  allComments(ExpenseId: Int, UpdateId: Int, limit: Int, offset: Int): [UpdateType]
   allUpdates(CollectiveId: Int!, includeHostedCollectives: Boolean, limit: Int, offset: Int): [UpdateType]
   allOrders(
     CollectiveId: Int
@@ -1547,6 +1630,9 @@ type User implements CollectiveInterface {
   backgroundImage: String
   settings: JSON
   data: JSON
+
+  """Specify if collective is allowed to create new VirtualCards"""
+  canCreateVirtualCards: Boolean
   slug: String
   path: String
 
@@ -1600,6 +1686,17 @@ type User implements CollectiveInterface {
   updates(limit: Int, offset: Int): [Event]
   events(limit: Int, offset: Int): [Event]
   paymentMethods(service: String, limit: Int, hasBalanceAboveZero: Boolean, isConfirmed: Boolean = true, types: [String], orderBy: PaymenMethodOrderField = type): [PaymentMethodType]
+
+  """
+  Get the virtual cards created by this collective. RemoteUser must be a collective admin.
+  """
+  createdVirtualCards(
+    limit: Int
+    offset: Int
+
+    """Wether the virtual card has been claimed or not"""
+    isConfirmed: Boolean
+  ): PaginatedPaymentMethod
   connectedAccounts: [ConnectedAccountType]
   stats: CollectiveStatsType
   firstName: String

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:3000/api/graphql
-# timestamp: Fri Dec 14 2018 10:12:19 GMT+0100 (Central European Standard Time)
+# timestamp: Fri Dec 14 2018 15:05:37 GMT+0100 (Central European Standard Time)
 
 """Application model"""
 type Application {
@@ -72,9 +72,6 @@ type Collective implements CollectiveInterface {
   backgroundImage: String
   settings: JSON
   data: JSON
-
-  """Specify if collective is allowed to create new VirtualCards"""
-  canCreateVirtualCards: Boolean
   slug: String
   path: String
 
@@ -231,9 +228,6 @@ interface CollectiveInterface {
   backgroundImage: String
   settings: JSON
   data: JSON
-
-  """Specify if collective is allowed to create new VirtualCards"""
-  canCreateVirtualCards: Boolean
   slug: String
   path: String
   isHost: Boolean
@@ -499,9 +493,6 @@ type Event implements CollectiveInterface {
   backgroundImage: String
   settings: JSON
   data: JSON
-
-  """Specify if collective is allowed to create new VirtualCards"""
-  canCreateVirtualCards: Boolean
   slug: String
   path: String
 
@@ -845,7 +836,7 @@ type Mutation {
     """
     currency: String
 
-    """The amount as an Integer without cents."""
+    """The amount as an Integer with cents."""
     amount: Int
     monthlyLimitPerMember: Int
 
@@ -1089,9 +1080,6 @@ type Organization implements CollectiveInterface {
   backgroundImage: String
   settings: JSON
   data: JSON
-
-  """Specify if collective is allowed to create new VirtualCards"""
-  canCreateVirtualCards: Boolean
   slug: String
   path: String
 
@@ -1670,9 +1658,6 @@ type User implements CollectiveInterface {
   backgroundImage: String
   settings: JSON
   data: JSON
-
-  """Specify if collective is allowed to create new VirtualCards"""
-  canCreateVirtualCards: Boolean
   slug: String
   path: String
 

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:3000/api/graphql
-# timestamp: Mon Dec 10 2018 09:46:19 GMT+0100 (Central European Standard Time)
+# timestamp: Fri Dec 14 2018 10:12:19 GMT+0100 (Central European Standard Time)
 
 """Application model"""
 type Application {
@@ -827,7 +827,47 @@ type Mutation {
 
     """The data attached to this PaymentMethod"""
     data: PaymentMethodDataVirtualCardInputType
-  ): PaymentMethodType
+  ): PaymentMethodType @deprecated(reason: "Please use createVirtualCards")
+  createVirtualCards(
+    CollectiveId: Int!
+    PaymentMethodId: Int
+
+    """
+    A list of emails to generate virtual cards for (only if numberOfVirtualCards is not provided)
+    """
+    emails: [String]
+
+    """Number of virtual cards to generate (only if emails is not provided)"""
+    numberOfVirtualCards: Int
+
+    """
+    An optional currency. If not provided, will use the collective currency.
+    """
+    currency: String
+
+    """The amount as an Integer without cents."""
+    amount: Int
+    monthlyLimitPerMember: Int
+
+    """
+    Limit this payment method to make donations to collectives having those tags
+    """
+    limitedToTags: [String]
+
+    """Limit this payment method to make donations to those collectives"""
+    limitedToCollectiveIds: [Int]
+
+    """
+    Limit this payment method to make donations to the collectives hosted by those hosts
+    """
+    limitedToHostCollectiveIds: [Int]
+
+    """
+    A custom message attached to the email that will be sent for this virtual card
+    """
+    description: String
+    expiryDate: String
+  ): [PaymentMethodType]
   claimPaymentMethod(code: String!, user: UserInputType): PaymentMethodType
 }
 

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:3000/api/graphql
-# timestamp: Fri Dec 14 2018 15:05:37 GMT+0100 (Central European Standard Time)
+# timestamp: Mon Dec 17 2018 15:22:26 GMT+0100 (Central European Standard Time)
 
 """Application model"""
 type Application {
@@ -852,6 +852,9 @@ type Mutation {
     Limit this payment method to make donations to the collectives hosted by those hosts
     """
     limitedToHostCollectiveIds: [Int]
+
+    """Set `limitedToHostCollectiveIds` to open-source collectives only"""
+    limitedToOpenSourceCollectives: Boolean
 
     """
     A custom message attached to the email that will be sent for this virtual card

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -264,7 +264,7 @@
   "editCollective.menu.tiers": "Tiers",
   "editCollective.menu.expenses": "Expenses",
   "editCollective.menu.paymentMethods": "Payment Methods",
-  "editCollective.menu.virtualCards": "Vritual Cards",
+  "editCollective.menu.virtualCards": "Gift Cards",
   "editCollective.menu.connectedAccounts": "Connected Accounts",
   "editCollective.menu.export": "Export",
   "editCollective.menu.advanced": "Advanced",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -264,6 +264,7 @@
   "editCollective.menu.tiers": "Tiers",
   "editCollective.menu.expenses": "Expenses",
   "editCollective.menu.paymentMethods": "Payment Methods",
+  "editCollective.menu.virtualCards": "Vritual Cards",
   "editCollective.menu.connectedAccounts": "Connected Accounts",
   "editCollective.menu.export": "Export",
   "editCollective.menu.advanced": "Advanced",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -264,6 +264,7 @@
   "editCollective.menu.tiers": "Tiers",
   "editCollective.menu.expenses": "Dépenses",
   "editCollective.menu.paymentMethods": "Méthodes de paiement",
+  "editCollective.menu.virtualCards": "Chèques Cadeaux",
   "editCollective.menu.connectedAccounts": "Comptes connectés",
   "editCollective.menu.export": "Exporter",
   "editCollective.menu.advanced": "Avancé",

--- a/src/lib/styled_components_utils.js
+++ b/src/lib/styled_components_utils.js
@@ -1,0 +1,19 @@
+/**
+ * Return the correct border color index depending on `error` and `success`.
+ *
+ * ## Examples
+ *
+ *    > getInputBorderColor({error: true})
+ *    'red.500'
+ */
+export const getInputBorderColor = (error, success) => {
+  if (error) {
+    return 'red.500';
+  }
+
+  if (success) {
+    return 'green.300';
+  }
+
+  return 'black.300';
+};

--- a/src/lib/styled_components_utils.js
+++ b/src/lib/styled_components_utils.js
@@ -3,7 +3,7 @@
  *
  * ## Examples
  *
- *    > getInputBorderColor({error: true})
+ *    > getInputBorderColor(true)
  *    'red.500'
  */
 export const getInputBorderColor = (error, success) => {

--- a/src/pages/__tests__/__snapshots__/search.test.js.snap
+++ b/src/pages/__tests__/__snapshots__/search.test.js.snap
@@ -5614,6 +5614,10 @@ Array [
   box-sizing: border-box;
 }
 
+.c12:disabled {
+  cursor: not-allowed;
+}
+
 .c5 {
   display: inline-block;
   vertical-align: middle;

--- a/src/server/pages.js
+++ b/src/server/pages.js
@@ -77,7 +77,10 @@ pages.add('marketing', '/:pageSlug(become-a-sponsor|how-it-works|gift-of-giving|
 
 // Collective
 
-pages.add('collective', '/:slug').add('editCollective', '/:slug/edit');
+pages
+  .add('collective', '/:slug')
+  .add('editCollective', '/:slug/edit')
+  .add('editCollectiveSection', '/:slug/edit/:section', 'editCollective');
 
 export default pages;
 

--- a/src/server/pages.js
+++ b/src/server/pages.js
@@ -77,10 +77,7 @@ pages.add('marketing', '/:pageSlug(become-a-sponsor|how-it-works|gift-of-giving|
 
 // Collective
 
-pages
-  .add('collective', '/:slug')
-  .add('editCollective', '/:slug/edit')
-  .add('editCollectiveSection', '/:slug/edit/:section', 'editCollective');
+pages.add('collective', '/:slug').add('editCollective', '/:slug/edit/:section?');
 
 export default pages;
 

--- a/styleguide/examples/StyledButton.md
+++ b/styleguide/examples/StyledButton.md
@@ -10,28 +10,56 @@ Default styling example using the `standard` button style theme:
 <StyledButton buttonStyle="primary">Primary Button</StyledButton>
 ```
 
+loading button with `primary` button style theme:
+
+```js
+<StyledButton buttonStyle="primary" loading>
+  Whatever
+</StyledButton>
+```
+
 Defaults to the `medium` button size:
 
 ```js
 initialState = { buttonSize: 'medium' };
 <React.Fragment>
-  <StyledButton buttonSize={state.buttonSize} mb={4} mx="auto" display="block">{state.buttonSize}</StyledButton>
+  <StyledButton buttonSize={state.buttonSize} mb={4} mx="auto" display="block">
+    {state.buttonSize}
+  </StyledButton>
 
   <fieldset onChange={event => setState({ buttonSize: event.target.value })}>
     <label htmlFor="small-button">
-      <input type="radio" name="buttonSize" value="small" id="small-button" defaultChecked={state.buttonSize === 'small'} />
+      <input
+        type="radio"
+        name="buttonSize"
+        value="small"
+        id="small-button"
+        defaultChecked={state.buttonSize === 'small'}
+      />
       small
     </label>
 
     <label htmlFor="medium-button">
-      <input type="radio" name="buttonSize" value="medium" id="medium-button" defaultChecked={state.buttonSize === 'medium'} />
+      <input
+        type="radio"
+        name="buttonSize"
+        value="medium"
+        id="medium-button"
+        defaultChecked={state.buttonSize === 'medium'}
+      />
       medium
     </label>
 
     <label htmlFor="large-button">
-      <input type="radio" name="buttonSize" value="large" id="large-button" defaultChecked={state.buttonSize === 'large'} />
+      <input
+        type="radio"
+        name="buttonSize"
+        value="large"
+        id="large-button"
+        defaultChecked={state.buttonSize === 'large'}
+      />
       large
     </label>
   </fieldset>
-</React.Fragment>
+</React.Fragment>;
 ```

--- a/styleguide/examples/StyledButtonSet.md
+++ b/styleguide/examples/StyledButtonSet.md
@@ -1,0 +1,28 @@
+### Default styling example with changing state
+
+```js
+initialState = { selected: null };
+<StyledButtonSet
+  items={['hello', 'world', 'wow']}
+  selected={state.selected}
+  onChange={item => setState({ selected: item })}
+>
+  {({ item }) => item}
+</StyledButtonSet>;
+```
+
+### Using links inside of buttons
+
+This is just an exemple. The way you style the links is completely up to you.
+
+You can use [StyledLink](#styledlink) for standard styles.
+
+```js
+<StyledButtonSet items={['ok', 'amazing', 'wow']} buttonProps={{ p: 0 }} selected="hello">
+  {({ item }) => (
+    <a target="_BLANK" style={{ padding: '0.75em 1em', display: 'block' }} href={`https://opencollective.com/${item}`}>
+      Open Collective is {item}
+    </a>
+  )}
+</StyledButtonSet>
+```

--- a/styleguide/examples/StyledCheckbox.md
+++ b/styleguide/examples/StyledCheckbox.md
@@ -1,4 +1,4 @@
-### Interactive
+### Normal
 
 ```js
 initialState = { checked: false };
@@ -9,28 +9,38 @@ initialState = { checked: false };
 />;
 ```
 
-### Normal
-
-```js
-<StyledCheckbox label="Unchecked" />
-<br/>
-<StyledCheckbox label="Checked" checked />
-```
-
 ### Disabled
 
 ```js
-<StyledCheckbox disabled label="Uncheckd" />
-<br/>
-<StyledCheckbox disabled checked label="Checked" />
+initialState = { checked: false };
+
+<div>
+  <StyledCheckbox disabled label="Unchecked" checked={state.checked} onChange={checked => setState({ checked })} />
+  <br />
+  <StyledCheckbox disabled checked label="Checked" />
+</div>;
 ```
 
 ### With custom sizes
 
 ```js
-<StyledCheckbox label="A little bit bigger" size="20px" />
-<br/>
-<StyledCheckbox label="Wow" size="30px"/>
-<br/>
-<StyledCheckbox label="This is huge" size="50px" />
+initialState = { checked: false };
+
+<div>
+  <StyledCheckbox
+    label="A little bit bigger"
+    size="20px"
+    checked={state.checked}
+    onChange={checked => setState({ checked })}
+  />
+  <br />
+  <StyledCheckbox label="Wow" size="30px" checked={state.checked} onChange={checked => setState({ checked })} />
+  <br />
+  <StyledCheckbox
+    label="This is huge"
+    size="50px"
+    checked={state.checked}
+    onChange={checked => setState({ checked })}
+  />
+</div>;
 ```

--- a/styleguide/examples/StyledCheckbox.md
+++ b/styleguide/examples/StyledCheckbox.md
@@ -1,0 +1,36 @@
+### Interactive
+
+```js
+initialState = { checked: false };
+<StyledCheckbox
+  checked={state.checked}
+  onChange={checked => setState({ checked })}
+  label={state.checked ? 'Checked' : 'Unchecked'}
+/>;
+```
+
+### Normal
+
+```js
+<StyledCheckbox label="Unchecked" />
+<br/>
+<StyledCheckbox label="Checked" checked />
+```
+
+### Disabled
+
+```js
+<StyledCheckbox disabled label="Uncheckd" />
+<br/>
+<StyledCheckbox disabled checked label="Checked" />
+```
+
+### With custom sizes
+
+```js
+<StyledCheckbox label="A little bit bigger" size="20px" />
+<br/>
+<StyledCheckbox label="Wow" size="30px"/>
+<br/>
+<StyledCheckbox label="This is huge" size="50px" />
+```

--- a/styleguide/examples/StyledInputAmount.md
+++ b/styleguide/examples/StyledInputAmount.md
@@ -1,0 +1,11 @@
+With currency set to `EUR`:
+
+```js
+<StyledInputAmount currency="EUR" />
+```
+
+With min amount to `$10`:
+
+```js
+<StyledInputAmount currency="USD" min="10" />
+```

--- a/styleguide/examples/StyledInputGroup.md
+++ b/styleguide/examples/StyledInputGroup.md
@@ -27,3 +27,9 @@ Error state:
 ```js
 <StyledInputGroup prepend="https://" type="url" placeholder="Error!" error />
 ```
+
+Error message:
+
+```js
+<StyledInputGroup prepend="https://" type="url" placeholder="Error!" error="This is not a valid URL" />
+```

--- a/styleguide/examples/StyledPaymentMethodChooser.md
+++ b/styleguide/examples/StyledPaymentMethodChooser.md
@@ -1,0 +1,52 @@
+```js
+<StyledPaymentMethodChooser
+  defaultPaymentMethod={{
+    id: 8771,
+    uuid: 'ce4e0885-ebb4-4e1b-b644-4fa009370300',
+    name: '4444',
+    data: {
+      expMonth: 2,
+      expYear: 2022,
+      brand: 'MasterCard',
+      country: 'US',
+    },
+    monthlyLimitPerMember: null,
+    service: 'stripe',
+    type: 'creditcard',
+    balance: 10000000,
+    currency: 'USD',
+    expiryDate: null,
+  }}
+  paymentMethods={[
+    {
+      id: 8771,
+      uuid: 'ce4e0885-ebb4-4e1b-b644-4fa009370300',
+      name: '4444',
+      data: {
+        expMonth: 2,
+        expYear: 2022,
+        brand: 'MasterCard',
+        country: 'US',
+      },
+      monthlyLimitPerMember: null,
+      service: 'stripe',
+      type: 'creditcard',
+      balance: 10000000,
+      currency: 'USD',
+      expiryDate: null,
+    },
+    {
+      id: 8783,
+      uuid: '493eb5de-905f-4f9a-a11e-668bd19d8750',
+      name: '$100 Gift Card from New Collective',
+      data: null,
+      monthlyLimitPerMember: null,
+      service: 'opencollective',
+      type: 'virtualcard',
+      balance: 2300,
+      currency: 'USD',
+      expiryDate: 'Sun Mar 03 2019 13:10:53 GMT+0100 (Central European Standard Time)',
+    },
+  ]}
+/>
+```

--- a/styleguide/examples/StyledSpinner.md
+++ b/styleguide/examples/StyledSpinner.md
@@ -1,0 +1,11 @@
+### Basic spinner
+
+```js
+<StyledSpinner />
+```
+
+### With `size="30px"`
+
+```js
+<StyledSpinner size="30px" />
+```


### PR DESCRIPTION
# Edit collective routes changes

I had to change the way edit collective routes work. Sections used to be assigned to URLs looking like `/collective/edit#paymentMethods`. This didn't play nice with the `Pagination` component. Routes now look like `/collective/edit/payment-methods` and I've added a function to redirect old schemes so we don't break the links we've sent by email in the past.

# New design-system components

- [StyledButtonSet](https://opencollective-styleguide.now.sh/#styledbuttonset)
- [StyledCheckBox](https://opencollective-styleguide.now.sh/#styledcheckbox)
- [StyledSpinner](https://opencollective-styleguide.now.sh/#styledspinner)
- [StyledInputAmount](https://opencollective-styleguide.now.sh/#styledinputamount)
- [StyledPaymentMethodChooser](https://opencollective-styleguide.now.sh/#styledpaymentmethodchooser)

# Modified design-system components

- StyledButton: Add "loading" state with spinner
- StyledInput: Add `not-allowed` cursor when disabled
- StyledInputGroup: Add ability to display fields errors 
- StyledSelect: Display popup with position absolute (floating) and fix sizes

# Screenshots

## Main view

![selection_883](https://user-images.githubusercontent.com/1556356/50060577-e4175500-0195-11e9-9c8c-1163d61d79c3.png)

## Filtered on `Redeemed`

![selection_881](https://user-images.githubusercontent.com/1556356/50060549-ac101200-0195-11e9-8fda-0bdb2ec18d50.png)

## Send by email

![selection_885](https://user-images.githubusercontent.com/1556356/50088906-94bc3d80-0204-11e9-8885-10e02872180b.png)

## Create gift card codes

![selection_884](https://user-images.githubusercontent.com/1556356/50088911-9a198800-0204-11e9-8cd3-d010e5adbd14.png)

---

:information_source: Resolve https://github.com/opencollective/opencollective/issues/1511
:information_source: Resolve https://github.com/opencollective/opencollective/issues/1512