### PR TITLE
ContributeDetails: Review how amount is handled

### DIFF
--- a/cypress/integration/12-contributionFlow.donate.test.js
+++ b/cypress/integration/12-contributionFlow.donate.test.js
@@ -25,10 +25,10 @@ describe('Contribution Flow: Donate', () => {
       cy.checkStepsProgress({ enabled: ['contributeAs', 'details'], disabled: 'payment' });
 
       // Has default amount selected
-      cy.get('fieldset .selected').should('exist');
+      cy.get('#totalAmount button.selected').should('exist');
 
       // Change amount
-      cy.get('fieldset input[type=number][name=totalAmount]').type('{selectall}1337');
+      cy.get('input[type=number][name=totalAmount]').type('{selectall}1337');
       cy.contains('.step-details', '$1,337.00');
 
       // Change frequency - monthly

--- a/cypress/integration/13-contributionFlow.order.test.js
+++ b/cypress/integration/13-contributionFlow.order.test.js
@@ -26,7 +26,7 @@ describe('Contribution Flow: Order', () => {
       // ---- Step 2: Contribute details ----
       cy.checkStepsProgress({ enabled: ['contributeAs', 'details'], disabled: 'payment' });
       // Has default amount selected
-      cy.get('fieldset .selected').should('exist');
+      cy.get('#totalAmount button.selected').should('exist');
 
       // Change amount
       cy.contains('button', '$500').click();

--- a/src/components/ContributeDetails.js
+++ b/src/components/ContributeDetails.js
@@ -3,15 +3,16 @@ import PropTypes from 'prop-types';
 import { compose, lifecycle, withHandlers, withState } from 'recompose';
 import moment from 'moment';
 import { FormattedMessage } from 'react-intl';
+import { get } from 'lodash';
 
 import Container from './Container';
 import { Flex } from '@rebass/grid';
 import StyledButtonSet from './StyledButtonSet';
 import StyledInputField from './StyledInputField';
-import StyledInput from './StyledInput';
 import StyledSelect from './StyledSelect';
 import { P, Span } from './Text';
 import Currency from './Currency';
+import StyledInputAmount from './StyledInputAmount';
 
 const frequencyOptions = {
   oneTime: 'One time',
@@ -25,12 +26,12 @@ const getChangeFromState = state => ({
 });
 
 const enhance = compose(
-  withState('state', 'setState', ({ amountOptions, totalAmount, interval }) => {
-    const defaultAmount = totalAmount || amountOptions[Math.floor(amountOptions.length / 2)];
+  withState('state', 'setState', ({ amountOptions, defaultAmount, defaultInterval }) => {
+    const totalAmount = defaultAmount || amountOptions[Math.floor(amountOptions.length / 2)];
     return {
-      amount: defaultAmount / 100,
-      totalAmount: defaultAmount,
-      interval: interval || Object.keys(frequencyOptions)[0],
+      totalAmount,
+      amount: totalAmount / 100,
+      interval: defaultInterval || Object.keys(frequencyOptions)[0],
     };
   }),
   lifecycle({
@@ -47,103 +48,132 @@ const enhance = compose(
   }),
 );
 
-const ContributeDetails = enhance(({ amountOptions, currency, disabledInterval, onChange, state, ...props }) => (
-  <Container as="fieldset" border="none" {...props}>
-    <Flex>
-      <StyledInputField
-        label={
-          <FormattedMessage
-            id="contribution.amount.currency.label"
-            values={{ currency }}
-            defaultMessage="Amount ({currency})"
-          />
-        }
-        htmlFor="totalAmount"
-        css={{ flexGrow: 1 }}
-      >
-        {fieldProps => (
-          <StyledButtonSet
-            {...fieldProps}
-            combo
-            items={amountOptions}
-            selected={state.totalAmount}
-            onChange={totalAmount => onChange({ totalAmount, amount: totalAmount / 100 })}
-          >
-            {({ item }) => <Currency value={item} currency={currency} />}
-          </StyledButtonSet>
-        )}
-      </StyledInputField>
-      <Container minWidth={90} maxWidth={100}>
+const ContributeDetails = enhance(
+  ({ amountOptions, currency, disabledInterval, disabledAmount, minAmount, onChange, state, ...props }) => {
+    const hasOptions = get(amountOptions, 'length', 0) > 0;
+    return (
+      <Flex width={1} flexDirection={hasOptions ? 'column' : 'row'} flexWrap="wrap" {...props}>
+        <Flex mb={3}>
+          {hasOptions && (
+            <StyledInputField
+              label={
+                <FormattedMessage
+                  id="contribution.amount.currency.label"
+                  values={{ currency }}
+                  defaultMessage="Amount ({currency})"
+                />
+              }
+              htmlFor="totalAmount"
+              css={{ flexGrow: 1 }}
+              disabled={disabledAmount}
+            >
+              {fieldProps => (
+                <StyledButtonSet
+                  {...fieldProps}
+                  combo
+                  items={amountOptions}
+                  selected={state.totalAmount}
+                  onChange={totalAmount => onChange({ totalAmount, amount: totalAmount / 100 })}
+                >
+                  {({ item }) => <Currency value={item} currency={currency} />}
+                </StyledButtonSet>
+              )}
+            </StyledInputField>
+          )}
+          <Container minWidth={100} maxWidth={120} mr={!hasOptions && 3}>
+            <StyledInputField
+              label={
+                hasOptions ? (
+                  <FormattedMessage id="contribution.amount.other.label" defaultMessage="Other" />
+                ) : (
+                  <FormattedMessage
+                    id="contribution.amount.currency.label"
+                    values={{ currency }}
+                    defaultMessage="Amount ({currency})"
+                  />
+                )
+              }
+              htmlFor="totalAmount"
+              disabled={disabledAmount}
+            >
+              {fieldProps => (
+                <StyledInputAmount
+                  type="number"
+                  currency={currency}
+                  min={minAmount / 100}
+                  {...fieldProps}
+                  value={state.amount}
+                  width={1}
+                  onChange={({ target }) => onChange({ amount: target.value, totalAmount: Number(target.value) * 100 })}
+                  containerProps={{ borderRadius: hasOptions ? '0 4px 4px 0' : 3, ml: '-1px' }}
+                  prependProps={{ pl: 2, pr: 0, bg: 'white.full', color: 'black.800' }}
+                  px="2px"
+                />
+              )}
+            </StyledInputField>
+          </Container>
+        </Flex>
+
         <StyledInputField
-          label={<FormattedMessage id="contribution.amount.other.label" defaultMessage="Other" />}
-          htmlFor="totalAmount"
+          label={<FormattedMessage id="contribution.interval.label" defaultMessage="Frequency" />}
+          htmlFor="interval"
+          disabled={disabledInterval}
         >
           {fieldProps => (
-            <StyledInput
-              type="number"
-              step="any"
-              min="0"
-              {...fieldProps}
-              value={state.amount}
-              fontSize="Paragraph"
-              lineHeight="Paragraph"
-              width={1}
-              borderRadius="0 4px 4px 0"
-              ml="-1px"
-              onChange={({ target }) => onChange({ amount: target.value, totalAmount: Number(target.value) * 100 })}
-            />
+            <Flex alignItems="center">
+              <StyledSelect
+                {...fieldProps}
+                options={frequencyOptions}
+                defaultValue={frequencyOptions[state.interval]}
+                onChange={({ key }) => onChange({ interval: key })}
+              >
+                {({ value }) => <Container minWidth={100}>{value}</Container>}
+              </StyledSelect>
+              {state.interval !== 'oneTime' && (
+                <P color="black.500" ml={3}>
+                  <FormattedMessage id="contribution.subscription.next.label" defaultMessage="Next contribution: " />
+                  <Span color="primary.500">
+                    {moment()
+                      .add(1, state.interval)
+                      .date(1)
+                      .format('MMM D, YYYY')}
+                  </Span>
+                </P>
+              )}
+            </Flex>
           )}
         </StyledInputField>
-      </Container>
-    </Flex>
-    <Flex mt={3} alignItems="flex-end" width={1}>
-      <StyledInputField
-        label={<FormattedMessage id="contribution.interval.label" defaultMessage="Frequency" />}
-        htmlFor="interval"
-        disabled={disabledInterval}
-      >
-        {fieldProps => (
-          <StyledSelect
-            {...fieldProps}
-            options={frequencyOptions}
-            defaultValue={frequencyOptions[state.interval]}
-            onChange={({ key }) => onChange({ interval: key })}
-          >
-            {({ value }) => <Container minWidth={100}>{value}</Container>}
-          </StyledSelect>
-        )}
-      </StyledInputField>
-      {state.interval !== 'oneTime' && (
-        <P color="black.500" ml={3} pb={2}>
-          <FormattedMessage id="contribution.subscription.next.label" defaultMessage="Next contribution: " />
-          <Span color="primary.500">
-            {moment()
-              .add(1, state.interval)
-              .date(1)
-              .format('MMM D, YYYY')}
-          </Span>
-        </P>
-      )}
-    </Flex>
-  </Container>
-));
+      </Flex>
+    );
+  },
+);
 
 ContributeDetails.propTypes = {
-  amountOptions: PropTypes.arrayOf(PropTypes.number).isRequired,
+  /**
+   * The list of amounts that user can pick directly. If not provided, only the
+   * custom input will be shown.
+   */
+  amountOptions: PropTypes.arrayOf(PropTypes.number),
   currency: PropTypes.string.isRequired,
   onChange: PropTypes.func,
-  /** Initial value for frequency select, defatuls to one time. */
-  interval: PropTypes.string,
   /** If true, the select for interval will be disabled */
   disabledInterval: PropTypes.bool,
-  /** initial value for amount Options, defaults to the first option */
-  totalAmount: PropTypes.number,
+  /** If true, the input for amount will be disabled */
+  disabledAmount: PropTypes.bool,
+  /** Initial value for frequency select, defaults to one time. */
+  defaultInterval: PropTypes.string,
+  /** initial value for amount options, defaults to the first option */
+  defaultAmount: PropTypes.number,
+  /** Min amount in cents */
+  minAmount: PropTypes.number,
 };
 
 ContributeDetails.defaultProps = {
   onChange: () => {},
   disabledInterval: false,
+  disabledAmount: false,
   interval: null,
+  minAmount: 100,
 };
 
 export default ContributeDetails;

--- a/src/components/StyledButtonSet.js
+++ b/src/components/StyledButtonSet.js
@@ -38,7 +38,7 @@ StyledButtonItem.propTypes = {
   combo: PropTypes.bool,
 };
 
-const StyledButtonSet = ({ size, items, children, selected, buttonProps, onChange, combo, ...props }) => (
+const StyledButtonSet = ({ size, items, children, selected, buttonProps, onChange, combo, disabled, ...props }) => (
   <Flex {...props}>
     {items.map(item => (
       <StyledButtonItem
@@ -48,6 +48,8 @@ const StyledButtonSet = ({ size, items, children, selected, buttonProps, onChang
         buttonStyle={item === selected ? 'primary' : 'standard'}
         onClick={onChange && (() => onChange(item))}
         className={item === selected ? 'selected' : undefined}
+        disabled={disabled}
+        type="button"
         {...buttonProps}
       >
         {children({ item, isSelected: item === selected })}
@@ -69,6 +71,8 @@ StyledButtonSet.propTypes = {
   onChange: PropTypes.func,
   /** Setting to style last item to look good in combination with a text input */
   combo: PropTypes.bool,
+  /** Disable user input */
+  disabled: PropTypes.bool,
 };
 
 StyledButtonSet.defaultProps = {

--- a/src/components/StyledInputGroup.js
+++ b/src/components/StyledInputGroup.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { themeGet } from 'styled-system';
 import { withState } from 'recompose';
+import { get } from 'lodash';
 
 import Container from './Container';
 import { Span } from './Text';
@@ -11,6 +12,16 @@ import StyledInput from './StyledInput';
 const InputContainer = styled(Container)`
   &:hover {
     border-color: ${themeGet('colors.primary.300')};
+  }
+
+  &:focus-within {
+    border-color: ${themeGet('colors.primary.500')};
+  }
+
+  input {
+    border: none;
+    outline: none;
+    box-shadow: none;
   }
 
   input:focus ~ div svg {
@@ -71,7 +82,19 @@ const getBorderColor = ({ error, focused, success }) => {
  * @see See [StyledInput](/#!/StyledInput) for details about props passed to it
  */
 const StyledInputGroup = withState('focused', 'setFocus', false)(
-  ({ append, prepend, focused, setFocus, disabled, success, error, maxWidth, ...inputProps }) => (
+  ({
+    append,
+    prepend,
+    focused,
+    setFocus,
+    disabled,
+    success,
+    error,
+    maxWidth,
+    containerProps,
+    prependProps,
+    ...inputProps
+  }) => (
     <React.Fragment>
       <InputContainer
         bg={disabled ? 'black.50' : 'white.full'}
@@ -81,12 +104,20 @@ const StyledInputGroup = withState('focused', 'setFocus', false)(
         borderRadius="4px"
         display="flex"
         alignItems="center"
+        {...containerProps}
       >
         {prepend && (
-          <Container bg={getBgColor({ error, focused, success })} borderRadius="4px 0 0 4px" py={2} px={3}>
-            <Span color={getColor({ error, focused, success })} fontSize="Paragraph">
-              {prepend}
-            </Span>
+          <Container
+            fontSize="Paragraph"
+            borderRadius="4px 0 0 4px"
+            py={2}
+            pl={2}
+            pr={2}
+            color={getColor({ error, focused, success })}
+            {...prependProps}
+            bg={(disabled && 'black.50') || get(prependProps, 'bg') || getBgColor({ error, focused, success })}
+          >
+            {prepend}
           </Container>
         )}
         <StyledInput
@@ -133,6 +164,10 @@ StyledInputGroup.propTypes = {
   success: PropTypes.bool,
   /** Passed to internal StyledInput */
   type: PropTypes.string,
+  /** Props passed to the `InputContainer` */
+  containerProps: PropTypes.object,
+  /** Props passed to the prepend `Container` */
+  prependProps: PropTypes.object,
 };
 
 export default StyledInputGroup;

--- a/styleguide/examples/ContributeDetails.md
+++ b/styleguide/examples/ContributeDetails.md
@@ -6,6 +6,33 @@ currency = 'USD';
 <ContributeDetails onChange={console.log} amountOptions={amountOptions} currency={currency} />;
 ```
 
+Set with initial value:
+
+```js
+amountOptions = [500, 1000, 2000, 5000, 10000];
+currency = 'USD';
+initialValue = {
+  defaultAmount: 10000,
+  defaultInterval: 'month',
+};
+<ContributeDetails onChange={console.log} amountOptions={amountOptions} currency={currency} {...initialValue} />;
+```
+
+Set with min amount (`$42`):
+
+```js
+amountOptions = [5000, 10000, 50000, 75000];
+currency = 'USD';
+<ContributeDetails onChange={console.log} amountOptions={amountOptions} currency={currency} minAmount={4200} />;
+```
+
+Without presets:
+
+```js
+currency = 'USD';
+<ContributeDetails onChange={console.log} currency={currency} defaultAmount={500} />;
+```
+
 Disabled interval:
 
 ```js
@@ -14,20 +41,9 @@ currency = 'USD';
 <ContributeDetails onChange={console.log} amountOptions={amountOptions} currency={currency} disabledInterval />;
 ```
 
-Set with initial value:
+Force value (disabledAmount):
 
 ```js
-amountOptions = [500, 1000, 2000, 5000, 10000];
 currency = 'USD';
-initialValue = {
-  totalAmount: 2000,
-  interval: 'month',
-};
-<ContributeDetails
-  onChange={console.log}
-  amountOptions={amountOptions}
-  currency={currency}
-  showFrequency
-  {...initialValue}
-/>;
+<ContributeDetails onChange={console.log} currency={currency} defaultAmount={500} disabledInterval disabledAmount />;
 ```


### PR DESCRIPTION
# Tiers amount behaviour

**Implements the behaviour specified in https://github.com/opencollective/opencollective/issues/1637** and fix https://github.com/opencollective/opencollective/issues/1636.

:warning: :art: For now inputs are only disabled but we need to come up with better design as the view looks really unbalanced and a lot of space is lost. Ping @cuiki 

## 1. If amount is set and there's no preset, force amount

![rule-1](https://user-images.githubusercontent.com/1556356/51328203-1f49c400-1a73-11e9-8efc-2462288c4944.gif)

## 2. If amount is not set and there's presets, then the input value should be greater than the amount of the minimum preset

![rule-2](https://user-images.githubusercontent.com/1556356/51329685-52418700-1a76-11e9-9ade-7281e25815c7.gif)

## 3. If amount and presets are set, then the input value should be the greater than the amount of the minimum preset, or greater than tier's default amount if it's lower than all the presets.

*Same behaviour as previous image*

# Add currency sign in amount input

Resolve https://github.com/opencollective/opencollective/issues/1641

![currencysign](https://user-images.githubusercontent.com/1556356/51328716-4785f280-1a74-11e9-8895-252ec0e78d23.gif)

## Don't allow negative amounts

Fix https://github.com/opencollective/opencollective/issues/1629

![positivevalue](https://user-images.githubusercontent.com/1556356/51329463-d6473f00-1a75-11e9-83c8-b92efe48a810.gif)
