### PR TITLE
Fix broken invoice link with gift cards transactions

### DIFF
--- a/src/apps/expenses/components/InvoiceDownloadLink.js
+++ b/src/apps/expenses/components/InvoiceDownloadLink.js
@@ -4,6 +4,8 @@ import * as api from '../../../lib/api';
 import { saveAs } from 'file-saver';
 
 import { collectiveInvoiceURL, invoiceServiceURL, transactionInvoiceURL } from '../../../lib/url_helpers';
+import { Span } from '../../../components/Text';
+import { FormattedMessage } from 'react-intl';
 
 export default class InvoiceDownloadLink extends Component {
   static propTypes = {
@@ -23,7 +25,7 @@ export default class InvoiceDownloadLink extends Component {
 
   constructor(props) {
     super(props);
-    this.state = { isLoading: false };
+    this.state = { isLoading: false, error: false };
   }
 
   getInvoiceUrl() {
@@ -43,15 +45,22 @@ export default class InvoiceDownloadLink extends Component {
     const getParams = { format: 'blob', allowExternal: invoiceServiceURL };
 
     this.setState({ isLoading: true });
-    const file = await api.get(invoiceUrl, getParams);
-    this.setState({ isLoading: false });
-
-    return saveAs(file, this.getFilename());
+    try {
+      const file = await api.get(invoiceUrl, getParams);
+      this.setState({ isLoading: false });
+      return saveAs(file, this.getFilename());
+    } catch (e) {
+      this.setState({ error: e.message, isLoading: false });
+    }
   }
 
   render() {
-    const { isLoading } = this.state;
-    return (
+    const { isLoading, error } = this.state;
+    return error ? (
+      <Span color="red.700">
+        <FormattedMessage id="errorMsg" defaultMessage="Error: {error}" values={{ error }} />
+      </Span>
+    ) : (
       <a onClick={() => !isLoading && this.download()}>
         {!isLoading && this.props.children}
         {isLoading && this.props.viewLoading()}

--- a/src/apps/expenses/components/Transactions.js
+++ b/src/apps/expenses/components/Transactions.js
@@ -44,6 +44,22 @@ class Transactions extends React.Component {
     });
   }
 
+  canDownloadInvoice(transaction) {
+    const { LoggedInUser, collective } = this.props;
+
+    // User must be logged in as collective admin or root
+    if (!LoggedInUser || (!LoggedInUser.canEditCollective(collective) && !LoggedInUser.isRoot())) {
+      return false;
+    }
+
+    // Transactions invoices for gift cards are only available to emitter collectives
+    if (transaction.usingVirtualCardFromCollective) {
+      return transaction.usingVirtualCardFromCollective.id === collective.id;
+    }
+
+    return true;
+  }
+
   render() {
     const { collective, transactions, LoggedInUser, showCSVlink, filters } = this.props;
 
@@ -162,9 +178,7 @@ class Transactions extends React.Component {
                 {...transaction}
                 isRefund={Boolean(transaction.refundTransaction)}
                 canRefund={LoggedInUser && LoggedInUser.isRoot()}
-                canDownloadInvoice={
-                  LoggedInUser && (LoggedInUser.canEditCollective(collective) || LoggedInUser.isRoot())
-                }
+                canDownloadInvoice={this.canDownloadInvoice(transaction)}
               />
             </Box>
           ))}

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -35,6 +35,7 @@ export const transactionFields = `
     image
   }
   usingVirtualCardFromCollective {
+    id
     slug
     name
   }


### PR DESCRIPTION
This PR fixes the recent issue that a user faced while trying to get an invoice for a transaction he made using a gift card from TripleByte.

It introduces two changes:

1. We don't show the link to the invoice to the user if the transaction was made using a gift card. Of course, the link is still available to the organization that emitted the gift card.

2. We now display the error message instead of blocking on `Loading...` if the invoice fetch failed

![2019-03-01_09 10 24](https://user-images.githubusercontent.com/1556356/53632280-cdb95b00-3c14-11e9-91db-dab0f84d867f.png)
