### PR TITLE
feat(MemberCard): Integrate new component

### DIFF
--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -43,8 +43,11 @@ const Avatar = ({ src, type = 'USER', radius, name, ...styleProps }) => {
 };
 
 Avatar.propTypes = {
+  /** Collective name */
   name: PropTypes.string,
+  /** Collective image url */
   src: PropTypes.string,
+  /** Collective type */
   type: PropTypes.oneOf(['USER', 'COLLECTIVE', 'ORGANIZATION', 'CHAPTER', 'ANONYMOUS']),
 };
 

--- a/src/components/CollectiveCover.js
+++ b/src/components/CollectiveCover.js
@@ -17,6 +17,7 @@ import Button from './Button';
 import GoalsCover from './GoalsCover';
 import MenuBar from './MenuBar';
 import TopBackersCoverWithData from './TopBackersCoverWithData';
+import UserCompany from './UserCompany';
 
 class CollectiveCover extends React.Component {
   static propTypes = {
@@ -349,12 +350,11 @@ ${description}`;
             {this.description && <div className="description">{this.description}</div>}
             {className !== 'small' && (
               <div>
-                {company && company.substr(0, 1) === '@' && (
+                {company && (
                   <p className="company">
-                    <Link route={`/${company.substr(1)}`}>{company.substr(1)}</Link>
+                    <UserCompany company={company} />
                   </p>
                 )}
-                {company && company.substr(0, 1) !== '@' && <p className="company">{company}</p>}
                 {collective.type !== 'EVENT' && (
                   <div className="contact">
                     {collective.host && collective.isActive && (

--- a/src/components/Member.js
+++ b/src/components/Member.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import colors from '../constants/colors';
-
+import { get } from 'lodash';
 import { defineMessages, injectIntl } from 'react-intl';
+import { Flex } from '@rebass/grid';
+
+import colors from '../constants/colors';
 import { formatCurrency, formatDate, firstSentence, singular, capitalize } from '../lib/utils';
 import Link from './Link';
 import CollectiveCard from './CollectiveCard';
 import Avatar from './Avatar';
-import { get } from 'lodash';
 
 class Member extends React.Component {
   static propTypes = {
@@ -97,15 +98,9 @@ ${totalDonationsStr}`;
               width: 200px;
             }
 
-            .Member :global(.Avatar) {
-              float: left;
-              width: 45px;
-              height: 45px;
-              margin-top: 1rem;
-            }
-
             .bubble {
               padding: 1rem;
+              padding-top: 0;
               text-align: left;
               overflow: hidden;
             }
@@ -131,21 +126,23 @@ ${totalDonationsStr}`;
         <div>
           {viewMode === 'USER' && (
             <Link route={'collective'} params={{ slug: this.props.member.member.slug }} target="_top" title={title}>
-              <Avatar src={member.image} radius={45} name={name} type={member.type} mt={2} className="noFrame" />
-              <div className="bubble">
-                <div className="name">{name}</div>
-                <div className="description" style={{ color: colors.darkgray }}>
-                  {firstSentence(description || member.description, 64)}
-                </div>
-                <div className="meta since" style={{ color: colors.darkgray }}>
-                  {memberSinceStr}
-                </div>
-                {totalDonationsStr && (
-                  <div className="meta totalDonations" style={{ color: colors.darkgray }}>
-                    {totalDonationsStr}
+              <Flex mt={2}>
+                <Avatar src={member.image} radius={45} name={name} type={member.type} className="noFrame" />
+                <div className="bubble">
+                  <div className="name">{name}</div>
+                  <div className="description" style={{ color: colors.darkgray }}>
+                    {firstSentence(description || member.description, 64)}
                   </div>
-                )}
-              </div>
+                  <div className="meta since" style={{ color: colors.darkgray }}>
+                    {memberSinceStr}
+                  </div>
+                  {totalDonationsStr && (
+                    <div className="meta totalDonations" style={{ color: colors.darkgray }}>
+                      {totalDonationsStr}
+                    </div>
+                  )}
+                </div>
+              </Flex>
             </Link>
           )}
           {viewMode === 'ORGANIZATION' && <CollectiveCard collective={member} membership={membership} />}

--- a/src/components/MemberCard.js
+++ b/src/components/MemberCard.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { themeGet } from 'styled-system';
+
+import { FormattedMessage } from 'react-intl';
+import StyledCard from './StyledCard';
+import { H5, Span } from './Text';
+import { Flex, Box } from '@rebass/grid';
+import Avatar from './Avatar';
+import Link from './Link';
+import UserCompany from './UserCompany';
+import Container from './Container';
+import { formatDate } from '../lib/utils';
+
+const MainContainer = styled(StyledCard)`
+  width: 144px;
+
+  a {
+    display: block;
+    text-decoration: none;
+    &:hover {
+      opacity: 0.8;
+    }
+  }
+`;
+
+const CollectiveLogoContainer = styled(Flex)`
+  border-top: 1px solid ${themeGet('colors.black.200')};
+  justify-content: center;
+`;
+
+const TruncatedText = styled(Container)`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+`;
+
+/**
+ * Display a member.
+ * Accept all the props from [StyledCard](/#/Atoms?id=styledcard).
+ */
+const MemberCard = ({ role, createdAt, collective, ...cardProps }) => (
+  <MainContainer {...cardProps}>
+    <CollectiveLogoContainer mt={52} mb={2}>
+      <Box mt={-32}>
+        <Link route="collective" params={{ slug: collective.slug }}>
+          <Avatar src={collective.image} radius={64} name={collective.name} />
+        </Link>
+      </Box>
+    </CollectiveLogoContainer>
+    <Flex flexDirection="column" alignItems="center" p={2}>
+      <Link route="collective" params={{ slug: collective.slug }}>
+        <H5 fontSize="Paragraph" fontWeight="bold" lineHeight="Caption">
+          {collective.name}
+        </H5>
+      </Link>
+      <TruncatedText minHeight={15} fontSize="Tiny" textAlign="center" color="black.500">
+        <UserCompany company={collective.company} />
+      </TruncatedText>
+      <Span textAlign="center" fontSize="Caption" color="black.600" mt={2} mb={2}>
+        <FormattedMessage
+          id="membership.description"
+          defaultMessage="{role, select, ADMIN {Core Contributor} MEMBER {Contributor} BACKER {Backer}} since {date}"
+          values={{ role, date: formatDate(createdAt) }}
+        />
+      </Span>
+    </Flex>
+  </MainContainer>
+);
+
+MemberCard.propTypes = {
+  /** Role */
+  role: PropTypes.oneOf(['ADMIN', 'MEMBER', 'BACKER']),
+  /** Member creation date */
+  createdAt: PropTypes.string.required,
+  /** Member's collective */
+  collective: PropTypes.shape({
+    slug: PropTypes.string.required,
+    name: PropTypes.string,
+    image: PropTypes.string,
+    company: PropTypes.string,
+  }).required,
+};
+
+export default MemberCard;

--- a/src/components/TeamSection.js
+++ b/src/components/TeamSection.js
@@ -1,19 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import withIntl from '../lib/withIntl';
 import { FormattedMessage } from 'react-intl';
 import SectionTitle from './SectionTitle';
-import Member from './Member';
+import { Flex } from '@rebass/grid';
+import MemberCard from './MemberCard';
 
 class TeamSection extends React.Component {
   static propTypes = {
     collective: PropTypes.object.isRequired, // collective.id
     LoggedInUser: PropTypes.object,
   };
-
-  constructor(props) {
-    super(props);
-  }
 
   render() {
     const { collective, LoggedInUser } = this.props;
@@ -27,7 +25,6 @@ class TeamSection extends React.Component {
     }
 
     const members = collective.members.filter(m => m.role === 'ADMIN' || m.role === 'MEMBER');
-
     return (
       <section id="team">
         <style jsx>
@@ -39,11 +36,11 @@ class TeamSection extends React.Component {
           `}
         </style>
         <SectionTitle section="team" action={action} />
-        <div className="Members cardsList">
-          {members.map(member => (
-            <Member key={member.id} member={member} collective={collective} LoggedInUser={LoggedInUser} />
+        <Flex justifyContent="space-evenly" flexWrap="wrap">
+          {members.map(({ id, role, createdAt, member }) => (
+            <MemberCard key={id} role={role} createdAt={createdAt} collective={member} m={3} />
           ))}
-        </div>
+        </Flex>
       </section>
     );
   }

--- a/src/components/UserCompany.js
+++ b/src/components/UserCompany.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Link from './Link';
+
+const UserCompany = ({ company }) => {
+  if (!company || company[0] !== '@') {
+    return company;
+  }
+
+  // This could be used to generate malicious URLs.
+  // By splitting on `/` we limit that risk.
+  const companySlug = company.split('/')[0].slice(1);
+  return (
+    <Link route="collective" params={{ slug: companySlug }}>
+      {companySlug}
+    </Link>
+  );
+};
+
+UserCompany.propTypes = {
+  company: PropTypes.string,
+};
+
+export default UserCompany;

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -410,6 +410,7 @@ const getCollectiveQuery = gql`
           type
           image
           backgroundImage
+          company
         }
       }
       ... on User {

--- a/styleguide/examples/Avatar.md
+++ b/styleguide/examples/Avatar.md
@@ -1,0 +1,3 @@
+```js
+<Avatar radius={64} name="Frank Zappa" />
+```

--- a/styleguide/examples/MemberCard.md
+++ b/styleguide/examples/MemberCard.md
@@ -1,0 +1,13 @@
+```js
+<MemberCard
+  role="ADMIN"
+  createdAt="Fri Feb 01 1953 15:29:07 GMT+0100 (GMT+01:00)"
+  collective={{
+    slug: 'frank-zappa',
+    name: 'Frank Zappa',
+    image:
+      'https://images.opencollective.com/proxy/images?src=https%3A%2F%2Fopencollective-staging.s3-us-west-1.amazonaws.com%2F40cf57a0-2fbf-11e9-85ef-e1ba4406e770.jpg&width=64',
+    company: 'Open Collective',
+  }}
+/>
+```


### PR DESCRIPTION
:wrench: Fix https://github.com/opencollective/opencollective/issues/1536
:art: Implements [design](https://www.figma.com/file/e71tBo0Sr8J7R5n6iMkqI42d/09.-Collectives?node-id=0%3A7428) 

---

### Implement the new member cards design

See [styleguide](https://deploy-preview-1410--oc-styleguide.netlify.com/#!/MemberCard)

![image](https://user-images.githubusercontent.com/1556356/52940873-dafa5e00-3367-11e9-8f22-9cefefb09304.png)

### Enforcing security on company link

User's company name is now stripped thanks to the `UserCompany` component to protect from a user settings an invalid value like `../../rewriting-full-url`.