### PR TITLE
Fix link to collectives with event type in home activity

### DIFF
--- a/src/components/HomepageActivityItem.js
+++ b/src/components/HomepageActivityItem.js
@@ -6,30 +6,27 @@ import { FormattedNumber } from 'react-intl';
 import Avatar from './Avatar';
 import Container from './Container';
 import { P, Span } from './Text';
-
-import { Link } from '../server/pages';
+import LinkCollective from './LinkCollective';
 
 const HomepageActivityItem = ({ amount, createdAt, currency, fromCollective, collective, subscription, type }) => {
   const formattedCreatedAt = new Date(createdAt).toISOString();
   return (
     <Container display="flex" alignItems="center">
-      <Link route="collective" params={{ slug: fromCollective.slug }} passHref>
-        <a title={fromCollective.name}>
-          <Avatar
-            src={fromCollective.image}
-            id={fromCollective.id}
-            radius={40}
-            className="noFrame"
-            type={fromCollective.type}
-            name={fromCollective.name}
-          />
-        </a>
-      </Link>
+      <LinkCollective collective={fromCollective} title={fromCollective.name}>
+        <Avatar
+          src={fromCollective.image}
+          id={fromCollective.id}
+          radius={40}
+          className="noFrame"
+          type={fromCollective.type}
+          name={fromCollective.name}
+        />
+      </LinkCollective>
       <Container ml={3}>
         <P fontSize="1.2rem" color="#9399A3" display="inline">
-          <Link route="collective" params={{ slug: fromCollective.slug }} passHref>
-            <a title={fromCollective.name}>{fromCollective.name}</a>
-          </Link>
+          <LinkCollective collective={fromCollective} title={fromCollective.name}>
+            {fromCollective.name}
+          </LinkCollective>
           {type === 'DEBIT' ? ' submitted a ' : ' contributed '}
           <Span color="#2E3033">
             <FormattedNumber
@@ -44,9 +41,9 @@ const HomepageActivityItem = ({ amount, createdAt, currency, fromCollective, col
           {subscription && ` a ${subscription.interval} `}
           {type === 'DEBIT' && ' expense '}
           {' to '}{' '}
-          <Link route="collective" params={{ slug: collective.slug }}>
-            <a title={collective.name}>{collective.name}</a>
-          </Link>
+          <LinkCollective collective={collective} title={collective.name}>
+            {collective.name}
+          </LinkCollective>
           .
         </P>
         <Container position="relative" top={4} left={4} display="inline-block">

--- a/src/components/LinkCollective.js
+++ b/src/components/LinkCollective.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Link from './Link';
+
+/**
+ * Returns event's parent collective slug. If the parent is not available,
+ * fallback on `collective` slug which will result in a valid URL: parent
+ * collective slug is only used to generate pretty URLs.
+ */
+const getEventParentCollectiveSlug = parentCollective => {
+  return parentCollective && parentCollective.slug ? parentCollective.slug : 'collective';
+};
+
+/**
+ * Create a `Link` to the collective, properly switching between `event` and `collective`
+ * routes based on collective type.
+ */
+const LinkCollective = ({ collective: { type, slug, parentCollective }, ...props }) => {
+  return type !== 'EVENT' ? (
+    <Link route="collective" params={{ slug }} {...props} />
+  ) : (
+    <Link
+      route="event"
+      params={{ eventSlug: slug, parentCollectiveSlug: getEventParentCollectiveSlug(parentCollective) }}
+      {...props}
+    />
+  );
+};
+
+LinkCollective.propTypes = {
+  collective: PropTypes.shape({
+    slug: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
+    parentCollective: PropTypes.shape({
+      slug: PropTypes.string,
+    }),
+  }).isRequired,
+};
+
+export default LinkCollective;

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -932,6 +932,10 @@ const query = gql`
         collective {
           name
           slug
+          type
+          parentCollective {
+            slug
+          }
         }
         ... on Order {
           order {


### PR DESCRIPTION
We were using `collective` route for events, but events must use the `event` route that includes a `parentCollectiveSlug`. This bug may be present in many other places where we use `<Link route="collective" />`.

# Fix

I've introduced the new `<LinkCollective />` to have a generic way to fix this. In the future we should try to use this component systematically to avoid any mistakes. (ping @xdamman @znarf)