### PR TITLE
ContributionFlow: Properly create organization

### DIFF
--- a/src/pages/createOrderNewFlow.js
+++ b/src/pages/createOrderNewFlow.js
@@ -552,7 +552,7 @@ class CreateOrderPage extends React.Component {
     };
 
     // check if we're creating a new organization
-    if (!currentStep && stepProfile && stepProfile.name && stepProfile.website && !stepProfile.id) {
+    if (!currentStep && stepProfile && stepProfile.name && !stepProfile.id) {
       this.setState({ error: null, submitting: true });
 
       try {
@@ -563,6 +563,8 @@ class CreateOrderPage extends React.Component {
         this.setState({ stepProfile: createdOrg, submitting: false });
       } catch (error) {
         this.setState({ error: error.message, submitting: false });
+        window.scrollTo(0, 0);
+        return false;
       }
     } else if (currentStep === 'details' && step === 'payment') {
       // Validate ContributeDetails step before going next


### PR DESCRIPTION
Organization website was not required in the component, but was required in the flow - resulting in organization not being properly created when going to the next step.

Also errors were not properly handled and it was possible to go to the next step if organization creation failed.

Fix https://github.com/opencollective/opencollective/issues/1643

![peek 04-02-2019 11-47](https://user-images.githubusercontent.com/1556356/52203856-bcc63580-2872-11e9-936a-aec4437333a7.gif)
