### PR TITLE
Don't pre-build pages and components with babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "build": "npm run build:clean && npm run build:updates && npm run build:server && npm run build:next",
     "build:clean": "rm -rf dist src/.next",
     "build:updates": "npm --prefix node_modules/cloudflare-ip run update-list",
-    "build:server": "babel --copy-files ./src --out-dir ./dist --ignore src/templates/widget.js,src/**/__tests__/*,src/.next/*",
+    "build:server": "babel --copy-files ./src --out-dir ./dist --ignore src/templates/widget.js,src/**/__tests__/*,src/.next/*,src/pages/**,src/components/**",
     "build:next": "next build dist",
     "test": "npm run test:jest && npm run test:e2e",
     "test:jest": "TZ=UTC jest src/*",


### PR DESCRIPTION
While investigating https://github.com/opencollective/opencollective/issues/1776 it was highlighted that we should not be pre-building `pages` and `components`. We're doing that to compile server-side only code.

It's not gonna fix the issue itself, but after the modification it's expected to throw a different error.

Related: https://github.com/opencollective/opencollective-frontend/pull/1514