### PR TITLE
Fix: Unstable onChange behaviour on ContributeDetails

### DIFF
--- a/src/components/ContributeDetails.js
+++ b/src/components/ContributeDetails.js
@@ -88,7 +88,7 @@ const ContributeDetails = ({
   const hasOptions = get(amountOptions, 'length', 0) > 0;
   const displayMap = amountOptions ? buildDisplayMap(amountOptions) : {};
   return (
-    <Flex width={1} flexDirection={hasOptions ? 'column' : 'row'} flexWrap="wrap" {...props}>
+    <Flex width={1} flexDirection={hasOptions ? 'column' : 'row'} flexWrap="wrap">
       <Flex mb={3}>
         {hasOptions && (
           <StyledInputField


### PR DESCRIPTION
`props` was spread unnecessarily on `Flex` component in  [`ContributeDetails.js`](https://github.com/opencollective/opencollective-frontend/blob/e0fff9d49d9d23ae0c9060bf2a9225e3c3268f81/src/components/ContributeDetails.js#L91) causing an invalid value and multiple calls during `onChange` event as explained in issue ([#1796](https://github.com/opencollective/opencollective/issues/1796)).