### PR TITLE
Contribution flow FAQ's

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,18 +77,12 @@ export default NewComponent;
 
 Check out the [React-Styleguidist docs](https://react-styleguidist.js.org/docs/documenting.html) for more details about documenting components with [JSDoc](http://usejsdoc.org/) annotations and writing interactive code examples.
 
-### Build for deployment
-
-```
-npm run styleguide:build
-```
-
 ### Deploy
 
 If you have access the Open Collective `now` team account:
 
 ```
-npx now styleguide && npx now alias -A styleguide/now.json
+npm run styleguide:deploy
 ```
 
 ## Tests

--- a/package.json
+++ b/package.json
@@ -130,7 +130,8 @@
     "prettier:check": "npm run prettier -- --list-different",
     "graphql:get-schema:dev": "npx graphql-cli get-schema -p opencollective -e dev",
     "styleguide:dev": "styleguidist server",
-    "styleguide:build": "styleguidist build"
+    "styleguide:build": "styleguidist build",
+    "styleguide:deploy": "npm run styleguide:build && npx now styleguide && npx now alias -A styleguide/now.json"
   },
   "devDependencies": {
     "@babel/cli": "7.0.0",

--- a/src/components/ContributeDetails.js
+++ b/src/components/ContributeDetails.js
@@ -47,8 +47,8 @@ const enhance = compose(
   }),
 );
 
-const ContributeDetails = enhance(({ amountOptions, currency, disabledInterval, onChange, state }) => (
-  <Container as="fieldset" border="none">
+const ContributeDetails = enhance(({ amountOptions, currency, disabledInterval, onChange, state, ...props }) => (
+  <Container as="fieldset" border="none" {...props}>
     <Flex>
       <StyledInputField
         label={
@@ -59,6 +59,7 @@ const ContributeDetails = enhance(({ amountOptions, currency, disabledInterval, 
           />
         }
         htmlFor="totalAmount"
+        css={{ flexGrow: 1 }}
       >
         {fieldProps => (
           <StyledButtonSet
@@ -72,7 +73,7 @@ const ContributeDetails = enhance(({ amountOptions, currency, disabledInterval, 
           </StyledButtonSet>
         )}
       </StyledInputField>
-      <Container maxWidth={100}>
+      <Container minWidth={90} maxWidth={100}>
         <StyledInputField
           label={<FormattedMessage id="contribution.amount.other.label" defaultMessage="Other" />}
           htmlFor="totalAmount"

--- a/src/components/CreateProfile.js
+++ b/src/components/CreateProfile.js
@@ -67,8 +67,18 @@ const enhance = compose(
  * Component for handling the creation of profiles, either personal or organizational
  */
 const CreateProfile = enhance(
-  ({ getFieldError, getFieldProps, onPersonalSubmit, onOrgSubmit, onSecondaryAction, state, setState, submitting }) => (
-    <StyledCard maxWidth={480} width={1}>
+  ({
+    getFieldError,
+    getFieldProps,
+    onPersonalSubmit,
+    onOrgSubmit,
+    onSecondaryAction,
+    state,
+    setState,
+    submitting,
+    ...props
+  }) => (
+    <StyledCard maxWidth={480} {...props}>
       <Flex>
         <Tab active={state.tab === 'personal'} setActive={() => setState({ ...state, tab: 'personal' })}>
           <FormattedMessage id="contribution.createPersoProfile" defaultMessage="Create Personal Profile" />
@@ -238,6 +248,8 @@ CreateProfile.propTypes = {
   onSecondaryAction: PropTypes.func.isRequired,
   /** Disable submit and show a spinner on button when set to true */
   submitting: PropTypes.bool,
+  /** All props from `StyledCard` */
+  ...StyledCard.propTypes,
 };
 
 CreateProfile.defaultProps = {

--- a/src/components/FAQ.js
+++ b/src/components/FAQ.js
@@ -1,0 +1,105 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { themeGet } from 'styled-system';
+import { Flex, Box } from '@rebass/grid';
+
+import { P } from './Text';
+
+/** A simple wrapper to group entries */
+const Container = styled(Box)``;
+
+/** Main entry container */
+const Entry = styled.details`
+  &[open] {
+    summary::after {
+      content: '−';
+    }
+  }
+
+  summary {
+    margin-top: ${themeGet('space.2')}px;
+    margin-bottom: ${themeGet('space.2')}px;
+    font-size: ${themeGet('fontSizes.Caption')}px;
+    font-weight: 500;
+    color: ${themeGet('colors.black.800')};
+    /* Remove arrow on Firefox */
+    list-style: none;
+
+    &:hover {
+      color: ${themeGet('colors.black.700')};
+    }
+  }
+
+  summary:focus {
+    outline: 1px dashed ${themeGet('colors.black.200')};
+    outline-offset: ${themeGet('space.1')}px;
+  }
+
+  summary::after {
+    content: '+';
+    display: inline-block;
+    padding-left: ${themeGet('space.2')}px;
+    color: ${themeGet('colors.black.500')};
+    font-weight: bold;
+  }
+
+  /* Remove arrow on Chrome */
+  summary::-webkit-details-marker {
+    display: none;
+  }
+`;
+
+/** Entry title */
+const Title = styled.summary``;
+
+/** Entry content (hidden by default) */
+const Content = styled(Box)``;
+Content.defaultProps = {
+  mb: 1,
+  fontSize: 'Caption',
+  color: 'black.500',
+};
+
+const Separator = styled.hr`
+  background: ${themeGet('colors.black.400')};
+  width: 100%;
+`;
+
+/**
+ * A small FAQ with expendable contents. You don't actually have
+ */
+export default class FAQ extends Component {
+  static propTypes = {
+    /**
+     * A render func that is given an object with the following entries:
+     *
+     * - `Container`: A simple container to group entries. Accept all `Box` properties.
+     * - `Entry`: Use this to wrap each individual FAQ entry
+     * - `Title`: A simple wrapper arround `summary`. Using a regular `summary` tag will have the same effect.
+     * - `Content`: The content, initially hidden.
+     * - `Separator`: A helper to add a full-width separator in the FAQ.
+     * */
+    children: PropTypes.func.isRequired,
+    /** The title to display above entries */
+    title: PropTypes.string,
+    /** All properties from `Flex` */
+    ...Flex.propTypes,
+  };
+
+  static defaultProps = {
+    title: "FAQ's",
+  };
+
+  render() {
+    const { title, children, ...props } = this.props;
+    return (
+      <Flex flexDirection="column" {...props}>
+        <P fontWeight="bold" mb={1}>
+          {title}
+        </P>
+        {children({ Container, Entry, Title, Content, Separator })}
+      </Flex>
+    );
+  }
+}

--- a/src/components/StyledButtonSet.js
+++ b/src/components/StyledButtonSet.js
@@ -11,6 +11,7 @@ const comboStyle = ({ combo }) => (combo ? '0' : `0 ${borderRadius} ${borderRadi
 
 const StyledButtonItem = styled(StyledButton)`
   border-radius: 0;
+  flex-grow: 1;
   &:active p {
     color: white;
   }

--- a/src/components/StyledInputField.js
+++ b/src/components/StyledInputField.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Box } from '@rebass/grid';
 import { P, Span } from './Text';
 
 /**
  * Form field to display an input element with a label and errors. Uses [renderProps](https://reactjs.org/docs/render-props.html#using-props-other-than-render) to pass field props like 'name' and 'id' to child input.
  */
-const StyledInputField = ({ children, label, htmlFor, error, success, disabled }) => (
-  <div>
+const StyledInputField = ({ children, label, htmlFor, error, success, disabled, ...props }) => (
+  <Box {...props}>
     {label && (
       <P as="label" htmlFor={htmlFor} display="block" color="black.500" mb={1}>
         {label}
@@ -18,7 +19,7 @@ const StyledInputField = ({ children, label, htmlFor, error, success, disabled }
         {error}
       </Span>
     )}
-  </div>
+  </Box>
 );
 
 StyledInputField.propTypes = {
@@ -34,6 +35,8 @@ StyledInputField.propTypes = {
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   /** Show success state for field */
   success: PropTypes.bool,
+  /** All props from `Box` */
+  ...Box.propTypes,
 };
 
 export default StyledInputField;

--- a/src/components/faqs/ContributeDetailsFAQ.js
+++ b/src/components/faqs/ContributeDetailsFAQ.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import FAQ from './FAQ';
+
+/**
+ * FAQ associated to the `ContributeDetails` component.
+ */
+const ContributeDetailsFAQ = props => (
+  <FAQ {...props}>
+    {({ Container, Entry, Title, Content }) => (
+      <Container>
+        <Entry>
+          <Title>
+            <FormattedMessage
+              id="ContributeDetails.faq.frequency.title"
+              defaultMessage="When will I be billed next time?"
+            />
+          </Title>
+          <Content>
+            <FormattedMessage
+              id="ContributeDetails.faq.frequency.content"
+              defaultMessage="Subscriptions are charged at the beginning of the chosen period, so monthly donations will be charged on the 1st of each month and yearly donations on the 1st of January."
+            />
+          </Content>
+        </Entry>
+      </Container>
+    )}
+  </FAQ>
+);
+
+export default ContributeDetailsFAQ;

--- a/src/components/faqs/CreateProfileFAQ.js
+++ b/src/components/faqs/CreateProfileFAQ.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import FAQ from './FAQ';
+
+/**
+ * FAQ associated to the `CreateProfile` component. Explains differences between
+ * account types (perso. vs org.) as well as anonymous contributions.
+ */
+const CreateProfileFAQ = props => (
+  <FAQ {...props}>
+    {({ Container, Entry, Title, Content }) => (
+      <Container>
+        <Entry>
+          <Title>
+            <FormattedMessage
+              id="createProfile.faq.persoVSOrg.title"
+              defaultMessage="Contributions: Personal vs Organization profile"
+            />
+          </Title>
+          <Content>
+            <FormattedMessage
+              id="createProfile.faq.persoVsOrg.content"
+              defaultMessage="Create an organization profile if you want to sponsor projects in the name of your company."
+            />
+          </Content>
+        </Entry>
+        <Entry>
+          <Title>
+            <FormattedMessage
+              id="createProfile.faq.anonymous.title"
+              defaultMessage="Looking to make an anonymous contribution?"
+            />
+          </Title>
+          <Content>
+            <FormattedMessage
+              id="createProfile.faq.anonymous.content"
+              defaultMessage="You can do so! However, in the effort of being transparent and compliant with KYC (Know Your Customer) regulations, anonymous contributions still require you to create an Open Collective account."
+            />
+          </Content>
+        </Entry>
+      </Container>
+    )}
+  </FAQ>
+);
+
+export default CreateProfileFAQ;

--- a/src/components/faqs/FAQ.js
+++ b/src/components/faqs/FAQ.js
@@ -1,13 +1,19 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { themeGet } from 'styled-system';
-import { Flex, Box } from '@rebass/grid';
+import { themeGet, display, minWidth } from 'styled-system';
+import { Box } from '@rebass/grid';
 
-import { P } from './Text';
+import { P } from '../Text';
+
+/** Main FAQ's container */
+const MainContainer = styled(Box)`
+  ${display};
+  ${minWidth};
+`;
 
 /** A simple wrapper to group entries */
-const Container = styled(Box)``;
+const EntryContainer = styled(Box)``;
 
 /** Main entry container */
 const Entry = styled.details`
@@ -83,8 +89,8 @@ export default class FAQ extends Component {
     children: PropTypes.func.isRequired,
     /** The title to display above entries */
     title: PropTypes.string,
-    /** All properties from `Flex` */
-    ...Flex.propTypes,
+    /** All properties from `Box` */
+    ...Box.propTypes,
   };
 
   static defaultProps = {
@@ -94,12 +100,12 @@ export default class FAQ extends Component {
   render() {
     const { title, children, ...props } = this.props;
     return (
-      <Flex flexDirection="column" {...props}>
+      <MainContainer {...props}>
         <P fontWeight="bold" mb={1}>
           {title}
         </P>
-        {children({ Container, Entry, Title, Content, Separator })}
-      </Flex>
+        {children({ Container: EntryContainer, Entry, Title, Content, Separator })}
+      </MainContainer>
     );
   }
 }

--- a/src/components/faqs/README.md
+++ b/src/components/faqs/README.md
@@ -1,0 +1,8 @@
+This folder is used to put all the small FAQ's made using the `FAQ` component.
+
+It has been made this way to:
+
+1. Centralize FAQ's, to make their edition easier.
+
+2. FAQs contains mostly text, and thus they're quite verbose. We don't want to
+   polute component's logic with this text.

--- a/src/pages/createOrderNewFlow.js
+++ b/src/pages/createOrderNewFlow.js
@@ -38,6 +38,7 @@ import StyledButton from '../components/StyledButton';
 import StepsProgress from '../components/StepsProgress';
 import StyledCard from '../components/StyledCard';
 import PayWithPaypalButton from '../components/PayWithPaypalButton';
+import CreateProfileFAQ from '../components/faqs/CreateProfileFAQ';
 import { fadeIn } from '../components/StyledKeyframes';
 
 const STEPS = ['contributeAs', 'details', 'payment'];
@@ -592,13 +593,17 @@ class CreateOrderPage extends React.Component {
           />
         </Flex>
       ) : (
-        <Flex justifyContent="center">
+        <Flex justifyContent="center" width="100%">
+          <Box width={[0, null, null, 1 / 6]} />
           <CreateProfile
             onPersonalSubmit={this.createProfile}
             onOrgSubmit={this.createProfile}
             onSecondaryAction={() => this.setState({ signIn: true })}
             submitting={submitting}
+            mx={4}
+            width={490}
           />
+          <CreateProfileFAQ mt={4} display={['none', null, 'block']} width={1 / 6} minWidth="335px" />
         </Flex>
       );
     }

--- a/src/pages/createOrderNewFlow.js
+++ b/src/pages/createOrderNewFlow.js
@@ -39,6 +39,8 @@ import StepsProgress from '../components/StepsProgress';
 import StyledCard from '../components/StyledCard';
 import PayWithPaypalButton from '../components/PayWithPaypalButton';
 import CreateProfileFAQ from '../components/faqs/CreateProfileFAQ';
+import ContributeDetailsFAQ from '../components/faqs/ContributeDetailsFAQ';
+import Container from '../components/Container';
 import { fadeIn } from '../components/StyledKeyframes';
 
 const STEPS = ['contributeAs', 'details', 'payment'];
@@ -447,20 +449,24 @@ class CreateOrderPage extends React.Component {
       );
     } else if (step === 'details') {
       return (
-        <Fragment>
-          <H5 textAlign="left" mb={3}>
-            <FormattedMessage id="contribute.details.label" defaultMessage="Contribution Details:" />
-          </H5>
-          <ContributeDetails
-            amountOptions={amountOptions}
-            currency={this.getCurrency()}
-            onChange={data => this.setState({ stepDetails: data })}
-            showFrequency={tierSlug ? true : false}
-            interval={get(this.state, 'stepDetails.interval') || get(tier, 'interval')}
-            totalAmount={get(this.state, 'stepDetails.totalAmount') || get(tier, 'amount')}
-            disabledInterval={Boolean(tier)}
-          />
-        </Fragment>
+        <Flex justifyContent="center" width={1}>
+          <Box width={[0, null, null, 1 / 5]} />
+          <Container mx={5} width={[0.95, null, 3 / 5]} maxWidth="465px">
+            <H5 textAlign="left" mb={3}>
+              <FormattedMessage id="contribute.details.label" defaultMessage="Contribution Details:" />
+            </H5>
+            <ContributeDetails
+              amountOptions={amountOptions}
+              currency={this.getCurrency()}
+              onChange={data => this.setState({ stepDetails: data })}
+              showFrequency={tierSlug ? true : false}
+              interval={get(this.state, 'stepDetails.interval') || get(tier, 'interval')}
+              totalAmount={get(this.state, 'stepDetails.totalAmount') || get(tier, 'amount')}
+              disabledInterval={Boolean(tier)}
+            />
+          </Container>
+          <ContributeDetailsFAQ mt={4} display={['none', null, 'block']} width={1 / 5} minWidth="335px" />
+        </Flex>
       );
     } else if (step === 'payment') {
       return (
@@ -610,8 +616,8 @@ class CreateOrderPage extends React.Component {
 
     const step = this.props.step || 'contributeAs';
     return (
-      <Flex flexDirection="column" alignItems="center" mx={3}>
-        <Box width={1}>{this.renderStep(step)}</Box>
+      <Flex flexDirection="column" alignItems="center" mx={3} width={1}>
+        {this.renderStep(step)}
         <Flex mt={4} justifyContent="center" flexWrap="wrap">
           {this.renderPrevStepButton(step)}
           {this.renderNextStepButton(step)}

--- a/styleguide/examples/FAQ.md
+++ b/styleguide/examples/FAQ.md
@@ -1,0 +1,29 @@
+```js
+<FAQ title="Just another FAQ" width="350px">
+  {({ Container, Entry, Title, Content, Separator }) => (
+    <Container>
+      <Entry>
+        <Title>Is it interactive?</Title>
+        <Content>Yes</Content>
+      </Entry>
+      <Entry>
+        <Title>And can we put anything we want in content?</Title>
+        <Content>
+          <img height="123" src="https://media.tenor.com/images/e5a23cc7dbfca75238635e689d562461/tenor.gif" alt="Gif" />
+        </Content>
+      </Entry>
+      <Entry>
+        <Title>And separators?</Title>
+        <Content>See the line below</Content>
+      </Entry>
+      <Separator />
+      <Entry>
+        <Title>
+          <span style={{ color: 'red' }}>And also custom title styles!</span>
+        </Title>
+        <Content>Indeed</Content>
+      </Entry>
+    </Container>
+  )}
+</FAQ>
+```


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/1628

# New Styled FAQ component

See it live: https://opencollective-styleguide.now.sh/#faq

![faq](https://user-images.githubusercontent.com/1556356/51141267-01008000-1849-11e9-9263-ea03150f7fd9.gif)

# Create profile

*Only displayed when screen width > 832px*

![localhost_3000_blockpotatoes_donate 3](https://user-images.githubusercontent.com/1556356/51174045-2926c800-18b7-11e9-9d92-007bf60f15da.png)

# Contribute details

*Only displayed when screen width > 832px*

![localhost_3000_blockpotatoes_donate_success_orderid 6410](https://user-images.githubusercontent.com/1556356/51174065-3774e400-18b7-11e9-90b7-f1f1c6fc8022.png)

# Styleguide deploy command

I've added a new `npm run styleguide:deploy` command to lean the deploy process. I've changed the README accordingly and removed the docs for `npm run styleguide:build` - I don't see why we would need to run it if not for deploying. Please correct me if I'm missing something.