### PR TITLE
Archive Collective: check balance before archiving

### DIFF
--- a/src/components/ArchiveCollective.js
+++ b/src/components/ArchiveCollective.js
@@ -79,13 +79,29 @@ const ArchiveCollective = ({ collective, archiveCollective, unarchiveCollective 
       )}
       {error && <P color="#ff5252">{error}</P>}
       {!isArchived && (
-        <StyledButton width={0.3} onClick={() => setModal({ type: 'Archive', show: true })} loading={processing}>
+        <StyledButton
+          width={0.3}
+          onClick={() => setModal({ type: 'Archive', show: true })}
+          loading={processing}
+          disabled={collective.stats.balance > 0 ? true : false}
+        >
           <FormattedMessage
             values={{ type: collectiveType.toLowerCase() }}
             id="collective.archive.button"
             defaultMessage={'Archive this {type}'}
           />
         </StyledButton>
+      )}
+      {!isArchived && collective.stats.balance >= 0 && (
+        <P>
+          <FormattedMessage
+            values={{ type: collectiveType.toLowerCase() }}
+            id="collective.archive.availableBalance"
+            defaultMessage={
+              'This {type} has available balance, submit an expense for the remaining balance or transfer to another collective before archiving.'
+            }
+          />
+        </P>
       )}
       {isArchived && confirmationMesg && (
         <MessageBox withIcon width={0.6} type="info" mb={4}>

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -36,7 +36,6 @@
   "collective.address.label": "Address",
   "collective.amount.label": "amount",
   "collective.archive.archivedConfirmMessage": "{message}.",
-  "collective.archive.archivedMessage": "This {type} is archived.",
   "collective.archive.availableBalance": "This {type} has available balance, submit an expense for the remaining balance or transfer to another collective before archiving.",
   "collective.archive.button": "Archive this {type}",
   "collective.archive.cancel.btn": "Cancel",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -36,6 +36,8 @@
   "collective.address.label": "Address",
   "collective.amount.label": "amount",
   "collective.archive.archivedConfirmMessage": "{message}.",
+  "collective.archive.archivedMessage": "This {type} is archived.",
+  "collective.archive.availableBalance": "This {type} has available balance, submit an expense for the remaining balance or transfer to another collective before archiving.",
   "collective.archive.button": "Archive this {type}",
   "collective.archive.cancel.btn": "Cancel",
   "collective.archive.confirm.btn": "{action}",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -36,6 +36,8 @@
   "collective.address.label": "Address",
   "collective.amount.label": "monto",
   "collective.archive.archivedConfirmMessage": "{message}.",
+  "collective.archive.archivedMessage": "{type} already archived.",
+  "collective.archive.availableBalance": "This {type} has available balance, submit an expense for the remaining balance or transfer to another collective before archiving.",
   "collective.archive.button": "Archive this {type}.",
   "collective.archive.cancel.btn": "Cancel",
   "collective.archive.confirm.btn": "Archive",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -36,7 +36,6 @@
   "collective.address.label": "Address",
   "collective.amount.label": "monto",
   "collective.archive.archivedConfirmMessage": "{message}.",
-  "collective.archive.archivedMessage": "{type} already archived.",
   "collective.archive.availableBalance": "This {type} has available balance, submit an expense for the remaining balance or transfer to another collective before archiving.",
   "collective.archive.button": "Archive this {type}.",
   "collective.archive.cancel.btn": "Cancel",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -36,6 +36,8 @@
   "collective.address.label": "Address",
   "collective.amount.label": "montant",
   "collective.archive.archivedConfirmMessage": "{message}.",
+  "collective.archive.archivedMessage": "{type} already archived.",
+  "collective.archive.availableBalance": "This {type} has available balance, submit an expense for the remaining balance or transfer to another collective before archiving.",
   "collective.archive.button": "Archive this {type}.",
   "collective.archive.cancel.btn": "Cancel",
   "collective.archive.confirm.btn": "Archive",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -36,7 +36,6 @@
   "collective.address.label": "Address",
   "collective.amount.label": "montant",
   "collective.archive.archivedConfirmMessage": "{message}.",
-  "collective.archive.archivedMessage": "{type} already archived.",
   "collective.archive.availableBalance": "This {type} has available balance, submit an expense for the remaining balance or transfer to another collective before archiving.",
   "collective.archive.button": "Archive this {type}.",
   "collective.archive.cancel.btn": "Cancel",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -36,7 +36,6 @@
   "collective.address.label": "Address",
   "collective.amount.label": "額",
   "collective.archive.archivedConfirmMessage": "{message}.",
-  "collective.archive.archivedMessage": "{type} already archived.",
   "collective.archive.availableBalance": "This {type} has available balance, submit an expense for the remaining balance or transfer to another collective before archiving.",
   "collective.archive.button": "Archive this {type}.",
   "collective.archive.cancel.btn": "Cancel",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -36,6 +36,8 @@
   "collective.address.label": "Address",
   "collective.amount.label": "額",
   "collective.archive.archivedConfirmMessage": "{message}.",
+  "collective.archive.archivedMessage": "{type} already archived.",
+  "collective.archive.availableBalance": "This {type} has available balance, submit an expense for the remaining balance or transfer to another collective before archiving.",
   "collective.archive.button": "Archive this {type}.",
   "collective.archive.cancel.btn": "Cancel",
   "collective.archive.confirm.btn": "Archive",


### PR DESCRIPTION
This PR disables archive collective button when collective balance is greater than zero and provides an explanation below the button. 
### Screenshot:

![Screenshot from 2019-03-25 15-50-05](https://user-images.githubusercontent.com/15707013/54930836-4cee3600-4f18-11e9-8dc5-7eb1a9c0c2d5.png)

Ref ([#1823](https://github.com/opencollective/opencollective/issues/1823))