### PR TITLE
ContributeAs: create organization on next step

### DIFF
--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -79,7 +79,11 @@ const createCollectiveQuery = gql`
   mutation createCollective($collective: CollectiveInputType!) {
     createCollective(collective: $collective) {
       id
+      name
       slug
+      type
+      website
+      twitterHandle
     }
   }
 `;
@@ -314,6 +318,10 @@ export const addCreateCollectiveMutation = graphql(createCollectiveQuery, {
       return await mutate({ variables: { collective: CollectiveInputType } });
     },
   }),
+  options: {
+    refetchQueries: ['LoggedInUser'],
+    awaitRefetchQueries: true,
+  },
 });
 
 export const addEditCollectiveMutation = graphql(editCollectiveQuery, {


### PR DESCRIPTION
Fixes opencollective/opencollective#1615 
Fixes https://github.com/opencollective/opencollective/issues/1619
Fixes https://github.com/opencollective/opencollective/issues/1617

This PR adds the `createCollective` mutation to the new contribution flow page to allow creating a new organization after selecting "A new organization" from the `contributeAs` step. 

Error Feedback:
<img width="527" alt="screen shot 2019-01-09 at 2 18 40 pm" src="https://user-images.githubusercontent.com/3051193/50932477-bbe8e200-1433-11e9-9005-9389b52d499d.png">


TODO:

- [x] figure out how to actually refresh the `LoggedInUser`with the new organization (https://www.apollographql.com/docs/angular/features/cache-updates.html#directAccess)