### PR TITLE
fix(MaterialSwitch): Properly set switch color

### DIFF
--- a/src/components/InputField.js
+++ b/src/components/InputField.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 import dynamic from 'next/dynamic';
 import { get } from 'lodash';
 import { Col, HelpBlock, FormGroup, InputGroup, FormControl, ControlLabel, Checkbox } from 'react-bootstrap';
-import Switch from '@material-ui/core/Switch';
 
 import InputTypeDropzone from './InputTypeDropzone';
 import InputTypeLocation from './InputTypeLocation';
 import InputTypeCreditCard from './InputTypeCreditCard';
+import InputSwitch from './InputSwitch';
 
 import { capitalize } from '../lib/utils';
 
@@ -465,7 +465,7 @@ class InputField extends React.Component {
                   </Col>
                 )}
                 <Col sm={10}>
-                  <Switch
+                  <InputSwitch
                     name={field.name}
                     defaultChecked={field.defaultValue}
                     onChange={event => this.handleChange(event.target.checked)}
@@ -478,7 +478,7 @@ class InputField extends React.Component {
               <div>
                 {field.label && <ControlLabel>{capitalize(field.label)}</ControlLabel>}
                 <div className="switch">
-                  <Switch
+                  <InputSwitch
                     name={field.name}
                     defaultChecked={field.defaultValue}
                     onChange={event => this.handleChange(event.target.checked)}
@@ -562,14 +562,6 @@ class InputField extends React.Component {
             .inputField .switch {
               display: flex;
               align-items: center;
-            }
-            .inputField span[class*='MuiSwitch-colorSecondary-'][class*='MuiSwitch-checked-'] {
-              color: #3385ff;
-            }
-            .inputField
-              span[class*='MuiSwitch-colorSecondary-'][class*='MuiSwitch-checked-']
-              + span[class*='MuiSwitch-bar-'] {
-              background-color: #3385ff !important;
             }
           `}
         </style>

--- a/src/components/InputSwitch.js
+++ b/src/components/InputSwitch.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { withStyles } from '@material-ui/core/styles';
+import Switch from '@material-ui/core/Switch';
+
+const styles = () => ({
+  colorSwitchBase: {
+    '&$colorChecked': {
+      color: '#3385ff',
+      '& + $colorBar': {
+        backgroundColor: '#3385ff',
+      },
+    },
+  },
+  colorBar: {},
+  colorChecked: {},
+});
+
+const InputSwitch = ({ classes, ...props }) => {
+  return (
+    <Switch
+      classes={{
+        switchBase: classes.colorSwitchBase,
+        checked: classes.colorChecked,
+        bar: classes.colorBar,
+      }}
+      {...props}
+    />
+  );
+};
+
+export default withStyles(styles)(InputSwitch);


### PR DESCRIPTION
![selection_970](https://user-images.githubusercontent.com/1556356/50512310-a669d480-0a91-11e9-9be8-8a89b38ea012.png) --> ![selection_971](https://user-images.githubusercontent.com/1556356/50512313-a79b0180-0a91-11e9-9c23-a602eda74e1d.png)

Material components cannot be simply styled with CSS as classes names will be different at build time ; we have to provide custom themes.