### PR TITLE
Improve end-to-end tests stability

### DIFF
--- a/cypress/integration/24-event.createOrder.test.js
+++ b/cypress/integration/24-event.createOrder.test.js
@@ -65,7 +65,6 @@ describe('event.createOrder page', () => {
     cy.contains('button', 'Next step').click();
     cy.useAnyPaymentMethod();
     cy.contains('button', 'Next step').click();
-    cy.wait(300);
 
     // Check step summary
     cy.contains('.breakdown-line', 'Item price').contains('€10.00');
@@ -73,14 +72,17 @@ describe('event.createOrder page', () => {
     cy.contains('.breakdown-line', 'Your contribution').contains('€80.00');
 
     // Algeria should not have taxes
+    cy.wait(500);
     cy.get('div[name=country]').click();
-    cy.contains('ul[role=listbox] li', 'Algeria').click({ force: true });
+    cy.wait(250);
+    cy.contains('ul[role=listbox] li', 'Algeria').click();
     cy.contains('.breakdown-line', 'VAT').contains('+ €0.00');
     cy.contains('.breakdown-line', 'TOTAL').contains('€80.00');
     cy.contains('button', 'Make contribution').should('not.be.disabled');
 
     // French should have taxes
     cy.get('div[name=country]').click();
+    cy.wait(250);
     cy.get('ul[role=listbox] > div').scrollTo(0, 2250);
     cy.contains('ul[role=listbox] li', 'France - FR').click();
     cy.contains('.breakdown-line', 'VAT').contains('+ €16.80');
@@ -120,6 +122,7 @@ describe('event.createOrder page', () => {
     // However if it's the same country than the collective than VAT should still apply,
     // even if the contributor is an organization
     cy.get('div[name=country]').click();
+    cy.wait(250);
     cy.get('ul[role=listbox] > div').scrollTo(0, 500);
     cy.contains('ul[role=listbox] li', 'Belgium - BE').click();
     cy.contains('.breakdown-line', 'VAT').contains('+ €16.80');

--- a/cypress/integration/25-host.apply.test.js
+++ b/cypress/integration/25-host.apply.test.js
@@ -1,27 +1,17 @@
-const init = (skip_signin = false) => {
-  if (skip_signin) {
-    cy.visit(
-      '/signin/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzY29wZSI6ImxvZ2luIiwiaWQiOjk0NzQsImVtYWlsIjoidGVzdHVzZXIrYWRtaW5Ab3BlbmNvbGxlY3RpdmUuY29tIiwiaWF0IjoxNTE1NDA5ODkxLCJleHAiOjE1MTgwMDE4OTEsImlzcyI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzA2MCIsInN1YiI6OTQ3NH0.FdisGSpfUyCgVJaWnnV5hp_IhRfO4_27kDc6DcCwqcI?next=/brusselstogetherasbl/apply',
-    );
-  } else {
+describe('apply to host', () => {
+  it('as a new collective', () => {
     cy.visit('/brusselstogetherasbl');
     cy.get('#hosting h1').contains('We are hosting 2 collectives');
     cy.get('.CollectiveCover button')
       .contains('Apply to create a collective')
-      .click({ force: true });
-    cy.wait(500);
+      .click();
     cy.fillInputField('email', 'testuser@opencollective.com');
-    cy.get('.LoginForm button').click();
-  }
-};
-
-describe('apply to host', () => {
-  it('as a new collective', () => {
-    init(false);
+    cy.wait(500);
+    cy.contains('.LoginForm button', 'Sign In').click();
     cy.fillInputField('name', 'New collective');
     cy.fillInputField('description', 'short description for new collective');
     cy.fillInputField('website', 'https://xdamman.com');
-    cy.get('.tos input[type="checkbox"]').click({ force: true });
+    cy.get('.tos input[type="checkbox"]').click();
     cy.wait(300);
     cy.get('.actions button').click();
     cy.wait(1000);

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -1,0 +1,25 @@
+import { flatten } from 'lodash';
+
+/** Helper to loop on specific test */
+export const repeatIt = (testName, count, func) => {
+  const range = Array(count).fill();
+  const tests = range.map((_, testNum) => it(`${testName} - ${testNum}`, func));
+  describe(`${testName} - Loop result 🙏`, () => giveResult(tests));
+};
+
+/** Helper to loop on specific describe */
+export const repeatDescribe = (describeName, count, func) => {
+  const range = Array(count).fill();
+  const describes = range.map((_, testNum) => describe(`${describeName} - ${testNum}`, func));
+  const tests = flatten(describes.map(d => d.tests));
+  describe(`${describeName} - Loop result 🙏`, () => giveResult(tests));
+};
+
+const giveResult = tests => {
+  it('Has a 100% success rate', () => {
+    const successCount = tests.reduce((total, t) => (t.state !== 'failed' ? total + 1 : total), 0);
+    const successRate = successCount / tests.length;
+    cy.log(`Success rate: ${successCount}/${tests.length} (${successRate * 100}%)`);
+    assert.equal(successRate, 1, 'Tests should never fail!');
+  });
+};

--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -25,6 +25,25 @@ else
   CYPRESS_RECORD=""
 fi
 
+# Wait for a service to be up
+function wait_for_service() {
+  printf "> Waiting for %s to be ready... " "$1"
+  while true; do
+    nc -z "$2" "$3"
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -eq 0 ]; then
+      printf "Application is up!\n"
+      break
+    fi
+    sleep 1
+  done
+}
+
+echo ""
+wait_for_service API 127.0.0.1 3000
+echo ""
+wait_for_service Frontend 127.0.0.1 3060
+
 echo ""
 echo "> Running cypress tests"
 npx cypress run ${CYPRESS_RECORD} --config ${CYPRESS_CONFIG}


### PR DESCRIPTION
PR to generally improve cypress tests stability.

## Introducing `repeatIt` and `repeatDescribe` test helpers

Helpers will make the test fail if success rate is below 100%. Use them whenever you're not sure about one of your tests stability.

```es6
// Replace...
it('my test', () => { ... })
// By...
repeatIt('my test', 12, () => { ... })
// To repeat a test 12 times
```

```es6
// Replace...
describe('my tests', () => { ... })
// By...
repeatDescribe('my tests', 12, () => { ... })
// To repeat all the tests in a describe 12 times
```

![image](https://user-images.githubusercontent.com/1556356/55038103-14398400-5020-11e9-9e3f-d89693641651.png)

## Wait for Frontend and API to be started before cypress

In `run_e2e_tests.sh`, we now ping API and frontend and wait for them to be started before running Cypress. This will ensure we don't get errors linked to the services not being ready.