### PR TITLE
Display only active distinct orders in Collective Tiers

### DIFF
--- a/src/components/TierCard.js
+++ b/src/components/TierCard.js
@@ -109,7 +109,7 @@ class TierCard extends React.Component {
     const { collective, tier, referral, intl } = this.props;
     const amount = tier.presets ? Math.min(tier.presets[0], tier.amount) : tier.amount;
     const disabled = (amount > 0 && !collective.isActive) || tier.stats.availableQuantity === 0;
-    const totalOrders = tier.stats.totalOrders;
+    const totalActiveDistinctOrders = tier.stats.totalActiveDistinctOrders;
     let errorMsg;
     if (!collective.host) {
       errorMsg = 'hostMissing';
@@ -306,16 +306,16 @@ class TierCard extends React.Component {
             </p>
           )}
         </div>
-        {tier.stats.totalOrders > 0 && (
+        {totalActiveDistinctOrders > 0 && (
           <div>
             <div className="divider" />
             <div className="footer">
               <div className="lastOrders">
-                {totalOrders > 0 && (
+                {totalActiveDistinctOrders > 0 && (
                   <div className="totalOrders">
-                    {totalOrders}{' '}
+                    {totalActiveDistinctOrders}{' '}
                     {intl.formatMessage(this.messages['contribution'], {
-                      n: totalOrders,
+                      n: totalActiveDistinctOrders,
                     })}
                   </div>
                 )}

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -370,9 +370,10 @@ const getCollectiveQuery = gql`
         stats {
           id
           totalOrders
+          totalActiveDistinctOrders
           availableQuantity
         }
-        orders(limit: 30) {
+        orders(limit: 30, isActive: true) {
           fromCollective {
             id
             slug

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:3000/api/graphql
-# timestamp: Thu Dec 20 2018 14:43:37 GMT+0100 (Central European Standard Time)
+# timestamp: Fri Jan 18 2019 12:03:41 GMT+0100 (Central European Standard Time)
 
 """Application model"""
 type Application {
@@ -1518,6 +1518,9 @@ type TierStatsType {
 
   """total number of people/organizations in this tier"""
   totalDistinctOrders: Int
+
+  """total number of active people/organizations in this tier"""
+  totalActiveDistinctOrders: Int
   availableQuantity: Int
 }
 


### PR DESCRIPTION
Related API PR: https://github.com/opencollective/opencollective-api/pull/1676

In the Tier sidebar, we would like to only display the active members for Tiers that are a subscription.

The displayed total should also be consistent with that.