### PR TITLE
Fix an issue preventing Firefox/Mac users to sign in

### DIFF
--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -36,7 +36,11 @@ const SignIn = withState('state', 'setState', { error: null, showError: false })
             name="email"
             onChange={({ target }) => {
               onEmailChange(target.value);
-              setState({ error: target.validationMessage, showError: false });
+              // Feel free to remove the setTimeout when that issue is fixed
+              // https://bugzilla.mozilla.org/show_bug.cgi?id=1524212
+              setTimeout(() => {
+                setState({ error: target.validationMessage, showError: false });
+              }, 0);
             }}
             onBlur={() => setState({ ...state, showError: true })}
             onInvalid={event => {


### PR DESCRIPTION
add a setTimeout before updating the state to mitigate a reported Firefox bug.

Bug was just reported on Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1524212

https://github.com/opencollective/opencollective/issues/1685