### PR TITLE
Set loading state to true when expense form is submitted

### DIFF
--- a/src/apps/expenses/components/CreateExpenseForm.js
+++ b/src/apps/expenses/components/CreateExpenseForm.js
@@ -152,6 +152,11 @@ class CreateExpenseForm extends React.Component {
     if (e) {
       e.preventDefault();
     }
+
+    this.setState({
+      loading: true,
+    });
+
     try {
       await this.props.onSubmit(this.state.expense);
       this.setState({


### PR DESCRIPTION
This Fix [#1586](https://github.com/opencollective/opencollective/issues/1586).

This PR sets [`loading`](https://github.com/flickz/opencollective-frontend/blob/ba06855f8184fafe3ac0b278c5233d962773b394/src/apps/expenses/components/CreateExpenseForm.js#L156) state to true when "Submit Expense" button is clicked in order to disable button. 