### PR TITLE
Fix: Responsiveness issue on ContributeAs

### DIFF
--- a/src/components/ContributeAs.js
+++ b/src/components/ContributeAs.js
@@ -196,7 +196,7 @@ const ContributeAs = enhance(
               ) : (
                 <Logo src={value.image} type={value.type} height="3.6rem" name={value.name} />
               )}
-              <Flex flexDirection="column" ml={2}>
+              <Flex flexDirection="column" ml={2} flex="1">
                 <P color="inherit" fontWeight={value.type ? 600 : 500}>
                   {value.name}
                 </P>


### PR DESCRIPTION
https://github.com/opencollective/opencollective/issues/1693
fix(ContributeAs): fixes contributeAs user description breaking on mobile

the username was breaking to a new line when the screen was very small. Adding a `flex:1` property to
the component allowed the component to grow and shrink, solving the issue.

<img width="320" alt="screen shot 2019-02-13 at 23 52 58" src="https://user-images.githubusercontent.com/1004681/52758235-ab0d2c80-2fee-11e9-98b5-3428928912a6.png">
