### PR TITLE
Order redirect with uuid (not id)

### DIFF
--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -23,6 +23,7 @@ const createOrderQuery = gql`
       }
       transactions(type: "CREDIT") {
         id
+        uuid
       }
     }
   }

--- a/src/pages/createOrder.js
+++ b/src/pages/createOrder.js
@@ -191,7 +191,7 @@ class CreateOrderLegacyPage extends React.Component {
             success: intl.formatMessage(this.messages['order.successRedirect'], { domain }),
           },
         });
-        const redirectTo = `${redirect}?transactionid=${get(orderCreated, 'transactions[0].uuid')}&status=${
+        const redirectTo = `${redirect}?transactionid=${get(orderCreated, 'transactions[0].id')}&status=${
           orderCreated.status
         }`;
         window.location.href = redirectTo;

--- a/src/pages/createOrder.js
+++ b/src/pages/createOrder.js
@@ -191,7 +191,7 @@ class CreateOrderLegacyPage extends React.Component {
             success: intl.formatMessage(this.messages['order.successRedirect'], { domain }),
           },
         });
-        const redirectTo = `${redirect}?transactionid=${get(orderCreated, 'transactions[0].id')}&status=${
+        const redirectTo = `${redirect}?transactionid=${get(orderCreated, 'transactions[0].uuid')}&status=${
           orderCreated.status
         }`;
         window.location.href = redirectTo;

--- a/src/pages/createOrderNewFlow.js
+++ b/src/pages/createOrderNewFlow.js
@@ -253,7 +253,7 @@ class CreateOrderPage extends React.Component {
       const orderCreated = res.data.createOrder;
       this.setState({ submitting: false, submitted: true, error: null });
       if (this.props.redirect && isURL(this.props.redirect)) {
-        const transactionId = get(orderCreated, 'transactions[0].id', null);
+        const transactionId = get(orderCreated, 'transactions[0].uuid', null);
         const status = orderCreated.status;
         const redirectTo = `${this.props.redirect}?transactionid=${transactionId}&status=${status}`;
         window.location.href = redirectTo;
@@ -788,8 +788,9 @@ const createOrderQuery = gql`
     createOrder(order: $order) {
       id
       status
-      transactions {
+      transactions(type: "CREDIT") {
         id
+        uuid
       }
     }
   }


### PR DESCRIPTION
Looking at the documentation for this feature, it seems that it was designed with `uuid` in mind.

`uuid` can't be brute-forced (unlike auto-incremental ids) and are usually not exposed to everyone.

Also changed the GraphQL query with `transactions(type: "CREDIT")` @Betree is that correct?