### PR TITLE
Fix: CreateExpenseForm spacing + Dropzone accessibility

### DIFF
--- a/src/apps/expenses/components/CreateExpenseForm.js
+++ b/src/apps/expenses/components/CreateExpenseForm.js
@@ -11,6 +11,8 @@ import InputField from '../../../components/InputField';
 import SignInForm from '../../../components/SignInForm';
 import categories from '../../../constants/categories';
 import Button from '../../../components/Button';
+import { P } from '../../../components/Text';
+import Container from '../../../components/Container';
 
 class CreateExpenseForm extends React.Component {
   static propTypes = {
@@ -179,7 +181,7 @@ class CreateExpenseForm extends React.Component {
             .CreateExpenseForm {
               font-size: 1.2rem;
               overflow: hidden;
-              margin: 0 1rem 5rem 1rem;
+              padding: 0 2rem 5rem;
             }
             .disclaimer,
             .expensePolicy {
@@ -297,7 +299,7 @@ class CreateExpenseForm extends React.Component {
           `}
         </style>
 
-        <form onSubmit={this.onSubmit}>
+        <Container as="form" onSubmit={this.onSubmit} maxWidth={[500, null, 800]} mx="auto">
           {!collective.expensePolicy && LoggedInUser && LoggedInUser.canEditCollective(collective) && (
             <div className="expensePolicy">
               <h2>
@@ -484,7 +486,7 @@ class CreateExpenseForm extends React.Component {
               {this.state.error && <div className="error">{this.state.error}</div>}
             </div>
           </div>
-        </form>
+        </Container>
       </div>
     );
   }
@@ -495,9 +497,9 @@ class CreateExpenseForm extends React.Component {
     if (!LoggedInUser) {
       return (
         <div className="CreateExpenseForm">
-          <p>
+          <P textAlign="center" mt={4} fontSize="LeadParagraph" lineHeight="LeadParagraph">
             <FormattedMessage id="expenses.create.login" defaultMessage="Sign up or login to submit an expense." />
-          </p>
+          </P>
           <SignInForm next={`/${collective.slug}/expenses/new`} />
         </div>
       );

--- a/src/components/InputTypeDropzone.js
+++ b/src/components/InputTypeDropzone.js
@@ -6,6 +6,7 @@ import { imagePreview } from '../lib/utils';
 import { upload } from '../lib/api';
 import withIntl from '../lib/withIntl';
 import { defineMessages } from 'react-intl';
+import { colors } from '../constants/theme';
 
 class InputTypeDropzone extends React.Component {
   static propTypes = {
@@ -176,14 +177,22 @@ class InputTypeDropzone extends React.Component {
             }
             .dropzone:hover,
             .dropzone.empty {
-              border: 2px dashed grey;
+              border-color: grey;
             }
             .dropzone:hover .placeholder,
             .dropzone.empty .placeholder {
               display: flex;
             }
+            .dropzone:focus {
+              border-color: ${colors.primary['300']};
+            }
             .removeImage {
+              color: ${colors.primary['400']};
+              cursor: pointer;
               font-size: 11px;
+            }
+            .removeImage:hover {
+              color: ${colors.primary['500']};
             }
           `}
         </style>
@@ -192,14 +201,26 @@ class InputTypeDropzone extends React.Component {
           onDrop={this.handleChange}
           className={`${this.props.name}-dropzone dropzone ${!this.state.value && 'empty'}`}
           style={{}}
+          inputProps={{ tabIndex: '-1' }}
+          tabIndex="0"
+          onKeyDown={({ key, target }) => {
+            if (key === 'Enter') {
+              target.querySelector('input[type="file"]').click();
+            }
+          }}
           {...options}
         >
           {this.renderContainer}
         </Dropzone>
         {this.state.value && (
-          <a className="removeImage" onClick={() => this.handleChange(null)}>
+          <span
+            className="removeImage"
+            tabIndex="0"
+            onClick={() => this.handleChange(null)}
+            onKeyDown={({ key }) => key === 'Enter' && this.handleChange(null)}
+          >
             ❌ remove image
-          </a>
+          </span>
         )}
       </div>
     );


### PR DESCRIPTION
This PR includes:

- corrected spacing for the create expense form
- keyboard navigation / usage for the `InputTypeDropzone` component

Preview:

**Updated spacing**
(small screen includes floating MenuBar, not a bug)
![screenshot_2018-12-21 vue - open collective 1](https://user-images.githubusercontent.com/3051193/50363092-48406d00-0538-11e9-8d13-32dc0684815a.png)
![screenshot_2018-12-21 vue - open collective 3](https://user-images.githubusercontent.com/3051193/50363093-48406d00-0538-11e9-9b61-9a610ef86d39.png)
![screenshot_2018-12-21 vue - open collective 2](https://user-images.githubusercontent.com/3051193/50363094-48406d00-0538-11e9-9ddd-516cde2c54da.png)
![screenshot_2018-12-21 vue - open collective](https://user-images.githubusercontent.com/3051193/50363095-48406d00-0538-11e9-971a-6839b12e88df.png)

**Dropzone Accessibility (focus states)**
<img width="850" alt="screen shot 2018-12-21 at 3 26 24 pm" src="https://user-images.githubusercontent.com/3051193/50363116-568e8900-0538-11e9-83a0-1dcb90b56958.png">
<img width="857" alt="screen shot 2018-12-21 at 3 26 06 pm" src="https://user-images.githubusercontent.com/3051193/50363117-568e8900-0538-11e9-8766-5dba180f85dd.png">
