### PR TITLE
Revamp GitHub flow for new collectives

### DIFF
--- a/cypress/integration/31-create-collectiveFromGithub.test.js
+++ b/cypress/integration/31-create-collectiveFromGithub.test.js
@@ -1,0 +1,46 @@
+describe('Create collective from Github', () => {
+  it('Should submit create github page', () => {
+    cy.server();
+    cy.route({
+      method: 'GET',
+      url: '/api/github-repositories?*',
+      response: [
+        {
+          description: 'Adblock Plus browser extension',
+          fork: true,
+          full_name: 'flickz/adblockpluschrome',
+          name: 'adblockpluschrome',
+          owner: { login: 'flickz', type: 'Organization' },
+          stargazers_count: 113,
+        },
+        {
+          description:
+            'A new form of association, transparent by design. Please report issues there. Feature requests and ideas welcome!',
+          fork: true,
+          full_name: 'flickz/jobtweets',
+          name: 'JobTweets',
+          owner: { login: 'flickz', type: 'User' },
+          stargazers_count: 103,
+        },
+      ],
+    });
+    cy.login({ email: 'testuser@opencollective.com', redirect: '/opensource/create?token=foofoo' });
+    cy.contains('Pick a repository');
+    cy.get('[type="radio"]')
+      .first()
+      .check();
+    cy.get('[name="name"]')
+      .first()
+      .type('Adblock plus');
+    cy.get('[name="slug"]')
+      .first()
+      .type('adblock');
+    cy.get('[type="submit"]')
+      .first()
+      .click();
+    cy.wait(3500);
+    cy.location().should(location => {
+      expect(location.search).to.eq('?status=collectiveCreated');
+    });
+  });
+});

--- a/cypress/integration/31-create-collectiveFromGithub.test.js
+++ b/cypress/integration/31-create-collectiveFromGithub.test.js
@@ -38,7 +38,7 @@ describe('Create collective from Github', () => {
     cy.get('[type="submit"]')
       .first()
       .click();
-    cy.wait(3500);
+    cy.wait(6500);
     cy.location().should(location => {
       expect(location.search).to.eq('?status=collectiveCreated');
     });

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -19,6 +19,7 @@ import {
   flexDirection,
   flexWrap,
   fontSize,
+  fontWeight,
   height,
   justifyContent,
   left,
@@ -68,6 +69,7 @@ const Container = styled(tag)`
   ${flex}
   ${flexDirection}
   ${flexWrap}
+  ${fontWeight}
   ${float}
   ${fontSize}
   ${height}

--- a/src/components/GithubRepositories.js
+++ b/src/components/GithubRepositories.js
@@ -36,7 +36,9 @@ const enhance = compose(
     },
   }),
 );
-
+/**
+ * Component for displaying list of public repositories
+ */
 const GithubRepositories = enhance(
   ({ repositories, onSearch, onCreateCollective, creatingCollective, state, ...fieldProps }) => {
     if (state.search) {
@@ -90,8 +92,11 @@ const GithubRepositories = enhance(
 );
 
 GithubRepositories.propTypes = {
+  /** List of public repositories */
   repositories: PropTypes.array.isRequired,
+  /** a boolean to know when a collective is being created */
   creatingCollective: PropTypes.bool,
+  /** handles the submitted collective */
   onCreateCollective: PropTypes.func.isRequired,
 };
 

--- a/src/components/GithubRepositories.js
+++ b/src/components/GithubRepositories.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { themeGet } from 'styled-system';
+import { withHandlers, withState, compose } from 'recompose';
+import styled from 'styled-components';
+import { Search } from 'styled-icons/octicons/Search.cjs';
+
+import { escapeInput } from '../lib/utils';
+import { H4 } from './Text';
+
+import Container from './Container';
+import StyledCard from './StyledCard';
+import StyledRadioList from './StyledRadioList';
+import StyledInput from './StyledInput';
+import GithubRepositoryEntry from './GithubRepositoryEntry';
+
+const SearchIcon = styled(Search)`
+  color: ${themeGet('colors.black.300')};
+`;
+
+const RepositoryEntryContainer = styled(Container)`
+  cursor: pointer;
+  &:hover {
+    background: ${themeGet('colors.black.50')};
+  }
+`;
+
+const enhance = compose(
+  withState('state', 'setState', { search: '' }),
+  withHandlers({
+    onSearch: ({ setState }) => ({ target }) => {
+      setState(state => ({
+        ...state,
+        search: target.value,
+      }));
+    },
+  }),
+);
+
+const GithubRepositories = enhance(({ repositories, onSearch, onCreateCollective, state, ...fieldProps }) => {
+  if (state.search) {
+    const test = new RegExp(escapeInput(state.search), 'i');
+    repositories = repositories.filter(repository => repository.name.match(test));
+  }
+
+  const showSearch = true; // repositories.length >= 5;
+  return (
+    <StyledCard maxWidth={500} minWidth={464}>
+      {showSearch && (
+        <Container display="flex" borderBottom="1px solid" borderColor="black.200" px={4} py={1} alignItems="center">
+          <SearchIcon size="16" />
+          <StyledInput
+            bare
+            type="text"
+            fontSize="Paragraph"
+            lineHeight="Paragraph"
+            placeholder="Filter by name..."
+            onChange={onSearch}
+            ml={2}
+          />
+        </Container>
+      )}
+
+      {repositories.length === 0 && (
+        <Container my={3}>
+          <H4 textAlign="center" fontSize="1.4rem" color="black.400">
+            No repository match
+          </H4>
+        </Container>
+      )}
+      <StyledRadioList {...fieldProps} options={repositories} keyGetter="name">
+        {({ value, radio, checked }) => {
+          return (
+            <RepositoryEntryContainer px={4} py={3}>
+              <GithubRepositoryEntry
+                radio={radio}
+                value={value}
+                checked={checked}
+                onCreateCollective={onCreateCollective}
+              />
+            </RepositoryEntryContainer>
+          );
+        }}
+      </StyledRadioList>
+    </StyledCard>
+  );
+});
+
+GithubRepositories.propTypes = {
+  repositories: PropTypes.array.isRequired,
+  onCreateCollective: PropTypes.func.isRequired,
+};
+
+export default GithubRepositories;

--- a/src/components/GithubRepositories.js
+++ b/src/components/GithubRepositories.js
@@ -37,57 +37,61 @@ const enhance = compose(
   }),
 );
 
-const GithubRepositories = enhance(({ repositories, onSearch, onCreateCollective, state, ...fieldProps }) => {
-  if (state.search) {
-    const test = new RegExp(escapeInput(state.search), 'i');
-    repositories = repositories.filter(repository => repository.name.match(test));
-  }
+const GithubRepositories = enhance(
+  ({ repositories, onSearch, onCreateCollective, creatingCollective, state, ...fieldProps }) => {
+    if (state.search) {
+      const test = new RegExp(escapeInput(state.search), 'i');
+      repositories = repositories.filter(repository => repository.name.match(test));
+    }
 
-  const showSearch = true; // repositories.length >= 5;
-  return (
-    <StyledCard maxWidth={500} minWidth={464}>
-      {showSearch && (
-        <Container display="flex" borderBottom="1px solid" borderColor="black.200" px={4} py={1} alignItems="center">
-          <SearchIcon size="16" />
-          <StyledInput
-            bare
-            type="text"
-            fontSize="Paragraph"
-            lineHeight="Paragraph"
-            placeholder="Filter by name..."
-            onChange={onSearch}
-            ml={2}
-          />
-        </Container>
-      )}
+    const showSearch = true; // repositories.length >= 5;
+    return (
+      <StyledCard maxWidth={500} minWidth={464}>
+        {showSearch && (
+          <Container display="flex" borderBottom="1px solid" borderColor="black.200" px={4} py={1} alignItems="center">
+            <SearchIcon size="16" />
+            <StyledInput
+              bare
+              type="text"
+              fontSize="Paragraph"
+              lineHeight="Paragraph"
+              placeholder="Filter by name..."
+              onChange={onSearch}
+              ml={2}
+            />
+          </Container>
+        )}
 
-      {repositories.length === 0 && (
-        <Container my={3}>
-          <H4 textAlign="center" fontSize="1.4rem" color="black.400">
-            No repository match
-          </H4>
-        </Container>
-      )}
-      <StyledRadioList {...fieldProps} options={repositories} keyGetter="name">
-        {({ value, radio, checked }) => {
-          return (
-            <RepositoryEntryContainer px={4} py={3}>
-              <GithubRepositoryEntry
-                radio={radio}
-                value={value}
-                checked={checked}
-                onCreateCollective={onCreateCollective}
-              />
-            </RepositoryEntryContainer>
-          );
-        }}
-      </StyledRadioList>
-    </StyledCard>
-  );
-});
+        {repositories.length === 0 && (
+          <Container my={3}>
+            <H4 textAlign="center" fontSize="1.4rem" color="black.400">
+              No repository match
+            </H4>
+          </Container>
+        )}
+        <StyledRadioList {...fieldProps} options={repositories} keyGetter="name">
+          {({ value, radio, checked }) => {
+            return (
+              <RepositoryEntryContainer px={4} py={3}>
+                <GithubRepositoryEntry
+                  radio={radio}
+                  value={value}
+                  checked={checked}
+                  onCreateCollective={onCreateCollective}
+                  creatingCollective={creatingCollective}
+                />
+              </RepositoryEntryContainer>
+            );
+          }}
+        </StyledRadioList>
+      </StyledCard>
+    );
+  },
+);
 
 GithubRepositories.propTypes = {
   repositories: PropTypes.array.isRequired,
+  creatingCollective: PropTypes.bool,
   onCreateCollective: PropTypes.func.isRequired,
 };
 

--- a/src/components/GithubRepositories.js
+++ b/src/components/GithubRepositories.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { themeGet } from 'styled-system';
 import { withHandlers, withState, compose } from 'recompose';
 import styled from 'styled-components';
-import { Search } from 'styled-icons/octicons/Search.cjs';
+import { Search } from 'styled-icons/octicons/Search';
 
 import { escapeInput } from '../lib/utils';
 import { H4 } from './Text';

--- a/src/components/GithubRepositoryEntry.js
+++ b/src/components/GithubRepositoryEntry.js
@@ -111,6 +111,7 @@ const RepositoryEntry = enhance(
                 const data = pick(state, ['name', 'slug']);
                 if (state.useOrg) {
                   data.githubHandle = login;
+                  data.githubRepo = value.full_name;
                 } else {
                   data.githubHandle = value.full_name;
                 }

--- a/src/components/GithubRepositoryEntry.js
+++ b/src/components/GithubRepositoryEntry.js
@@ -54,8 +54,8 @@ const enhance = compose(
 );
 
 const RepositoryEntry = enhance(
-  ({ getFieldError, getFieldProps, onCreateCollective, radio, value, checked, state }) => {
-    const { type } = value.owner;
+  ({ getFieldError, getFieldProps, onCreateCollective, radio, value, checked, state, creatingCollective }) => {
+    const { type, login } = value.owner;
     const repositoryTypeName = type === 'User' ? 'Personal Repo' : 'Organization Repo';
 
     return (
@@ -99,6 +99,7 @@ const RepositoryEntry = enhance(
               onSubmit={event => {
                 event.preventDefault();
                 const data = pick(state, ['name', 'slug']);
+                data.githubHandle = login;
                 onCreateCollective(data);
               }}
             >
@@ -137,6 +138,7 @@ const RepositoryEntry = enhance(
                   width={1}
                   buttonSize="medium"
                   disabled={!state.name || !state.slug}
+                  loading={creatingCollective}
                   type="submit"
                 >
                   Create collective
@@ -165,6 +167,7 @@ RepositoryEntry.propTypes = {
     name: PropTypes.string,
   }),
   checked: PropTypes.bool,
+  creatingCollective: PropTypes.bool,
   onCreateCollective: PropTypes.func,
 };
 

--- a/src/components/GithubRepositoryEntry.js
+++ b/src/components/GithubRepositoryEntry.js
@@ -2,8 +2,8 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Box } from '@rebass/grid';
 import { pick } from 'lodash';
-import { Github } from 'styled-icons/fa-brands/Github.cjs';
-import { Star } from 'styled-icons/fa-solid/Star.cjs';
+import { Github } from 'styled-icons/fa-brands/Github';
+import { Star } from 'styled-icons/fa-solid/Star';
 import { withState, withHandlers, compose } from 'recompose';
 
 import { colors } from '../constants/theme';

--- a/src/components/GithubRepositoryEntry.js
+++ b/src/components/GithubRepositoryEntry.js
@@ -1,0 +1,171 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { Box } from '@rebass/grid';
+import { pick } from 'lodash';
+import { Github } from 'styled-icons/fa-brands/Github.cjs';
+import { Star } from 'styled-icons/fa-solid/Star.cjs';
+import { withState, withHandlers, compose } from 'recompose';
+
+import { colors } from '../constants/theme';
+import Container from './Container';
+import { P } from './Text';
+import StyledInputField from './StyledInputField';
+import StyledInputGroup from './StyledInputGroup';
+import StyledInput from './StyledInput';
+import StyledButton from './StyledButton';
+import StyledCheckbox from './StyledCheckbox';
+import Link from './Link';
+
+const enhance = compose(
+  withState('state', 'setState', ({ errors = {} }) => ({ errors })),
+  withHandlers({
+    getFieldError: ({ state }) => name => state.errors[name],
+    onChange: ({ setState }) => event => {
+      event.stopPropagation();
+      const { target } = event;
+
+      setState(state => ({
+        ...state,
+        [target.name]: target.value,
+        errors: { ...state.errors, [target.name]: null },
+      }));
+    },
+    onInvalid: ({ setState }) => event => {
+      event.persist();
+      event.preventDefault();
+      setState(state => ({
+        ...state,
+        errors: { ...state.errors, [event.target.name]: event.target.validationMessage },
+      }));
+    },
+  }),
+  // follows composition of onChange && onInvalid to access them from props
+  withHandlers({
+    getFieldProps: ({ state, onChange, onInvalid }) => name => ({
+      defaultValue: state[name] || '',
+      fontSize: 'Paragraph',
+      lineHeight: 'Paragraph',
+      onChange,
+      onInvalid,
+      type: 'text',
+      width: 1,
+    }),
+  }),
+);
+
+const RepositoryEntry = enhance(
+  ({ getFieldError, getFieldProps, onCreateCollective, radio, value, checked, state }) => {
+    const { type } = value.owner;
+    const repositoryTypeName = type === 'User' ? 'Personal Repo' : 'Organization Repo';
+
+    return (
+      <Fragment>
+        <Container display="flex" justifyContent="space-between" alignItems="flex-start">
+          <Container display="flex">
+            <Box as="span" mr={3}>
+              {radio}
+            </Box>
+            <Box as="span" mr={3}>
+              <Github size={40} color={colors.black[300]} />
+            </Box>
+            <Box as="span">
+              <P fontWeight={500} fontSize="1.4rem">
+                {value.full_name}
+              </P>
+              <P textTransform="uppercase" color="black.400" fontSize="1rem">
+                {repositoryTypeName}
+              </P>
+            </Box>
+          </Container>
+          <Container>
+            <Box>
+              <P fontWeight={300} fontSize="1.2rem">
+                {value.stargazers_count} <Star size={12} />
+              </P>
+            </Box>
+          </Container>
+        </Container>
+        <Container width={1} mx={3} my={2} px={2}>
+          {value.description && (
+            <P color="black.600" fontSize="1.2rem" fontWeight="400">
+              {value.description}
+            </P>
+          )}
+          {checked && (
+            <Container
+              as="form"
+              my={3}
+              method="POST"
+              onSubmit={event => {
+                event.preventDefault();
+                const data = pick(state, ['name', 'slug']);
+                onCreateCollective(data);
+              }}
+            >
+              <P fontSize="1.6rem" fontWeight="bold" mb={4}>
+                {'Please enter the Collective’s info:'}
+              </P>
+              {type === 'Organization' && (
+                <StyledCheckbox
+                  name="useOrg"
+                  label={`Use GitHub organization (${value.owner.login})`}
+                  onChange={() => {}}
+                />
+              )}
+              <Box mb={3} mt={4}>
+                <StyledInputField label="Collective name" htmlFor="name" error={getFieldError('name')}>
+                  {inputProps => <StyledInput {...inputProps} {...getFieldProps(inputProps.name)} required width={1} />}
+                </StyledInputField>
+              </Box>
+
+              <Box mb={3}>
+                <StyledInputField label="Collective URL" htmlFor="slug" error={getFieldError('slug')}>
+                  {inputProps => (
+                    <StyledInputGroup
+                      {...inputProps}
+                      {...getFieldProps(inputProps.name)}
+                      prepend="opencollective.com/"
+                      required
+                    />
+                  )}
+                </StyledInputField>
+              </Box>
+
+              <Container mb={3} width={1} textAlign="center">
+                <StyledButton
+                  buttonStyle="primary"
+                  width={1}
+                  buttonSize="medium"
+                  disabled={!state.name || !state.slug}
+                  type="submit"
+                >
+                  Create collective
+                </StyledButton>
+              </Container>
+              <P textAlign="center" color="black.500" fontSize="1.2rem" fontWeight="normal">
+                By pressing ‘Create Collective’ you agree to our <Link route="/tos">Terms of Service</Link> and the{' '}
+                <Link route="/privacypolicy">Privacy Policy</Link> of the Fiscal Host that will collect money on behalf
+                of this collective.
+              </P>
+            </Container>
+          )}
+        </Container>
+      </Fragment>
+    );
+  },
+);
+
+RepositoryEntry.propTypes = {
+  radio: PropTypes.object,
+  value: PropTypes.shape({
+    description: PropTypes.string,
+    owner: PropTypes.object,
+    stargazers_count: PropTypes.number,
+    full_name: PropTypes.string,
+    name: PropTypes.string,
+  }),
+  checked: PropTypes.bool,
+  onCreateCollective: PropTypes.func,
+};
+
+export default RepositoryEntry;

--- a/src/components/GithubRepositoryEntry.js
+++ b/src/components/GithubRepositoryEntry.js
@@ -17,7 +17,7 @@ import StyledCheckbox from './StyledCheckbox';
 import Link from './Link';
 
 const enhance = compose(
-  withState('state', 'setState', ({ errors = {} }) => ({ errors })),
+  withState('state', 'setState', ({ errors = {} }) => ({ errors, useOrg: false })),
   withHandlers({
     getFieldError: ({ state }) => name => state.errors[name],
     onChange: ({ setState }) => event => {
@@ -54,8 +54,18 @@ const enhance = compose(
 );
 
 const RepositoryEntry = enhance(
-  ({ getFieldError, getFieldProps, onCreateCollective, radio, value, checked, state, creatingCollective }) => {
-    const { type } = value.owner;
+  ({
+    getFieldError,
+    getFieldProps,
+    onCreateCollective,
+    radio,
+    value,
+    checked,
+    state,
+    creatingCollective,
+    setState,
+  }) => {
+    const { type, login } = value.owner;
     const repositoryTypeName = type === 'User' ? 'Personal Repo' : 'Organization Repo';
 
     return (
@@ -99,7 +109,11 @@ const RepositoryEntry = enhance(
               onSubmit={event => {
                 event.preventDefault();
                 const data = pick(state, ['name', 'slug']);
-                data.githubHandle = value.full_name;
+                if (state.useOrg) {
+                  data.githubHandle = login;
+                } else {
+                  data.githubHandle = value.full_name;
+                }
                 onCreateCollective(data);
               }}
             >
@@ -110,7 +124,12 @@ const RepositoryEntry = enhance(
                 <StyledCheckbox
                   name="useOrg"
                   label={`Use GitHub organization (${value.owner.login})`}
-                  onChange={() => {}}
+                  onChange={({ checked }) => {
+                    setState(state => ({
+                      ...state,
+                      useOrg: checked,
+                    }));
+                  }}
                 />
               )}
               <Box mb={3} mt={4}>

--- a/src/components/GithubRepositoryEntry.js
+++ b/src/components/GithubRepositoryEntry.js
@@ -55,7 +55,7 @@ const enhance = compose(
 
 const RepositoryEntry = enhance(
   ({ getFieldError, getFieldProps, onCreateCollective, radio, value, checked, state, creatingCollective }) => {
-    const { type, login } = value.owner;
+    const { type } = value.owner;
     const repositoryTypeName = type === 'User' ? 'Personal Repo' : 'Organization Repo';
 
     return (
@@ -99,7 +99,7 @@ const RepositoryEntry = enhance(
               onSubmit={event => {
                 event.preventDefault();
                 const data = pick(state, ['name', 'slug']);
-                data.githubHandle = login;
+                data.githubHandle = value.full_name;
                 onCreateCollective(data);
               }}
             >

--- a/src/components/GithubRepositoryEntry.js
+++ b/src/components/GithubRepositoryEntry.js
@@ -13,11 +13,11 @@ import StyledInputField from './StyledInputField';
 import StyledInputGroup from './StyledInputGroup';
 import StyledInput from './StyledInput';
 import StyledButton from './StyledButton';
-import StyledCheckbox from './StyledCheckbox';
 import Link from './Link';
+import StyledRadioList from './StyledRadioList';
 
 const enhance = compose(
-  withState('state', 'setState', ({ errors = {} }) => ({ errors, useOrg: false })),
+  withState('state', 'setState', ({ errors = {} }) => ({ errors, useType: 'repository' })),
   withHandlers({
     getFieldError: ({ state }) => name => state.errors[name],
     onChange: ({ setState }) => event => {
@@ -109,7 +109,7 @@ const RepositoryEntry = enhance(
               onSubmit={event => {
                 event.preventDefault();
                 const data = pick(state, ['name', 'slug']);
-                if (state.useOrg) {
+                if (state.useType === 'organization') {
                   data.githubHandle = login;
                   data.githubRepo = value.full_name;
                 } else {
@@ -118,20 +118,45 @@ const RepositoryEntry = enhance(
                 onCreateCollective(data);
               }}
             >
-              <P fontSize="1.6rem" fontWeight="bold" mb={4}>
+              <P fontSize="1.6rem" fontWeight="bold" mb={3}>
                 {'Please enter the Collective’s info:'}
               </P>
               {type === 'Organization' && (
-                <StyledCheckbox
-                  name="useOrg"
-                  label={`Use GitHub organization (${value.owner.login})`}
-                  onChange={({ checked }) => {
+                <StyledRadioList
+                  id="useType"
+                  name="useType"
+                  options={['repository', 'organization']}
+                  defaultValue={'repository'}
+                  onChange={({ key }) => {
                     setState(state => ({
                       ...state,
-                      useOrg: checked,
+                      useType: key,
                     }));
                   }}
-                />
+                >
+                  {props => {
+                    return (
+                      <Container cursor="pointer">
+                        {props.value === 'repository' && (
+                          <Container fontWeight="400" fontSize="1.4rem" mb={4}>
+                            <Box as="span" mr={3}>
+                              {props.radio}
+                            </Box>
+                            Create a Collective for the Repository ({value.name}).
+                          </Container>
+                        )}
+                        {props.value === 'organization' && (
+                          <Container fontWeight="400" fontSize="1.4rem">
+                            <Box as="span" mr={3}>
+                              {props.radio}
+                            </Box>
+                            Create a Collective for the Organization ({login}).
+                          </Container>
+                        )}
+                      </Container>
+                    );
+                  }}
+                </StyledRadioList>
               )}
               <Box mb={3} mt={4}>
                 <StyledInputField label="Collective name" htmlFor="name" error={getFieldError('name')}>

--- a/src/components/StyledCard.js
+++ b/src/components/StyledCard.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import {
+  textAlign,
   background,
   borderColor,
   borders,
@@ -36,6 +37,7 @@ const StyledCard = styled(Box)`
   ${minHeight}
   ${minWidth}
   ${overflow}
+  ${textAlign}
 `;
 
 StyledCard.propTypes = {
@@ -70,6 +72,8 @@ StyledCard.propTypes = {
    * see: https://github.com/jxnblk/styled-system/blob/master/docs/api.md#space
    */
   space: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
+  /** styled-system prop: accepts any css 'text-align' value */
+  textAlign: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
 };
 
 StyledCard.defaultProps = {

--- a/src/components/StyledRadioList.js
+++ b/src/components/StyledRadioList.js
@@ -24,7 +24,9 @@ const StyledRadioList = enhance(
         border="none"
         m={0}
         p={0}
-        onChange={({ target }) => {
+        onChange={event => {
+          event.stopPropagation();
+          const target = event.target;
           const selectedItem = find(items, item => item.key === target.value);
           onChange({ type: 'fieldset', name, key: selectedItem.key, value: selectedItem.value });
           setSelected(target.value);

--- a/src/components/faqs/GithubRepositoriesFAQ.js
+++ b/src/components/faqs/GithubRepositoriesFAQ.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import FAQ from './FAQ';
+
+/**
+ * FAQ associated to the `GithubRepositories` component.
+ */
+const GithubRepositoriesFAQ = props => (
+  <FAQ {...props}>
+    {({ Container, Entry, Title, Content }) => (
+      <Container>
+        <Entry>
+          <Title>
+            <FormattedMessage
+              id="GithubRepositories.faq.repoStar.title"
+              defaultMessage="Why only repos with at least 100 stars?"
+            />
+          </Title>
+          <Content>
+            <FormattedMessage
+              id="GithubRepositories.faq.repoStar.content"
+              defaultMessage="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam."
+            />
+          </Content>
+        </Entry>
+      </Container>
+    )}
+  </FAQ>
+);
+
+export default GithubRepositoriesFAQ;

--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -98,6 +98,7 @@ const createCollectiveFromGithubQuery = gql`
       name
       slug
       type
+      githubHandle
     }
   }
 `;

--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -338,32 +338,7 @@ export const addCreateCollectiveMutation = graphql(createCollectiveQuery, {
 export const addCreateCollectiveFromGithubMutation = graphql(createCollectiveFromGithubQuery, {
   props: ({ mutate }) => ({
     createCollectiveFromGithub: async collective => {
-      const CollectiveInputType = pick(collective, [
-        'slug',
-        'type',
-        'name',
-        'image',
-        'description',
-        'longDescription',
-        'location',
-        'twitterHandle',
-        'githubHandle',
-        'website',
-        'tags',
-        'startsAt',
-        'endsAt',
-        'timezone',
-        'maxAmount',
-        'currency',
-        'quantity',
-        'HostCollectiveId',
-        'ParentCollectiveId',
-        'data',
-      ]);
-      CollectiveInputType.tiers = (collective.tiers || []).map(tier =>
-        pick(tier, ['type', 'name', 'description', 'amount', 'maxQuantity', 'maxQuantityPerUser']),
-      );
-      CollectiveInputType.location = pick(collective.location, ['name', 'address', 'lat', 'long']);
+      const CollectiveInputType = pick(collective, ['slug', 'type', 'name', 'description', 'githubHandle']);
       return await mutate({
         variables: { collective: CollectiveInputType },
         update: (store, { data: { createCollectiveFromGithub } }) => {

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -770,6 +770,7 @@ input MemberInputType {
 """This is the root mutation"""
 type Mutation {
   createCollective(collective: CollectiveInputType!): CollectiveInterface
+  createCollectiveFromGithub(collective: CollectiveInputType!): CollectiveInterface
   editCollective(collective: CollectiveInputType!): CollectiveInterface
   deleteCollective(id: Int!): CollectiveInterface
   claimCollective(id: Int!): CollectiveInterface

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,8 +1,6 @@
 import fetch from 'cross-fetch';
 import { isValidEmail, getBrowserWebsiteUrl } from './utils';
 
-const MIN_REPO_STARS = 100;
-
 // Webpack error: Cannot find module 'webpack/lib/RequestShortener'
 // import queryString from 'query-string';
 

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,6 +1,8 @@
 import fetch from 'cross-fetch';
 import { isValidEmail, getBrowserWebsiteUrl } from './utils';
 
+const MIN_REPO_STARS = 100;
+
 // Webpack error: Cannot find module 'webpack/lib/RequestShortener'
 // import queryString from 'query-string';
 
@@ -156,4 +158,12 @@ export function get(path, options = {}) {
     if (format === 'blob') return response.blob();
     return checkResponseStatus(response);
   });
+}
+
+export function getGithubRepos(token) {
+  return fetch(`/api/github-repositories?access_token=${token}`)
+    .then(checkResponseStatus)
+    .then(repos => {
+      return repos.filter(repo => repo.stargazers_count >= MIN_REPO_STARS);
+    });
 }

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -161,9 +161,5 @@ export function get(path, options = {}) {
 }
 
 export function getGithubRepos(token) {
-  return fetch(`/api/github-repositories?access_token=${token}`)
-    .then(checkResponseStatus)
-    .then(repos => {
-      return repos.filter(repo => repo.stargazers_count >= MIN_REPO_STARS);
-    });
+  return fetch(`/api/github-repositories?access_token=${token}`).then(checkResponseStatus);
 }

--- a/src/pages/openSourceApply.js
+++ b/src/pages/openSourceApply.js
@@ -1,14 +1,15 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Flex, Box } from '@rebass/grid';
 
 import Page from '../components/Page';
 import Loading from '../components/Loading';
+import Container from '../components/Container';
 import { withUser } from '../components/UserProvider';
 import withIntl from '../lib/withIntl';
 import { addCreateCollectiveFromGithubMutation } from '../graphql/mutations';
 import StyledCard from '../components/StyledCard';
-import { H3, P } from '../components/Text';
+import { H3, P, H2 } from '../components/Text';
 import StyledButton from '../components/StyledButton';
 import GithubRepositories from '../components/GithubRepositories';
 import StyledInputField from '../components/StyledInputField';
@@ -87,8 +88,6 @@ class OpenSourceApplyPage extends Component {
       Router.pushRoute('collective', {
         slug: collective.slug,
         status: 'collectiveCreated',
-        CollectiveId: collective.id,
-        CollectiveSlug: collective.slug,
       });
     } catch (err) {
       console.error('>>> createCollective error: ', JSON.stringify(err)); // TODO - Remove
@@ -105,19 +104,30 @@ class OpenSourceApplyPage extends Component {
     const { repositories, creatingCollective } = this.state;
     if (repositories.length !== 0) {
       return (
-        <StyledInputField htmlFor="collective">
-          {fieldProps => (
-            <GithubRepositories
-              {...fieldProps}
-              repositories={repositories}
-              creatingCollective={creatingCollective}
-              onCreateCollective={data => {
-                this.setState({ creatingCollective: true });
-                this.createCollectives(data);
-              }}
-            />
-          )}
-        </StyledInputField>
+        <Fragment>
+          <Container maxWidth={500} mb={4}>
+            <H2 textAlign="center" mb={3} fontSize="3.2rem">
+              Pick a repository
+            </H2>
+            <P textAlign="center" fontSize="1.6rem" color="black.400">
+              Select a project you wish to create a collective for. Only repositories with at least 100 stars are
+              eligible.
+            </P>
+          </Container>
+          <StyledInputField htmlFor="collective">
+            {fieldProps => (
+              <GithubRepositories
+                {...fieldProps}
+                repositories={repositories}
+                creatingCollective={creatingCollective}
+                onCreateCollective={data => {
+                  this.setState({ creatingCollective: true });
+                  this.createCollectives(data);
+                }}
+              />
+            )}
+          </StyledInputField>
+        </Fragment>
       );
     }
   }

--- a/src/pages/openSourceApply.js
+++ b/src/pages/openSourceApply.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import { Flex, Box } from '@rebass/grid';

--- a/src/pages/openSourceApply.js
+++ b/src/pages/openSourceApply.js
@@ -16,6 +16,7 @@ import GithubRepositories from '../components/GithubRepositories';
 import StyledInputField from '../components/StyledInputField';
 import MessageBox from '../components/MessageBox';
 import SignInOrJoinFree from '../components/SignInOrJoinFree';
+import GithubRepositoriesFAQ from '../components/faqs/GithubRepositoriesFAQ';
 import { Router } from '../server/pages';
 
 import { getGithubRepos } from '../lib/api';
@@ -104,32 +105,35 @@ class OpenSourceApplyPage extends Component {
     const { repositories, creatingCollective } = this.state;
     if (repositories.length !== 0) {
       return (
-        <Fragment>
-          <Container maxWidth={500} mb={4}>
-            <H2 textAlign="center" mb={3} fontSize="3.2rem">
-              <FormattedMessage id="openSourceApply.GithubRepositories.title" defaultMessage="Pick a repository" />
-            </H2>
-            <P textAlign="center" fontSize="1.6rem" color="black.400">
-              <FormattedMessage
-                id="openSourceApply.GithubRepositories.description"
-                defaultMessage="Select a project you wish to create a collective for. Only repositories with at least 100 stars are eligible."
-              />
-            </P>
+        <Container maxWidth={500} mb={4} mr={4}>
+          <H2 textAlign="center" mb={3} fontSize="3.2rem">
+            <FormattedMessage id="openSourceApply.GithubRepositories.title" defaultMessage="Pick a repository" />
+          </H2>
+          <P textAlign="center" fontSize="1.6rem" mb={4} color="black.400">
+            <FormattedMessage
+              id="openSourceApply.GithubRepositories.description"
+              defaultMessage="Select a project you wish to create a collective for. Only repositories with at least 100 stars are eligible."
+            />
+          </P>
+          <Container display="flex">
+            <StyledInputField htmlFor="collective">
+              {fieldProps => (
+                <GithubRepositories
+                  {...fieldProps}
+                  repositories={repositories}
+                  creatingCollective={creatingCollective}
+                  onCreateCollective={data => {
+                    this.setState({ creatingCollective: true });
+                    this.createCollectives(data);
+                  }}
+                />
+              )}
+            </StyledInputField>
+            <Container ml={4}>
+              <GithubRepositoriesFAQ mt={4} display={['none', null, 'block']} width={1 / 5} minWidth="335px" />
+            </Container>
           </Container>
-          <StyledInputField htmlFor="collective">
-            {fieldProps => (
-              <GithubRepositories
-                {...fieldProps}
-                repositories={repositories}
-                creatingCollective={creatingCollective}
-                onCreateCollective={data => {
-                  this.setState({ creatingCollective: true });
-                  this.createCollectives(data);
-                }}
-              />
-            )}
-          </StyledInputField>
-        </Fragment>
+        </Container>
       );
     }
   }

--- a/src/pages/openSourceApply.js
+++ b/src/pages/openSourceApply.js
@@ -1,4 +1,5 @@
 import React, { Component, Fragment } from 'react';
+import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import { Flex, Box } from '@rebass/grid';
 
@@ -107,11 +108,13 @@ class OpenSourceApplyPage extends Component {
         <Fragment>
           <Container maxWidth={500} mb={4}>
             <H2 textAlign="center" mb={3} fontSize="3.2rem">
-              Pick a repository
+              <FormattedMessage id="openSourceApply.GithubRepositories.title" defaultMessage="Pick a repository" />
             </H2>
             <P textAlign="center" fontSize="1.6rem" color="black.400">
-              Select a project you wish to create a collective for. Only repositories with at least 100 stars are
-              eligible.
+              <FormattedMessage
+                id="openSourceApply.GithubRepositories.title"
+                defaultMessage="Select a project you wish to create a collective for. Only repositories with at least 100 stars are eligible."
+              />
             </P>
           </Container>
           <StyledInputField htmlFor="collective">
@@ -136,10 +139,15 @@ class OpenSourceApplyPage extends Component {
     const connectUrl = `/api/connected-accounts/github?redirect=${WEBSITE_URL}/opensource/apply`;
     return (
       <StyledCard minWidth={400} maxWidth={500} border="none" minHeight={350} p={4} textAlign="center">
-        <H3 mb={2}>For Open Source projects</H3>
+        <H3 mb={2}>
+          <FormattedMessage id="openSourceApply.title" defaultMessage="For Open Source projects" />
+        </H3>
         <P mb={4}>
-          You need a Github account and a repository with over 100 stars. If you run into trouble, file an issue in our
-          Github Issues section.
+          <FormattedMessage
+            id="openSourceApply.description"
+            defaultMessage="You need a Github account and a repository with over 100 stars. If you run into trouble, file an issue in our
+            Github Issues section."
+          />
         </P>
         <StyledButton
           textAlign="center"

--- a/src/pages/openSourceApply.js
+++ b/src/pages/openSourceApply.js
@@ -1,0 +1,29 @@
+import React from 'react';
+// import PropTypes from 'prop-types';
+
+import Page from '../components/Page';
+// import Loading from '../components/Loading';
+import { withUser } from '../components/UserProvider';
+import { Flex } from '@rebass/grid';
+
+class OpenSourceApplyPage extends React.Component {
+  static async getInitalProps({ query }) {
+    return {
+      token: query && query.token,
+    };
+  }
+
+  componentDidMount() {
+    console.log(this.props.token);
+  }
+
+  render() {
+    return (
+      <Page>
+        <Flex alignItems="center" flexDirection="column" mx="auto" width={300} pt={4} mb={4} />
+      </Page>
+    );
+  }
+}
+
+export default withUser(OpenSourceApplyPage);

--- a/src/pages/openSourceApply.js
+++ b/src/pages/openSourceApply.js
@@ -1,26 +1,128 @@
 import React from 'react';
-// import PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
 
 import Page from '../components/Page';
-// import Loading from '../components/Loading';
+import Loading from '../components/Loading';
 import { withUser } from '../components/UserProvider';
 import { Flex } from '@rebass/grid';
+import StyledCard from '../components/StyledCard';
+import { H3, P } from '../components/Text';
+import StyledLink from '../components/StyledLink';
+import GithubRepositories from '../components/GithubRepositories';
+import StyledInputField from '../components/StyledInputField';
+// import { getGithubRepos } from '../lib/api';
+
+const { WEBSITE_URL } = process.env;
+
+const repositoriesDummy = [
+  {
+    description: 'Adblock Plus browser extension',
+    fork: true,
+    full_name: 'flickz/adblockpluschrome',
+    name: 'adblockpluschrome',
+    owner: { login: 'flickz', type: 'Organization' },
+    stargazers_count: 113,
+  },
+  {
+    description:
+      'A new form of association, transparent by design. Please report issues there. Feature requests and ideas welcome!',
+    fork: true,
+    full_name: 'flickz/jobtweets',
+    name: 'JobTweets',
+    owner: { login: 'flickz', type: 'User' },
+    stargazers_count: 103,
+  },
+];
 
 class OpenSourceApplyPage extends React.Component {
-  static async getInitalProps({ query }) {
+  static async getInitialProps({ query }) {
     return {
       token: query && query.token,
     };
   }
 
+  static propTypes = {
+    token: PropTypes.string,
+    loadingLoggedInUser: PropTypes.bool,
+    LoggedInUser: PropTypes.object,
+  };
+
+  state = {
+    error: null,
+    loadingGithub: false,
+    repositories: [],
+  };
+
   componentDidMount() {
-    console.log(this.props.token);
+    const { token } = this.props;
+    if (!token) {
+      return;
+    }
+    this.setState({
+      repositories: repositoriesDummy,
+    });
+    // getGithubRepos(token)
+    //   .then(repos => {
+    //     console.log(repos);
+    //   })
+    //   .catch(err => {
+    //     console.log(err);
+    //   });
+  }
+
+  renderContent() {
+    const { token, LoggedInUser } = this.props;
+    if (!LoggedInUser) {
+      return;
+    } else if (!token) {
+      return this.renderConnectGithubButton();
+    } else {
+      return this.renderGithubRepos();
+    }
+  }
+
+  renderGithubRepos() {
+    const { repositories } = this.state;
+    if (repositories.length !== 0) {
+      return (
+        <StyledInputField htmlFor="collective">
+          {fieldProps => (
+            <GithubRepositories
+              {...fieldProps}
+              repositories={repositories}
+              onCreateCollective={data => {
+                console.log(data);
+              }}
+            />
+          )}
+        </StyledInputField>
+      );
+    }
+  }
+
+  renderConnectGithubButton() {
+    const connectUrl = `/api/connected-accounts/github?redirect=${WEBSITE_URL}/opensource/apply`;
+    return (
+      <StyledCard minWidth={400} maxWidth={500} border="none" minHeight={350} mb={4} mt={4} p={4} textAlign="center">
+        <H3 mb={4}>For Open Source projects</H3>
+        <P mb={4}>
+          You need a Github account and a repository with over 100 stars. If you run into trouble, file an issue in our
+          Github Issues section.
+        </P>
+        <StyledLink href={connectUrl} textAlign="center" buttonSize="large" buttonStyle="primary" my={4}>
+          Get started
+        </StyledLink>
+      </StyledCard>
+    );
   }
 
   render() {
+    const { loadingLoggedInUser } = this.props;
     return (
       <Page>
-        <Flex alignItems="center" flexDirection="column" mx="auto" width={300} pt={4} mb={4} />
+        <Flex alignItems="center" flexDirection="column" mx="auto" width={300} pt={4} mb={4}>
+          {loadingLoggedInUser ? <Loading /> : this.renderContent()}
+        </Flex>
       </Page>
     );
   }

--- a/src/pages/openSourceApply.js
+++ b/src/pages/openSourceApply.js
@@ -19,8 +19,7 @@ import SignInOrJoinFree from '../components/SignInOrJoinFree';
 import { Router } from '../server/pages';
 
 import { getGithubRepos } from '../lib/api';
-
-const { WEBSITE_URL } = process.env;
+import { getBrowserWebsiteUrl } from '../lib/utils';
 
 class OpenSourceApplyPage extends Component {
   static async getInitialProps({ query }) {
@@ -112,7 +111,7 @@ class OpenSourceApplyPage extends Component {
             </H2>
             <P textAlign="center" fontSize="1.6rem" color="black.400">
               <FormattedMessage
-                id="openSourceApply.GithubRepositories.title"
+                id="openSourceApply.GithubRepositories.description"
                 defaultMessage="Select a project you wish to create a collective for. Only repositories with at least 100 stars are eligible."
               />
             </P>
@@ -136,7 +135,7 @@ class OpenSourceApplyPage extends Component {
   }
 
   renderConnectGithubButton() {
-    const connectUrl = `/api/connected-accounts/github?redirect=${WEBSITE_URL}/opensource/apply`;
+    const connectUrl = `/api/connected-accounts/github?redirect=${getBrowserWebsiteUrl()}/opensource/apply`;
     return (
       <StyledCard minWidth={400} maxWidth={500} border="none" minHeight={350} p={4} textAlign="center">
         <H3 mb={2}>

--- a/src/pages/openSourceApply.js
+++ b/src/pages/openSourceApply.js
@@ -6,7 +6,7 @@ import Page from '../components/Page';
 import Loading from '../components/Loading';
 import { withUser } from '../components/UserProvider';
 import withIntl from '../lib/withIntl';
-import { addCreateCollectiveMutation } from '../graphql/mutations';
+import { addCreateCollectiveFromGithubMutation } from '../graphql/mutations';
 import StyledCard from '../components/StyledCard';
 import { H3, P } from '../components/Text';
 import StyledButton from '../components/StyledButton';
@@ -31,7 +31,7 @@ class OpenSourceApplyPage extends Component {
     token: PropTypes.string,
     loadingLoggedInUser: PropTypes.bool,
     LoggedInUser: PropTypes.object,
-    createCollective: PropTypes.func,
+    createCollectiveFromGithub: PropTypes.func,
   };
 
   state = {
@@ -63,7 +63,6 @@ class OpenSourceApplyPage extends Component {
         loadingRepos: false,
         result: { type: 'error', mesg: 'Error: An unknown error occured' },
       });
-      console.log(error);
     }
   }
 
@@ -83,9 +82,14 @@ class OpenSourceApplyPage extends Component {
   async createCollectives(collectiveInputType) {
     collectiveInputType.type = 'COLLECTIVE';
     try {
-      const res = await this.props.createCollective(collectiveInputType);
-      const collective = res.data.createCollective;
-      Router.pushRoute('collective', { slug: collective.slug });
+      const res = await this.props.createCollectiveFromGithub(collectiveInputType);
+      const collective = res.data.createCollectiveFromGithub;
+      Router.pushRoute('collective', {
+        slug: collective.slug,
+        status: 'collectiveCreated',
+        CollectiveId: collective.id,
+        CollectiveSlug: collective.slug,
+      });
     } catch (err) {
       console.error('>>> createCollective error: ', JSON.stringify(err)); // TODO - Remove
       const errorMsg = err.graphQLErrors && err.graphQLErrors[0] ? err.graphQLErrors[0].message : err.message;
@@ -147,10 +151,10 @@ class OpenSourceApplyPage extends Component {
     const { loadingLoggedInUser } = this.props;
     const { result } = this.state;
     return (
-      <Page>
+      <Page title="Sign up GitHub repository">
         <Flex alignItems="center" flexDirection="column" mx="auto" maxWidth={500} pt={4} my={4}>
           {result.mesg && (
-            <Box>
+            <Box mb={2}>
               <MessageBox withIcon type={result.type}>
                 {result.mesg}
               </MessageBox>
@@ -163,4 +167,4 @@ class OpenSourceApplyPage extends Component {
   }
 }
 
-export default withIntl(withUser(addCreateCollectiveMutation(OpenSourceApplyPage)));
+export default withIntl(withUser(addCreateCollectiveFromGithubMutation(OpenSourceApplyPage)));

--- a/src/pages/openSourceApply.js
+++ b/src/pages/openSourceApply.js
@@ -1,6 +1,5 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
 import { Flex, Box } from '@rebass/grid';
 
 import Page from '../components/Page';
@@ -20,26 +19,6 @@ import { Router } from '../server/pages';
 import { getGithubRepos } from '../lib/api';
 
 const { WEBSITE_URL } = process.env;
-
-const repositoriesDummy = [
-  {
-    description: 'Adblock Plus browser extension',
-    fork: true,
-    full_name: 'flickz/adblockpluschrome',
-    name: 'adblockpluschrome',
-    owner: { login: 'flickz', type: 'Organization' },
-    stargazers_count: 113,
-  },
-  {
-    description:
-      'A new form of association, transparent by design. Please report issues there. Feature requests and ideas welcome!',
-    fork: true,
-    full_name: 'flickz/jobtweets',
-    name: 'JobTweets',
-    owner: { login: 'flickz', type: 'User' },
-    stargazers_count: 103,
-  },
-];
 
 class OpenSourceApplyPage extends Component {
   static async getInitialProps({ query }) {

--- a/src/server/pages.js
+++ b/src/server/pages.js
@@ -22,6 +22,7 @@ pages
   .add('createHost', '/:collectiveSlug/connect/stripe')
   .add('button', '/:collectiveSlug/:verb(contribute|donate)/button')
   .add('createEvent', '/:parentCollectiveSlug/events/(new|create)')
+  .add('openSourceApply', '/opensource/(apply|create)')
   .add('createCollective', '/:hostCollectiveSlug?/(apply|create)')
   .add('createOrganization', '/organizations/new')
   .add('events-iframe', '/:collectiveSlug/events.html')

--- a/styleguide/examples/GithubRepositories.md
+++ b/styleguide/examples/GithubRepositories.md
@@ -1,0 +1,29 @@
+Display the list of repositories 
+```js
+const repositories = [
+  {
+    description: 'Adblock Plus browser extension',
+    fork: true,
+    full_name: 'flickz/adblockpluschrome',
+    name: 'adblockpluschrome',
+    owner: { login: 'flickz', type: 'Organization' },
+    stargazers_count: 113,
+  },
+  {
+    description:
+      'A new form of association, transparent by design. Please report issues there. Feature requests and ideas welcome!',
+    fork: true,
+    full_name: 'flickz/jobtweets',
+    name: 'JobTweets',
+    owner: { login: 'flickz', type: 'User' },
+    stargazers_count: 103,
+  }
+];
+
+<GithubRepositories
+  repositories={repositories}
+  onCreateCollective={data => {
+    console.log(data)
+  }}
+  />
+```


### PR DESCRIPTION
This PR revamps the Github Opensource collective application flow as explained here [#1699](https://github.com/opencollective/opencollective/issues/1699), [#1703](https://github.com/opencollective/opencollective/issues/1703)

- [x] Creates a `GithubRepositories` component
![screenshot from 2019-02-05 16-50-02](https://user-images.githubusercontent.com/15707013/52401574-4586e080-2ac2-11e9-9d7e-836898049e58.png)

- [x] Fetch GitHub repositories >= 100 stars
![peek 2019-02-07 10-27](https://user-images.githubusercontent.com/15707013/52402068-9a772680-2ac3-11e9-9906-55166fc8afc2.gif)

- [x] Creates collectives with Github (backend)

- [x] Error and Info Handlings
      - [ ] When Github token is invalid or server error
      - [ ]  When Github account has no repository >= 100 stars
       - [ ] Render `SignInOrJoinFree` component for unauthenticated users

- [x] Handle locale

- [ ]  Add `GithubRepositories` components Style guide

- [x]  Write end to end test
