### PR TITLE
GithubHandle: Better explanation for input label

### DIFF
--- a/src/components/CreateCollectiveForm.js
+++ b/src/components/CreateCollectiveForm.js
@@ -72,7 +72,7 @@ class CreateCollectiveForm extends React.Component {
       },
       'githubHandle.description': {
         id: 'collective.githubHandle.description',
-        defaultMessage: 'Enter your Github organization name if you have one',
+        defaultMessage: 'A Github profile or repository',
       },
       'location.label': {
         id: 'collective.location.label',

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -228,7 +228,7 @@
   "collective.website.label": "Website",
   "collective.website.description": "Enter the URL of your website or Facebook Page",
   "collective.githubHandle.label": "Github",
-  "collective.githubHandle.description": "Enter your Github organization name if you have one",
+  "collective.githubHandle.description": "A Github profile or repository",
   "collective.location.label": "City",
   "collective.meetup.label": "Meetup URL",
   "collective.members.label": "Number of members",


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective-api/pull/1717
Fix opencollective/opencollective#1700

New label is:
> A Github profile or repository