### PR TITLE
ContributionFlow: Compatiblity with legacy routes parameters

### DIFF
--- a/cypress/integration/12-contributionFlow.donate.test.js
+++ b/cypress/integration/12-contributionFlow.donate.test.js
@@ -115,4 +115,17 @@ describe('Contribution Flow: Donate', () => {
       cy.contains('Evil Corp is now a backer of APEX.');
     });
   });
+
+  it('Forces params if given in URL', () => {
+    cy.signup({ redirect: '/apex/donate/42/year', visitParams }).then(() => {
+      cy.contains('Next step').click();
+
+      // Amount must be disabled
+      cy.get('#totalAmount[disabled]').should('have.value', '42');
+      // Frequency must be disabled
+      cy.contains('#interval[disabled]', 'Yearly');
+      // Ensure all values are dispatched in state
+      cy.contains('.step-details', '$42.00 per year');
+    });
+  });
 });

--- a/src/server/pages.js
+++ b/src/server/pages.js
@@ -59,17 +59,25 @@ pages
 
 const createOrderPage = parseToBoolean(getEnvVar('USE_NEW_CREATE_ORDER')) ? 'createOrderNewFlow' : 'createOrder';
 
-// Generic Route -> Feature Flag
-pages.add('orderCollective', '/:collectiveSlug/:verb(donate|pay|contribute)', createOrderPage);
-
 // Special route to force New Flow
 pages.add('orderCollectiveNewForce', '/:collectiveSlug/:verb(donate|pay|contribute)/newFlow', 'createOrderNewFlow');
 
 // Special route to force Legacy Flow
 pages.add('orderCollectiveLegacyForce', '/:collectiveSlug/:verb(donate|pay|contribute)/legacy', 'createOrder');
 
+// Generic Route -> Feature Flag
+pages.add(
+  'orderCollective',
+  '/:collectiveSlug/:verb(donate|pay|contribute)/:amount(\\d+)?/:interval(month|monthly|year|yearly)?/:description?',
+  createOrderPage,
+);
+
 // Old Route -> Old Flow (should be handled by a redirect once feature flag is gone)
-pages.add('orderCollectiveTier', '/:collectiveSlug/order/:TierId', 'createOrder');
+pages.add(
+  'orderCollectiveTier',
+  '/:collectiveSlug/order/:TierId/:amount(\\d+)?/:interval(month|monthly|year|yearly)?',
+  'createOrder',
+);
 
 // New Routes -> New flow
 pages


### PR DESCRIPTION
- Make it compatible with old routes using the pattern `/donate/:amount?/:interval?/:description?`
- Pass the `amount` instead of the `totalAmount` when changing steps in URL
- Tested E2E