### PR TITLE
Typo: Add missing OR in 'Accept one time recurring donations'

### DIFF
--- a/src/static/how-it-works-page/index.html
+++ b/src/static/how-it-works-page/index.html
@@ -48,7 +48,7 @@
           <h1 class='h600 pb2'>Create different tiers.</h1>
         </header>
         <ul class='styled-list'>
-          <li>Accept one time recurring donations.</li>
+          <li>Accept one time or recurring donations.</li>
           <li>Define different tiers for members of sponsors.</li>
         </ul>
       </div>


### PR DESCRIPTION
I believe the proper message here is "Accept one time OR recurring donations."

Before:
![image](https://user-images.githubusercontent.com/11527560/51395795-b1051000-1b0b-11e9-839d-73a19ef83d96.png)
After:
![image](https://user-images.githubusercontent.com/11527560/51395820-bf532c00-1b0b-11e9-9e9a-a324d3a3ad7d.png)
