### PR TITLE
Disable CDN cache in members.json

### DIFF
--- a/src/server/controllers/members.js
+++ b/src/server/controllers/members.js
@@ -26,8 +26,6 @@ export async function list(req, res, next) {
   if (req.headers.authorization) {
     res.setHeader('cache-control', 'no-cache'); // don't cache at CDN level as the result contains private information
     headers.authorization = req.headers.authorization;
-  } else {
-    res.setHeader('cache-control', 'max-age=6000');
   }
 
   const client = new GraphQLClient(getGraphqlUrl(), { headers });


### PR DESCRIPTION
Fix: https://github.com/opencollective/opencollective/issues/1736

The activity on this endpoint doesn't require a CDN cache.

If performance is a problem in the future, we should better make the GraphQL query fast.