### PR TITLE
ContributeDetails component

### DIFF
--- a/src/components/ContributeDetails.js
+++ b/src/components/ContributeDetails.js
@@ -1,0 +1,126 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { compose, withHandlers, withState } from 'recompose';
+import moment from 'moment';
+import { pick } from 'lodash';
+import { FormattedMessage } from 'react-intl';
+
+import Container from './Container';
+import { Flex } from '@rebass/grid';
+import StyledButtonSet from './StyledButtonSet';
+import StyledInputField from './StyledInputField';
+import StyledInput from './StyledInput';
+import StyledSelect from './StyledSelect';
+import { P, Span } from './Text';
+import Currency from './Currency';
+
+const frequencyOptions = {
+  year: 'Yearly',
+  month: 'Monthly',
+};
+
+const enhance = compose(
+  withState('state', 'setState', ({ amountOptions, showFrequency }) => ({
+    amount: amountOptions[0] / 100,
+    totalAmount: amountOptions[0],
+    interval: showFrequency ? Object.keys(frequencyOptions)[0] : undefined,
+  })),
+  withHandlers({
+    onChange: ({ state, setState, onChange }) => newState => {
+      newState = { ...state, ...newState };
+      setState(newState);
+      onChange(pick(newState, ['totalAmount', 'interval']));
+    },
+  }),
+);
+
+const ContributeDetails = enhance(({ amountOptions, currency, showFrequency, onChange, state }) => (
+  <Container as="fieldset" border="none">
+    <Flex>
+      <StyledInputField
+        label={
+          <FormattedMessage
+            id="contribution.amount.currency.label"
+            values={{ currency }}
+            defaultMessage="Amount ({currency})"
+          />
+        }
+        htmlFor="totalAmount"
+      >
+        {fieldProps => (
+          <StyledButtonSet
+            {...fieldProps}
+            combo
+            items={amountOptions}
+            selected={state.totalAmount}
+            onChange={totalAmount => onChange({ totalAmount, amount: totalAmount / 100 })}
+          >
+            {({ item }) => <Currency value={item} currency={currency} />}
+          </StyledButtonSet>
+        )}
+      </StyledInputField>
+      <Container maxWidth={100}>
+        <StyledInputField
+          label={<FormattedMessage id="contribution.amount.other.label" defaultMessage="Other" />}
+          htmlFor="totalAmount"
+        >
+          {fieldProps => (
+            <StyledInput
+              type="number"
+              step="any"
+              {...fieldProps}
+              value={state.amount}
+              fontSize="Paragraph"
+              lineHeight="Paragraph"
+              width={1}
+              borderRadius="0 4px 4px 0"
+              ml="-1px"
+              onChange={({ target }) => onChange({ amount: target.value, totalAmount: Number(target.value) * 100 })}
+            />
+          )}
+        </StyledInputField>
+      </Container>
+    </Flex>
+    {showFrequency && (
+      <Flex mt={3} alignItems="flex-end" width={0.5}>
+        <StyledInputField
+          label={<FormattedMessage id="contribution.interval.label" defaultMessage="Frequency" />}
+          htmlFor="interval"
+        >
+          {fieldProps => (
+            <StyledSelect
+              {...fieldProps}
+              options={frequencyOptions}
+              defaultValue={frequencyOptions[state.interval]}
+              onChange={({ key }) => onChange({ interval: key })}
+            >
+              {({ value }) => <Container minWidth={100}>{value}</Container>}
+            </StyledSelect>
+          )}
+        </StyledInputField>
+        <P color="black.500" ml={3} pb={2}>
+          <FormattedMessage id="contribution.subscription.next.label" defaultMessage="Next contribution: " />
+          <Span color="primary.500">
+            {moment()
+              .add(1, state.interval)
+              .format('MMM d, YYYY')}
+          </Span>
+        </P>
+      </Flex>
+    )}
+  </Container>
+));
+
+ContributeDetails.propTypes = {
+  amountOptions: PropTypes.arrayOf(PropTypes.number).isRequired,
+  currency: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
+  showFrequency: PropTypes.bool,
+};
+
+ContributeDetails.defaultProps = {
+  onChange: () => {},
+  showFrequency: false,
+};
+
+export default ContributeDetails;

--- a/src/components/StyledButtonSet.js
+++ b/src/components/StyledButtonSet.js
@@ -7,6 +7,8 @@ import StyledButton from './StyledButton';
 
 const borderRadius = '4px';
 
+const comboStyle = ({ combo }) => (combo ? '0' : `0 ${borderRadius} ${borderRadius} 0`);
+
 const StyledButtonItem = styled(StyledButton)`
   border-radius: 0;
   &:active p {
@@ -27,14 +29,15 @@ const StyledButtonItem = styled(StyledButton)`
     margin-left: -1px;
   }
   &:last-child {
-    border-radius: 0 ${borderRadius} ${borderRadius} 0;
+    border-radius: ${comboStyle};
   }
 `;
 
-const StyledButtonSet = ({ size, items, children, selected, buttonProps, onChange, ...props }) => (
+const StyledButtonSet = ({ size, items, children, selected, buttonProps, onChange, combo, ...props }) => (
   <Flex {...props}>
     {items.map(item => (
       <StyledButtonItem
+        combo={combo}
         key={item}
         buttonSize={size}
         buttonStyle={item === selected ? 'primary' : 'standard'}
@@ -56,11 +59,14 @@ StyledButtonSet.propTypes = {
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   /** Currently selected item */
   selected: PropTypes.any,
-  /** An optionnal func called with the new item when option changes */
+  /** An optional func called with the new item when option changes */
   onChange: PropTypes.func,
+  /** Setting to style last item to look good in combination with a text input */
+  combo: PropTypes.bool,
 };
 
 StyledButtonSet.defaultProps = {
+  combo: false,
   size: 'medium',
 };
 

--- a/src/components/StyledInputField.js
+++ b/src/components/StyledInputField.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { P, Span } from './Text';
 
@@ -6,7 +6,7 @@ import { P, Span } from './Text';
  * Form field to display an input element with a label and errors. Uses [renderProps](https://reactjs.org/docs/render-props.html#using-props-other-than-render) to pass field props like 'name' and 'id' to child input.
  */
 const StyledInputField = ({ children, label, htmlFor, error, success, disabled }) => (
-  <Fragment>
+  <div>
     {label && (
       <P as="label" htmlFor={htmlFor} display="block" color="black.500" mb={1}>
         {label}
@@ -18,7 +18,7 @@ const StyledInputField = ({ children, label, htmlFor, error, success, disabled }
         {error}
       </Span>
     )}
-  </Fragment>
+  </div>
 );
 
 StyledInputField.propTypes = {

--- a/src/components/StyledInputField.js
+++ b/src/components/StyledInputField.js
@@ -31,7 +31,7 @@ StyledInputField.propTypes = {
   /** the label's 'for' attribute to be used as the 'name' and 'id' for the input */
   htmlFor: PropTypes.string,
   /** text to display above the input */
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   /** Show success state for field */
   success: PropTypes.bool,
 };

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -16,6 +16,7 @@ module.exports = {
   styleguideComponents: {
     Wrapper: path.join(__dirname, 'styleguide/ThemeWrapper'),
   },
+  title: 'Open Collective Frontend Style Guide',
   usageMode: 'expand',
   webpackConfig: createConfig([babel()]),
 };

--- a/styleguide/ThemeWrapper.js
+++ b/styleguide/ThemeWrapper.js
@@ -3,6 +3,7 @@ import { ThemeProvider } from 'styled-components';
 import theme from '../src/constants/theme';
 import AppGlobalStyles from '../src/pages/global-styles';
 import { createGlobalStyle } from 'styled-components';
+import { IntlProvider } from 'react-intl';
 
 const StyleguideGlobalStyles = createGlobalStyle`
   body {
@@ -16,7 +17,9 @@ export default class ThemeWrapper extends Component {
       <Fragment>
         <AppGlobalStyles />
         <StyleguideGlobalStyles />
-        <ThemeProvider theme={theme}>{this.props.children}</ThemeProvider>
+        <ThemeProvider theme={theme}>
+          <IntlProvider locale="en">{this.props.children}</IntlProvider>
+        </ThemeProvider>
       </Fragment>
     );
   }

--- a/styleguide/examples/ContributeDetails.md
+++ b/styleguide/examples/ContributeDetails.md
@@ -1,0 +1,11 @@
+```js
+amountOptions = [500, 1000, 2000, 5000, 10000];
+currency = 'USD';
+<ContributeDetails onChange={console.log} amountOptions={amountOptions} currency={currency} showFrequency />
+```
+
+```js
+amountOptions = [500, 1000, 2000, 5000, 10000];
+currency = 'USD';
+<ContributeDetails onChange={console.log} amountOptions={amountOptions} currency={currency} />
+```


### PR DESCRIPTION
Fixes opencollective/opencollective#1489

Includes:

- `IntlProvider` support in the ThemeWrapper for the styleguide
- `combo` prop for the `StyledButtonSet` to support using it in combination with a `StyledInput`
- `ContributeDetails` component

Live preview:

https://opencollective-styleguide-wlcfpfuvrx.now.sh/#!/ContributeDetails

Static preview:

![image](https://user-images.githubusercontent.com/3051193/50716524-f4fa0e80-104f-11e9-837f-22cbb04b64cc.png)
