### PR TITLE
Trims trailing spaces from email address

### DIFF
--- a/cypress/integration/07-signin.test.js
+++ b/cypress/integration/07-signin.test.js
@@ -16,6 +16,12 @@ describe('signin', () => {
     cy.get('input[name=email]').should('exist');
   });
 
+  it('trims the email when it has trailing spaces', () => {
+    cy.visit('/signin');
+    cy.get('input[name=email]').type('  user@opencollective.com  ');
+    cy.get('button[type=submit]').should('not.be.disabled');
+  });
+
   it("doesn't go into redirect loop if given own address in redirect", () => {
     cy.visit('/signin?next=/signin');
     cy.get('input[name=email]').type('testuser+admin@opencollective.com');

--- a/cypress/integration/07-signin.test.js
+++ b/cypress/integration/07-signin.test.js
@@ -19,6 +19,12 @@ describe('signin', () => {
   it('trims the email when it has trailing spaces', () => {
     cy.visit('/signin');
     cy.get('input[name=email]').type('  user@opencollective.com  ');
+    cy.get('input[name=email]').should('have.value', 'user@opencollective.com');
+  });
+
+  it('does not disable submit button when email has trailing spaces', () => {
+    cy.visit('/signin');
+    cy.get('input[name=email]').type('  user@opencollective.com  ');
     cy.get('button[type=submit]').should('not.be.disabled');
   });
 

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -71,7 +71,7 @@ export default class SignIn extends React.Component {
               id="email"
               name="email"
               onChange={({ target }) => {
-                onEmailChange(target.value);
+                onEmailChange(target.value.trim());
                 // Feel free to remove the setTimeout when that issue is fixed
                 // https://bugzilla.mozilla.org/show_bug.cgi?id=1524212
                 setTimeout(() => {

--- a/src/components/SignInOrJoinFree.js
+++ b/src/components/SignInOrJoinFree.js
@@ -124,7 +124,7 @@ class SignInOrJoinFree extends React.Component {
         {displayedForm !== 'create-account' ? (
           <SignIn
             email={email}
-            onEmailChange={email => this.setState({ email })}
+            onEmailChange={email => this.setState({ email: email.trim() })}
             onSecondaryAction={routes.join || (() => this.switchForm('create-account'))}
             onSubmit={this.signIn}
             loading={submitting}

--- a/src/components/SignInOrJoinFree.js
+++ b/src/components/SignInOrJoinFree.js
@@ -124,7 +124,7 @@ class SignInOrJoinFree extends React.Component {
         {displayedForm !== 'create-account' ? (
           <SignIn
             email={email}
-            onEmailChange={email => this.setState({ email: email.trim() })}
+            onEmailChange={email => this.setState({ email })}
             onSecondaryAction={routes.join || (() => this.switchForm('create-account'))}
             onSubmit={this.signIn}
             loading={submitting}


### PR DESCRIPTION
Changes the onEmailChange method to trim spaces from the email address on SignIn form as requested on https://github.com/opencollective/opencollective/issues/1701. Also, added a cypress test to verify the 'feature'.

This is to prevent users from getting validation errors when copying and pasting from password managers

If there is anything that could be improved, let me know :D

