### PR TITLE
Add Address field to Collective Edit Form

### DIFF
--- a/src/components/EditCollectiveForm.js
+++ b/src/components/EditCollectiveForm.js
@@ -196,6 +196,10 @@ class EditCollectiveForm extends React.Component {
         id: 'collective.country.label',
         defaultMessage: 'Country',
       },
+      'address.label': {
+        id: 'collective.address.label',
+        defaultMessage: 'Address',
+      },
     });
 
     collective.backgroundImage = collective.backgroundImage || defaultBackgroundImage[collective.type];
@@ -249,7 +253,14 @@ class EditCollectiveForm extends React.Component {
 
   handleChange(fieldname, value) {
     const collective = {};
-    collective[fieldname] = value;
+    // GrarphQL schema has address emebed within location
+    // mutation expects { location: { address: '' } }
+    if (fieldname === 'address') {
+      collective['location'] = value;
+    } else {
+      collective[fieldname] = value;
+    }
+
     this.setState({
       modified: true,
       collective: Object.assign({}, this.state.collective, collective),
@@ -325,12 +336,17 @@ class EditCollectiveForm extends React.Component {
           maxLength: 255,
           placeholder: '',
         },
+        {
+          name: 'address',
+          placeholder: '',
+          maxLength: 255,
+        },
         // {
         //   name: 'location',
         //   placeholder: 'Search cities',
         //   type: 'location',
         //   options: {
-        //     types: ['cities']
+        //     types: ['cities']location
         //   }
         // },
         {

--- a/src/components/InputField.js
+++ b/src/components/InputField.js
@@ -140,7 +140,7 @@ class InputField extends React.Component {
   }
 
   handleChange(value) {
-    const { type } = this.props;
+    const { type, name } = this.props;
     if (type === 'number') {
       value = parseInt(value) || null;
     } else if (type === 'currency') {
@@ -152,6 +152,11 @@ class InputField extends React.Component {
     } else {
       this.setState({ validationState: 'error' });
     }
+
+    if (name === 'address') {
+      value = { address: value };
+    }
+
     this.setState({ value });
     this.props.onChange(value);
   }
@@ -541,7 +546,8 @@ class InputField extends React.Component {
         );
         break;
 
-      default:
+      default: {
+        const addressDefaultValue = field.name === 'address' ? context['location'][field.name] : '';
         this.input = (
           <FieldGroup
             onChange={event => this.handleChange(event.target.value)}
@@ -557,12 +563,12 @@ class InputField extends React.Component {
             autoFocus={field.focus}
             placeholder={field.placeholder}
             className={field.className}
-            defaultValue={field.defaultValue}
+            defaultValue={field.defaultValue || addressDefaultValue}
             validationState={this.state.validationState}
           />
         );
-
         break;
+      }
     }
 
     return (

--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -114,6 +114,9 @@ const editCollectiveQuery = gql`
       backgroundImage
       description
       longDescription
+      location {
+        address
+      }
       website
       twitterHandle
       githubHandle

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -198,6 +198,9 @@ const getCollectiveToEditQuery = gql`
       backgroundImage
       description
       longDescription
+      location {
+        address
+      }
       tags
       countryISO
       twitterHandle
@@ -327,6 +330,9 @@ const getCollectiveQuery = gql`
       backgroundImage
       description
       longDescription
+      location {
+        address
+      }
       twitterHandle
       githubHandle
       website


### PR DESCRIPTION
This fix [#1639](https://github.com/opencollective/opencollective/issues/1639)

- Adds Address [input field](https://github.com/flickz/opencollective-frontend/blob/87cbfd5b0c7aa0c987caf49766800816b9b45c91/src/components/EditCollectiveForm.js#L339) to collective edit form
- Update the collective [queries](https://github.com/flickz/opencollective-frontend/blob/927b98947def54e7f38f2e54e99764d243214ba7/src/graphql/mutations.js#L104) and [mutations](https://github.com/flickz/opencollective-frontend/blob/927b98947def54e7f38f2e54e99764d243214ba7/src/graphql/mutations.js#L104).

cc @xdamman  @znarf 