### PR TITLE
Fix: ContributeAs validation UX

### DIFF
--- a/src/components/ContributeAs.js
+++ b/src/components/ContributeAs.js
@@ -110,7 +110,11 @@ const enhance = compose(
       defaultValue: state[name] || '',
       fontSize: 'Paragraph',
       lineHeight: 'Paragraph',
-      onBlur: event => event.target.reportValidity(),
+      onBlur: event => {
+        const hasValue = event.target.value;
+        const wasUpdatedOnce = state.hasOwnProperty(event.target.name);
+        if (hasValue || wasUpdatedOnce) event.target.reportValidity();
+      },
       onInvalid,
       type: 'text',
       width: 1,

--- a/src/components/ContributeAs.js
+++ b/src/components/ContributeAs.js
@@ -57,6 +57,7 @@ const enhance = compose(
       const { target } = event;
       if (!target.validity.valid) {
         onChange(null);
+        setState({ ...state, [target.name]: undefined });
         return;
       }
 
@@ -68,7 +69,9 @@ const enhance = compose(
         ...newState,
         errors: { ...state.errors, [target.name]: null },
       });
-      onChange({ type: 'ORGANIZATION', ...omit(newState, ['errors']) });
+      if (newState.name && newState.website) {
+        onChange({ type: 'ORGANIZATION', ...omit(newState, ['errors']) });
+      }
     },
     onInvalid: ({ setState }) => event => {
       event.persist();

--- a/src/pages/createOrderNewFlow.js
+++ b/src/pages/createOrderNewFlow.js
@@ -129,7 +129,7 @@ class CreateOrderPage extends React.Component {
     super(props);
     this.recaptcha = null;
     this.recaptchaToken = null;
-    this.contributeDetailsFormRef = React.createRef();
+    this.activeFormRef = React.createRef();
     this.state = {
       loading: false,
       submitting: false,
@@ -327,9 +327,6 @@ class CreateOrderPage extends React.Component {
 
   /** Return the index of the last step user can switch to */
   getMaxStepIdx() {
-    // Validate step profile
-    if (!this.state.stepProfile) return 0;
-
     // Validate step details
     if (!this.state.stepDetails || isNil(this.state.stepDetails.totalAmount)) return 1;
     if (this.state.stepDetails.totalAmount === 0 && !this.isFreeTier()) return 1;
@@ -471,13 +468,15 @@ class CreateOrderPage extends React.Component {
           }
         >
           {fieldProps => (
-            <ContributeAs
-              {...fieldProps}
-              onChange={this.updateProfile}
-              profiles={profiles}
-              personal={personal}
-              defaultSelectedProfile={this.getLoggedInUserDefaultContibuteProfile()}
-            />
+            <Container as="form" onSubmit={e => e.preventDefault()} ref={this.activeFormRef}>
+              <ContributeAs
+                {...fieldProps}
+                onChange={this.updateProfile}
+                profiles={profiles}
+                personal={personal}
+                defaultSelectedProfile={this.getLoggedInUserDefaultContibuteProfile()}
+              />
+            </Container>
           )}
         </StyledInputField>
       );
@@ -488,7 +487,7 @@ class CreateOrderPage extends React.Component {
           <Container
             as="form"
             onSubmit={e => e.preventDefault()}
-            ref={this.contributeDetailsFormRef}
+            ref={this.activeFormRef}
             mx={5}
             width={[0.95, null, 3 / 5]}
             maxWidth="465px"
@@ -568,7 +567,11 @@ class CreateOrderPage extends React.Component {
       }
     } else if (currentStep === 'details' && step === 'payment') {
       // Validate ContributeDetails step before going next
-      if (!this.contributeDetailsFormRef.current || !this.contributeDetailsFormRef.current.reportValidity()) {
+      if (!this.activeFormRef.current || !this.activeFormRef.current.reportValidity()) {
+        return false;
+      }
+    } else if (!currentStep || currentStep === 'contributeAs') {
+      if (this.activeFormRef.current && !this.activeFormRef.current.reportValidity()) {
         return false;
       }
     }


### PR DESCRIPTION
Fixes the bug where we could create an org without website.
Stop validating skipped fields, only validate the field if we're actually adding value or if that field already had any value in the past.

About the validation when clicking the **Next Step** button:
Not sure if the UX worths the refactor.
There are two validations happening here: _Field Validation_ and _Step Validation_.

_Field Validation_ is responsible for validating our inputs in `ContributeAs` component.
It is triggered by input events, which are internal to `ContributeAs`.
If fields are valid, `ContributeAs` calls `updateProfile` from `createOrderNewFlow` page. `updateProfile` does exactly what it says it does, it updates `stepProfile`.

_Step Validation_ is responsible for enabling the Next Step.
This happens one level above, in `createOrderNewFlow` page.
It is processed in `getMaxStepIdx()` which is responsible for passing to `renderNextStepButton()` (triggered on rendering).

The problem is that we have two validations happening in different levels of abstraction.
`ContributeAs` and the Next Step button are siblings and children of `createOrderNewFlow`.
IMO, if we want to start calling step functions when clicking this button, this means these buttons should be children of the page and not siblings.
The other solution is implementing and Observer pattern (use events) to trigger actions across different components, but if we go with that, we'll eventually end up in _I made queso_.

Fixes: https://github.com/opencollective/opencollective/issues/1692