### PR TITLE
Goals Cover: Fixes, refactor and logarithmic view

### DIFF
--- a/src/components/GoalsCover.js
+++ b/src/components/GoalsCover.js
@@ -157,6 +157,7 @@ class GoalsCover extends React.Component {
 
     const maxGoal = maxBy(get(props.collective, 'settings.goals', []), g => (g.title ? g.amount : 0));
     this.currentProgress = maxGoal ? this.getMaxCurrentAchievement() / maxGoal.amount : 1.0;
+    this.interpolation = props.interpolation || get(props.collective, 'settings.goalsInterpolation', 'auto');
     this.state = { ...this.populateGoals(true, true) };
   }
 
@@ -181,9 +182,7 @@ class GoalsCover extends React.Component {
 
   /** Returns a percentage (0.0-1.0) that reprensent X position */
   getTranslatedPercentage(x) {
-    const { interpolation } = this.props;
-
-    if (interpolation === 'logarithm' || (interpolation === 'auto' && this.currentProgress <= 0.3)) {
+    if (this.interpolation === 'logarithm' || (this.interpolation === 'auto' && this.currentProgress <= 0.3)) {
       // See https://www.desmos.com/calculator/30pua5xx7q
       return -1 * Math.pow(x - 1, 2) + 1;
     }

--- a/src/components/GoalsCover.js
+++ b/src/components/GoalsCover.js
@@ -1,28 +1,123 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, defineMessages } from 'react-intl';
-import { get, maxBy } from 'lodash';
+import { get, maxBy, debounce, sortBy } from 'lodash';
+import styled, { css } from 'styled-components';
+import slugify from 'slugify';
+
 import withIntl from '../lib/withIntl';
 import { formatCurrency } from '../lib/utils';
+import { fadeIn } from './StyledKeyframes';
+
+const GoalContainer = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  text-align: right;
+  transition: width 3s;
+  height: 20px;
+  border-right: 1px solid ${props => (props.goal.isReached ? '#64c800' : '#3399ff')};
+  width: ${props => `${props.goal.progress * 100}%`};
+  z-index: ${props => (['balance', 'yearlyBudget'].includes(props.goal.slug) ? 310 : (20 - props.index) * 10)};
+  transition: ${props =>
+    `opacity 0.3s, height 1s, padding-top 1s${props.goal.animateProgress ? ', width 2s ease-in-out;' : ''};`}
+
+  .caption {
+    padding: 1rem 0.5rem 1rem 0.5rem;
+    color: #aaaeb3;
+    font-size: 13px;
+    line-height: 15px;
+  }
+
+  .label {
+    background: #252729;
+    color: #aaaeb3;
+    padding: 0;
+    line-height: 1.5;
+    font-size: 13px;
+    text-align: right;
+  }
+
+  .amount {
+    color: white;
+    font-weight: bold;
+  }
+
+  .interval {
+    color: #aaaeb3;
+    font-size: 10px;
+    font-weight: normal;
+  }
+
+  ${props =>
+    props.goal.isReached &&
+    props.goal.position === 'below' &&
+    css`
+      border-top: 4px solid #64c800;
+    `}
+
+  ${props =>
+    props.goal.position === 'above' &&
+    css`
+      border-bottom: 4px solid #3399ff;
+      top: auto;
+      bottom: 76px;
+
+      .caption {
+        margin-top: -4.5rem;
+      }
+    `}
+
+  ${props => {
+    if (props.goal.level === 1) {
+      if (props.goal.position === 'below') {
+        return css`
+          height: 60px;
+          padding-top: 4rem;
+        `;
+      } else {
+        return css`
+          height: 60px;
+        `;
+      }
+    }
+  }}
+
+  ${props => {
+    if (props.goal.isOverlapping) {
+      return css`
+        opacity: 0.2;
+      `;
+    } else {
+      return css`
+        animation: ${fadeIn} 0.3s;
+      `;
+    }
+  }}
+
+  ${props =>
+    props.goal.hidden &&
+    css`
+      opacity: 0;
+    `}
+`;
 
 class GoalsCover extends React.Component {
   static propTypes = {
     collective: PropTypes.object.isRequired,
     LoggedInUser: PropTypes.object,
+    interpolation: PropTypes.oneOf(['linear', 'logarithm', 'auto']),
+  };
+
+  static defaultProps = {
+    interpolation: 'auto',
   };
 
   constructor(props) {
     super(props);
     this.renderGoal = this.renderGoal.bind(this);
-    this.nodes = {};
-    this.state = {
-      goals: {},
-      styles: {
-        balance: { textAlign: 'left', left: 0 },
-        yearlyBudget: { textAlign: 'right', right: 0 },
-      },
-    };
-
+    this.updateGoals = debounce(this.updateGoals.bind(this), 100, { maxWait: 200 });
+    this.labelsRefs = {};
     this.messages = defineMessages({
       admin: { id: 'menu.admin', defaultMessage: 'admin' },
       backer: { id: 'menu.backer', defaultMessage: 'backer' },
@@ -59,199 +154,283 @@ class GoalsCover extends React.Component {
         defaultMessage: 'Estimated Annual Budget',
       },
     });
+
+    const maxGoal = maxBy(get(props.collective, 'settings.goals', []), g => (g.title ? g.amount : 0));
+    this.currentProgress = maxGoal ? this.getMaxCurrentAchievement() / maxGoal.amount : 1.0;
+    this.state = { ...this.populateGoals(true, true) };
   }
 
   componentDidMount() {
-    const state = this.populateGoals();
-    this.setState(state);
+    this.setState({ ...this.populateGoals(false, true), firstMount: true });
+    window.addEventListener('resize', this.updateGoals);
   }
 
-  populateGoals() {
-    const { intl, collective } = this.props;
-    const state = this.state;
-    const previous = {};
+  componentDidUpdate() {
+    if (this.state.firstMount) {
+      this.updateGoals();
+    }
+  }
 
-    this.goals = [
-      {
-        slug: 'balance',
-        animate: true,
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.updateGoals);
+  }
+
+  updateGoals(firstMount = false) {
+    this.setState({ ...this.populateGoals(), firstMount });
+  }
+
+  /** Returns a percentage (0.0-1.0) that reprensent X position */
+  getTranslatedPercentage(x) {
+    const { interpolation } = this.props;
+
+    if (interpolation === 'logarithm' || (interpolation === 'auto' && this.currentProgress <= 0.3)) {
+      // See https://www.desmos.com/calculator/30pua5xx7q
+      return -1 * Math.pow(x - 1, 2) + 1;
+    }
+
+    return x;
+  }
+
+  /** Create goal object with correct defaults and store a ref for React */
+  createGoal(slug, params) {
+    this.labelsRefs[slug] = this.labelsRefs[slug] || React.createRef();
+    return {
+      precision: 0,
+      isReached: false,
+      level: 0,
+      position: 'above',
+      ...params,
+      slug,
+    };
+  }
+
+  /** Returns the main goals current progress, either max balance or annual budget */
+  getMaxCurrentAchievement() {
+    const { collective } = this.props;
+    return Math.max(get(collective, 'stats.balance'), get(collective, 'stats.yearlyBudget', 0));
+  }
+
+  /**
+   * Returns the base goals (balance, yearly budget...) without custom goals.
+   * All goals returned here have a slug prefilled.
+   */
+  getInitialGoals() {
+    const { intl, collective } = this.props;
+
+    // Always show current balance
+    const goals = [
+      this.createGoal('balance', {
+        animateProgress: true,
         title: intl.formatMessage(this.messages['bar.balance']),
         amount: get(collective, 'stats.balance'),
         precision: 2,
         position: 'below',
-      },
+        isReached: true,
+      }),
     ];
 
+    // Add yearly budget
     if (
       get(collective, 'stats.yearlyBudget') > 0 &&
       get(collective, 'stats.yearlyBudget') !== get(collective, 'stats.balance')
     ) {
-      this.goals.push({
-        slug: 'yearlyBudget',
-        title: intl.formatMessage(this.messages['bar.yearlyBudget']),
-        amount: get(collective, 'stats.yearlyBudget'),
-        precision: 0,
-        position: 'below',
-      });
+      goals.push(
+        this.createGoal('yearlyBudget', {
+          animateProgress: true,
+          title: intl.formatMessage(this.messages['bar.yearlyBudget']),
+          amount: get(collective, 'stats.yearlyBudget'),
+          precision: 0,
+          position: 'below',
+          isReached: true,
+        }),
+      );
     }
 
-    const maxGoalsToShow = window.screen.availWidth < 400 ? this.goals.length + 1 : 10;
-
-    (get(collective, 'settings.goals') || []).map(g => {
-      if (g.title) {
-        this.hasCustomGoals = true;
-        this.goals.push(g);
-      }
-    });
-
-    this.goals.sort((a, b) => a.amount > b.amount);
-
-    const lastGoalAtPosition = {};
-    for (let i = 0; i < this.goals.length; i++) {
-      const goal = { ...this.goals[i] };
-      goal.slug = goal.slug || `goal${i}`;
-      goal.position = goal.position || 'above';
-      lastGoalAtPosition[goal.position] = goal;
-      goal.style = {
-        textAlign: lastGoalAtPosition[goal.position] ? 'right' : 'left',
-      };
-      this.goals[i] = goal;
+    // Animate only the most advanced one
+    if (goals.length === 2) {
+      if (goals[0].amount <= goals[1].amount) goals[0].animateProgress = false;
+      else goals[1].animateProgress = false;
     }
 
-    this.goals = this.goals.slice(0, maxGoalsToShow);
-
-    this.maxAmount = maxBy(this.goals, g => g.amount).amount;
-
-    this.goals.forEach(goal => {
-      const pos = { level: 0, amount: goal.amount };
-      const { slug, position } = goal;
-      if (this.nodes[slug]) {
-        pos.posX = this.nodes[slug].offsetWidth;
-        pos.width = this.nodes[slug].querySelector('.label').offsetWidth;
-        pos.height = '20px';
-      }
-      // if the previous item's position is overlapping, we change the level
-      if (previous[position] && pos.posX < previous[position].posX + previous[position].width) {
-        pos.level = previous[position].level === 1 ? 0 : 1;
-
-        // Make sure we don't overlap with previous goal on the same level (previous' previous)
-        if (previous[position].previous) {
-          const overlap = previous[position].previous.posX - pos.posX + pos.width;
-          if (overlap > 0) {
-            pos.opacity = 0.2;
-            pos.posX = pos.posX + overlap;
-          }
-        }
-
-        if (position === 'above' && pos.level === 1) {
-          pos.height = '60px';
-          state.styles.barContainer = { marginTop: '10rem' };
-        }
-      }
-      if (goal.animate && this.nodes.barContainer) {
-        const barLength = this.nodes.barContainer.offsetWidth;
-        const width = Math.ceil((goal.amount / this.maxAmount) * barLength);
-        pos.posX = width;
-      }
-      pos.slug = slug;
-      pos.previous = previous[position];
-      state.goals[slug] = pos;
-      previous[position] = pos;
-    });
-    return state;
+    return goals;
   }
 
-  renderGoal(goal, index, state) {
-    if (!goal.title) return;
-    const { collective } = this.props;
-    const posX = goal.animate ? 0 : `${Math.round((goal.amount / this.maxAmount) * 100)}%`;
-    const slug = goal.slug || `goal${index}`;
-    const zIndex = (20 - index) * 10;
-    const amount = formatCurrency(
-      goal.animate ? get(state, `goals.${slug}.amount`) || 0 : goal.amount,
-      collective.currency,
-      { precision: goal.precision || 0 },
-    );
-    const position = goal.position || 'above';
-    const level = get(state, `goals.${slug}.level`) || 0;
-    const style = {
-      width: get(state, `goals.${slug}.posX`) || posX,
-      opacity: get(state, `goals.${slug}.opacity`) || 1,
-      zIndex,
-    };
+  /**
+   * Get at most `maxCustomGoalsToShow` custom goals. If goals are filtered,
+   * we make sure to always return the last one to have a complete progress bar.
+   *
+   * Also adds a unique slug to goals.
+   */
+  getCustomGoals(maxCustomGoalsToShow) {
+    const settingsGoals = get(this.props.collective, 'settings.goals', []);
+    const goalsWithTitle = settingsGoals.reduce((goals, goal) => (goal.title ? [...goals, goal] : goals), []);
+    const sortedGoals = sortBy(goalsWithTitle, 'amount');
+    const goals = sortedGoals.map((goal, idx) => this.createGoal(`goal-${idx}-${slugify(goal.title)}`, goal));
 
-    if (position === 'below' && level === 1) {
-      style.paddingTop = '4rem';
-      style.height = '60px';
+    // No need to remove goals
+    if (goals.length <= maxCustomGoalsToShow) {
+      return goals;
+    }
+    // Filter goals, ensure we keep the last one
+    const lastGoal = goals[goals.length - 1];
+    if (!maxCustomGoalsToShow) {
+      return [lastGoal];
     }
 
+    return [...goals.slice(0, maxCustomGoalsToShow - 1), lastGoal];
+  }
+
+  /**
+   * If a ref exists for this goal, get its real with. Otherwise estimate
+   * it based on its title (for initial rendering and server-side rendering)
+   */
+  getGoalLabelWidthInPx(goal) {
+    const ref = this.labelsRefs[goal.slug];
+    if (ref && ref.current) {
+      return ref.current.offsetWidth + 15; // Add a bigger hit box
+    }
+    return goal.title.length * 8;
+  }
+
+  /** Given a percent size, returns its value in pixels */
+  percentageToPx(availWidth, percentage) {
+    const progressBarPercentageWidth = availWidth > 420 ? 0.8 : 0.95;
+    const progressBarWidthInPx = availWidth * progressBarPercentageWidth;
+    return percentage * progressBarWidthInPx;
+  }
+
+  /** Given a pixels size, returns its value as a percentage of availWidth */
+  pxToPercentage(availWidth, widthInPx) {
+    return widthInPx / availWidth;
+  }
+
+  /** Returns the overlap size if any, 0 otherwise */
+  goalsOverlapInPx(availWidth, maxAmount, prevGoal, goal) {
+    if (!prevGoal) {
+      return 0;
+    }
+
+    // No overlap is possible if not at the same position or level
+    if (goal.position !== prevGoal.position || goal.level !== prevGoal.level) {
+      return 0;
+    }
+
+    // Get position and distance between the markers
+    const prevX = this.percentageToPx(availWidth, this.getTranslatedPercentage(prevGoal.amount / maxAmount));
+    const curX = this.percentageToPx(availWidth, this.getTranslatedPercentage(goal.amount / maxAmount));
+    const prevWidth = this.getGoalLabelWidthInPx(prevGoal);
+    // If goal is at the far left of the graphic, label will be moved to the right
+    const xLabelOffset = prevX - prevWidth;
+    const distance = xLabelOffset < 0 ? curX - prevX + xLabelOffset : curX - prevX;
+
+    // Calculate overlap size
+    const curWidth = this.getGoalLabelWidthInPx(goal);
+    const offset = distance - curWidth;
+    return offset < 0 ? -offset : 0;
+  }
+
+  /**
+   * Test goals position against the first previous goal on the same position / level
+   *
+   * @returns {goal, overlap}
+   */
+  overlapWithPrev(availWidth, maxAmount, prevGoals, goal) {
+    for (let i = prevGoals.length - 1; i >= 0; i--) {
+      const prevGoal = prevGoals[i];
+      if (goal.position === prevGoal.position && goal.level === prevGoal.level) {
+        return {
+          prevGoal,
+          overlap: this.goalsOverlapInPx(availWidth, maxAmount, prevGoal, goal),
+        };
+      }
+    }
+    return { prevGoal: null, overlap: 0 };
+  }
+
+  /** @returns {Object} {goals, hasCustomGoals, maxAmount, maxLevelAbove} */
+  populateGoals(isServerSide, isInitialRender) {
+    // Show only one custom goal on mobile
+    let maxLevelAbove = 0;
+    let availWidth = 700;
+    let maxCustomGoalsToShow = 10;
+    if (isServerSide) {
+      maxCustomGoalsToShow = 0;
+    } else {
+      availWidth = get(window, 'screen.availWidth') || 400;
+      if (availWidth <= 400) maxCustomGoalsToShow = 1;
+      else if (availWidth < 800) maxCustomGoalsToShow = 2;
+      else if (availWidth < 1000) maxCustomGoalsToShow = 3;
+      else if (availWidth < 1200) maxCustomGoalsToShow = 4;
+    }
+
+    // Get all goals sorted by amount
+    const initialGoals = this.getInitialGoals();
+    const customGoals = this.getCustomGoals(maxCustomGoalsToShow);
+    const goals = sortBy([...initialGoals, ...customGoals], 'amount');
+    const maxAmount = maxBy(goals, g => g.amount).amount;
+    const maxAchievedYet = this.getMaxCurrentAchievement();
+
+    // Set goals positions
+    for (let i = 0; i < goals.length; i++) {
+      const isLastGoal = i === goals.length - 1;
+      const goal = goals[i];
+      goal.progress = this.getTranslatedPercentage(goal.amount / maxAmount);
+      goal.isReached = goal.isReached || maxAchievedYet > goal.amount;
+      goal.hidden = false;
+
+      const prevGoals = goals.slice(0, i);
+      const overlapWithPrev = goal => this.overlapWithPrev(availWidth, maxAmount, prevGoals, goal);
+      const { prevGoal, overlap } = overlapWithPrev(goal);
+
+      // -- Overlap 😱 --
+      if (overlap > 0) {
+        // 1st strategy: we change the level by 1
+        const newLevel = Number(!prevGoal.level);
+        if (overlapWithPrev({ ...goal, level: newLevel }).overlap === 0) {
+          goal.level = newLevel;
+          if (goal.position === 'above') {
+            maxLevelAbove = Math.max(maxLevelAbove, newLevel);
+          }
+        } else {
+          // 2nd strategy: we shift by given offset, and we change opacity
+          // - of the prev goal if this is last goal, of the current otherwise
+          // Will not shift at less than 0% or more than 100%
+          if (!isLastGoal) {
+            goal.isOverlapping = true;
+            const newProgress = goal.progress + this.pxToPercentage(availWidth, overlap);
+            goal.progress = newProgress <= 1 ? newProgress : 1;
+          } else {
+            prevGoal.isOverlapping = true;
+            const newProgress = prevGoal.progress - this.pxToPercentage(availWidth, overlap);
+            prevGoal.progress = newProgress >= 0 ? newProgress : 0;
+          }
+        }
+      }
+
+      // Change progress to animate goal. Never animate the last goal as it would
+      // result in a patial progress bar for first rendering. Hide when rendered
+      // on server side to avoid getting the marker stuck while waiting for
+      // re-hydrating
+      if (goal.animateProgress && !isLastGoal) {
+        if (isServerSide) goal.hidden = true;
+        if (isInitialRender) goal.progress = 0;
+      }
+    }
+
+    return { goals, maxAmount, maxLevelAbove, hasCustomGoals: customGoals.length > 0 };
+  }
+
+  renderGoal(goal, index) {
+    const { collective } = this.props;
+    const slug = goal.slug;
+    const amount = formatCurrency(goal.amount, collective.currency, { precision: goal.precision || 0 });
+
     return (
-      <div key={slug} className={`goal bar ${slug} ${position}`} style={style} ref={node => (this.nodes[slug] = node)}>
-        <style jsx>
-          {`
-            .bar {
-              height: 20px;
-              width: 100%;
-              position: absolute;
-              top: 0;
-              left: 0;
-              text-align: right;
-              transition: width 3s;
-            }
-
-            .bar.balance {
-              transition: width 2s;
-              width: 150px;
-              border-top: 4px solid #64c800;
-              border-right: 1px solid #64c800;
-            }
-
-            .bar.yearlyBudget {
-              border-top: 4px solid #3399ff;
-              border-right: 1px solid #3399ff;
-            }
-
-            .bar.goal.above {
-              border-bottom: 4px solid #3399ff;
-              border-right: 1px solid #3399ff;
-              top: auto;
-              bottom: 76px;
-            }
-
-            .caption {
-              padding: 1rem 0.5rem 1rem 0.5rem;
-              color: #aaaeb3;
-              font-size: 13px;
-              line-height: 15px;
-            }
-            .bar.goal.above .caption {
-              margin-top: -4.5rem;
-            }
-
-            .label {
-              background: #252729;
-              color: #aaaeb3;
-              padding: 0;
-              line-height: 1.5;
-              font-size: 13px;
-              text-align: right;
-            }
-
-            .amount {
-              background: #252729;
-              color: white;
-              font-weight: bold;
-            }
-
-            .interval {
-              color: #aaaeb3;
-              font-size: 10px;
-              font-weight: normal;
-            }
-          `}
-        </style>
+      <GoalContainer className={`goal ${goal.slug}`} key={slug} goal={goal} index={index}>
         <div className="caption">
-          <div className="label">{goal.title}</div>
+          <div className="label" ref={this.labelsRefs[goal.slug]}>
+            {goal.title}
+          </div>
           <div className="amount">
             {amount}
             {goal.type === 'yearlyBudget' && (
@@ -265,7 +444,7 @@ class GoalsCover extends React.Component {
             )}
           </div>
         </div>
-      </div>
+      </GoalContainer>
     );
   }
 
@@ -300,7 +479,11 @@ class GoalsCover extends React.Component {
             }
 
             .barContainer.withGoals {
-              margin-top: 9rem;
+              margin-top: 10rem;
+            }
+
+            .barContainer.max-level-above-1 {
+              margin-top: 15rem;
             }
 
             .annualBudget {
@@ -315,7 +498,7 @@ class GoalsCover extends React.Component {
             }
           `}
         </style>
-        <div className="">
+        <div>
           {get(collective, 'stats.backers.all') > 0 && (
             <div className="budgetText">
               <FormattedMessage
@@ -328,12 +511,15 @@ class GoalsCover extends React.Component {
             </div>
           )}
           <div
-            className={`barContainer ${this.hasCustomGoals ? 'withGoals' : ''}`}
-            style={get(this.state, 'styles.barContainer')}
-            ref={node => (this.nodes.barContainer = node)}
+            className={`barContainer max-level-above-${this.state.maxLevelAbove} ${
+              this.state.hasCustomGoals ? 'withGoals' : ''
+            }`}
           >
             <div className="bars">
-              {this.goals && this.goals.map((goal, index) => this.renderGoal(goal, index, this.state))}
+              {this.state.goals &&
+                this.state.goals.map((goal, index) => {
+                  return this.renderGoal(goal, index);
+                })}
             </div>
           </div>
         </div>

--- a/src/components/StyledKeyframes.js
+++ b/src/components/StyledKeyframes.js
@@ -1,0 +1,23 @@
+/**
+ * A set of styled-components keyframes animations
+ */
+
+import { keyframes } from 'styled-components';
+
+export const rotating = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+`;
+
+export const fadeIn = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`;

--- a/src/components/StyledSpinner.js
+++ b/src/components/StyledSpinner.js
@@ -1,19 +1,11 @@
 import PropTypes from 'prop-types';
 import { LoaderAlt } from 'styled-icons/boxicons-regular/LoaderAlt.cjs';
-import styled, { keyframes } from 'styled-components';
-
-const spin = keyframes`
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-`;
+import styled from 'styled-components';
+import { rotating } from './StyledKeyframes';
 
 /** A loading spinner using SVG + css animation. */
 const StyledSpinner = styled(LoaderAlt)`
-  animation: ${spin} 1s linear infinite;
+  animation: ${rotating} 1s linear infinite;
 `;
 
 StyledSpinner.defaultProps = {


### PR DESCRIPTION
This PR fixes the overlapping goals bug (https://github.com/opencollective/opencollective/issues/1434) that was mainly due to React 16 new `ref` system. I've refactored the code to deal with these changes in a clean way, and made a few opinionated enhancements. 

**Changes** describe these opinionated changes, while **fixes** describe the fixes.

# Changes

## 1. Logarithmic view

One of the thing that motivated me to work on this was a conversation I had a few weeks ago with someone who've made a lot of (successful) online fundraising campaigns for political causes. One of the thing he would really insist on was that it is tremendously important to never show an empty progress bar - people don't want to be the first ones to donate for a cause. According to him, the hardest part are the first 30%.

This is actually a well known [psychology principle](https://digitalpsychology.io/social-proof/) that pushes news websites to display fake numbers on their share buttons to incentive people to click. The guy I met would usually trick the platform he was using to fake the progress bar until 33% by making manual donations that he would later cancel. Well in our case we're certainly not going to cheat on the numbers, but what we can do is to use a logarithmic scale instead of a linear one.

Today, we display values according to the red line. What I'm proposing it to display them as the green one for the first **30%**.

![selection_941](https://user-images.githubusercontent.com/1556356/50376688-d25c0480-0610-11e9-96cb-c3b0f3ebebf0.png)

**TLDR ;** People are more inclined to engage in a action if others have done it too (social proof). We should enlarge the initial progress to make it look bigger. See details below for real-world examples.

<details>

All examples below show the difference as **new logarithmic version above, normal version below**. Again remember that this new scale **only** applies when global progress is lower than 30%.

**Manyverse**
![selection_946](https://user-images.githubusercontent.com/1556356/50377225-c7f23880-0619-11e9-992e-a521ca645b4b.png)

**TypeORM**
![selection_947](https://user-images.githubusercontent.com/1556356/50377533-308fe400-061f-11e9-9d37-84d7a51f119a.png)

**React Native Firebase**
![selection_948](https://user-images.githubusercontent.com/1556356/50377559-d17e9f00-061f-11e9-9eed-1b8e7b3306a0.png)

**Code for denver**
![selection_949](https://user-images.githubusercontent.com/1556356/50377563-e824f600-061f-11e9-8418-56fb89548fa0.png)

**Celery**
![selection_950](https://user-images.githubusercontent.com/1556356/50377576-0559c480-0620-11e9-8ce1-08b1640ac9f5.png)

**Riot JS**
![selection_951](https://user-images.githubusercontent.com/1556356/50377582-1e627580-0620-11e9-933c-1540cb68ee35.png)

</details>

## 2. Show estimated annual budget in green

This second change goes in the same direction, and address something that seemed unclear to me and to at least one person I've talked with about that.

As of today, we show this progress bar for Webpack:

![Webpack](https://user-images.githubusercontent.com/1556356/50376893-11d82000-0614-11e9-8c95-8a3aae24091b.png)

The information I get from a first look is that Webpack are far from reaching their goals, despite the fact that they already raise $384,000/year and have actually reached their first goal. I've changed this behaviour to show `Estimated annual budget` progress in green.

![Webpack - new](https://user-images.githubusercontent.com/1556356/50376997-e5250800-0615-11e9-8336-9a70989a0055.png)

## 3. Show completed goal markers in green

Before > After

![image](https://user-images.githubusercontent.com/1556356/50377034-62507d00-0616-11e9-906a-6df15fbd4f7c.png) ![image](https://user-images.githubusercontent.com/1556356/50377038-6c727b80-0616-11e9-9779-4c873008911d.png)

## 4. Responsiveness

A logic to show only one custom goal on mobile was already setup, I've extended it to show only:
- 1 on screen < 400
- 2 on screen < 800
- 3 on screen < 1000
- 4 on screen < 1200

![Resize preview](https://user-images.githubusercontent.com/1556356/50376835-8494cb80-0613-11e9-9839-cc0d6b3ce25e.gif)

# Fixes

- [x] Pre-render a basic progress bar without the goals on server-side rendering
- [x] Responsiveness
- [x] Fix overlapping
- [x] Watch window resize to update when view size change (ex: mobile phone rotated, or window resized)



