### PR TITLE
Fix order success page tags alignment

### DIFF
--- a/src/pages/orderSuccess.js
+++ b/src/pages/orderSuccess.js
@@ -221,7 +221,7 @@ class OrderSuccessPage extends React.Component {
                 <Flex mt={3} flexWrap="wrap" justifyContent="center" css={{ maxWidth: 130 }}>
                   {collective.tags.map(tag => (
                     <Link key={tag} route="search" params={{ q: tag }} passHref>
-                      <StyledLink fontSize="Paragraph" lineHeight="Caption" mr={1}>
+                      <StyledLink fontSize="Paragraph" lineHeight="Caption" mr={1} textAlign="center">
                         #{tag}
                       </StyledLink>
                     </Link>


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/1725

![selection_999 083](https://user-images.githubusercontent.com/1556356/52638556-80c64c80-2ed2-11e9-8e6a-689b826e49ff.png)
