### PR TITLE
ContributionFlow: Add tier ID in URL

### DIFF
--- a/cypress/integration/13-contributionFlow.order.test.js
+++ b/cypress/integration/13-contributionFlow.order.test.js
@@ -11,7 +11,7 @@ describe('Contribution Flow: Order', () => {
 
     const userParams = { firstName: 'Order', lastName: 'Tester' };
     const visitParams = { onBeforeLoad: mockRecaptcha };
-    cy.signup({ user: userParams, redirect: '/apex/contribute/tier/sponsors', visitParams }).then(user => {
+    cy.signup({ user: userParams, redirect: '/apex/contribute/tier/470-sponsors', visitParams }).then(user => {
       // ---- Step 1: Select profile ----
       // Personnal account must be the first entry, and it must be checked
       cy.contains('#contributeAs > label:first', `${user.firstName} ${user.lastName}`);

--- a/src/components/TierCard.js
+++ b/src/components/TierCard.js
@@ -132,13 +132,13 @@ class TierCard extends React.Component {
     if (parseToBoolean(getEnvVar('USE_NEW_CREATE_ORDER'))) {
       linkRoute = {
         name: 'orderCollectiveTierNew',
-        params: { collectiveSlug: collective.slug, tierSlug: tier.slug, verb: 'contribute' },
+        params: { collectiveSlug: collective.slug, tierId: tier.id, tierSlug: tier.slug, verb: 'contribute' },
         anchor: '#content',
       };
     } else {
       linkRoute = {
         name: 'orderCollectiveTier',
-        params: { collectiveSlug: collective.slug, TierId: tier.id },
+        params: { collectiveSlug: collective.slug, tierId: tier.id },
         anchor: '#content',
       };
     }

--- a/src/pages/createOrderNewFlow.js
+++ b/src/pages/createOrderNewFlow.js
@@ -73,6 +73,7 @@ class CreateOrderPage extends React.Component {
     query: {
       collectiveSlug,
       eventSlug,
+      tierId,
       tierSlug,
       amount,
       quantity,
@@ -87,6 +88,7 @@ class CreateOrderPage extends React.Component {
   }) {
     return {
       slug: eventSlug || collectiveSlug,
+      tierId,
       tierSlug,
       quantity,
       totalAmount: totalAmount || amount * 100,
@@ -326,9 +328,9 @@ class CreateOrderPage extends React.Component {
 
   /** Return the currently selected tier, or a falsy value if none selected */
   getTier() {
-    const { data, tierSlug } = this.props;
-    if (tierSlug) {
-      return get(data, 'Collective.tiers', []).find(t => t.slug == tierSlug);
+    const { data, tierId } = this.props;
+    if (tierId) {
+      return get(data, 'Collective.tiers', []).find(t => t.id == tierId);
     }
   }
 
@@ -480,7 +482,7 @@ class CreateOrderPage extends React.Component {
   }
 
   renderStep(step) {
-    const { LoggedInUser, tierSlug } = this.props;
+    const { LoggedInUser, tierId } = this.props;
     const [personal, profiles] = this.getProfiles();
     const tier = this.getTier();
 
@@ -517,7 +519,7 @@ class CreateOrderPage extends React.Component {
               amountOptions={this.getAmountsPresets()}
               currency={this.getCurrency()}
               onChange={this.updateDetails}
-              showFrequency={tierSlug ? true : false}
+              showFrequency={Boolean(tierId)}
               defaultInterval={get(this.state, 'stepDetails.interval') || get(tier, 'interval')}
               defaultAmount={get(this.state, 'stepDetails.totalAmount') || get(tier, 'amount')}
               disabledInterval={Boolean(tier)}
@@ -585,13 +587,13 @@ class CreateOrderPage extends React.Component {
     }
 
     let route;
-    if (this.props.tierSlug) {
+    if (this.props.tierId) {
       route = `orderCollectiveTierNew${routeSuffix}`;
     } else {
       route = `orderCollectiveNew${routeSuffix}`;
     }
 
-    await Router.pushRoute(route, { ...params, ...pick(this.props, ['verb', 'tierSlug']) });
+    await Router.pushRoute(route, { ...params, ...pick(this.props, ['verb', 'tierId', 'tierSlug']) });
     window.scrollTo(0, 0);
   };
 

--- a/src/server/pages.js
+++ b/src/server/pages.js
@@ -80,13 +80,13 @@ pages
   )
   .add(
     'orderCollectiveTierNew',
-    '/:collectiveSlug/:verb(donate|pay|contribute)/tier/:tierSlug/:step(contributeAs|details|payment)?',
+    '/:collectiveSlug/:verb(donate|pay|contribute)/tier/:tierId-:tierSlug?/:step(contributeAs|details|payment)?',
     'createOrderNewFlow',
   )
   .add('orderCollectiveNewSuccess', '/:collectiveSlug/:verb(donate|pay|contribute)/success', 'orderSuccess')
   .add(
     'orderCollectiveTierNewSuccess',
-    '/:collectiveSlug/:verb(donate|pay|contribute)/tier/:tierSlug/success',
+    '/:collectiveSlug/:verb(donate|pay|contribute)/tier/:tierId-:tierSlug?/success',
     'orderSuccess',
   );
 


### PR DESCRIPTION
Adds Tier ID in URL, so that new URLs take this form:

```
/:collectiveSlug/:verb(donate|pay|contribute)/tier/:TierId-:tierSlug?/:step
```

Tier slug is passed when building URLs to make them prettier but it has no effect on the route.

# Examples of valid URLs

> http://localhost:3000/collective/contribute/tier/42-sponsor
> http://localhost:3000/collective/contribute/tier/99-sponsor-gold/success
> http://localhost:3000/collective/contribute/tier/99-anySlugHereWillDoTheJob

# Motivations

We would have love to skip having the ID in the URL but a lot of tiers doesn't have a unique slug. We don't want to migrate them because some collectives rely on this to get all backers pictures with a common slug.

For example, you could have 3 "Sponsor" tiers with the same slug but different amounts. To show them all with the widget, we just need to pass `slug=sponsor`.