### PR TITLE
GiftCards: Change open source host limit label and default value

### DIFF
--- a/cypress/integration/30-virtualcards-admin.js
+++ b/cypress/integration/30-virtualcards-admin.js
@@ -24,7 +24,6 @@ describe('Virtual cards admin', () => {
     cy.get('#virtualcard-amount').type('42');
     cy.get('.deliver-type-selector label[data-name="manual"] .radio-btn').click();
     cy.get('#virtualcard-numberOfVirtualCards').type(`{selectall}${numberOfVirtualCards}`);
-    cy.get('input[name="onlyOpensource"]').click();
     cy.get('.FormInputs button[type="submit"]').click();
 
     // Success page
@@ -72,7 +71,6 @@ describe('Virtual cards admin', () => {
     );
     cy.get('#virtualcard-amount').type('12');
     checkSubmit(true, 'Create 3 gift cards');
-    cy.get('input[name="onlyOpensource"]').click();
     cy.get('.FormInputs button[type="submit"]').click();
     cy.contains('Your 3 gift cards have been sent!');
   });

--- a/src/components/CreateVirtualCardsForm.js
+++ b/src/components/CreateVirtualCardsForm.js
@@ -29,8 +29,11 @@ const MAX_AMOUNT = 10000;
 
 const InlineField = ({ name, children, label, isLabelClickable }) => (
   <Flex flexWrap="wrap" alignItems="center" mb="2.5em" className={`field-${name}`}>
-    <Box css={{ flexBasis: '12em' }}>
-      <label htmlFor={`virtualcard-${name}`} style={isLabelClickable && { cursor: 'pointer' }}>
+    <Box width={[1, 0.3]}>
+      <label
+        htmlFor={`virtualcard-${name}`}
+        style={{ cursor: isLabelClickable ? 'pointer' : 'inherit', width: '100%' }}
+      >
         {label}
       </label>
     </Box>
@@ -106,7 +109,7 @@ class CreateVirtualCardsForm extends Component {
       deliverType: 'email', // email or manual
       values: {
         amount: MIN_AMOUNT,
-        onlyOpensource: true,
+        onlyOpensource: false,
         emails: [],
         customMessage: '',
         numberOfVirtualCards: 1,
@@ -421,7 +424,14 @@ class CreateVirtualCardsForm extends Component {
             label={
               <FormattedMessage
                 id="virtualCards.create.onlyOpensource"
-                defaultMessage="Limit to opensource collectives"
+                defaultMessage="Limit to collectives hosted by the {openSourceCollectiveLink}"
+                values={{
+                  openSourceCollectiveLink: (
+                    <Link route="collective" params={{ slug: 'opensourcecollective' }}>
+                      Open Source Collective 501c6 (Non Profit)
+                    </Link>
+                  ),
+                }}
               />
             }
           >

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -269,7 +269,7 @@
   "virtualCards.create.number": "Number of gift cards",
   "virtualCards.create.amount": "Amount",
   "virtualCards.create.paymentMethod": "Payment Method",
-  "virtualCards.create.onlyOpensource": "Limit to opensource collectives",
+  "virtualCards.create.onlyOpensource": "Limit to collectives hosted by the {openSourceCollectiveLink}",
   "virtualCards.create.expiryDate": "Expiry date",
   "virtualCards.create.sendEmails": "Send the cards by email",
   "virtualCards.create.generateCodes": "I'll send the codes myself",


### PR DESCRIPTION
As suggested by @alannallama in https://opencollective.slack.com/archives/GFH4N961L/p1549486867006100?thread_ts=1549378435.003100&cid=GFH4N961L

- Change default label for limit to open source collectives to:

> Limit to collectives hosted by the Open Source Collective 501c6 (Non Profit)

- Set default value to `false`

## Preview

![selection_999 086](https://user-images.githubusercontent.com/1556356/52707722-a6ae2880-2f88-11e9-8221-23c62e51d911.png)
