### PR TITLE
Allow multiline in expense private instructions

### DIFF
--- a/src/apps/expenses/components/ExpenseDetails.js
+++ b/src/apps/expenses/components/ExpenseDetails.js
@@ -172,6 +172,10 @@ class ExpenseDetails extends React.Component {
             .col.large {
               width: 100%;
             }
+
+            .privateMessage {
+              white-space: pre-line;
+            }
           `}
         </style>
 


### PR DESCRIPTION
This PR fixes [#1757](https://github.com/opencollective/opencollective/issues/1757) by adding:
```css
 .privateMessage {
      white-space: pre-line;
   }
```
to the styles.
Before, private instructions with multi line
![screenshot from 2019-03-06 14-46-36](https://user-images.githubusercontent.com/15707013/53885859-085d3200-401f-11e9-9d37-c3e8ea59f023.png)
After:
![screenshot from 2019-03-06 14-47-17](https://user-images.githubusercontent.com/15707013/53885908-23c83d00-401f-11e9-8088-98bb629c1e93.png)
