### PR TITLE
Unify components sizes in contribution flow

### DIFF
--- a/src/components/ContributePayment.js
+++ b/src/components/ContributePayment.js
@@ -72,7 +72,7 @@ const getPaymentMethodMetadata = pm => {
 };
 
 const StyledCardElement = styled(CardElement)`
-  max-width: 350px;
+  max-width: 450px;
   max-height: 55px;
   margin: 0px;
   border-width: 1px;
@@ -238,7 +238,7 @@ class ContributePayment extends React.Component {
   render() {
     const { paymentMethodsOptions, errors } = this.state;
     return (
-      <StyledCard maxWidth={500} mx="auto">
+      <StyledCard width={1} maxWidth={500} mx="auto">
         <StyledRadioList
           id="PaymentMethod"
           name="PaymentMethod"

--- a/src/pages/createOrderNewFlow.js
+++ b/src/pages/createOrderNewFlow.js
@@ -537,7 +537,7 @@ class CreateOrderPage extends React.Component {
           />
         </MessageBox>
       ) : (
-        <Flex flexDirection="column">
+        <Flex flexDirection="column" width={1} css={{ maxWidth: 480 }}>
           <H5 textAlign="left" mb={3}>
             <FormattedMessage id="contribute.payment.label" defaultMessage="Choose a payment method:" />
           </H5>
@@ -711,7 +711,7 @@ class CreateOrderPage extends React.Component {
 
     const step = this.props.step || 'contributeAs';
     return (
-      <Flex flexDirection="column" alignItems="center" mx={3} width={1}>
+      <Flex flexDirection="column" alignItems="center" mx={3} width={0.95}>
         {this.renderStep(step)}
         <Flex mt={[4, null, 5]} justifyContent="center" flexWrap="wrap">
           {this.renderPrevStepButton(step)}


### PR DESCRIPTION
# Make ContributePayment the same width as ContributeAs

![selection_999 051](https://user-images.githubusercontent.com/1556356/51853815-7aa86b80-2329-11e9-8593-b7d085d40396.png)

# Add a thin padding for mobile

![selection_999 052](https://user-images.githubusercontent.com/1556356/51853821-7f6d1f80-2329-11e9-9827-6cacd5607777.png)
