### PR TITLE
Strip react prop-types in production build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,21 +1,38 @@
 {
   "presets": [
-    ["next/babel", {
-      "preset-env": {
-        "modules": "auto"
+    [
+      "next/babel",
+      {
+        "preset-env": {
+          "modules": "auto"
+        }
       }
-    }]
+    ]
   ],
   "plugins": [
     "lodash",
-    ["react-intl", {
-      "messagesDir": "./dist/messages/"
-    }],
+    [
+      "react-intl",
+      {
+        "messagesDir": "./dist/messages/"
+      }
+    ],
     "styled-components"
   ],
   "env": {
-    "development" : {
+    "development": {
       "compact": false
+    },
+    "production": {
+      "plugins": [
+        [
+          "transform-react-remove-prop-types",
+          {
+            "removeImport": true
+          }
+        ],
+        "transform-styled-components-remove-prop-types"
+      ]
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3100,9 +3100,16 @@
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-transform-react-remove-prop-types": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.15.tgz",
-      "integrity": "sha512-bFxxYdkZBwTjTgtZEPTLqu9g8Ajz8x8uEP/O1iVuaZIz2RuxJ2gtx0EXDJRonC++KGsgsW/4Hqvk4KViEtE2nw=="
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
+      "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==",
+      "dev": true
+    },
+    "babel-plugin-transform-styled-components-remove-prop-types": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-styled-components-remove-prop-types/-/babel-plugin-transform-styled-components-remove-prop-types-0.0.5.tgz",
+      "integrity": "sha1-1i9x5weLREKYmezcM4NkZHFi5YQ=",
+      "dev": true
     },
     "babel-preset-jest": {
       "version": "24.1.0",
@@ -15147,6 +15154,11 @@
           "requires": {
             "regenerator-runtime": "^0.12.0"
           }
+        },
+        "babel-plugin-transform-react-remove-prop-types": {
+          "version": "0.4.15",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.15.tgz",
+          "integrity": "sha512-bFxxYdkZBwTjTgtZEPTLqu9g8Ajz8x8uEP/O1iVuaZIz2RuxJ2gtx0EXDJRonC++KGsgsW/4Hqvk4KViEtE2nw=="
         },
         "commander": {
           "version": "2.17.1",

--- a/package.json
+++ b/package.json
@@ -141,6 +141,8 @@
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-react-intl": "^3.0.1",
     "babel-plugin-styled-components": "1.8.0",
+    "babel-plugin-transform-react-remove-prop-types": "0.4.24",
+    "babel-plugin-transform-styled-components-remove-prop-types": "0.0.5",
     "commitizen": "^3.0.7",
     "cypress": "^3.1.5",
     "cz-conventional-changelog": "^2.1.0",


### PR DESCRIPTION
We could gain way more by stripping propTypes from libraries but `react-bootstrap` actually relies on them, see https://github.com/facebook/create-react-app/issues/209#issuecomment-235308444

|                       File                      | Before | After | Diff   |
|:-----------------------------------------------:|:------:|-------|--------|
| dist/.next/server/static/lpR5Zg0KMP9v_FNkztC9a  | 22976  | 22428 | -548kb |

