### PR TITLE
Support Page

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -61,7 +61,7 @@ const navigation = {
     'Report an issue': 'https://github.com/opencollective/opencollective/issues',
     Slack: 'https://slack.opencollective.com',
     'Docs & help': 'https://docs.opencollective.com',
-    'Email Support': 'mailto:support@opencollective.com',
+    Support: '/support',
   },
   COMPANY: {
     About: 'https://docs.opencollective.com/help/about',

--- a/src/pages/__tests__/__snapshots__/search.test.js.snap
+++ b/src/pages/__tests__/__snapshots__/search.test.js.snap
@@ -1230,9 +1230,10 @@ Array [
             >
               <a
                 className="c14"
-                href="mailto:support@opencollective.com"
+                href="/support"
+                onClick={[Function]}
               >
-                Email Support
+                Support
               </a>
             </li>
           </ul>
@@ -2535,9 +2536,10 @@ Array [
             >
               <a
                 className="c14"
-                href="mailto:support@opencollective.com"
+                href="/support"
+                onClick={[Function]}
               >
-                Email Support
+                Support
               </a>
             </li>
           </ul>
@@ -3985,9 +3987,10 @@ exports[`Search Page renders error message 1`] = `
             >
               <a
                 className="c41"
-                href="mailto:support@opencollective.com"
+                href="/support"
+                onClick={[Function]}
               >
-                Email Support
+                Support
               </a>
             </li>
           </ul>
@@ -5385,9 +5388,10 @@ Array [
             >
               <a
                 className="c14"
-                href="mailto:support@opencollective.com"
+                href="/support"
+                onClick={[Function]}
               >
-                Email Support
+                Support
               </a>
             </li>
           </ul>
@@ -6945,9 +6949,10 @@ Array [
             >
               <a
                 className="c14"
-                href="mailto:support@opencollective.com"
+                href="/support"
+                onClick={[Function]}
               >
-                Email Support
+                Support
               </a>
             </li>
           </ul>

--- a/src/pages/static/index.js
+++ b/src/pages/static/index.js
@@ -1,5 +1,6 @@
 import privacypolicy from './privacypolicy.md';
 import tos from './tos.md';
 import widgets from './widgets.md';
+import support from './support.md';
 
-export default { privacypolicy, tos, widgets };
+export default { privacypolicy, tos, widgets, support };

--- a/src/pages/static/support.md
+++ b/src/pages/static/support.md
@@ -1,0 +1,9 @@
+# Support
+
+Support is available from Monday to Friday. We usually answer in less than 24 hours.
+
+We have team members answering from the USA, France, Belgium, Germany and New Zealand.
+
+To contact support, write by email to:
+
+<span style="font-size: 2em">[support@opencollective.com](mailto:support@opencollective.com)</span>

--- a/src/server/pages.js
+++ b/src/server/pages.js
@@ -4,7 +4,7 @@ const pages = nextRoutes();
 
 pages
   .add('home', '/')
-  .add('static', '/:pageSlug(widgets|tos|privacypolicy)', 'staticPage')
+  .add('static', '/:pageSlug(widgets|tos|privacypolicy|support)', 'staticPage')
   .add('redeem', '/redeem/:code?')
   .add('redeemed', '/redeemed/:code?')
   .add('signinLinkSent', '/signin/sent')


### PR DESCRIPTION
I think a support page is a better approach than just having a link in the footer.

Sometime, it's required to have a support URL (GitHub marketplace).

![Screen Shot 2019-03-22 at 11 32 08](https://user-images.githubusercontent.com/806/54817125-7009b300-4c96-11e9-9171-6bee64e89ed9.png)

> Support

> Support is available from Monday to Friday. We usually answer in less than 24 hours.

> We have team members answering from the USA, France, Belgium, Germany and New Zealand.

> To contact support, write by email to:

> support@opencollective.com

