### PR TITLE
Persist email state across email inputs in contribution flow.

### DIFF
--- a/src/components/CreateProfile.js
+++ b/src/components/CreateProfile.js
@@ -262,7 +262,7 @@ CreateProfile.propTypes = {
   /** Disable submit and show a spinner on button when set to true */
   submitting: PropTypes.bool,
   /** Set the value of email input */
-  email: PropTypes.func.isRequired,
+  email: PropTypes.string.isRequired,
   /** handles changes in the email input */
   onEmailChange: PropTypes.func.isRequired,
   /** All props from `StyledCard` */

--- a/src/components/CreateProfile.js
+++ b/src/components/CreateProfile.js
@@ -105,7 +105,8 @@ const CreateProfile = enhance(
           p={4}
           onSubmit={event => {
             event.preventDefault();
-            onPersonalSubmit(pick(state, ['email', 'firstName', 'lastName']));
+            const data = pick(state, ['firstName', 'lastName']);
+            onPersonalSubmit({ ...data, email });
           }}
           method="POST"
         >
@@ -155,9 +156,8 @@ const CreateProfile = enhance(
           p={4}
           onSubmit={event => {
             event.preventDefault();
-            onOrgSubmit(
-              pick(state, ['email', 'firstName', 'lastName', 'orgName', 'website', 'githubHandle', 'twitterHandle']),
-            );
+            const data = pick(state, ['firstName', 'lastName', 'orgName', 'website', 'githubHandle', 'twitterHandle']);
+            onOrgSubmit({ ...data, email });
           }}
           method="POST"
         >

--- a/src/components/CreateProfile.js
+++ b/src/components/CreateProfile.js
@@ -34,12 +34,22 @@ const enhance = compose(
   withState('state', 'setState', ({ errors }) => ({ errors, tab: 'personal' })),
   withHandlers({
     getFieldError: ({ state, errors }) => name => (errors && errors[name]) || state.errors[name],
-    onChange: ({ setState }) => ({ target }) =>
-      setState(state => ({
-        ...state,
-        [target.name]: target.value,
-        errors: { ...state.errors, [target.name]: null },
-      })),
+    onChange: ({ setState, onEmailChange }) => ({ target }) => {
+      // Email state is not local so any changes should be handled seprately
+      if (target.name === 'email') {
+        onEmailChange(target.value);
+        setState(state => ({
+          ...state,
+          errors: { ...state.errors, [target.name]: null },
+        }));
+      } else {
+        setState(state => ({
+          ...state,
+          [target.name]: target.value,
+          errors: { ...state.errors, [target.name]: null },
+        }));
+      }
+    },
     onInvalid: ({ setState }) => event => {
       event.persist();
       event.preventDefault();
@@ -76,6 +86,7 @@ const CreateProfile = enhance(
     state,
     setState,
     submitting,
+    email,
     ...props
   }) => (
     <StyledCard width={1} maxWidth={480} {...props}>
@@ -106,6 +117,7 @@ const CreateProfile = enhance(
                   {...getFieldProps(inputProps.name)}
                   type="email"
                   placeholder="i.e. yourname@yourhost.com"
+                  value={email}
                   required
                 />
               )}
@@ -126,7 +138,7 @@ const CreateProfile = enhance(
 
           <StyledButton
             buttonStyle="primary"
-            disabled={!state.email}
+            disabled={!email}
             width={1}
             type="submit"
             fontWeight="600"
@@ -159,6 +171,7 @@ const CreateProfile = enhance(
                   {...inputProps}
                   {...getFieldProps(inputProps.name)}
                   type="email"
+                  value={email}
                   placeholder="i.e. yourname@yourhost.com"
                   required
                 />
@@ -216,7 +229,7 @@ const CreateProfile = enhance(
 
           <StyledButton
             buttonStyle="primary"
-            disabled={!state.email || !state.orgName}
+            disabled={!email || !state.orgName}
             width={1}
             type="submit"
             fontWeight="600"

--- a/src/components/CreateProfile.js
+++ b/src/components/CreateProfile.js
@@ -261,6 +261,10 @@ CreateProfile.propTypes = {
   onSecondaryAction: PropTypes.func.isRequired,
   /** Disable submit and show a spinner on button when set to true */
   submitting: PropTypes.bool,
+  /** Set the value of email input */
+  email: PropTypes.func.isRequired,
+  /** handles changes in the email input */
+  onEmailChange: PropTypes.func.isRequired,
   /** All props from `StyledCard` */
   ...StyledCard.propTypes,
 };

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -97,6 +97,10 @@ SignIn.propTypes = {
   loading: PropTypes.bool,
   /** Set this to true to display the unknown email message */
   unknownEmail: PropTypes.bool,
+  /** Set the value of email input */
+  email: PropTypes.func.isRequired,
+  /** handles changes in the email input */
+  onEmailChange: PropTypes.func.isRequired,
 };
 
 export default SignIn;

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -13,8 +13,8 @@ import { FormattedMessage } from 'react-intl';
 /**
  * Component for handing user sign-in or redirecting to sign-up
  */
-const SignIn = withState('state', 'setState', { email: '', error: null, showError: false })(
-  ({ state, setState, onSubmit, onSecondaryAction, loading, unknownEmail }) => (
+const SignIn = withState('state', 'setState', { error: null, showError: false })(
+  ({ state, setState, onSubmit, onSecondaryAction, loading, unknownEmail, email, onEmailChange }) => (
     <StyledCard maxWidth={480} width={1}>
       <Box py={4} px={[3, 4]}>
         <H5 as="label" fontWeight="bold" htmlFor="email" mb={3} textAlign="left" display="block">
@@ -34,9 +34,10 @@ const SignIn = withState('state', 'setState', { email: '', error: null, showErro
             fontSize="Paragraph"
             id="email"
             name="email"
-            onChange={({ target }) =>
-              setState({ email: target.value, error: target.validationMessage, showError: false })
-            }
+            onChange={({ target }) => {
+              onEmailChange(target.value);
+              setState({ error: target.validationMessage, showError: false });
+            }}
             onBlur={() => setState({ ...state, showError: true })}
             onInvalid={event => {
               event.preventDefault();
@@ -44,14 +45,14 @@ const SignIn = withState('state', 'setState', { email: '', error: null, showErro
             }}
             placeholder="i.e. yourname@yourhost.com"
             required
-            value={state.email}
+            value={email}
             type="email"
             width={1}
           />
           <StyledButton
             buttonStyle="primary"
             fontWeight="600"
-            disabled={!state.email || state.error}
+            disabled={!email || state.error}
             loading={loading}
             minWidth={100}
             ml={3}

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -44,6 +44,7 @@ const SignIn = withState('state', 'setState', { email: '', error: null, showErro
             }}
             placeholder="i.e. yourname@yourhost.com"
             required
+            value={state.email}
             type="email"
             width={1}
           />

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -26,7 +26,7 @@ const SignIn = withState('state', 'setState', { error: null, showError: false })
           noValidate
           onSubmit={event => {
             event.preventDefault();
-            onSubmit(state.email);
+            onSubmit(email);
           }}
         >
           <StyledInput
@@ -98,7 +98,7 @@ SignIn.propTypes = {
   /** Set this to true to display the unknown email message */
   unknownEmail: PropTypes.bool,
   /** Set the value of email input */
-  email: PropTypes.func.isRequired,
+  email: PropTypes.string.isRequired,
   /** handles changes in the email input */
   onEmailChange: PropTypes.func.isRequired,
 };

--- a/src/components/SignInOrJoinFree.js
+++ b/src/components/SignInOrJoinFree.js
@@ -82,7 +82,6 @@ class SignInOrJoinFree extends React.Component {
     if (this.state.submitting) {
       return false;
     }
-
     const user = pick(data, ['email', 'firstName', 'lastName']);
     const organizationData = pick(data, ['orgName', 'githubHandle', 'twitterHandle', 'website']);
     const organization = Object.keys(organizationData).length > 0 ? organizationData : null;

--- a/src/components/SignInOrJoinFree.js
+++ b/src/components/SignInOrJoinFree.js
@@ -37,6 +37,7 @@ class SignInOrJoinFree extends React.Component {
     error: null,
     submitting: false,
     unknownEmailError: false,
+    email: '',
   };
 
   switchForm = form => {
@@ -103,7 +104,7 @@ class SignInOrJoinFree extends React.Component {
   };
 
   render() {
-    const { form, submitting, error, unknownEmailError } = this.state;
+    const { form, submitting, error, unknownEmailError, email } = this.state;
     return (
       <Flex flexDirection="column" width={1} alignItems="center">
         {error && (
@@ -113,6 +114,8 @@ class SignInOrJoinFree extends React.Component {
         )}
         {form === 'signIn' ? (
           <SignIn
+            email={email}
+            onEmailChange={email => this.setState({ email })}
             onSecondaryAction={() => this.switchForm('signUp')}
             onSubmit={this.signIn}
             loading={submitting}
@@ -123,6 +126,8 @@ class SignInOrJoinFree extends React.Component {
             <Flex justifyContent="center" width={1}>
               <Box width={[0, null, null, 1 / 5]} />
               <CreateProfile
+                email={email}
+                onEmailChange={email => this.setState({ email })}
                 onPersonalSubmit={this.createProfile}
                 onOrgSubmit={this.createProfile}
                 onSecondaryAction={() => this.switchForm('signIn')}

--- a/src/pages/createOrderNewFlow.js
+++ b/src/pages/createOrderNewFlow.js
@@ -145,6 +145,7 @@ class CreateOrderPage extends React.Component {
       stepPayment: null,
       error: null,
       stripe: null,
+      email: '',
     };
   }
 

--- a/src/pages/createOrderNewFlow.js
+++ b/src/pages/createOrderNewFlow.js
@@ -145,7 +145,6 @@ class CreateOrderPage extends React.Component {
       stepPayment: null,
       error: null,
       stripe: null,
-      email: '',
     };
   }
 


### PR DESCRIPTION
This should fix [#1605](https://github.com/opencollective/opencollective/issues/1605).

 Basically this PR lifts email input state up to [`CreateOrderPage`](https://github.com/flickz/opencollective-frontend/blob/14f410dff97f8a101f3ca64451737a65b0edac9c/src/pages/createOrderNewFlow.js#L138) component and pass it as prop to [`SignIn`](https://github.com/flickz/opencollective-frontend/blob/14f410dff97f8a101f3ca64451737a65b0edac9c/src/pages/createOrderNewFlow.js#L674) and [`CreateProfile`](https://github.com/flickz/opencollective-frontend/blob/14f410dff97f8a101f3ca64451737a65b0edac9c/src/pages/createOrderNewFlow.js#L687) along with an [`onEmailChange`](https://github.com/flickz/opencollective-frontend/blob/14f410dff97f8a101f3ca64451737a65b0edac9c/src/pages/createOrderNewFlow.js#L677) function prop to update the state.

cc @Betree @znarf 