### PR TITLE
Add new SignInOrJoinFree component on /signIn

### DIFF
--- a/cypress/integration/07-signin.test.js
+++ b/cypress/integration/07-signin.test.js
@@ -1,25 +1,77 @@
-const randomNumber = Math.round(Math.random() * 100000);
+import { randomEmail } from '../support/faker';
 
 describe('signin', () => {
-  it('signin', () => {
+  it('redirects directly when using a dev test account', () => {
     cy.visit('/signin?next=/testuseradmin');
-    cy.fillInputField('email', 'testuser+admin@opencollective.com');
-    cy.get('.LoginForm button').click();
-    cy.get('.LoginTopBarProfileButton-name').contains('testuseradmin', {
-      timeout: 15000,
-    });
+    cy.get('input[name=email]').type('testuser+admin@opencollective.com');
+    cy.get('button[type=submit]').click();
+    cy.get('.LoginTopBarProfileButton-name').contains('testuseradmin', { timeout: 15000 });
   });
 
-  it('signup', () => {
-    cy.visit('/signin?next=/testuseradmin');
-    cy.fillInputField('email', `newuser+${randomNumber}@opencollective.com`);
-    cy.get('.LoginForm button').click();
-    cy.fillInputField('firstName', 'Xavier');
-    cy.fillInputField('lastName', 'Damman');
-    cy.fillInputField('website', 'http://xdamman.com');
-    cy.fillInputField('twitterHandle', 'xdamman');
-    cy.fillInputField('description', 'just me :)');
-    cy.get('button.signup').click();
-    cy.get('.signupSuccessful').contains('success');
+  it('shows an error when token gets rejected', () => {
+    cy.visit('/signin?token=InvalidToken');
+    cy.contains('Sign In failed: Invalid token.');
+    cy.contains('You can ask for a new sign in link using the form below.');
+    cy.contains('Sign in using your email address:');
+    cy.get('input[name=email]').should('exist');
+  });
+
+  it("doesn't go into redirect loop if given own address in redirect", () => {
+    cy.visit('/signin?next=/signin');
+    cy.get('input[name=email]').type('testuser+admin@opencollective.com');
+    cy.get('button[type=submit]').click();
+    cy.url().should('eq', `${Cypress.config().baseUrl}/`);
+  });
+
+  it('can signup as regular user', () => {
+    cy.visit('/signin');
+
+    // Go to CreateProfile
+    cy.contains('button', 'Join Free').click();
+
+    // Test frontend validations
+    cy.get('input[name=email]').type('Incorrect value');
+    cy.get('button[type=submit]').click();
+    cy.contains("Please include an '@' in the email address. 'Incorrectvalue' is missing an '@'.");
+
+    // Test backend validations
+    cy.get('input[name=email]').type('{selectall}Incorrect@value');
+    cy.get('button[type=submit]').click();
+    cy.contains('Validation error: Email must be valid');
+
+    // Submit the form with correct values
+    const email = randomEmail();
+    cy.get('input[name=email]').type(`{selectall}${email}`);
+    cy.get('button[type=submit]').click();
+    cy.contains('Your magic link is on its way!');
+    cy.contains(`We've sent it to ${email}.`);
+  });
+
+  it('can signup as organization', () => {
+    cy.visit('/signin');
+
+    // Go to CreateProfile
+    cy.contains('button', 'Join Free').click();
+
+    // Select "Create oganization"
+    cy.contains('Create Organization Profile').click();
+
+    // Test frontend validations
+    cy.get('input[name=orgName]').type('Test Organization');
+    cy.get('input[name=email]').type('Incorrect value');
+    cy.get('button[type=submit]').click();
+    cy.contains("Please include an '@' in the email address. 'Incorrectvalue' is missing an '@'.");
+
+    // Test backend validations
+    cy.get('input[name=email]').type('{selectall}Incorrect@value');
+    cy.get('button[type=submit]').click();
+    cy.contains('Validation error: Email must be valid');
+
+    // Submit the form with correct values
+    const email = randomEmail();
+    cy.get('input[name=email]').type(`{selectall}${email}`);
+    cy.get('button[type=submit]').click();
+    cy.contains('Your magic link is on its way!');
+    cy.contains(`We've sent it to ${email}.`);
   });
 });

--- a/cypress/integration/07-signin.test.js
+++ b/cypress/integration/07-signin.test.js
@@ -40,7 +40,7 @@ describe('signin', () => {
     cy.contains('Validation error: Email must be valid');
 
     // Submit the form with correct values
-    const email = randomEmail();
+    const email = randomEmail(false);
     cy.get('input[name=email]').type(`{selectall}${email}`);
     cy.get('button[type=submit]').click();
     cy.contains('Your magic link is on its way!');
@@ -68,7 +68,7 @@ describe('signin', () => {
     cy.contains('Validation error: Email must be valid');
 
     // Submit the form with correct values
-    const email = randomEmail();
+    const email = randomEmail(false);
     cy.get('input[name=email]').type(`{selectall}${email}`);
     cy.get('button[type=submit]').click();
     cy.contains('Your magic link is on its way!');

--- a/cypress/integration/11-contributionFlow.signIn.test.js
+++ b/cypress/integration/11-contributionFlow.signIn.test.js
@@ -26,7 +26,10 @@ describe('Contribution Flow: Sign In', () => {
     cy.visit('/apex/donate');
     cy.get('#content input[name=email]').type(validUserEmail);
     cy.get('#content button[type=submit]').click();
-    cy.contains('Your magic link is on its way!');
-    cy.contains(`We've sent it to ${validUserEmail}.`);
+
+    // Test user are logged in directly
+    cy.contains('Contribute As');
+    cy.contains('anonymous');
+    cy.contains('TestOrg');
   });
 });

--- a/cypress/support/faker.js
+++ b/cypress/support/faker.js
@@ -5,7 +5,10 @@ import uuidv4 from 'uuid/v4';
  * These emails match the format of API E2E testing accounts and thus they
  * can be used to signin directly using cy.login().
  * See `opencollective-api/server/controllers/users.js`
+ *
+ * @param {bool} directSignIn: Set this to false to generage an email that cannot signin directly
  */
-export const randomEmail = () => {
-  return `oc-test-${uuidv4().split('-')[0]}@opencollective.com`;
+export const randomEmail = (directSignIn = true) => {
+  const randomID = uuidv4().split('-')[0];
+  return directSignIn ? `oc-test-${randomID}@opencollective.com` : `oc-noDirectSignIn-${randomID}@opencollective.com`;
 };

--- a/src/components/CreateProfile.js
+++ b/src/components/CreateProfile.js
@@ -229,7 +229,7 @@ const CreateProfile = enhance(
 
       <Container alignItems="center" bg="black.50" display="flex" justifyContent="space-between" px={4} py={3}>
         <P color="black.700">Already have an account?</P>
-        <StyledButton fontWeight="600" onClick={onSecondaryAction} disabled={submitting}>
+        <StyledButton asLink fontSize="Paragraph" fontWeight="bold" onClick={onSecondaryAction} disabled={submitting}>
           <FormattedMessage id="signIn" defaultMessage="Sign In" />
         </StyledButton>
       </Container>

--- a/src/components/CreateProfile.js
+++ b/src/components/CreateProfile.js
@@ -78,7 +78,7 @@ const CreateProfile = enhance(
     submitting,
     ...props
   }) => (
-    <StyledCard maxWidth={480} {...props}>
+    <StyledCard width={1} maxWidth={480} {...props}>
       <Flex>
         <Tab active={state.tab === 'personal'} setActive={() => setState({ ...state, tab: 'personal' })}>
           <FormattedMessage id="contribution.createPersoProfile" defaultMessage="Create Personal Profile" />

--- a/src/components/LoginBtn.js
+++ b/src/components/LoginBtn.js
@@ -4,17 +4,20 @@ import { FormattedMessage } from 'react-intl';
 
 import { Link } from '../server/pages';
 import StyledLink from './StyledLink';
+import { withUser } from './UserProvider';
+import StyledSpinner from './StyledSpinner';
 
 /**
- * A user login button with proper redirect function. This will **not** check
- * if user is already logged in.
+ * A user login button with proper redirect function.
+ * If user is currently loggin in, button will be disabled and will show a spinner.
  */
-export default class LoginBtn extends React.Component {
+class LoginBtn extends React.Component {
   static propTypes = {
     /**
-     * Login button label. Default: "Login"
+     * Login button label. Default: "Sign In"
      */
     children: PropTypes.node,
+    loadingLoggedInUser: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -32,6 +35,14 @@ export default class LoginBtn extends React.Component {
     }
   }
 
+  renderContent() {
+    if (this.props.loadingLoggedInUser) {
+      return <StyledSpinner size="1em" />;
+    }
+
+    return this.props.children || <FormattedMessage id="login.button" defaultMessage="Sign In" />;
+  }
+
   render() {
     return (
       <Link route="signin" params={{ next: this.redirectAfterSignin }} passHref>
@@ -44,9 +55,11 @@ export default class LoginBtn extends React.Component {
           px={3}
           py={2}
         >
-          {this.props.children || <FormattedMessage id="login.button" defaultMessage="Login" />}
+          {this.renderContent()}
         </StyledLink>
       </Link>
     );
   }
 }
+
+export default withUser(LoginBtn);

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -78,7 +78,7 @@ const SignIn = withState('state', 'setState', { email: '', error: null, showErro
         <P color="black.700">
           <FormattedMessage id="signin.noAccount" defaultMessage="Don't have an account?" />
         </P>
-        <StyledButton fontWeight="600" onClick={onSecondaryAction} disabled={loading}>
+        <StyledButton asLink fontSize="Paragraph" fontWeight="bold" onClick={onSecondaryAction} disabled={loading}>
           <FormattedMessage id="signin.joinFree" defaultMessage="Join Free" />
         </StyledButton>
       </Container>

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -15,7 +15,7 @@ import { FormattedMessage } from 'react-intl';
  */
 const SignIn = withState('state', 'setState', { email: '', error: null, showError: false })(
   ({ state, setState, onSubmit, onSecondaryAction, loading, unknownEmail }) => (
-    <StyledCard maxWidth={450} width={1}>
+    <StyledCard maxWidth={480} width={1}>
       <Box py={4} px={[3, 4]}>
         <H5 as="label" fontWeight="bold" htmlFor="email" mb={3} textAlign="left" display="block">
           <FormattedMessage id="signin.usingEmail" defaultMessage="Sign in using your email address:" />

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -16,7 +16,7 @@ import { FormattedMessage } from 'react-intl';
 const SignIn = withState('state', 'setState', { email: '', error: null, showError: false })(
   ({ state, setState, onSubmit, onSecondaryAction, loading, unknownEmail }) => (
     <StyledCard maxWidth={450} width={1}>
-      <Box p={4}>
+      <Box py={4} px={[3, 4]}>
         <H5 as="label" fontWeight="bold" htmlFor="email" mb={3} textAlign="left" display="block">
           <FormattedMessage id="signin.usingEmail" defaultMessage="Sign in using your email address:" />
         </H5>
@@ -74,8 +74,10 @@ const SignIn = withState('state', 'setState', { email: '', error: null, showErro
         )}
       </Box>
 
-      <Container alignItems="center" bg="black.50" px={4} py={3} display="flex" justifyContent="space-between">
-        <P color="black.700">Don&apos;t have an account?</P>
+      <Container alignItems="center" bg="black.50" px={[3, 4]} py={3} display="flex" justifyContent="space-between">
+        <P color="black.700">
+          <FormattedMessage id="signin.noAccount" defaultMessage="Don't have an account?" />
+        </P>
         <StyledButton fontWeight="600" onClick={onSecondaryAction} disabled={loading}>
           <FormattedMessage id="signin.joinFree" defaultMessage="Join Free" />
         </StyledButton>

--- a/src/components/SignInForm.js
+++ b/src/components/SignInForm.js
@@ -7,6 +7,9 @@ import { isValidEmail } from '../lib/utils';
 import withIntl from '../lib/withIntl';
 import * as api from '../lib/api';
 
+/**
+ * @deprecated Since 2019/01/25 - Use `SignIn` component instead.
+ */
 class LoginForm extends React.Component {
   static propTypes = {
     signin: PropTypes.bool,

--- a/src/components/SignInOrJoinFree.js
+++ b/src/components/SignInOrJoinFree.js
@@ -125,7 +125,6 @@ class SignInOrJoinFree extends React.Component {
                 onSecondaryAction={() => this.switchForm('signIn')}
                 submitting={submitting}
                 mx={[2, 4]}
-                width={490}
               />
               <CreateProfileFAQ mt={4} display={['none', null, 'block']} width={1 / 5} minWidth="335px" />
             </Flex>

--- a/src/components/SignInOrJoinFree.js
+++ b/src/components/SignInOrJoinFree.js
@@ -54,8 +54,15 @@ class SignInOrJoinFree extends React.Component {
     try {
       const userExists = await api.checkUserExistence(email);
       if (userExists) {
-        await api.signin({ email }, this.props.redirect);
-        await Router.pushRoute('signinLinkSent', { email });
+        const response = await api.signin({ email }, this.props.redirect);
+
+        // In dev/test, API directly returns a redirect URL for emails like
+        // test*@opencollective.com.
+        if (response.redirect) {
+          await Router.replaceRoute(response.redirect);
+        } else {
+          await Router.pushRoute('signinLinkSent', { email });
+        }
         window.scrollTo(0, 0);
       } else {
         this.setState({ unknownEmailError: true, submitting: false });

--- a/src/components/SignInOrJoinFree.js
+++ b/src/components/SignInOrJoinFree.js
@@ -1,0 +1,157 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+import { Flex, Box } from '@rebass/grid';
+import { FormattedMessage } from 'react-intl';
+import { pick } from 'lodash';
+
+import * as api from '../lib/api';
+import { Router } from '../server/pages';
+
+import Link from './Link';
+import SignIn from './SignIn';
+import CreateProfile from './CreateProfile';
+import CreateProfileFAQ from './faqs/CreateProfileFAQ';
+import { P } from './Text';
+import MessageBox from './MessageBox';
+import { createUserQuery } from '../graphql/mutations';
+import { graphql } from 'react-apollo';
+
+/**
+ * Shows a SignIn form by default, with the ability to switch to SignUp form. It
+ * also has the API methods binded, so you can use it directly.
+ */
+class SignInOrJoinFree extends React.Component {
+  static propTypes = {
+    /** Redirect URL */
+    redirect: PropTypes.string,
+    /** createUserQuery binding */
+    createUser: PropTypes.func,
+  };
+
+  static defaultProps = {
+    redirect: '/',
+  };
+
+  state = {
+    form: 'signIn',
+    error: null,
+    submitting: false,
+    unknownEmailError: false,
+  };
+
+  switchForm = form => {
+    this.setState({ form });
+    window.scrollTo(0, 0);
+  };
+
+  signIn = email => {
+    if (this.state.submitting) {
+      return false;
+    }
+
+    this.setState({ submitting: true });
+    return api
+      .checkUserExistence(email)
+      .then(exists => {
+        if (exists) {
+          return api.signin({ email }, this.props.redirect).then(() => {
+            Router.pushRoute('signinLinkSent', { email });
+          });
+        } else {
+          this.setState({ unknownEmailError: true, submitting: false });
+        }
+      })
+      .catch(e => {
+        this.setState({ error: e.message, submitting: false });
+        window.scrollTo(0, 0);
+      });
+  };
+
+  createProfile = data => {
+    if (this.state.submitting) {
+      return false;
+    }
+
+    const redirect = window.location.pathname;
+    const user = pick(data, ['email', 'firstName', 'lastName']);
+    const organizationData = pick(data, ['orgName', 'githubHandle', 'twitterHandle', 'website']);
+    const organization = Object.keys(organizationData).length > 0 ? organizationData : null;
+    if (organization) {
+      organization.name = organization.orgName;
+      delete organization.orgName;
+    }
+
+    this.setState({ submitting: true });
+    this.props
+      .createUser({ user, organization, redirect })
+      .then(() => {
+        Router.pushRoute('signinLinkSent', { email: user.email }).then(() => window.scrollTo(0, 0));
+      })
+      .catch(error => {
+        this.setState({ error: error.message, submitting: false });
+        window.scrollTo(0, 0);
+      });
+  };
+
+  render() {
+    const { form, submitting, error, unknownEmailError } = this.state;
+    return (
+      <Flex flexDirection="column" width={1} alignItems="center">
+        {error && (
+          <MessageBox type="error" withIcon mb={[3, 4]}>
+            {error.replace('GraphQL error: ', 'Error: ')}
+          </MessageBox>
+        )}
+        {form === 'signIn' ? (
+          <SignIn
+            onSecondaryAction={() => this.switchForm('signUp')}
+            onSubmit={this.signIn}
+            loading={submitting}
+            unknownEmail={unknownEmailError}
+          />
+        ) : (
+          <Flex flexDirection="column" width={1} alignItems="center">
+            <Flex justifyContent="center" width={1}>
+              <Box width={[0, null, null, 1 / 5]} />
+              <CreateProfile
+                onPersonalSubmit={this.createProfile}
+                onOrgSubmit={this.createProfile}
+                onSecondaryAction={() => this.switchForm('signIn')}
+                submitting={submitting}
+                mx={[2, 4]}
+                width={490}
+              />
+              <CreateProfileFAQ mt={4} display={['none', null, 'block']} width={1 / 5} minWidth="335px" />
+            </Flex>
+            <P mt={4} color="black.500" fontSize="Caption">
+              <FormattedMessage
+                id="contributeFlow.createProfile.legal"
+                defaultMessage="By joining, you agree to our {tosLink} and {privacyPolicyLink}."
+                values={{
+                  tosLink: (
+                    <Link route="/tos">
+                      <FormattedMessage id="tos" defaultMessage="Terms of Service" />
+                    </Link>
+                  ),
+                  privacyPolicyLink: (
+                    <Link route="/privacypolicy">
+                      <FormattedMessage id="privacyPolicy" defaultMessage="Privacy Policy" />
+                    </Link>
+                  ),
+                }}
+              />
+            </P>
+          </Flex>
+        )}
+      </Flex>
+    );
+  }
+}
+
+const addCreateUserMutation = graphql(createUserQuery, {
+  props: ({ mutate }) => ({
+    createUser: variables => mutate({ variables }),
+  }),
+});
+
+export default addCreateUserMutation(SignInOrJoinFree);

--- a/src/components/SignInOrJoinFree.js
+++ b/src/components/SignInOrJoinFree.js
@@ -44,27 +44,26 @@ class SignInOrJoinFree extends React.Component {
     window.scrollTo(0, 0);
   };
 
-  signIn = email => {
+  signIn = async email => {
     if (this.state.submitting) {
       return false;
     }
 
     this.setState({ submitting: true });
-    return api
-      .checkUserExistence(email)
-      .then(exists => {
-        if (exists) {
-          return api.signin({ email }, this.props.redirect).then(() => {
-            Router.pushRoute('signinLinkSent', { email });
-          });
-        } else {
-          this.setState({ unknownEmailError: true, submitting: false });
-        }
-      })
-      .catch(e => {
-        this.setState({ error: e.message, submitting: false });
+
+    try {
+      const userExists = await api.checkUserExistence(email);
+      if (userExists) {
+        await api.signin({ email }, this.props.redirect);
+        await Router.pushRoute('signinLinkSent', { email });
         window.scrollTo(0, 0);
-      });
+      } else {
+        this.setState({ unknownEmailError: true, submitting: false });
+      }
+    } catch (e) {
+      this.setState({ error: e.message || 'Server error', submitting: false });
+      window.scrollTo(0, 0);
+    }
   };
 
   createProfile = data => {

--- a/src/components/SignInUp.js
+++ b/src/components/SignInUp.js
@@ -6,6 +6,9 @@ import { debounce } from 'lodash';
 import { isValidEmail, capitalize } from '../lib/utils';
 import { defineMessages, injectIntl } from 'react-intl';
 
+/**
+ * @deprecated Since 2019/01/25 - Use `SignInOrJoinFree` component instead.
+ */
 class SignInUp extends React.Component {
   static propTypes = {
     label: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),

--- a/src/components/StyledButton.js
+++ b/src/components/StyledButton.js
@@ -35,20 +35,6 @@ const StyledButtonContent = styled(tag.button)`
   ${buttonStyle}
   ${buttonSize}
 
-  ${bgColor}
-  ${border}
-  ${borderRadius}
-  ${color}
-  ${display}
-  ${fontFamily}
-  ${fontSize}
-  ${fontWeight}
-  ${minWidth}
-  ${maxWidth}
-  ${space}
-  ${textAlign}
-  ${width}
-
   ${props =>
     props.asLink &&
     css`
@@ -63,6 +49,20 @@ const StyledButtonContent = styled(tag.button)`
         color: ${themeGet('colors.primary.400')};
       }
     `}
+
+  ${bgColor}
+  ${border}
+  ${borderRadius}
+  ${color}
+  ${display}
+  ${fontFamily}
+  ${fontSize}
+  ${fontWeight}
+  ${minWidth}
+  ${maxWidth}
+  ${space}
+  ${textAlign}
+  ${width}
 `;
 
 const StyledButton = ({ loading, ...props }) =>

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -229,7 +229,7 @@
   "collective.create.button": "Create Collective",
   "organization.create": "Create organization",
   "events.create.login": "You need to be logged in as a core contributor of this collective to be able to create an event.",
-  "login.button": "login",
+  "login.button": "Sign In",
   "collective.connectedAccounts.stripe.button": "Connect Stripe",
   "collective.connectedAccounts.stripe.description": "Connect a Stripe account to start accepting donations",
   "host.types.label": "Type of host entity",

--- a/src/lib/withLoggedInUser.js
+++ b/src/lib/withLoggedInUser.js
@@ -9,8 +9,12 @@ import LoggedInUser from '../classes/LoggedInUser';
 import { getLoggedInUserQuery } from '../graphql/queries';
 
 const maybeRefreshAccessToken = async currentToken => {
-  const { exp } = jwt.decode(currentToken);
-  const shouldUpdate = moment(exp * 1000)
+  const decodeResult = jwt.decode(currentToken);
+  if (!decodeResult) {
+    return;
+  }
+
+  const shouldUpdate = moment(decodeResult.exp * 1000)
     .subtract(1, 'month')
     .isBefore(new Date());
   if (shouldUpdate) {
@@ -44,31 +48,48 @@ export default WrappedComponent => {
         }
       });
 
+    /**
+     * If `token` is passed in `options`, function it will throw if
+     * that token is invalid and it won't try to load user from the local cache
+     * but instead force refetch it from the server.
+     */
     getLoggedInUser = async (options = {}) => {
-      const { ignoreLocalStorage = false } = options;
+      const { ignoreLocalStorage = false, token = null } = options;
 
       // only Client Side for now
       if (!process.browser || !window) {
         return null;
       }
 
-      // If no localStorage token, reset LoggedInUser
-      const token = window.localStorage.getItem('accessToken');
-      if (!token) {
-        storage.set('LoggedInUser', null);
-        return null;
-      }
+      if (token) {
+        // Ensure token is valid
+        const decodeResult = jwt.decode(token);
+        if (!decodeResult || !decodeResult.exp) {
+          throw new Error('Invalid token');
+        }
+        storage.set('accessToken', token);
+        await maybeRefreshAccessToken(token);
+      } else {
+        // If no localStorage token, reset LoggedInUser
+        const localStorageToken = window.localStorage.getItem('accessToken');
+        if (!localStorageToken) {
+          if (storage.get('LoggedInUser')) {
+            storage.set('LoggedInUser', null);
+          }
+          return null;
+        }
 
-      // refresh Access Token in the background if needed
-      maybeRefreshAccessToken(token);
+        // refresh Access Token in the background if needed
+        maybeRefreshAccessToken(localStorageToken);
 
-      // From cache
-      const cache = storage.get('LoggedInUser');
-      if (!ignoreLocalStorage && cache) {
-        // This is asynchronous and will take care of updating the cache
-        this.getLoggedInUserFromServer();
-        // Return from cache immediately
-        return new LoggedInUser(cache);
+        // From cache
+        const cache = storage.get('LoggedInUser');
+        if (!ignoreLocalStorage && cache) {
+          // This is asynchronous and will take care of updating the cache
+          this.getLoggedInUserFromServer();
+          // Return from cache immediately
+          return new LoggedInUser(cache);
+        }
       }
 
       // Synchronously

--- a/src/pages/__tests__/__snapshots__/search.test.js.snap
+++ b/src/pages/__tests__/__snapshots__/search.test.js.snap
@@ -108,6 +108,14 @@ Array [
   padding-bottom: 8px;
 }
 
+.c14 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  -webkit-animation: iVXCSc 1s linear infinite;
+  animation: iVXCSc 1s linear infinite;
+}
+
 .c2 {
   -webkit-animation: iECmZH 0.8s infinite linear;
   animation: iECmZH 0.8s infinite linear;
@@ -307,9 +315,22 @@ Array [
             href="/signin?next=%2F"
             onClick={[Function]}
           >
-            <span>
-              Login
-            </span>
+            <svg
+              className="c14"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              role="img"
+              viewBox="0 0 24 24"
+              width="1em"
+            >
+              <title>
+                Loading
+              </title>
+              <path
+                d="M12 20c-4.337 0-8-3.663-8-8 0-4.336 3.663-8 8-8V2C6.579 2 2 6.58 2 12c0 5.421 4.579 10 10 10s10-4.579 10-10h-2c0 4.337-3.663 8-8 8z"
+              />
+            </svg>
           </a>
         </div>
       </div>
@@ -1360,6 +1381,14 @@ Array [
   padding-bottom: 8px;
 }
 
+.c14 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  -webkit-animation: iVXCSc 1s linear infinite;
+  animation: iVXCSc 1s linear infinite;
+}
+
 .c2 {
   -webkit-animation: iECmZH 0.8s infinite linear;
   animation: iECmZH 0.8s infinite linear;
@@ -1559,9 +1588,22 @@ Array [
             href="/signin?next=%2F"
             onClick={[Function]}
           >
-            <span>
-              Login
-            </span>
+            <svg
+              className="c14"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              role="img"
+              viewBox="0 0 24 24"
+              width="1em"
+            >
+              <title>
+                Loading
+              </title>
+              <path
+                d="M12 20c-4.337 0-8-3.663-8-8 0-4.336 3.663-8 8-8V2C6.579 2 2 6.58 2 12c0 5.421 4.579 10 10 10s10-4.579 10-10h-2c0 4.337-3.663 8-8 8z"
+              />
+            </svg>
           </a>
         </div>
       </div>
@@ -2523,7 +2565,7 @@ exports[`Search Page renders error message 1`] = `
   padding-right: 16px;
 }
 
-.c33 {
+.c34 {
   box-sizing: border-box;
   margin-bottom: 16px;
   width: 50%;
@@ -2568,7 +2610,7 @@ exports[`Search Page renders error message 1`] = `
   display: flex;
 }
 
-.c21 {
+.c22 {
   box-sizing: border-box;
   margin-left: auto;
   margin-right: auto;
@@ -2591,7 +2633,7 @@ exports[`Search Page renders error message 1`] = `
   justify-content: space-between;
 }
 
-.c23 {
+.c24 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2603,7 +2645,7 @@ exports[`Search Page renders error message 1`] = `
   justify-content: center;
 }
 
-.c32 {
+.c33 {
   box-sizing: border-box;
   margin-top: 16px;
   -webkit-flex: 1 1 auto;
@@ -2669,7 +2711,7 @@ exports[`Search Page renders error message 1`] = `
   overflow: hidden;
 }
 
-.c24 {
+.c25 {
   color: #6E747A;
   font-size: 1.4rem;
   line-height: Paragraph;
@@ -2683,7 +2725,7 @@ exports[`Search Page renders error message 1`] = `
   text-align: center;
 }
 
-.c34 {
+.c35 {
   color: #C2C6CC;
   font-size: 1.2rem;
   line-height: Paragraph;
@@ -2696,7 +2738,7 @@ exports[`Search Page renders error message 1`] = `
   text-align: center;
 }
 
-.c20 {
+.c21 {
   box-sizing: border-box;
   border-top: 1px solid #aaaaaa;
   bottom: 0px;
@@ -2706,7 +2748,7 @@ exports[`Search Page renders error message 1`] = `
   width: 100%;
 }
 
-.c22 {
+.c23 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2720,7 +2762,7 @@ exports[`Search Page renders error message 1`] = `
   width: 100%;
 }
 
-.c25 {
+.c26 {
   box-sizing: border-box;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2768,10 +2810,18 @@ exports[`Search Page renders error message 1`] = `
   padding-bottom: 8px;
 }
 
-.c36 {
+.c37 {
   list-style: none;
   margin-bottom: 8px;
   text-align: center;
+}
+
+.c20 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  -webkit-animation: iVXCSc 1s linear infinite;
+  animation: iVXCSc 1s linear infinite;
 }
 
 .c8 {
@@ -2867,18 +2917,6 @@ exports[`Search Page renders error message 1`] = `
   font-size: 1.4rem;
 }
 
-.c29 {
-  display: inline-block;
-  vertical-align: -.125em;
-  overflow: hidden;
-}
-
-.c27 {
-  display: inline-block;
-  vertical-align: -.125em;
-  overflow: hidden;
-}
-
 .c30 {
   display: inline-block;
   vertical-align: -.125em;
@@ -2893,11 +2931,23 @@ exports[`Search Page renders error message 1`] = `
 
 .c31 {
   display: inline-block;
+  vertical-align: -.125em;
+  overflow: hidden;
+}
+
+.c29 {
+  display: inline-block;
+  vertical-align: -.125em;
+  overflow: hidden;
+}
+
+.c32 {
+  display: inline-block;
   vertical-align: middle;
   overflow: hidden;
 }
 
-.c26 {
+.c27 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2917,12 +2967,12 @@ exports[`Search Page renders error message 1`] = `
   width: 48px;
 }
 
-.c26:hover,
-.c26:focus {
+.c27:hover,
+.c27:focus {
   opacity: 1;
 }
 
-.c37 {
+.c38 {
   color: #6e747a;
   display: block;
   fontsize: 1.4rem;
@@ -2931,7 +2981,7 @@ exports[`Search Page renders error message 1`] = `
   padding: 0;
 }
 
-.c35 {
+.c36 {
   box-sizing: border-box;
   padding-left: 0px;
   padding-right: 8px;
@@ -2952,13 +3002,13 @@ exports[`Search Page renders error message 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c33 {
+  .c34 {
     width: 25%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c21 {
+  .c22 {
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
@@ -2966,7 +3016,7 @@ exports[`Search Page renders error message 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c21 {
+  .c22 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
@@ -2975,7 +3025,7 @@ exports[`Search Page renders error message 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c23 {
+  .c24 {
     -webkit-box-pack: start;
     -webkit-justify-content: flex-start;
     -ms-flex-pack: start;
@@ -2984,7 +3034,7 @@ exports[`Search Page renders error message 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c32 {
+  .c33 {
     -webkit-order: 2;
     -ms-flex-order: 2;
     order: 2;
@@ -2992,25 +3042,25 @@ exports[`Search Page renders error message 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c24 {
+  .c25 {
     text-align: left;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c34 {
+  .c35 {
     text-align: left;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c22 {
+  .c23 {
     width: 33.33333333333333%;
   }
 }
 
 @media screen and (min-width:52em) {
-  .c25 {
+  .c26 {
     -webkit-order: 3;
     -ms-flex-order: 3;
     order: 3;
@@ -3048,7 +3098,7 @@ exports[`Search Page renders error message 1`] = `
 }
 
 @media screen and (min-width:52em) {
-  .c36 {
+  .c37 {
     text-align: left;
   }
 }
@@ -3254,9 +3304,22 @@ exports[`Search Page renders error message 1`] = `
             href="/signin?next=%2F"
             onClick={[Function]}
           >
-            <span>
-              Login
-            </span>
+            <svg
+              className="c20"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              role="img"
+              viewBox="0 0 24 24"
+              width="1em"
+            >
+              <title>
+                Loading
+              </title>
+              <path
+                d="M12 20c-4.337 0-8-3.663-8-8 0-4.336 3.663-8 8-8V2C6.579 2 2 6.58 2 12c0 5.421 4.579 10 10 10s10-4.579 10-10h-2c0 4.337-3.663 8-8 8z"
+              />
+            </svg>
           </a>
         </div>
       </div>
@@ -3280,17 +3343,17 @@ exports[`Search Page renders error message 1`] = `
     </div>
   </main>
   <div
-    className="c20"
+    className="c21"
     id="footer"
   >
     <div
-      className="c21"
+      className="c22"
     >
       <div
-        className="c22"
+        className="c23"
       >
         <div
-          className="c23"
+          className="c24"
         >
           <object
             data="/static/images/opencollectivelogo-footer.svg"
@@ -3299,21 +3362,21 @@ exports[`Search Page renders error message 1`] = `
           />
         </div>
         <p
-          className="c24"
+          className="c25"
         >
           An organization for your community, transparent by design.
         </p>
       </div>
       <div
-        className="c25"
+        className="c26"
       >
         <a
-          className="c26"
+          className="c27"
           href="https://medium.com/open-collective"
         >
           <svg
             aria-hidden="true"
-            className="c27"
+            className="c28"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -3328,12 +3391,12 @@ exports[`Search Page renders error message 1`] = `
           </svg>
         </a>
         <a
-          className="c26"
+          className="c27"
           href="https://twitter.com/opencollect"
         >
           <svg
             aria-hidden="true"
-            className="c28"
+            className="c29"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -3348,12 +3411,12 @@ exports[`Search Page renders error message 1`] = `
           </svg>
         </a>
         <a
-          className="c26"
+          className="c27"
           href="https://github.com/opencollective"
         >
           <svg
             aria-hidden="true"
-            className="c29"
+            className="c30"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -3368,12 +3431,12 @@ exports[`Search Page renders error message 1`] = `
           </svg>
         </a>
         <a
-          className="c26"
+          className="c27"
           href="https://slack.opencollective.com"
         >
           <svg
             aria-hidden="true"
-            className="c30"
+            className="c31"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -3388,12 +3451,12 @@ exports[`Search Page renders error message 1`] = `
           </svg>
         </a>
         <a
-          className="c26"
+          className="c27"
           href="mailto:info@opencollective.com"
         >
           <svg
             aria-hidden="true"
-            className="c31"
+            className="c32"
             color="#9399A3"
             fill="currentColor"
             focusable="false"
@@ -3408,7 +3471,7 @@ exports[`Search Page renders error message 1`] = `
         </a>
       </div>
       <nav
-        className="c32"
+        className="c33"
         order={
           Array [
             "3",
@@ -3418,7 +3481,7 @@ exports[`Search Page renders error message 1`] = `
         }
       >
         <div
-          className="c33"
+          className="c34"
           width={
             Array [
               0.5,
@@ -3428,18 +3491,18 @@ exports[`Search Page renders error message 1`] = `
           }
         >
           <p
-            className="c34"
+            className="c35"
           >
             PLATFORM
           </p>
           <ul
-            className="c35"
+            className="c36"
           >
             <li
-              className="c36"
+              className="c37"
             >
               <a
-                className="c37"
+                className="c38"
                 href="/discover"
                 onClick={[Function]}
               >
@@ -3447,10 +3510,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c36"
+              className="c37"
             >
               <a
-                className="c37"
+                className="c38"
                 href="/how-it-works"
                 onClick={[Function]}
               >
@@ -3458,10 +3521,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c36"
+              className="c37"
             >
               <a
-                className="c37"
+                className="c38"
                 href="/signin"
                 onClick={[Function]}
               >
@@ -3469,10 +3532,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c36"
+              className="c37"
             >
               <a
-                className="c37"
+                className="c38"
                 href="/signin"
                 onClick={[Function]}
               >
@@ -3482,7 +3545,7 @@ exports[`Search Page renders error message 1`] = `
           </ul>
         </div>
         <div
-          className="c33"
+          className="c34"
           width={
             Array [
               0.5,
@@ -3492,18 +3555,18 @@ exports[`Search Page renders error message 1`] = `
           }
         >
           <p
-            className="c34"
+            className="c35"
           >
             JOIN THE MOVEMENT
           </p>
           <ul
-            className="c35"
+            className="c36"
           >
             <li
-              className="c36"
+              className="c37"
             >
               <a
-                className="c37"
+                className="c38"
                 href="/create"
                 onClick={[Function]}
               >
@@ -3511,10 +3574,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c36"
+              className="c37"
             >
               <a
-                className="c37"
+                className="c38"
                 href="/become-a-sponsor"
                 onClick={[Function]}
               >
@@ -3522,10 +3585,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c36"
+              className="c37"
             >
               <a
-                className="c37"
+                className="c38"
                 href="/chapters"
                 onClick={[Function]}
               >
@@ -3533,10 +3596,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c36"
+              className="c37"
             >
               <a
-                className="c37"
+                className="c38"
                 href="/pledges/new"
                 onClick={[Function]}
               >
@@ -3544,10 +3607,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c36"
+              className="c37"
             >
               <a
-                className="c37"
+                className="c38"
                 href="/gift-cards"
                 onClick={[Function]}
               >
@@ -3557,7 +3620,7 @@ exports[`Search Page renders error message 1`] = `
           </ul>
         </div>
         <div
-          className="c33"
+          className="c34"
           width={
             Array [
               0.5,
@@ -3567,18 +3630,18 @@ exports[`Search Page renders error message 1`] = `
           }
         >
           <p
-            className="c34"
+            className="c35"
           >
             COMMUNITY
           </p>
           <ul
-            className="c35"
+            className="c36"
           >
             <li
-              className="c36"
+              className="c37"
             >
               <a
-                className="c37"
+                className="c38"
                 href="/opensource"
                 onClick={[Function]}
               >
@@ -3586,10 +3649,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c36"
+              className="c37"
             >
               <a
-                className="c37"
+                className="c38"
                 href="https://github.com/opencollective/opencollective/issues"
                 onClick={[Function]}
               >
@@ -3597,10 +3660,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c36"
+              className="c37"
             >
               <a
-                className="c37"
+                className="c38"
                 href="https://slack.opencollective.com"
                 onClick={[Function]}
               >
@@ -3608,10 +3671,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c36"
+              className="c37"
             >
               <a
-                className="c37"
+                className="c38"
                 href="https://github.com/opencollective/opencollective/wiki"
                 onClick={[Function]}
               >
@@ -3619,10 +3682,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c36"
+              className="c37"
             >
               <a
-                className="c37"
+                className="c38"
                 href="mailto:support@opencollective.com"
                 onClick={[Function]}
               >
@@ -3632,7 +3695,7 @@ exports[`Search Page renders error message 1`] = `
           </ul>
         </div>
         <div
-          className="c33"
+          className="c34"
           width={
             Array [
               0.5,
@@ -3642,18 +3705,18 @@ exports[`Search Page renders error message 1`] = `
           }
         >
           <p
-            className="c34"
+            className="c35"
           >
             COMPANY
           </p>
           <ul
-            className="c35"
+            className="c36"
           >
             <li
-              className="c36"
+              className="c37"
             >
               <a
-                className="c37"
+                className="c38"
                 href="/about"
                 onClick={[Function]}
               >
@@ -3661,10 +3724,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c36"
+              className="c37"
             >
               <a
-                className="c37"
+                className="c38"
                 href="/faq"
                 onClick={[Function]}
               >
@@ -3672,10 +3735,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c36"
+              className="c37"
             >
               <a
-                className="c37"
+                className="c38"
                 href="https://medium.com/open-collective"
                 onClick={[Function]}
               >
@@ -3683,10 +3746,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c36"
+              className="c37"
             >
               <a
-                className="c37"
+                className="c38"
                 href="/tos"
                 onClick={[Function]}
               >
@@ -3694,10 +3757,10 @@ exports[`Search Page renders error message 1`] = `
               </a>
             </li>
             <li
-              className="c36"
+              className="c37"
             >
               <a
-                className="c37"
+                className="c38"
                 href="/privacypolicy"
                 onClick={[Function]}
               >
@@ -3818,6 +3881,14 @@ Array [
   padding-right: 16px;
   padding-top: 8px;
   padding-bottom: 8px;
+}
+
+.c14 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  -webkit-animation: iVXCSc 1s linear infinite;
+  animation: iVXCSc 1s linear infinite;
 }
 
 .c2 {
@@ -4019,9 +4090,22 @@ Array [
             href="/signin?next=%2F"
             onClick={[Function]}
           >
-            <span>
-              Login
-            </span>
+            <svg
+              className="c14"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              role="img"
+              viewBox="0 0 24 24"
+              width="1em"
+            >
+              <title>
+                Loading
+              </title>
+              <path
+                d="M12 20c-4.337 0-8-3.663-8-8 0-4.336 3.663-8 8-8V2C6.579 2 2 6.58 2 12c0 5.421 4.579 10 10 10s10-4.579 10-10h-2c0 4.337-3.663 8-8 8z"
+              />
+            </svg>
           </a>
         </div>
       </div>
@@ -5174,6 +5258,14 @@ Array [
   padding-bottom: 8px;
 }
 
+.c14 {
+  display: inline-block;
+  vertical-align: middle;
+  overflow: hidden;
+  -webkit-animation: iVXCSc 1s linear infinite;
+  animation: iVXCSc 1s linear infinite;
+}
+
 .c2 {
   -webkit-animation: iECmZH 0.8s infinite linear;
   animation: iECmZH 0.8s infinite linear;
@@ -5373,9 +5465,22 @@ Array [
             href="/signin?next=%2F"
             onClick={[Function]}
           >
-            <span>
-              Login
-            </span>
+            <svg
+              className="c14"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              role="img"
+              viewBox="0 0 24 24"
+              width="1em"
+            >
+              <title>
+                Loading
+              </title>
+              <path
+                d="M12 20c-4.337 0-8-3.663-8-8 0-4.336 3.663-8 8-8V2C6.579 2 2 6.58 2 12c0 5.421 4.579 10 10 10s10-4.579 10-10h-2c0 4.337-3.663 8-8 8z"
+              />
+            </svg>
           </a>
         </div>
       </div>

--- a/src/pages/signin.js
+++ b/src/pages/signin.js
@@ -49,7 +49,11 @@ class SigninPage extends React.Component {
     // User logged in
     if (!this.props.errorLoggedInUser && !oldProps.LoggedInUser && this.props.LoggedInUser) {
       this.setState({ success: true });
-      Router.replaceRoute(this.props.next || '/').then(window.scroll(0, 0));
+      // Avoid redirect loop: replace '/signin' redirects by '/'
+      const { next } = this.props;
+      const redirect = next && next.match(/^\/?signin[?/]?/) ? null : next;
+      await Router.replaceRoute(redirect || '/');
+      window.scroll(0, 0);
     }
 
     // There's a new token in town

--- a/src/pages/signin.js
+++ b/src/pages/signin.js
@@ -46,18 +46,16 @@ class SigninPage extends React.Component {
   }
 
   async componentDidUpdate(oldProps) {
-    // User logged in
     if (!this.props.errorLoggedInUser && !oldProps.LoggedInUser && this.props.LoggedInUser) {
+      // --- User logged in ---
       this.setState({ success: true });
       // Avoid redirect loop: replace '/signin' redirects by '/'
       const { next } = this.props;
       const redirect = next && next.match(/^\/?signin[?/]?/) ? null : next;
       await Router.replaceRoute(redirect || '/');
       window.scroll(0, 0);
-    }
-
-    // There's a new token in town
-    else if (this.props.token && oldProps.token !== this.props.token) {
+    } else if (this.props.token && oldProps.token !== this.props.token) {
+      // --- There's a new token in town ---
       const user = await this.props.login(this.props.token);
       if (!user) {
         this.setState({ error: 'Token rejected' });

--- a/src/pages/signin.js
+++ b/src/pages/signin.js
@@ -45,10 +45,19 @@ class SigninPage extends React.Component {
     }
   }
 
-  componentDidUpdate(oldProps) {
+  async componentDidUpdate(oldProps) {
+    // User logged in
     if (!this.props.errorLoggedInUser && !oldProps.LoggedInUser && this.props.LoggedInUser) {
       this.setState({ success: true });
       Router.replaceRoute(this.props.next || '/').then(window.scroll(0, 0));
+    }
+
+    // There's a new token in town
+    else if (this.props.token && oldProps.token !== this.props.token) {
+      const user = await this.props.login(this.props.token);
+      if (!user) {
+        this.setState({ error: 'Token rejected' });
+      }
     }
   }
 


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/1676. Will hopefully fix https://github.com/opencollective/opencollective/issues/1673. If not it will at least provide useful error messages that should help us to move forward with it.

# New SignInOrJoinFree component

This new component groups the logic of switching between `Sign In` and `Join Free`. It also displays SignIn's FAQ and disclaimer (`By Joining, you agree to...`).

The style is the same as in new contribution flow implementation, except for the `Sign In` and `Join Free` buttons that are now displayed as links:

![peek 28-01-2019 14-17](https://user-images.githubusercontent.com/1556356/51838724-7e2afb00-2307-11e9-89b6-8ffa124ccf33.gif)

# "Login" button

- Change label to Sign In

![selection_999 045](https://user-images.githubusercontent.com/1556356/51838918-f7c2e900-2307-11e9-8bb8-03df948194af.png)

- Show a loading spinner instead of "Sign In" when user is loading

![peek 28-01-2019 14-23](https://user-images.githubusercontent.com/1556356/51839049-57b98f80-2308-11e9-8972-eed69bc52e67.gif)

# Refactor /signin

The `signin.js` page has been refactored to use this new `SignInOrJoinFree` component. The new behaviour has two significant changes:

1. Previous implementation used to send two signin requests, this new version only sends one.

2. Authenticating with a bad token used to redirect without informing the user about the error. This new version makes it explicit by showing any error preventing the authentication and not redirecting.

![selection_999 046](https://user-images.githubusercontent.com/1556356/51839369-563c9700-2309-11e9-93a9-a688efab2920.png)
