### PR TITLE
fix(TopBar): Incorrect link nesting

### DIFF
--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -125,11 +125,9 @@ class TopBar extends React.Component {
                 </Link>
               </Box>
               <Box as="li" px={3}>
-                <a href="https://docs.opencollective.com">
-                  <NavLink>
-                    <FormattedMessage id="menu.docs" defaultMessage="Docs & Help" />
-                  </NavLink>
-                </a>
+                <NavLink href="https://docs.opencollective.com">
+                  <FormattedMessage id="menu.docs" defaultMessage="Docs & Help" />
+                </NavLink>
               </Box>
               <Box as="li" px={3}>
                 <NavLink href="https://medium.com/open-collective">

--- a/src/pages/__tests__/__snapshots__/search.test.js.snap
+++ b/src/pages/__tests__/__snapshots__/search.test.js.snap
@@ -304,15 +304,12 @@ Array [
               className="c11"
             >
               <a
+                className="c12"
                 href="https://docs.opencollective.com"
               >
-                <a
-                  className="c12"
-                >
-                  <span>
-                    Docs & Help
-                  </span>
-                </a>
+                <span>
+                  Docs & Help
+                </span>
               </a>
             </li>
             <li
@@ -1602,15 +1599,12 @@ Array [
               className="c11"
             >
               <a
+                className="c12"
                 href="https://docs.opencollective.com"
               >
-                <a
-                  className="c12"
-                >
-                  <span>
-                    Docs & Help
-                  </span>
-                </a>
+                <span>
+                  Docs & Help
+                </span>
               </a>
             </li>
             <li
@@ -3350,15 +3344,12 @@ exports[`Search Page renders error message 1`] = `
               className="c17"
             >
               <a
+                className="c18"
                 href="https://docs.opencollective.com"
               >
-                <a
-                  className="c18"
-                >
-                  <span>
-                    Docs & Help
-                  </span>
-                </a>
+                <span>
+                  Docs & Help
+                </span>
               </a>
             </li>
             <li
@@ -4147,15 +4138,12 @@ Array [
               className="c11"
             >
               <a
+                className="c12"
                 href="https://docs.opencollective.com"
               >
-                <a
-                  className="c12"
-                >
-                  <span>
-                    Docs & Help
-                  </span>
-                </a>
+                <span>
+                  Docs & Help
+                </span>
               </a>
             </li>
             <li
@@ -5540,15 +5528,12 @@ Array [
               className="c11"
             >
               <a
+                className="c12"
                 href="https://docs.opencollective.com"
               >
-                <a
-                  className="c12"
-                >
-                  <span>
-                    Docs & Help
-                  </span>
-                </a>
+                <span>
+                  Docs & Help
+                </span>
               </a>
             </li>
             <li


### PR DESCRIPTION
Following warning was issued since https://github.com/opencollective/opencollective-frontend/commit/d83a6d1855aa2fecd7037979070ff43043de929d :

```
index.js:2178 Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
    in a (created by Context.Consumer)
    in StyledComponent (created by TopBar__NavLink)
    in a (created by TopBar)
    in li (created by Context.Consumer)
    in StyledComponent (created by Box)
    in ul (created by Context.Consumer)
    in StyledComponent (created by TopBar__NavList)
    in div (created by Context.Consumer)
    in StyledComponent (created by Hide)
    in div (created by Context.Consumer)
    in StyledComponent (created by Flex)
    in div (created by Context.Consumer)
    in StyledComponent (created by Flex)
    in TopBar (created by Context.Consumer)
    in WithUser (created by InjectIntl(WithUser))
    in InjectIntl(WithUser) (created by WithIntl(undefined))
```