### PR TITLE
Contribute Flow: fixes from testing notes

### DIFF
--- a/src/components/ContributeAs.js
+++ b/src/components/ContributeAs.js
@@ -9,6 +9,8 @@ import { Box, Flex } from '@rebass/grid';
 
 import { Search } from 'styled-icons/octicons/Search.cjs';
 
+import { escapeInput } from '../lib/utils';
+
 import Avatar from './Avatar';
 import Container from './Container';
 import Logo from './Logo';
@@ -25,6 +27,9 @@ const SearchIcon = styled(Search)`
 
 const ContributeAsEntryContainer = styled(Container)`
   cursor: pointer;
+  &:hover {
+    background: ${themeGet('colors.black.50')};
+  }
 `;
 
 const enhance = compose(
@@ -129,7 +134,7 @@ const ContributeAs = enhance(
     ...fieldProps
   }) => {
     if (state.search) {
-      const test = new RegExp(state.search, 'i');
+      const test = new RegExp(escapeInput(state.search), 'i');
       profiles = profiles.filter(profile => profile.name.match(test));
     }
 

--- a/src/components/StyledButtonSet.js
+++ b/src/components/StyledButtonSet.js
@@ -33,6 +33,10 @@ const StyledButtonItem = styled(StyledButton)`
   }
 `;
 
+StyledButtonItem.propTypes = {
+  combo: PropTypes.bool,
+};
+
 const StyledButtonSet = ({ size, items, children, selected, buttonProps, onChange, combo, ...props }) => (
   <Flex {...props}>
     {items.map(item => (

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -332,3 +332,7 @@ export const loadScriptAsync = (url, opts = {}) =>
       }
     });
   });
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Using_special_characters
+// From section about escapting user input
+export const escapeInput = string => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/src/pages/createOrderNewFlow.js
+++ b/src/pages/createOrderNewFlow.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { graphql, compose } from 'react-apollo';
@@ -10,7 +10,8 @@ import styled from 'styled-components';
 import { ErrorCircle } from 'styled-icons/boxicons-regular/ErrorCircle.cjs';
 
 import { Router } from '../server/pages';
-import { H2, P, Span } from '../components/Text';
+
+import { H2, H5, P, Span } from '../components/Text';
 import Logo from '../components/Logo';
 import ErrorPage from '../components/ErrorPage';
 import Page from '../components/Page';
@@ -105,12 +106,10 @@ class CreateOrderPage extends React.Component {
 
     const tier = this.getTier();
     const interval = (props.interval || '').toLowerCase().replace(/ly$/, '');
-    const amountOptions = (tier && tier.presets) || [500, 1000, 2000, 5000];
-    const defaultAmount = amountOptions[Math.floor(amountOptions.length / 2)];
     const initialDetails = {
       quantity: parseInt(props.quantity, 10) || 1,
       interval: ['month', 'year'].includes(interval) ? interval : null,
-      totalAmount: parseInt(props.totalAmount, 10) || defaultAmount,
+      totalAmount: parseInt(props.totalAmount, 10) || null,
     };
 
     this.state = {
@@ -364,7 +363,14 @@ class CreateOrderPage extends React.Component {
 
     if (step === 'contributeAs') {
       return (
-        <StyledInputField htmlFor="contributeAs" label="Contribute as:">
+        <StyledInputField
+          htmlFor="contributeAs"
+          label={
+            <H5 textAlign="left" mb={3}>
+              <FormattedMessage id="contribute.profile.label" defaultMessage="Contribute As:" />
+            </H5>
+          }
+        >
           {fieldProps => (
             <ContributeAs
               {...fieldProps}
@@ -378,17 +384,26 @@ class CreateOrderPage extends React.Component {
       );
     } else if (step === 'details') {
       return (
-        <ContributeDetails
-          amountOptions={amountOptions}
-          currency={(tier && tier.currency) || data.Collective.currency}
-          onChange={data => this.setState({ stepDetails: data })}
-          showFrequency={Boolean(TierId) || undefined}
-          interval={get(this.state, 'stepDetails.interval')}
-          totalAmount={get(this.state, 'stepDetails.totalAmount')}
-        />
+        <Fragment>
+          <H5 textAlign="left" mb={3}>
+            <FormattedMessage id="contribute.details.label" defaultMessage="Contribution Details:" />
+          </H5>
+          <ContributeDetails
+            amountOptions={amountOptions}
+            currency={(tier && tier.currency) || data.Collective.currency}
+            onChange={data => this.setState({ stepDetails: data })}
+            showFrequency={Boolean(TierId) || undefined}
+            interval={get(this.state, 'stepDetails.interval')}
+            totalAmount={get(this.state, 'stepDetails.totalAmount')}
+          />
+        </Fragment>
       );
     } else if (step === 'payment') {
       return (
+        <Fragment>
+          <H5 textAlign="left" mb={3}>
+            <FormattedMessage id="contribute.payment.label" defaultMessage="Choose a payment method:" />
+          </H5>
         <ContributePayment
           onChange={stepPayment => this.setState({ stepPayment })}
           paymentMethods={get(LoggedInUser, 'collective.paymentMethods', [])}
@@ -396,6 +411,7 @@ class CreateOrderPage extends React.Component {
           defaultValue={this.state.stepPayment}
           onNewCardFormReady={({ stripe }) => this.setState({ stripe })}
         />
+        </Fragment>
       );
     }
 
@@ -518,7 +534,7 @@ class CreateOrderPage extends React.Component {
     const step = this.props.step || 'contributeAs';
     return (
       <Flex flexDirection="column" alignItems="center" mx={3}>
-        <Box>{this.renderStep(step)}</Box>
+        <Box width={1}>{this.renderStep(step)}</Box>
         <Flex mt={5}>
           {this.renderPrevStepButton(step)}
           {this.renderNextStepButton(step)}

--- a/src/pages/createOrderNewFlow.js
+++ b/src/pages/createOrderNewFlow.js
@@ -403,13 +403,13 @@ class CreateOrderPage extends React.Component {
           <H5 textAlign="left" mb={3}>
             <FormattedMessage id="contribute.payment.label" defaultMessage="Choose a payment method:" />
           </H5>
-        <ContributePayment
-          onChange={stepPayment => this.setState({ stepPayment })}
-          paymentMethods={get(LoggedInUser, 'collective.paymentMethods', [])}
-          collective={this.state.stepProfile}
-          defaultValue={this.state.stepPayment}
-          onNewCardFormReady={({ stripe }) => this.setState({ stripe })}
-        />
+          <ContributePayment
+            onChange={stepPayment => this.setState({ stepPayment })}
+            paymentMethods={get(LoggedInUser, 'collective.paymentMethods', [])}
+            collective={this.state.stepProfile}
+            defaultValue={this.state.stepPayment}
+            onNewCardFormReady={({ stripe }) => this.setState({ stripe })}
+          />
         </Fragment>
       );
     }

--- a/src/pages/createOrderNewFlow.js
+++ b/src/pages/createOrderNewFlow.js
@@ -104,7 +104,6 @@ class CreateOrderPage extends React.Component {
     this.recaptcha = null;
     this.recaptchaToken = null;
 
-    const tier = this.getTier();
     const interval = (props.interval || '').toLowerCase().replace(/ly$/, '');
     const initialDetails = {
       quantity: parseInt(props.quantity, 10) || 1,


### PR DESCRIPTION
Includes fixes for:

- hover styles for `ContributeAs` radio items
- min value for `totalAmount` input
- full width for ContributeDetails component
- "next contribution" message on one-line
- ContributeDetails: default to monthly
- ContributeAs: escape reserved regex characters for searching
- adds labels above each step
- ContributeDetails: calls `onChange` with default values when component mounts

Notes:

**Don't populate custom amount by default**

The custom amount field value is bound to amount selected in state. So when an amount button is selected, the amount in the number field changes with it. I think this is helpful for controlling the state of the selected amount and showing people how to use the custom amount field as well. 

**Missing currency sign in amount field**

I've tried to implement this several ways, but nothing works without either breaking the number input or compromising UX by forcing the use of a plain `text` field and complicating the logic for keeping track of the changing value.

Preview:
<img width="687" alt="screen shot 2019-01-10 at 5 58 13 pm" src="https://user-images.githubusercontent.com/3051193/51002899-caea9580-1502-11e9-9a9d-8931c6b3ec28.png">
<img width="660" alt="screen shot 2019-01-10 at 5 34 33 pm" src="https://user-images.githubusercontent.com/3051193/51002900-caea9580-1502-11e9-9bca-556a4b41491d.png">
<img width="731" alt="screen shot 2019-01-10 at 5 34 00 pm" src="https://user-images.githubusercontent.com/3051193/51002901-caea9580-1502-11e9-99cd-a3780d85ded0.png">
