### PR TITLE
fix(hostDashboard): Expenses filtering breaks after payment

### DIFF
--- a/src/apps/expenses/components/ExpensesWithData.js
+++ b/src/apps/expenses/components/ExpensesWithData.js
@@ -13,11 +13,14 @@ class ExpensesWithData extends React.Component {
     host: PropTypes.object,
     limit: PropTypes.number,
     view: PropTypes.string, // "compact" for homepage (can't edit expense, don't show header), "summary" for list view, "details" for details view
-    filter: PropTypes.object, // { category, recipient }
+    hasFilters: PropTypes.bool,
+    filters: PropTypes.object, // { category, recipient, status }
     defaultAction: PropTypes.string, // "new" to open the new expense form by default
     includeHostedCollectives: PropTypes.bool,
-    filters: PropTypes.bool,
     LoggedInUser: PropTypes.object,
+    fetchMore: PropTypes.func, // from addExpensesData
+    data: PropTypes.object, // from addExpensesData
+    onFiltersChange: PropTypes.func, // from addExpensesData
   };
 
   constructor(props) {
@@ -25,7 +28,7 @@ class ExpensesWithData extends React.Component {
   }
 
   render() {
-    const { data, LoggedInUser, collective, host, view, includeHostedCollectives, filters } = this.props;
+    const { data, LoggedInUser, collective, host, view, includeHostedCollectives } = this.props;
 
     if (data.error) {
       console.error('graphql error>>>', data.error.message);
@@ -40,11 +43,13 @@ class ExpensesWithData extends React.Component {
           collective={collective}
           host={host}
           expenses={expenses}
-          refetch={data.refetch}
           editable={view !== 'compact'}
           view={view}
           fetchMore={this.props.fetchMore}
-          filters={filters}
+          updateVariables={this.props.onFiltersChange}
+          loading={data.loading}
+          status={data.variables.status}
+          filters={this.props.hasFilters}
           LoggedInUser={LoggedInUser}
           includeHostedCollectives={includeHostedCollectives}
         />
@@ -120,7 +125,7 @@ const getExpensesVariables = props => {
     offset: 0,
     limit: props.limit || EXPENSES_PER_PAGE * 2,
     includeHostedCollectives: props.includeHostedCollectives || false,
-    ...props.filter,
+    ...props.filters,
   };
   if (vars.category) {
     vars.fromCollectiveSlug = null;

--- a/src/components/HostDashboard.js
+++ b/src/components/HostDashboard.js
@@ -32,7 +32,7 @@ class HostDashboard extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = { selectedCollective: null };
+    this.state = { selectedCollective: null, expensesFilters: null };
   }
 
   pickCollective(selectedCollective) {
@@ -156,7 +156,9 @@ class HostDashboard extends React.Component {
                   host={host}
                   includeHostedCollectives={includeHostedCollectives}
                   LoggedInUser={LoggedInUser}
-                  filters={true}
+                  hasFilters
+                  filters={this.state.expensesFilters}
+                  onFiltersChange={expensesFilters => this.setState({ expensesFilters })}
                   editable={true}
                 />
               </div>

--- a/src/pages/expenses.js
+++ b/src/pages/expenses.js
@@ -66,7 +66,7 @@ class ExpensesPage extends React.Component {
       }
       if (this.props.filter === 'recipients') {
         const recipient = decodeURIComponent(this.props.value);
-        filter = { recipient };
+        filter = { fromCollectiveSlug: recipient };
         subtitle = (
           <FormattedMessage id="expenses.byRecipient" defaultMessage="Expenses by {recipient}" values={{ recipient }} />
         );
@@ -130,7 +130,7 @@ class ExpensesPage extends React.Component {
 
             <div className=" columns">
               <div className="col large">
-                <ExpensesWithData collective={collective} LoggedInUser={this.state.LoggedInUser} filter={filter} />
+                <ExpensesWithData collective={collective} LoggedInUser={this.state.LoggedInUser} filters={filter} />
               </div>
 
               <div className="col side">

--- a/src/pages/host.dashboard.js
+++ b/src/pages/host.dashboard.js
@@ -7,6 +7,7 @@ import Loading from '../components/Loading';
 
 import withData from '../lib/withData';
 import withIntl from '../lib/withIntl';
+import Page from '../components/Page';
 
 class HostExpensesPage extends React.Component {
   static getInitialProps({ query: { hostCollectiveSlug } }) {
@@ -17,7 +18,8 @@ class HostExpensesPage extends React.Component {
     hostCollectiveSlug: PropTypes.string, // for addData
     ssr: PropTypes.bool,
     data: PropTypes.object, // from withData
-    getLoggedInUser: PropTypes.func.isRequired, // from withLoggedInUser
+    loadingLoggedInUser: PropTypes.bool.isRequired, // from withUser
+    LoggedInUser: PropTypes.object, // from withUser
   };
 
   render() {
@@ -26,7 +28,9 @@ class HostExpensesPage extends React.Component {
     return (
       <div className="HostExpensesPage">
         {loadingLoggedInUser ? (
-          <Loading />
+          <Page>
+            <Loading />
+          </Page>
         ) : (
           <HostDashboard hostCollectiveSlug={this.props.hostCollectiveSlug} LoggedInUser={LoggedInUser} />
         )}


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/1500 by lifting filters state up

Also fix filtering expenses by recipient on `/collective/expenses` page