### PR TITLE
Fix typo on "How it works" page

### DIFF
--- a/src/static/how-it-works-page/index.html
+++ b/src/static/how-it-works-page/index.html
@@ -49,7 +49,7 @@
         </header>
         <ul class='styled-list'>
           <li>Accept one time or recurring donations.</li>
-          <li>Define different tiers for members of sponsors.</li>
+          <li>Define different tiers for members or sponsors.</li>
         </ul>
       </div>
       <div class='md-col-5 center'>


### PR DESCRIPTION
`Define different tiers for members of sponsors.` -> `Define different tiers for members or sponsors.` 

(of -> or)