### PR TITLE
fix /faq/about that was returning 404

### DIFF
--- a/src/pages/static/faq/index.js
+++ b/src/pages/static/faq/index.js
@@ -1,11 +1,13 @@
 import backers from './backers.md';
 import becomingAnOpenCollectiveHost from './becoming-an-open-collective-host.md';
 import collectives from './collectives.md';
+import about from './about.md';
 import expenses from './expenses.md';
 import hosts from './hosts.md';
 import index from './index.md';
 
 export default {
+  about,
   backers,
   'becoming-an-open-collective-host': becomingAnOpenCollectiveHost,
   collectives,

--- a/src/server/pages.js
+++ b/src/server/pages.js
@@ -7,7 +7,7 @@ pages
   .add('about', '/:pageSlug(about|widgets|tos|privacypolicy)', 'staticPage')
   .add(
     'faq',
-    '/:path(faq)/:pageSlug(collectives|backers|expenses|hosts|becoming-an-open-collective-host)?',
+    '/:path(faq)/:pageSlug(about|collectives|backers|expenses|hosts|becoming-an-open-collective-host)?',
     'staticPage',
   )
   .add('redeem', '/redeem/:code?')


### PR DESCRIPTION
I introduced this bug myself when I moved things around in the FAQ (https://github.com/opencollective/opencollective-frontend/pull/1183) and created the new page `/faq/about` (and I forgot to create the route) 🤦🏻‍♂️