### PR TITLE
Allow postal code to be skipped in Credit Card form

### DIFF
--- a/src/components/ContributePayment.js
+++ b/src/components/ContributePayment.js
@@ -249,6 +249,7 @@ class ContributePayment extends React.Component {
                     error={errors.newCreditCardInfo}
                     onChange={this.onChange}
                     onReady={this.props.onNewCardFormReady}
+                    hidePostalCode={this.props.hideCreditCardPostalCode}
                   />
                 </Box>
               )}
@@ -288,12 +289,17 @@ ContributePayment.propTypes = {
   onNewCardFormReady: PropTypes.func,
   /** From withStripeLoader */
   loadStripe: PropTypes.func.isRequired,
+  /**
+   * Wether we should ask for postal code in Credit Card form
+   */
+  hideCreditCardPostalCode: PropTypes.bool,
 };
 
 ContributePayment.defaultProps = {
   withPaypal: false,
   paymentMethods: [],
   collective: null,
+  hideCreditCardPostalCode: false,
 };
 
 export default withIntl(withStripeLoader(ContributePayment));

--- a/src/components/NewCreditCardForm.js
+++ b/src/components/NewCreditCardForm.js
@@ -29,6 +29,7 @@ class NewCreditCardFormWithoutStripe extends React.Component {
     name: PropTypes.string,
     error: PropTypes.string,
     hasSaveCheckBox: PropTypes.bool,
+    hidePostalCode: PropTypes.bool,
     onChange: PropTypes.func,
     onReady: PropTypes.func,
     stripe: PropTypes.object,
@@ -36,6 +37,7 @@ class NewCreditCardFormWithoutStripe extends React.Component {
 
   static defaultProps = {
     hasSaveCheckBox: true,
+    hidePostalCode: false,
   };
 
   componentDidMount() {
@@ -51,10 +53,13 @@ class NewCreditCardFormWithoutStripe extends React.Component {
   }
 
   render() {
-    const { name, onChange, error, hasSaveCheckBox } = this.props;
+    const { name, onChange, error, hasSaveCheckBox, hidePostalCode } = this.props;
     return (
       <Flex flexDirection="column">
-        <StyledCardElement onChange={value => onChange({ name, type: 'StripeCreditCard', value })} />
+        <StyledCardElement
+          hidePostalCode={hidePostalCode}
+          onChange={value => onChange({ name, type: 'StripeCreditCard', value })}
+        />
         {error && (
           <Span display="block" color="red.500" pt={2} fontSize="Tiny">
             {error}

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -131,6 +131,7 @@ export const getLoggedInUserQuery = gql`
             balance
             expiryDate
           }
+          settings
         }
       }
     }

--- a/src/pages/createOrder.js
+++ b/src/pages/createOrder.js
@@ -527,6 +527,11 @@ class CreateOrderPage extends React.Component {
     return get(this.props.data, 'Collective.host.id') === 11004 && !get(this.state, 'stepDetails.interval');
   }
 
+  /* We might have problems with postal code and this should be disablable */
+  shouldHideCreditCardPostalCode() {
+    return get(this.state, 'stepProfile.settings.hideCreditCardPostalCode', false);
+  }
+
   /**
    * When using an order with fixed amount, this function returns the details to
    * show the user order amount as step details is skipped.
@@ -680,6 +685,7 @@ class CreateOrderPage extends React.Component {
               onNewCardFormReady={({ stripe }) => this.setState({ stripe })}
               withPaypal={this.hasPaypal()}
               manual={this.getManualPaymentMethod()}
+              hideCreditCardPostalCode={this.shouldHideCreditCardPostalCode()}
               margins="0 auto"
             />
           </Flex>


### PR DESCRIPTION
A donator is having problems with the postal code when trying to pay with an American Express card.

The only fix is to disable the postal code, but it's not recommended to do that by default, certainly to prevent fraud.

Related issue: https://github.com/stripe/react-stripe-elements/issues/20