### PR TITLE
Rename ContributeAs onChange Prop to onProfileChange

### DIFF
--- a/cypress/integration/13-contributionFlow.order.test.js
+++ b/cypress/integration/13-contributionFlow.order.test.js
@@ -58,22 +58,23 @@ describe('Contribution Flow: Order', () => {
 
     const visitParams = { onBeforeLoad: mockRecaptcha };
     // Login and redirect to the order page
-    cy.login({ redirect: '/apex/contribute/tier/470-sponsors', visitParams });
+    cy.login({ redirect: '/apex/contribute/tier/470-sponsors', visitParams }).then(() => {
+      // Select 'Test Collective' organization profile
+      cy.get('[type="radio"][value="10880"]').check();
+      cy.tick(1000);
+      cy.get('input[type=radio][name=contributeAs][value=10880]').should('be.checked');
 
-    // Select 'Test Collective' organization profile
-    cy.get('[type="radio"][value="10880"]').check();
-    cy.contains('Next step').click();
+      cy.contains('Next step').click();
 
-    cy.checkStepsProgress({ enabled: ['contributeAs', 'details'], disabled: 'payment' });
-    cy.get('#interval[disabled]').should('exist');
-    cy.contains('Next charge: Jun 1, 2042');
-    cy.contains('Next step').click();
-    cy.checkStepsProgress({ enabled: ['contributeAs', 'details', 'payment'] });
-    cy.get('input[type=checkbox][name=save]').should('be.checked');
-    cy.wait(1000); // Wait for stripe to be loaded
-    cy.fillStripeInput();
-    cy.contains('button', 'Make contribution').click();
-    cy.get('#page-order-success', { timeout: 20000 }).contains('$100.00 per month');
-    cy.contains("Test Collective is now a member of APEX's 'Sponsors' tier!");
+      cy.checkStepsProgress({ enabled: ['contributeAs', 'details'], disabled: 'payment' });
+      cy.get('#interval[disabled]').should('exist');
+      cy.contains('Next charge: Jun 1, 2042');
+      cy.contains('Next step').click();
+      cy.checkStepsProgress({ enabled: ['contributeAs', 'details', 'payment'] });
+
+      cy.contains('button', 'Make contribution').click();
+      cy.get('#page-order-success', { timeout: 20000 }).contains('$100.00 per month');
+      cy.contains("Test Collective is now a member of APEX's 'Sponsors' tier!");
+    });
   });
 });

--- a/cypress/integration/13-contributionFlow.order.test.js
+++ b/cypress/integration/13-contributionFlow.order.test.js
@@ -57,7 +57,7 @@ describe('Contribution Flow: Order', () => {
     cy.clock(Date.parse('2042/05/25'));
 
     const visitParams = { onBeforeLoad: mockRecaptcha };
-    // Login and rediect to the order page
+    // Login and redirect to the order page
     cy.login({ redirect: '/apex/contribute/tier/470-sponsors', visitParams });
 
     // Select 'Test Collective' organization profile

--- a/cypress/integration/13-contributionFlow.order.test.js
+++ b/cypress/integration/13-contributionFlow.order.test.js
@@ -52,4 +52,28 @@ describe('Contribution Flow: Order', () => {
       cy.contains(`${user.firstName} ${user.lastName} is now a member of APEX's 'Sponsors' tier!`);
     });
   });
+
+  it('Can order with an existing orgnanization', () => {
+    cy.clock(Date.parse('2042/05/25'));
+
+    const visitParams = { onBeforeLoad: mockRecaptcha };
+    // Login and rediect to the order page
+    cy.login({ redirect: '/apex/contribute/tier/470-sponsors', visitParams });
+
+    // Select 'Test Collective' organization profile
+    cy.get('[type="radio"][value="10880"]').check();
+    cy.contains('Next step').click();
+
+    cy.checkStepsProgress({ enabled: ['contributeAs', 'details'], disabled: 'payment' });
+    cy.get('#interval[disabled]').should('exist');
+    cy.contains('Next charge: Jun 1, 2042');
+    cy.contains('Next step').click();
+    cy.checkStepsProgress({ enabled: ['contributeAs', 'details', 'payment'] });
+    cy.get('input[type=checkbox][name=save]').should('be.checked');
+    cy.wait(1000); // Wait for stripe to be loaded
+    cy.fillStripeInput();
+    cy.contains('button', 'Make contribution').click();
+    cy.get('#page-order-success', { timeout: 20000 }).contains('$100.00 per month');
+    cy.contains("Test Collective is now a member of APEX's 'Sponsors' tier!");
+  });
 });

--- a/cypress/integration/13-contributionFlow.order.test.js
+++ b/cypress/integration/13-contributionFlow.order.test.js
@@ -55,35 +55,44 @@ describe('Contribution Flow: Order', () => {
 
   it('Can order with an existing orgnanization', () => {
     cy.clock(Date.parse('2042/05/25'));
-
+    let collectiveSlug = null;
     const visitParams = { onBeforeLoad: mockRecaptcha };
-    // Login and redirect to the order page
-    cy.login({ redirect: '/apex/contribute/tier/470-sponsors', visitParams }).then(() => {
-      // Select 'Test Collective' organization profile
-      cy.get('[type="radio"][value="10880"]').check();
-      cy.tick(1000);
-      cy.get('input[type=radio][name=contributeAs][value=10880]').should('be.checked');
 
-      cy.contains('Next step').click();
+    cy.login().then(() => {
+      // Create a new organization
+      cy.createCollective({ type: 'ORGANIZATION' }).then(collective => {
+        collectiveSlug = collective.slug;
+        // Add a paymentMethod to the organization profile
+        cy.addCreditCardToCollective({ collectiveSlug });
 
-      cy.checkStepsProgress({ enabled: ['contributeAs', 'details'], disabled: 'payment' });
-      cy.get('#interval[disabled]').should('exist');
-      cy.contains('Next charge: Jun 1, 2042');
-      cy.contains('Next step').click();
-      cy.checkStepsProgress({ enabled: ['contributeAs', 'details', 'payment'] });
+        cy.visit('/apex/contribute/tier/470-sponsors', visitParams);
+        // Check the newly created organization
+        cy.get(`[type="radio"][name=contributeAs][value=${collective.id}]`).check();
+        cy.tick(1000);
+        cy.get(`input[type=radio][name=contributeAs][value=${collective.id}]`).should('be.checked');
 
-      cy.get('#PaymentMethod').then($paymentMethod => {
-        // Checks if the organization already has a payment method configured
-        if ($paymentMethod.text().includes('VISA **** 4242')) {
-          cy.contains('button', 'Make contribution').click();
-        } else {
-          cy.get('input[type=checkbox][name=save]').should('be.checked');
-          cy.wait(1000); // Wait for stripe to be loaded
-          cy.fillStripeInput();
-          cy.contains('button', 'Make contribution').click();
-        }
-        cy.get('#page-order-success', { timeout: 20000 }).contains('$100.00 per month');
-        cy.contains("Test Collective is now a member of APEX's 'Sponsors' tier!");
+        cy.contains('Next step').click();
+
+        cy.checkStepsProgress({ enabled: ['contributeAs', 'details'], disabled: 'payment' });
+        cy.get('#interval[disabled]').should('exist');
+        cy.contains('Next charge: Jun 1, 2042');
+        cy.contains('Next step').click();
+        cy.checkStepsProgress({ enabled: ['contributeAs', 'details', 'payment'] });
+
+        cy.get('#PaymentMethod').then($paymentMethod => {
+          // Checks if the organization already has a payment method configured
+          if ($paymentMethod.text().includes('VISA **** 4242')) {
+            cy.contains('button', 'Make contribution').click();
+          } else {
+            cy.get('input[type=checkbox][name=save]').should('be.checked');
+            cy.wait(1000); // Wait for stripe to be loaded
+            cy.fillStripeInput();
+            cy.contains('button', 'Make contribution').click();
+          }
+          cy.get('#page-order-success', { timeout: 20000 }).contains('$100.00 per month');
+          // TestOrg is the name of the created organization.
+          cy.contains("TestOrg is now a member of APEX's 'Sponsors' tier!");
+        });
       });
     });
   });

--- a/cypress/integration/13-contributionFlow.order.test.js
+++ b/cypress/integration/13-contributionFlow.order.test.js
@@ -72,9 +72,19 @@ describe('Contribution Flow: Order', () => {
       cy.contains('Next step').click();
       cy.checkStepsProgress({ enabled: ['contributeAs', 'details', 'payment'] });
 
-      cy.contains('button', 'Make contribution').click();
-      cy.get('#page-order-success', { timeout: 30000 }).contains('$100.00 per month');
-      cy.contains("Test Collective is now a member of APEX's 'Sponsors' tier!");
+      cy.get('#PaymentMethod').then($paymentMethod => {
+        // Checks if the organization already has a payment method configured
+        if ($paymentMethod.text().includes('VISA **** 4242')) {
+          cy.contains('button', 'Make contribution').click();
+        } else {
+          cy.get('input[type=checkbox][name=save]').should('be.checked');
+          cy.wait(1000); // Wait for stripe to be loaded
+          cy.fillStripeInput();
+          cy.contains('button', 'Make contribution').click();
+        }
+        cy.get('#page-order-success', { timeout: 20000 }).contains('$100.00 per month');
+        cy.contains("Test Collective is now a member of APEX's 'Sponsors' tier!");
+      });
     });
   });
 });

--- a/cypress/integration/13-contributionFlow.order.test.js
+++ b/cypress/integration/13-contributionFlow.order.test.js
@@ -73,7 +73,7 @@ describe('Contribution Flow: Order', () => {
       cy.checkStepsProgress({ enabled: ['contributeAs', 'details', 'payment'] });
 
       cy.contains('button', 'Make contribution').click();
-      cy.get('#page-order-success', { timeout: 20000 }).contains('$100.00 per month');
+      cy.get('#page-order-success', { timeout: 30000 }).contains('$100.00 per month');
       cy.contains("Test Collective is now a member of APEX's 'Sponsors' tier!");
     });
   });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -10,14 +10,14 @@ import { randomEmail } from './faker';
  *    - email: User email
  */
 Cypress.Commands.add('login', (params = {}) => {
-  const { email = defaultTestUserEmail, redirect = null } = params;
+  const { email = defaultTestUserEmail, redirect = null, visitParams } = params;
   const user = { email, newsletterOptIn: false };
 
   return signinRequest(user, redirect).then(({ body: { redirect } }) => {
     // Test users are allowed to signin directly with E2E, thus a signin URL
     // is directly returned by the API. See signin function in
     // opencollective-api/server/controllers/users.js for more info
-    return cy.visit(redirect).then(() => user);
+    return cy.visit(redirect, visitParams).then(() => user);
   });
 });
 

--- a/src/components/ContributeAs.js
+++ b/src/components/ContributeAs.js
@@ -31,31 +31,31 @@ const ContributeAsEntryContainer = styled(Container)`
   }
 `;
 
-const useForm = ({ onChange }) => {
+const useForm = ({ onProfileChange }) => {
   const [state, setState] = useState({ errors: {} });
   return {
     getFieldError: name => state.errors[name],
     onChange: selected => {
       if (selected.key === 'new-org') {
         if (state.name && state.website) {
-          return onChange({ type: 'ORGANIZATION', ...omit(state, ['errors']) });
+          return onProfileChange({ type: 'ORGANIZATION', ...omit(state, ['errors']) });
         } else {
-          return onChange(null);
+          return onProfileChange(null);
         }
       }
 
       if (selected.key === 'anonymous') {
-        return onChange({ name: 'anonymous' });
+        return onProfileChange({ name: 'anonymous' });
       }
 
-      return onChange(selected.value);
+      return onProfileChange(selected.value);
     },
     onFieldChange: event => {
       event.stopPropagation();
 
       const { target } = event;
       if (!target.validity.valid) {
-        onChange(null);
+        onProfileChange(null);
         setState({ ...state, [target.name]: undefined });
         return;
       }
@@ -68,7 +68,7 @@ const useForm = ({ onChange }) => {
         ...newState,
         errors: { ...state.errors, [target.name]: null },
       });
-      onChange({ type: 'ORGANIZATION', ...omit(newState, ['errors']) });
+      onProfileChange({ type: 'ORGANIZATION', ...omit(newState, ['errors']) });
     },
     onSearch: ({ target }) => {
       setState(state => ({
@@ -119,8 +119,8 @@ const useForm = ({ onChange }) => {
 /**
  * Search is displayed if 5 or more profiles are passed in.
  */
-const ContributeAs = ({ onChange, personal, profiles, defaultSelectedProfile, ...fieldProps }) => {
-  const { getFieldError, getFieldProps, onFieldChange, onSearch, state } = useForm({ onChange });
+const ContributeAs = ({ onProfileChange, personal, profiles, defaultSelectedProfile, ...fieldProps }) => {
+  const { getFieldError, getFieldProps, onFieldChange, onSearch, onChange, state } = useForm({ onProfileChange });
   if (state.search) {
     const test = new RegExp(escapeInput(state.search), 'i');
     profiles = profiles.filter(profile => profile.name.match(test));
@@ -272,7 +272,7 @@ ContributeAs.propTypes = {
    * if 'A new organization' is selected, the latest data from that form is returned <br />
    * else the data passed to `profiles` or `personal` is returned
    */
-  onChange: PropTypes.func,
+  onProfileChange: PropTypes.func,
   defaultSelectedProfile: PropTypes.shape({
     id: PropTypes.number,
   }),
@@ -295,7 +295,7 @@ ContributeAs.propTypes = {
 };
 
 ContributeAs.defaultProps = {
-  onChange: () => {}, // noop
+  onProfileChange: () => {}, // noop
 };
 
 export default ContributeAs;

--- a/src/components/ContributeAs.js
+++ b/src/components/ContributeAs.js
@@ -158,7 +158,7 @@ const ContributeAs = ({ onProfileChange, personal, profiles, defaultSelectedProf
         {...fieldProps}
         options={options}
         keyGetter="id"
-        defaultValue={defaultSelectedProfile.id}
+        defaultValue={defaultSelectedProfile ? defaultSelectedProfile.id : undefined}
         onChange={onChange}
       >
         {({ key, value, radio, checked, index }) => (
@@ -267,17 +267,18 @@ ContributeAs.displayName = 'ContributeAs';
 
 ContributeAs.propTypes = {
   /**
-   * emits latest selected profile <br />
-   * if enhance( enhance( enhance( enhance( anoymous is selected, only `{name: 'anonymous'}` is returned <br />
-   * if 'A new organization' is selected, the latest data from that form is returned <br />
-   * else the data passed to `profiles` or `personal` is returned
+   * emits latest selected profile
+   *
+   *  - if anoymous is selected, only `{name: 'anonymous'}` is returned
+   *  - if 'A new organization' is selected, the latest data from that form is returned
+   *  - else the data passed to `profiles` or `personal` is returned
    */
   onProfileChange: PropTypes.func,
   defaultSelectedProfile: PropTypes.shape({
     id: PropTypes.number,
   }),
   personal: PropTypes.shape({
-    id: PropTypes.number,
+    id: PropTypes.number.isRequired,
     email: PropTypes.string,
     image: PropTypes.string,
     name: PropTypes.string,
@@ -285,7 +286,7 @@ ContributeAs.propTypes = {
   }),
   profiles: PropTypes.arrayOf(
     PropTypes.shape({
-      id: PropTypes.number,
+      id: PropTypes.number.isRequired,
       email: PropTypes.string,
       image: PropTypes.string,
       name: PropTypes.string,

--- a/src/pages/createOrder.js
+++ b/src/pages/createOrder.js
@@ -603,7 +603,7 @@ class CreateOrderPage extends React.Component {
             <Container as="form" onSubmit={e => e.preventDefault()} ref={this.activeFormRef}>
               <ContributeAs
                 {...fieldProps}
-                onChange={this.updateProfile}
+                onProfileChange={this.updateProfile}
                 profiles={profiles}
                 personal={personal}
                 defaultSelectedProfile={this.getLoggedInUserDefaultContibuteProfile()}

--- a/styleguide/examples/ContributeAs.md
+++ b/styleguide/examples/ContributeAs.md
@@ -1,14 +1,19 @@
 ```js
-const {
-  default: profiles,
-  personalProfile,
-} = require('../mocks/profiles');
+const { default: profiles, personalProfile } = require('../mocks/profiles');
 
-<ContributeAs
-  onChange={console.log}
-  profiles={profiles}
-  personal={personalProfile}
-  id="contribute-as"
-  name="contribute-as"
-/>
+initialState = null;
+<div style={{ display: 'flex', flexWrap: 'wrap' }}>
+  <ContributeAs
+    onProfileChange={setState}
+    profiles={profiles}
+    personal={personalProfile}
+    defaultSelectedProfile={state || personalProfile}
+    id="contribute-as"
+    name="contribute-as"
+  />
+  <div style={{ margin: 24, maxWidth: 300 }}>
+    <strong>State</strong>
+    <pre style={{ whiteSpace: 'pre-wrap' }}>{JSON.stringify(state, null, 2)}</pre>
+  </div>
+</div>;
 ```

--- a/styleguide/mocks/profiles.js
+++ b/styleguide/mocks/profiles.js
@@ -1,32 +1,39 @@
 export const personalProfile = {
+  id: 42,
   email: 'example.person@example.com',
   name: 'Example Person',
   type: 'USER',
 };
 
-export default {
-  '13': {
+export default [
+  {
+    id: 1,
     name: 'Open Collective Inc.',
     type: 'COLLECTIVE',
   },
-  '26': {
+  {
+    id: 2,
     name: 'Sustain',
     type: 'COLLECTIVE',
   },
-  '39': {
+  {
+    id: 3,
     name: 'Democracy Earth Foundation',
     type: 'COLLECTIVE',
   },
-  '52': {
+  {
+    id: 4,
     name: 'Airbnb',
     type: 'ORGANIZATION',
   },
-  '65': {
+  {
+    id: 5,
     name: 'Trivago',
     type: 'ORGANIZATION',
   },
-  '65': {
+  {
+    id: 6,
     name: 'Trivago',
     type: 'ORGANIZATION',
   },
-};
+];


### PR DESCRIPTION
Currently there is a `prop` name mix up between [`onChange`](https://github.com/opencollective/opencollective-frontend/blob/master/src/components/ContributeAs.js#L38) returned by [`useForm`](https://github.com/opencollective/opencollective-frontend/blob/master/src/components/ContributeAs.js#L34) hook and [`onChange`](https://github.com/opencollective/opencollective-frontend/blob/master/src/components/ContributeAs.js#L34) prop of `ContributeAs` component causing the error in [issue 1788](https://github.com/opencollective/opencollective/issues/1788).

I renamed `onChange` prop of `ContributeAs` to `onProfileChange` in this PR.