### PR TITLE
fix(HostDashboard): Crash when adding funds

### DIFF
--- a/src/pages/host.dashboard.js
+++ b/src/pages/host.dashboard.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { withUser } from '../components/UserProvider';
 import HostDashboard from '../components/HostDashboard';
+import Loading from '../components/Loading';
 
 import withData from '../lib/withData';
 import withIntl from '../lib/withIntl';
-import withLoggedInUser from '../lib/withLoggedInUser';
 
 class HostExpensesPage extends React.Component {
   static getInitialProps({ query: { hostCollectiveSlug } }) {
@@ -19,26 +20,19 @@ class HostExpensesPage extends React.Component {
     getLoggedInUser: PropTypes.func.isRequired, // from withLoggedInUser
   };
 
-  constructor(props) {
-    super(props);
-    this.state = { selectedCollective: null };
-  }
-
-  async componentDidMount() {
-    const { getLoggedInUser } = this.props;
-    const LoggedInUser = await getLoggedInUser();
-    this.setState({ LoggedInUser });
-  }
-
   render() {
-    const { LoggedInUser } = this.state;
+    const { LoggedInUser, loadingLoggedInUser } = this.props;
 
     return (
       <div className="HostExpensesPage">
-        <HostDashboard hostCollectiveSlug={this.props.hostCollectiveSlug} LoggedInUser={LoggedInUser} />
+        {loadingLoggedInUser ? (
+          <Loading />
+        ) : (
+          <HostDashboard hostCollectiveSlug={this.props.hostCollectiveSlug} LoggedInUser={LoggedInUser} />
+        )}
       </div>
     );
   }
 }
 
-export default withData(withIntl(withLoggedInUser(HostExpensesPage)));
+export default withData(withIntl(withUser(HostExpensesPage)));


### PR DESCRIPTION
https://github.com/opencollective/opencollective-frontend/pull/1242 introduced a crash when trying to add funds from host dashboard.

**Why**
Query to get host data was triggered before LoggedInUser was loaded, and thus did not contain any payment method (not logged in users are not allowed to get that info).

**Fix**
The fix is just waiting for the loggedInUser to be loaded before displaying the host dashboard. It shows a loading spinner during the wait.