### PR TITLE
Fix expenses route conflict

### DIFF
--- a/src/components/EditCollectiveForm.js
+++ b/src/components/EditCollectiveForm.js
@@ -204,7 +204,15 @@ class EditCollectiveForm extends React.Component {
       // routes (like `/collective/edit/payment-methods`) but we keep this
       // legacy redirect for old emails sent with the old URL scheme
       // Deprecated on 2018-12-08
-      const legacySections = ['info', 'images', 'members', 'payment-methods', 'connected-accounts', 'advanced'];
+      const legacySections = [
+        'info',
+        'images',
+        'members',
+        'payment-methods',
+        'connected-accounts',
+        'advanced',
+        'expenses',
+      ];
       let section = hash.substr(1);
       if (section === 'connectedAccounts') section = 'connected-accounts';
       else if (section === 'paymentMethods') section = 'payment-methods';

--- a/src/components/Event.js
+++ b/src/components/Event.js
@@ -319,7 +319,7 @@ class Event extends React.Component {
                         LoggedInUser && LoggedInUser.canEditCollective(event)
                           ? {
                               label: intl.formatMessage(this.messages['event.tickets.edit']),
-                              href: `${event.path}/edit/tiers`,
+                              href: `${event.path}/edit#tiers`,
                             }
                           : null
                       }

--- a/src/server/pages.js
+++ b/src/server/pages.js
@@ -26,6 +26,7 @@ pages
   .add('banner-iframe', '/:collectiveSlug/banner.html')
   .add('event', '/:parentCollectiveSlug/events/:eventSlug')
   .add('editEvent', '/:parentCollectiveSlug/events/:eventSlug/edit')
+  .add('editCollective', '/:slug/edit/:section?')
   .add('events', '/:collectiveSlug/events')
   .add('subscriptions', '/:collectiveSlug/subscriptions')
   .add('orderCollectiveTier', '/:collectiveSlug/order/:TierId/:amount?/:interval?', 'createOrder')
@@ -77,7 +78,7 @@ pages.add('marketing', '/:pageSlug(become-a-sponsor|how-it-works|gift-of-giving|
 
 // Collective
 
-pages.add('collective', '/:slug').add('editCollective', '/:slug/edit/:section?');
+pages.add('collective', '/:slug');
 
 export default pages;
 


### PR DESCRIPTION
`/:parentCollective/:collective/expenses`
had a higher priority than
`/:collective/edit/expenses`

which could cause "not found" errors with frontend routing.