### PR TITLE
Remove newrelic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1553,46 +1553,6 @@
         "glob-to-regexp": "^0.3.0"
       }
     },
-    "@newrelic/koa": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-1.0.8.tgz",
-      "integrity": "sha512-kY//FlLQkGdUIKEeGJlyY3dJRU63EG77YIa48ACMGZxQbWRd3WZMikyft33f8XScTq6WpCDo9xa0viNo8zeYkg==",
-      "requires": {
-        "methods": "^1.1.2"
-      }
-    },
-    "@newrelic/native-metrics": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-4.0.0.tgz",
-      "integrity": "sha512-ZDUlOufD++AdiY9vWC9zpsUw0Q3od7M2mZSG/avTQnQYR6MtGhaOoXqY7GuAlmbNiN8lGkDR+4BkbYO57hq70g==",
-      "optional": true,
-      "requires": {
-        "nan": "^2.12.1",
-        "semver": "^5.5.1"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.12.1",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-          "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
-          "optional": true
-        },
-        "semver": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
-          "optional": true
-        }
-      }
-    },
-    "@newrelic/superagent": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@newrelic/superagent/-/superagent-1.0.2.tgz",
-      "integrity": "sha512-B2fM48kfY+5L6pwk6Yt79yk1JzMWKu1wV73If2shAzMsujNqSA4P+mLKCnTthIuKlhE78OfB1MzSpRMeB7kgWw==",
-      "requires": {
-        "methods": "^1.1.2"
-      }
-    },
     "@nodelib/fs.stat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
@@ -1792,11 +1752,6 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
       "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
-    },
-    "@tyriar/fibonacci-heap": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@tyriar/fibonacci-heap/-/fibonacci-heap-2.0.9.tgz",
-      "integrity": "sha512-bYuSNomfn4hu2tPiDN+JZtnzCpSpbJ/PNeulmocDy3xN2X5OkJL65zo6rPZp65cPPhLF9vfT/dgE+RtFRCSxOA=="
     },
     "@vxna/mini-html-webpack-template": {
       "version": "0.1.7",
@@ -2671,14 +2626,6 @@
       "resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
       "integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg==",
       "dev": true
-    },
-    "agent-base": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
-      "requires": {
-        "es6-promisify": "^5.0.0"
-      }
     },
     "ajv": {
       "version": "5.5.2",
@@ -7330,14 +7277,6 @@
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
       "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
     },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "requires": {
-        "es6-promise": "^4.0.3"
-      }
-    },
     "es6-templates": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz",
@@ -10571,30 +10510,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
-    },
-    "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
-      "requires": {
-        "agent-base": "^4.1.0",
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        }
-      }
     },
     "husky": {
       "version": "1.3.1",
@@ -16683,23 +16598,6 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.2.tgz",
       "integrity": "sha512-vdqTKI9GBIYcAEbFAcpKPErKINfPF5zIuz3/niBfq8WUZjpT2tytLlFVrBgWdOtqI4uaA/Rb6No0hux39XXDuw=="
-    },
-    "newrelic": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-5.2.1.tgz",
-      "integrity": "sha512-yB2ZEUeJLHCZfk4enXa3YFWVyK3yc+BuS+Y65jWOgXq/vaYq4KG8/gvqIdfKz0ziFWBfA//N3vm9RiyeZq3VJg==",
-      "requires": {
-        "@newrelic/koa": "^1.0.0",
-        "@newrelic/native-metrics": "^4.0.0",
-        "@newrelic/superagent": "^1.0.0",
-        "@tyriar/fibonacci-heap": "^2.0.7",
-        "async": "^2.1.4",
-        "concat-stream": "^1.5.0",
-        "https-proxy-agent": "^2.2.1",
-        "json-stringify-safe": "^5.0.0",
-        "readable-stream": "^2.1.4",
-        "semver": "^5.3.0"
-      }
     },
     "next": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "markdown-loader": "5.0.0",
     "moment": "2.24.0",
     "moment-timezone": "0.5.23",
-    "newrelic": "5.2.1",
     "next": "7.0.2",
     "next-routes": "1.4.2",
     "node-fetch": "2.3.0",

--- a/src/env.js
+++ b/src/env.js
@@ -5,11 +5,6 @@ import dotenv from 'dotenv';
 dotenv.config();
 debug.enable(process.env.DEBUG);
 
-// Only load newrelic when we explicitly want it
-if (process.env.NEW_RELIC_LICENSE_KEY) {
-  require('newrelic');
-}
-
 const defaults = {
   PORT: 3000,
   NODE_ENV: 'development',


### PR DESCRIPTION
Similar to https://github.com/opencollective/opencollective-api/pull/1650

We're not using it. The UI is complicated and confusing. The data available on the free plan was never useful for us. We better just check Heroku metrics.