### PR TITLE
Prune dev dependencies on now deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ ENV API_KEY $API_KEY
 
 RUN npm run build
 
+RUN npm prune --production
+
 EXPOSE ${PORT}
 
 CMD [ "npm", "run", "start" ]

--- a/now.json
+++ b/now.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "name": "opencollective-frontend",
   "type": "docker",
   "env": {},


### PR DESCRIPTION
We do prune dev dependencies in our staging/production environments.

With this change, we will be closer to that.

We want to fail if we rely on a dev dependency to run the app.