### PR TITLE
Don't build in postinstall

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,10 @@ jobs:
       - run: sudo apt -y install libgconf-2-4 libnss3 libxss1
       - run: sudo apt -y install libasound2 xvfb
       - run: npm ci
-      - run: npm run build
+      - run: npm run build:clean
+      - run: npm run build:updates
+      - run: npm run build:server
+      - run: npm run build:next
       - run: ./scripts/setup_circleci.sh
       - save_cache: # special step to save the dependency cache
           key: cache-{{ checksum "package.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,12 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - restore_cache: # special step to restore the dependency cache
+      - restore_cache:
+          # Find a cache corresponding to this specific package-lock.json checksum
+          # when this file is changed, this key will fail
           key: cache-{{ checksum "package.json" }}
+          # Find the most recently generated cache used from any branch
+          key: cache-
       - run: sudo apt -y update
       - run: sudo apt -y install postgresql-client
       # Cypress dependencies
@@ -27,11 +31,13 @@ jobs:
       - run: npm run build:server
       - run: npm run build:next
       - run: ./scripts/setup_circleci.sh
-      - save_cache: # special step to save the dependency cache
+      - save_cache:
           key: cache-{{ checksum "package.json" }}
           paths:
             - ./node_modules
-            - ../.cache
+            #  This is where we store Cypress binary
+            - ../.cache #
+            # This is where we store the opencollective-api
             - ../cache
       - run: npm run test
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
       - run: sudo apt -y install libgconf-2-4 libnss3 libxss1
       - run: sudo apt -y install libasound2 xvfb
       - run: npm ci
+      - run: npm run build
       - run: ./scripts/setup_circleci.sh
       - save_cache: # special step to save the dependency cache
           key: cache-{{ checksum "package.json" }}

--- a/cypress/integration/31-create-collectiveFromGithub.test.js
+++ b/cypress/integration/31-create-collectiveFromGithub.test.js
@@ -38,7 +38,6 @@ describe('Create collective from Github', () => {
     cy.get('[type="submit"]')
       .first()
       .click();
-    cy.wait(6500);
     cy.location().should(location => {
       expect(location.search).to.eq('?status=collectiveCreated');
     });

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "deploy:staging": "./scripts/pre-deploy.sh staging && git push -f staging master && heroku ps:scale web=1 -a opencollective-staging-api && heroku ps:scale web=1 -a oc-staging-frontend && heroku ps:scale web=1 -a opencollective-staging-website",
     "stop:staging": "heroku ps:scale web=0 -a oc-staging-frontend && heroku ps:scale web=0 -a opencollective-staging-website && heroku ps:scale web=0 -a opencollective-staging-api",
     "git:clean": "./scripts/git_clean.sh",
-    "postinstall": "if test \"$NODE_ENV\" = \"\" || test \"$NODE_ENV\" = \"development\" ; then echo \"Skipping postinstall build because NODE_ENV is '${NODE_ENV}'\" ; else npm run build ; fi",
     "lint": "eslint \"cypress/**/*.js\" \"src/**/*.js\" \"test/**/*.js\"",
     "lint:fix": "npm run lint -- --fix",
     "lint:quiet": "npm run lint -- --quiet",
@@ -214,5 +213,6 @@
   "cacheDirectories": [
     ".cache",
     "node_modules"
-  ]
+  ],
+  "heroku-run-build-script": true
 }

--- a/scripts/setup_circleci.sh
+++ b/scripts/setup_circleci.sh
@@ -52,7 +52,7 @@ then
   mv "opencollective-api-${BRANCH//\//-}" opencollective-api
   cd "opencollective-api"
   echo "> Running npm install for api"
-  npm install
+  npm ci
   echo "> Running build for api"
   npm run build
   cd ..

--- a/scripts/setup_circleci.sh
+++ b/scripts/setup_circleci.sh
@@ -55,6 +55,8 @@ then
   cd "opencollective-api"
   echo "> Running npm install for api"
   npm install
+  echo "> Running build for api"
+  npm run build
   cd ..
 fi
 

--- a/scripts/setup_circleci.sh
+++ b/scripts/setup_circleci.sh
@@ -9,8 +9,6 @@ else
   exit;
 fi
 
-sudo apt-get install GraphicsMagick
-
 mkdir -p ~/cache
 cd ~/cache
 


### PR DESCRIPTION
We were doing that because the way Heroku was building projects. Heroku is changing its behavior, so we don't need it anymore.

Fix: https://github.com/opencollective/opencollective/issues/1729

Let's merge the similar PR on master first: https://github.com/opencollective/opencollective-api/pull/1721