### PR TITLE
Next.js 7 / Don't import our own webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "unified": "7.1.0",
     "uuid": "3.3.2",
     "validator": "10.11.0",
-    "webpack": "4.20.2",
     "winston": "3.2.1"
   },
   "scripts": {
@@ -195,8 +194,7 @@
       "@babel/node",
       "@babel/runtime",
       "react-mde",
-      "styled-jsx",
-      "webpack"
+      "styled-jsx"
     ]
   },
   "husky": {

--- a/src/next.config.js
+++ b/src/next.config.js
@@ -1,3 +1,4 @@
+/*  eslint-disable-next-line import/no-unresolved */
 import webpack from 'webpack';
 import withCSS from '@zeit/next-css';
 import { get } from 'lodash';


### PR DESCRIPTION
Now that we downgraded to Next.js 7, it seems it's still a good idea to not include webpack in our package.json.