### PR TITLE
DesignSystem: Implement message boxes

### DIFF
--- a/src/components/MessageBox.js
+++ b/src/components/MessageBox.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import * as styledSystem from 'styled-system';
+import { Box } from '@rebass/grid';
+
+import { InfoCircle } from 'styled-icons/fa-solid/InfoCircle.cjs';
+import { CheckCircle } from 'styled-icons/fa-solid/CheckCircle.cjs';
+import { ExclamationCircle } from 'styled-icons/fa-solid/ExclamationCircle.cjs';
+import { ExclamationTriangle } from 'styled-icons/fa-solid/ExclamationTriangle.cjs';
+
+import { messageType } from '../constants/theme';
+import StyledCard from './StyledCard';
+
+const Message = styled(Box)`
+  border: 1px solid;
+  border-radius: 8px;
+  padding: ${styledSystem.themeGet('space.3')}px;
+
+  ${styledSystem.display}
+  ${styledSystem.height}
+  ${styledSystem.maxHeight}
+  ${styledSystem.maxWidth}
+  ${styledSystem.minHeight}
+  ${styledSystem.minWidth}
+
+  ${messageType}
+`;
+
+const icons = {
+  info: <InfoCircle size="1em" />,
+  success: <CheckCircle size="1em" />,
+  warning: <ExclamationTriangle size="1em" />,
+  error: <ExclamationCircle size="1em" />,
+};
+
+/**
+ * Display messages in a box contextualized for message type (error, success...etc)
+ */
+const MessageBox = ({ withIcon, children, ...props }) => {
+  const icon = withIcon && icons[props.type];
+  return (
+    <Message {...props}>
+      {icon && (
+        <Box mr={2} css={{ display: 'inline-block' }}>
+          {icon}
+        </Box>
+      )}
+      {children}
+    </Message>
+  );
+};
+
+MessageBox.propTypes = {
+  /** Type of the message */
+  type: PropTypes.oneOf(['white', 'dark', 'info', 'success', 'warning', 'error']),
+  /** Weither icon should be hidden. Icons are only set for info, success, warning and error messages. */
+  withIcon: PropTypes.bool,
+  /** Message */
+  children: PropTypes.node,
+  /** All props from `StyledCard` */
+  ...StyledCard.propTypes,
+};
+
+MessageBox.defaultProps = {
+  type: 'white',
+  withIcon: false,
+};
+
+export default MessageBox;

--- a/src/constants/theme.js
+++ b/src/constants/theme.js
@@ -1,4 +1,5 @@
 import { variant } from 'styled-system';
+import { transparentize } from 'polished';
 
 export const colors = {
   black: {
@@ -168,6 +169,37 @@ const theme = {
       paddingTop: toPx(space[1]),
     },
   },
+  messageTypes: {
+    white: {
+      backgroundColor: colors.white.full,
+      borderColor: colors.black[200],
+    },
+    dark: {
+      backgroundColor: transparentize(0.2, colors.black[900]),
+      borderColor: colors.black[900],
+      color: colors.white.full,
+    },
+    info: {
+      backgroundColor: colors.primary[50],
+      borderColor: colors.primary[500],
+      color: colors.primary[700],
+    },
+    success: {
+      backgroundColor: colors.green[100],
+      borderColor: colors.green[500],
+      color: colors.green[700],
+    },
+    warning: {
+      backgroundColor: colors.yellow[100],
+      borderColor: colors.yellow[700],
+      color: colors.yellow[700],
+    },
+    error: {
+      backgroundColor: colors.red[100],
+      borderColor: colors.red[500],
+      color: colors.red[700],
+    },
+  },
 };
 
 export const buttonStyle = variant({
@@ -178,6 +210,11 @@ export const buttonStyle = variant({
 export const buttonSize = variant({
   key: 'buttonSizes',
   prop: 'buttonSize',
+});
+
+export const messageType = variant({
+  key: 'messageTypes',
+  prop: 'type',
 });
 
 export default theme;

--- a/styleguide/examples/MessageBox.md
+++ b/styleguide/examples/MessageBox.md
@@ -1,0 +1,43 @@
+### Base types
+
+```js
+<MessageBox>Default (white)</MessageBox>
+<br/>
+<MessageBox type="dark">Default (dark)</MessageBox>
+<br/>
+<MessageBox type="info">Info</MessageBox>
+<br/>
+<MessageBox type="success">Success</MessageBox>
+<br/>
+<MessageBox type="warning">Warning</MessageBox>
+<br/>
+<MessageBox type="error">Error</MessageBox>
+```
+
+### Examples with Lorem Ipsum
+
+```js
+<MessageBox>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</MessageBox>
+<br/>
+<MessageBox type="dark">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</MessageBox>
+<br/>
+<MessageBox type="info">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</MessageBox>
+<br/>
+<MessageBox type="success">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</MessageBox>
+<br/>
+<MessageBox type="warning">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</MessageBox>
+<br/>
+<MessageBox type="error">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</MessageBox>
+```
+
+### With icons
+
+```js
+<MessageBox withIcon type="info">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</MessageBox>
+<br/>
+<MessageBox withIcon type="success">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</MessageBox>
+<br/>
+<MessageBox withIcon type="warning">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</MessageBox>
+<br/>
+<MessageBox withIcon type="error">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</MessageBox>
+```


### PR DESCRIPTION
Implement message boxes to display errors, warnings, infos... using the theme from https://www.figma.com/file/N4Xbl652BhzOutXmzhcrLGch/01.-Atoms?node-id=14%3A0

Try it live: https://deploy-preview-1318--oc-styleguide.netlify.com/#!/MessageBox

The goal is to centralize this as early as possible for future components to have coherency between pages and to avoid re-inventing the wheel every time we need to display an error.

![selection_999 034](https://user-images.githubusercontent.com/1556356/51402901-10d0da80-1b4f-11e9-8022-ca4558d04a0d.png)

