### PR TITLE
feat(host dashboard): new filter ready to pay

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -44,6 +44,7 @@
   "expenses.all": "all",
   "expenses.pending": "pending",
   "expenses.approved": "approved",
+  "expenses.ready": "ready to pay",
   "expenses.paid": "paid",
   "expenses.empty": "No expenses",
   "loadMore": "load more",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -44,6 +44,7 @@
   "expenses.all": "all",
   "expenses.pending": "pending",
   "expenses.approved": "aprobados",
+  "expenses.ready": "ready to pay",
   "expenses.paid": "paid",
   "expenses.empty": "No expenses",
   "loadMore": "cargar más",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -44,6 +44,7 @@
   "expenses.all": "tout",
   "expenses.pending": "en attente",
   "expenses.approved": "approuvé",
+  "expenses.ready": "ready to pay",
   "expenses.paid": "payé",
   "expenses.empty": "Pas de dépenses",
   "loadMore": "voir plus",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -44,6 +44,7 @@
   "expenses.all": "全て",
   "expenses.pending": "保留中",
   "expenses.approved": "承認済み",
+  "expenses.ready": "ready to pay",
   "expenses.paid": "支払い済み",
   "expenses.empty": "経費申請がありません",
   "loadMore": "もっと見る",


### PR DESCRIPTION
Fixes https://github.com/opencollective/opencollective/issues/1767

It's a quick hack that filters on the frontend side but it will already make @piamancini and @alannallama's job much easier.

(Ideally we should introduce a new status on the backend)

![](https://d.pr/free/i/mr3PMm+)

This pull request also makes the locking mechanism on a per collective basis. 
So that you don't have to wait to start paying an expense for another collective. It will also speed up things.