### PR TITLE
Fix URL redirect with certain types of characters in SignIn

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -45,11 +45,27 @@ export function filterCollection(array, cond, inverse) {
   return array.filter(r => (inverse ? !test(r, cond) : test(r, cond)));
 }
 
+/** @deprecated since 28/01/2018 - this doesn't work for path with a `_` in it */
 export const isValidUrl = url => {
   if (typeof url !== 'string') return false;
   return Boolean(
     url.match(/^(?:([A-Za-z]+):)?(\/{0,3})([0-9.\-A-Za-z]+)(?::(\d+))?(?:\/([^?#]*))?(?:\?([^#]*))?(?:#(.*))?$/),
   );
+};
+
+/**
+ * Validate a relative path.
+ * > isValidRelativeUrl('a/b/c/d/e/f/g')
+ * true
+ * > isValidRelativeUrl('about.html')
+ * true
+ * > isValidRelativeUrl('//')
+ * false
+ * > isValidRelativeUrl('https://google.com')
+ * false
+ */
+export const isValidRelativeUrl = url => {
+  return Boolean(url.match(/^[^/]*\/[^/].*$|^\/[^/].*$/));
 };
 
 export const isValidEmail = email => {

--- a/src/pages/signin.js
+++ b/src/pages/signin.js
@@ -9,7 +9,7 @@ import Header from '../components/Header';
 import Body from '../components/Body';
 import Footer from '../components/Footer';
 
-import { isValidUrl } from '../lib/utils';
+import { isValidRelativeUrl } from '../lib/utils';
 
 import withIntl from '../lib/withIntl';
 import { withUser } from '../components/UserProvider';
@@ -19,7 +19,7 @@ import MessageBox from '../components/MessageBox';
 
 class SigninPage extends React.Component {
   static getInitialProps({ query: { token, next } }) {
-    next = isValidUrl(next) && next.substr(0, 1) === '/' ? next : null;
+    next = next && isValidRelativeUrl(next) ? next : null;
     return { token, next };
   }
 


### PR DESCRIPTION
In SignIn, redirect would not work with URLs like `/test_with_underscore` because the regex used in `isValidUrl` does not work for it.