### PR TITLE
Default dev environment to staging

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,5 +1,2 @@
 API_URL=http://localhost:3060
 API_KEY=dvl-1510egmf4a23d80342403fb599qd
-WEBSITE_URL=http://localhost:3000
-IMAGES_URL=https://images.opencollective.com
-INVOICES_URL=http://localhost:3002

--- a/.env.staging
+++ b/.env.staging
@@ -1,5 +1,0 @@
-API_URL=https://api-staging.opencollective.com
-API_KEY=09u624Pc9F47zoGLlkg1TBSbOl2ydSAq
-WEBSITE_URL=http://localhost:3000
-IMAGES_URL=https://images-staging.opencollective.com
-INVOICES_URL=https://invoices-staging.opencollective.com

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ npm install
 
 ### Environment variables
 
-This project requires an access to the Open Collective API. You have two options:
+This project requires an access to the Open Collective API. By default, it will try to connect to the Open Colllective staging API.
 
-- `cp .env.staging .env` to connect to the Open Collective staging API
-- `cp .env.local .env` to connect to the API running locally
+If you want to connect to the Open Collective API running locally:
 
-If you decide to pick the local strategy, make sure you install and run the [opencollective-api](https://github.com/opencollective/opencollective-api) project.
+- clone, install and start [opencollective-api](https://github.com/opencollective/opencollective-api)
+- in this project, create an `.env` file (if necessary), then copy the data from the `[.env.local](.env.local)` file
 
 ### Start
 

--- a/src/env.js
+++ b/src/env.js
@@ -1,4 +1,3 @@
-// Load environment variables
 import debug from 'debug';
 import dotenv from 'dotenv';
 
@@ -8,7 +7,11 @@ debug.enable(process.env.DEBUG);
 const defaults = {
   PORT: 3000,
   NODE_ENV: 'development',
-  IMAGES_URL: 'https://images.opencollective.com',
+  API_KEY: '09u624Pc9F47zoGLlkg1TBSbOl2ydSAq',
+  API_URL: 'https://api-staging.opencollective.com',
+  IMAGES_URL: 'https://images-staging.opencollective.com',
+  WEBSITE_URL: 'http://localhost:3000',
+  INVOICES_URL: 'https://invoices-staging.opencollective.com',
   PAYPAL_ENVIRONMENT: 'sandbox',
   STRIPE_KEY: 'pk_test_5aBB887rPuzvWzbdRiSzV3QB',
   GOOGLE_MAPS_API_KEY: 'AIzaSyCRLIexl7EkMQk_0_yNsjO4Vqb_MccD-RI',


### PR DESCRIPTION
It can be a problem for developers to pick staging vs local, and reliably edit the `.env` file accordingly.

We can simply default to staging and developers willing to use the local API will do the extra step of setting environment variables.