### PR TITLE
Show dates instead of intervals on transactions page

### DIFF
--- a/src/apps/expenses/components/Transaction.js
+++ b/src/apps/expenses/components/Transaction.js
@@ -56,6 +56,12 @@ class Transaction extends React.Component {
     }),
     type: PropTypes.oneOf(['CREDIT', 'DEBIT']),
     isRefund: PropTypes.bool, // whether or not this transaction refers to a refund
+    /** Choose between date (eg. 2018/12/09) or interval (eg. two months ago) */
+    dateDisplayType: PropTypes.oneOf(['date', 'interval']),
+  };
+
+  static defaultProps = {
+    dateDisplayType: 'interval',
   };
 
   state = { showDetails: false };
@@ -114,6 +120,7 @@ class Transaction extends React.Component {
       collective,
       type,
       paymentProcessorFeeInHostCurrency,
+      dateDisplayType,
     } = this.props;
 
     if (!fromCollective) {
@@ -150,7 +157,7 @@ class Transaction extends React.Component {
           <Container fontSize="1.2rem" color="#AEB2B8">
             {this.renderPaymentOrigin()}
             {' | '}
-            <Moment relative={true} value={createdAt} />
+            <Moment relative={dateDisplayType === 'interval'} value={createdAt} />
             {paymentProcessorFeeInHostCurrency !== undefined && (
               <Fragment>
                 {' | '}

--- a/src/apps/expenses/components/Transactions.js
+++ b/src/apps/expenses/components/Transactions.js
@@ -20,6 +20,7 @@ class Transactions extends React.Component {
     refetch: PropTypes.func,
     fetchMore: PropTypes.func,
     LoggedInUser: PropTypes.object,
+    dateDisplayType: PropTypes.oneOf(['date', 'interval']),
   };
 
   constructor(props) {
@@ -179,6 +180,7 @@ class Transactions extends React.Component {
                 isRefund={Boolean(transaction.refundTransaction)}
                 canRefund={LoggedInUser && LoggedInUser.isRoot()}
                 canDownloadInvoice={this.canDownloadInvoice(transaction)}
+                dateDisplayType={this.props.dateDisplayType}
               />
             </Box>
           ))}

--- a/src/apps/expenses/components/TransactionsWithData.js
+++ b/src/apps/expenses/components/TransactionsWithData.js
@@ -14,6 +14,7 @@ class TransactionsWithData extends React.Component {
     limit: PropTypes.number,
     filters: PropTypes.bool,
     LoggedInUser: PropTypes.object,
+    dateDisplayType: PropTypes.oneOf(['date', 'interval']),
   };
 
   constructor(props) {
@@ -46,6 +47,7 @@ class TransactionsWithData extends React.Component {
           filters={filters}
           LoggedInUser={LoggedInUser}
           showCSVlink={showCSVlink}
+          dateDisplayType={this.props.dateDisplayType}
         />
       </div>
     );

--- a/src/components/Moment.js
+++ b/src/components/Moment.js
@@ -1,8 +1,22 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import moment from 'moment';
+import { FormattedDate } from 'react-intl';
 
 const formatDate = value => new Date(value).toISOString();
 
-const Moment = ({ value }) => <span title={moment(value).format('LLLL')}>{moment(formatDate(value)).fromNow()}</span>;
+const Moment = ({ value, relative }) => {
+  const formattedLongDateStr = moment(value).format('LLLL');
+  return (
+    <span title={formattedLongDateStr}>
+      {relative ? moment(formatDate(value)).fromNow() : <FormattedDate value={value} />}
+    </span>
+  );
+};
+
+Moment.propTypes = {
+  value: PropTypes.string.isRequired,
+  relative: PropTypes.bool,
+};
 
 export default Moment;

--- a/src/pages/transactions.js
+++ b/src/pages/transactions.js
@@ -75,6 +75,7 @@ class TransactionsPage extends React.Component {
               LoggedInUser={this.state.LoggedInUser}
               showCSVlink={true}
               filters={true}
+              dateDisplayType="date"
             />
           </div>
         </Body>


### PR DESCRIPTION
Only applied on `/{collective}/transactions`

![image](https://user-images.githubusercontent.com/1556356/54702539-5aca4280-4b37-11e9-8610-1046b930bc90.png)

This change doesn't affect the way we display dates on others pages:

![2019-03-20_17:34:13](https://user-images.githubusercontent.com/1556356/54702468-35d5cf80-4b37-11e9-9daa-cc4942e9f930.png)
