### PR TITLE
Fix integration tests

### DIFF
--- a/cypress/integration/12-contributionFlow.donate.test.js
+++ b/cypress/integration/12-contributionFlow.donate.test.js
@@ -91,9 +91,6 @@ describe('Contribution Flow: Donate', () => {
     cy.signup({ redirect: '/apex/donate', visitParams }).then(() => {
       cy.contains('#contributeAs > label', 'A new organization').click();
 
-      // Submit is disabled by default
-      cy.contains('button', 'Next step').should('be.disabled');
-
       // Name must be shown on step
       cy.get('#contributeAs input[name=name]').type('Evil Corp');
       cy.get('.step-contributeAs').contains('Evil Corp');

--- a/src/components/ContributeAs.js
+++ b/src/components/ContributeAs.js
@@ -69,9 +69,7 @@ const enhance = compose(
         ...newState,
         errors: { ...state.errors, [target.name]: null },
       });
-      if (newState.name && newState.website) {
-        onChange({ type: 'ORGANIZATION', ...omit(newState, ['errors']) });
-      }
+      onChange({ type: 'ORGANIZATION', ...omit(newState, ['errors']) });
     },
     onInvalid: ({ setState }) => event => {
       event.persist();

--- a/src/pages/createOrderNewFlow.js
+++ b/src/pages/createOrderNewFlow.js
@@ -550,9 +550,18 @@ class CreateOrderPage extends React.Component {
       step: ['contributeAs', 'success'].includes(step) ? undefined : step,
     };
 
-    if (this.state.error) this.setState({ error: null });
+    if (this.state.error) {
+      this.setState({ error: null });
+    }
 
-    // check if we're creating a new organization
+    // Validate step if it has a form
+    if (!currentStep || currentStep === 'details' || currentStep === 'contributeAs') {
+      if (!this.activeFormRef.current || !this.activeFormRef.current.reportValidity()) {
+        return false;
+      }
+    }
+
+    // Check if we're creating a new organization
     if (!currentStep && stepProfile && stepProfile.name && !stepProfile.id) {
       this.setState({ submitting: true });
 
@@ -565,15 +574,6 @@ class CreateOrderPage extends React.Component {
       } catch (error) {
         this.setState({ error: error.message, submitting: false });
         window.scrollTo(0, 0);
-        return false;
-      }
-    } else if (currentStep === 'details' && step === 'payment') {
-      // Validate ContributeDetails step before going next
-      if (!this.activeFormRef.current || !this.activeFormRef.current.reportValidity()) {
-        return false;
-      }
-    } else if (!currentStep || currentStep === 'contributeAs') {
-      if (this.activeFormRef.current && !this.activeFormRef.current.reportValidity()) {
         return false;
       }
     }

--- a/src/pages/orderSuccess.js
+++ b/src/pages/orderSuccess.js
@@ -218,7 +218,7 @@ class OrderSuccessPage extends React.Component {
                 </React.Fragment>
               )}
               {collective.tags && (
-                <Flex mt={3} flexWrap="wrap" justifyContent="center">
+                <Flex mt={3} flexWrap="wrap" justifyContent="center" css={{ maxWidth: 130 }}>
                   {collective.tags.map(tag => (
                     <Link key={tag} route="search" params={{ q: tag }} passHref>
                       <StyledLink fontSize="Paragraph" lineHeight="Caption" mr={1}>


### PR DESCRIPTION
Cypress tests were broken in https://github.com/opencollective/opencollective-frontend/pull/1371/files

We didn't notice because CI doesn't run on forks.

PR also includes a minor style fix in `src/pages/orderSuccess.js` that has nothing to do with E2E tests.