### PR TITLE
StyledButton: Disable onClick while loading

### DIFF
--- a/src/components/StyledButton.js
+++ b/src/components/StyledButton.js
@@ -69,7 +69,7 @@ const StyledButton = ({ loading, ...props }) =>
   !loading ? (
     <StyledButtonContent {...props} />
   ) : (
-    <StyledButtonContent {...props}>
+    <StyledButtonContent {...props} onClick={undefined}>
       <StyledSpinner />
     </StyledButtonContent>
   );

--- a/styleguide/examples/StyledButton.md
+++ b/styleguide/examples/StyledButton.md
@@ -75,3 +75,21 @@ initialState = { buttonSize: 'medium' };
   </fieldset>
 </React.Fragment>;
 ```
+
+### Button is not clickable when loading
+
+```js
+initialState = { loading: false, nbClicks: 0 };
+
+<StyledButton
+  buttonSize="large"
+  width={300}
+  loading={state.loading}
+  onClick={() => {
+    setState(state => ({ loading: true, nbClicks: state.nbClicks + 1 }));
+    setTimeout(() => setState({ loading: false }), 2000);
+  }}
+>
+  Clicked {state.nbClicks} times
+</StyledButton>;
+```


### PR DESCRIPTION
In 99% of the cases, a loading button means that an async action is pending and we don't want the user to be able to trigger it multiple times. Ex: submit payment, submit comment...etc

For that we usually end up doing:

 ```es6
<StyledButton loading={loading} disabled={loading} />
```

This has an effect on component style.

With this PR, it is not required to disable a button anymore : the `onClick` function will never be triggered if `loading` is true.