### PR TITLE
Apollo cache refresh when editing collectives

### DIFF
--- a/src/components/EditGoals.js
+++ b/src/components/EditGoals.js
@@ -38,6 +38,10 @@ class EditGoals extends React.Component {
         defaultMessage: 'yearly budget',
       },
       'title.label': { id: 'goal.title.label', defaultMessage: 'title' },
+      'title.placeholder': {
+        id: 'goal.title.placeholder',
+        defaultMessage: 'Required if you want the goal to be displayed on the collective page',
+      },
       'description.label': {
         id: 'goal.description.label',
         defaultMessage: 'description',
@@ -70,6 +74,7 @@ class EditGoals extends React.Component {
         name: 'title',
         label: intl.formatMessage(this.messages['title.label']),
         maxLength: 64,
+        placeholder: intl.formatMessage(this.messages['title.placeholder']),
       },
       {
         name: 'description',

--- a/src/components/GoalsCover.js
+++ b/src/components/GoalsCover.js
@@ -166,8 +166,8 @@ class GoalsCover extends React.Component {
     window.addEventListener('resize', this.updateGoals);
   }
 
-  componentDidUpdate() {
-    if (this.state.firstMount) {
+  componentDidUpdate(oldProps) {
+    if (this.state.firstMount || this.props.collective !== oldProps.collective) {
       this.updateGoals();
     }
   }

--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -103,14 +103,15 @@ const createCollectiveFromGithubQuery = gql`
   }
 `;
 
+/* eslint-disable graphql/template-strings, graphql/no-deprecated-fields, graphql/capitalized-type-name, graphql/named-operations */
 const editCollectiveQuery = gql`
   mutation editCollective($collective: CollectiveInputType!) {
     editCollective(collective: $collective) {
-      ...CollectiveToEditFields
+      ${getCollectiveToEditQueryFields}
     }
   }
-  ${getCollectiveToEditQueryFields}
 `;
+/* eslint-enable graphql/template-strings, graphql/no-deprecated-fields, graphql/capitalized-type-name, graphql/named-operations */
 
 const deleteEventCollectiveQuery = gql`
   mutation deleteEventCollective($id: Int!) {

--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -2,7 +2,7 @@ import { graphql, compose } from 'react-apollo';
 import gql from 'graphql-tag';
 import { pick, isArray } from 'lodash';
 
-import { getLoggedInUserQuery } from './queries';
+import { getLoggedInUserQuery, getCollectiveToEditQueryFields } from './queries';
 
 const createOrderQuery = gql`
   mutation createOrder($order: OrderInputType!) {
@@ -106,83 +106,10 @@ const createCollectiveFromGithubQuery = gql`
 const editCollectiveQuery = gql`
   mutation editCollective($collective: CollectiveInputType!) {
     editCollective(collective: $collective) {
-      id
-      type
-      slug
-      name
-      image
-      backgroundImage
-      description
-      longDescription
-      location {
-        name
-        address
-        country
-        lat
-        long
-      }
-      website
-      twitterHandle
-      githubHandle
-      isActive
-      isArchived
-      hostFeePercent
-      host {
-        id
-        createdAt
-        slug
-        name
-        image
-        backgroundImage
-        settings
-        description
-        website
-        twitterHandle
-        stats {
-          id
-          collectives {
-            hosted
-          }
-        }
-      }
-      members(roles: ["ADMIN", "MEMBER", "HOST"]) {
-        id
-        createdAt
-        role
-        description
-        stats {
-          totalDonations
-        }
-        tier {
-          id
-          name
-        }
-        member {
-          id
-          name
-          image
-          slug
-          twitterHandle
-          description
-          ... on User {
-            email
-          }
-        }
-      }
-      tiers {
-        id
-        slug
-        type
-        name
-        description
-        amount
-        presets
-        interval
-        currency
-        maxQuantity
-      }
+      ...CollectiveToEditFields
     }
   }
+  ${getCollectiveToEditQueryFields}
 `;
 
 const deleteEventCollectiveQuery = gql`

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -169,169 +169,168 @@ const getTiersQuery = gql`
   }
 `;
 
-export const getCollectiveToEditQueryFields = gql`
-  fragment CollectiveToEditFields on Collective {
+export const getCollectiveToEditQueryFields = `
+  id
+  type
+  slug
+  createdByUser {
     id
-    type
+  }
+  host {
+    id
+    createdAt
     slug
-    createdByUser {
-      id
-    }
-    host {
-      id
-      createdAt
-      slug
-      name
-      currency
-      image
-      backgroundImage
-      settings
-      description
-      website
-      twitterHandle
-      location {
-        country
-      }
-      stats {
-        id
-        collectives {
-          hosted
-        }
-      }
-    }
     name
-    company
+    currency
     image
     backgroundImage
-    description
-    longDescription
-    location {
-      name
-      address
-      country
-      lat
-      long
-    }
-    tags
-    twitterHandle
-    githubHandle
-    website
-    currency
     settings
-    createdAt
-    isActive
-    isArchived
-    isDeletable
-    isHost
-    hostFeePercent
-    expensePolicy
+    description
+    website
+    twitterHandle
+    location {
+      country
+    }
     stats {
       id
-      yearlyBudget
-      balance
-      backers {
-        all
+      collectives {
+        hosted
       }
-      totalAmountSpent
     }
-    tiers {
+  }
+  name
+  company
+  image
+  backgroundImage
+  description
+  longDescription
+  location {
+    name
+    address
+    country
+    lat
+    long
+  }
+  tags
+  twitterHandle
+  githubHandle
+  website
+  currency
+  settings
+  createdAt
+  isActive
+  isArchived
+  isDeletable
+  isHost
+  hostFeePercent
+  expensePolicy
+  stats {
+    id
+    yearlyBudget
+    balance
+    backers {
+      all
+    }
+    totalAmountSpent
+  }
+  tiers {
+    id
+    slug
+    type
+    name
+    description
+    amount
+    presets
+    interval
+    currency
+    maxQuantity
+  }
+  memberOf {
+    id
+    createdAt
+    role
+    stats {
+      totalDonations
+    }
+    tier {
       id
+      name
+    }
+    collective {
+      id
+      type
       slug
-      type
       name
-      description
-      amount
-      presets
-      interval
       currency
-      maxQuantity
-    }
-    memberOf {
-      id
-      createdAt
-      role
-      stats {
-        totalDonations
-      }
-      tier {
-        id
-        name
-      }
-      collective {
-        id
-        type
-        slug
-        name
-        currency
-        description
-        settings
-        image
-        stats {
-          id
-          backers {
-            all
-          }
-          yearlyBudget
-        }
-      }
-    }
-    members(roles: ["ADMIN", "MEMBER", "HOST"]) {
-      id
-      createdAt
-      role
       description
-      stats {
-        totalDonations
-      }
-      tier {
-        id
-        name
-      }
-      member {
-        id
-        name
-        image
-        slug
-        twitterHandle
-        description
-        ... on User {
-          email
-        }
-      }
-    }
-    paymentMethods(types: ["creditcard", "virtualcard", "prepaid"], hasBalanceAboveZero: true) {
-      id
-      uuid
-      name
-      data
-      monthlyLimitPerMember
-      service
-      type
-      balance
-      currency
-      expiryDate
-      orders(hasActiveSubscription: true) {
-        id
-      }
-    }
-    connectedAccounts {
-      id
-      service
-      username
-      createdAt
       settings
+      image
+      stats {
+        id
+        backers {
+          all
+        }
+        yearlyBudget
+      }
     }
+  }
+  members(roles: ["ADMIN", "MEMBER", "HOST"]) {
+    id
+    createdAt
+    role
+    description
+    stats {
+      totalDonations
+    }
+    tier {
+      id
+      name
+    }
+    member {
+      id
+      name
+      image
+      slug
+      twitterHandle
+      description
+      ... on User {
+        email
+      }
+    }
+  }
+  paymentMethods(types: ["creditcard", "virtualcard", "prepaid"], hasBalanceAboveZero: true) {
+    id
+    uuid
+    name
+    data
+    monthlyLimitPerMember
+    service
+    type
+    balance
+    currency
+    expiryDate
+    orders(hasActiveSubscription: true) {
+      id
+    }
+  }
+  connectedAccounts {
+    id
+    service
+    username
+    createdAt
+    settings
   }
 `;
 
+/* eslint-disable graphql/template-strings, graphql/no-deprecated-fields, graphql/capitalized-type-name, graphql/named-operations */
 const getCollectiveToEditQuery = gql`
   query Collective($slug: String) {
     Collective(slug: $slug) {
-      ...CollectiveToEditFields
+      ${getCollectiveToEditQueryFields}
     }
   }
-  ${getCollectiveToEditQueryFields}
 `;
+/* eslint-enable graphql/template-strings, graphql/no-deprecated-fields, graphql/capitalized-type-name, graphql/named-operations */
 
 const getCollectiveQuery = gql`
   query Collective($slug: String) {

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -169,161 +169,168 @@ const getTiersQuery = gql`
   }
 `;
 
+export const getCollectiveToEditQueryFields = gql`
+  fragment CollectiveToEditFields on Collective {
+    id
+    type
+    slug
+    createdByUser {
+      id
+    }
+    host {
+      id
+      createdAt
+      slug
+      name
+      currency
+      image
+      backgroundImage
+      settings
+      description
+      website
+      twitterHandle
+      location {
+        country
+      }
+      stats {
+        id
+        collectives {
+          hosted
+        }
+      }
+    }
+    name
+    company
+    image
+    backgroundImage
+    description
+    longDescription
+    location {
+      name
+      address
+      country
+      lat
+      long
+    }
+    tags
+    twitterHandle
+    githubHandle
+    website
+    currency
+    settings
+    createdAt
+    isActive
+    isArchived
+    isDeletable
+    isHost
+    hostFeePercent
+    expensePolicy
+    stats {
+      id
+      yearlyBudget
+      balance
+      backers {
+        all
+      }
+      totalAmountSpent
+    }
+    tiers {
+      id
+      slug
+      type
+      name
+      description
+      amount
+      presets
+      interval
+      currency
+      maxQuantity
+    }
+    memberOf {
+      id
+      createdAt
+      role
+      stats {
+        totalDonations
+      }
+      tier {
+        id
+        name
+      }
+      collective {
+        id
+        type
+        slug
+        name
+        currency
+        description
+        settings
+        image
+        stats {
+          id
+          backers {
+            all
+          }
+          yearlyBudget
+        }
+      }
+    }
+    members(roles: ["ADMIN", "MEMBER", "HOST"]) {
+      id
+      createdAt
+      role
+      description
+      stats {
+        totalDonations
+      }
+      tier {
+        id
+        name
+      }
+      member {
+        id
+        name
+        image
+        slug
+        twitterHandle
+        description
+        ... on User {
+          email
+        }
+      }
+    }
+    paymentMethods(types: ["creditcard", "virtualcard", "prepaid"], hasBalanceAboveZero: true) {
+      id
+      uuid
+      name
+      data
+      monthlyLimitPerMember
+      service
+      type
+      balance
+      currency
+      expiryDate
+      orders(hasActiveSubscription: true) {
+        id
+      }
+    }
+    connectedAccounts {
+      id
+      service
+      username
+      createdAt
+      settings
+    }
+  }
+`;
+
 const getCollectiveToEditQuery = gql`
   query Collective($slug: String) {
     Collective(slug: $slug) {
-      id
-      type
-      slug
-      createdByUser {
-        id
-      }
-      host {
-        id
-        createdAt
-        slug
-        name
-        currency
-        image
-        backgroundImage
-        settings
-        description
-        website
-        twitterHandle
-        location {
-          country
-        }
-        stats {
-          id
-          collectives {
-            hosted
-          }
-        }
-      }
-      name
-      company
-      image
-      backgroundImage
-      description
-      longDescription
-      location {
-        name
-        address
-        country
-        lat
-        long
-      }
-      tags
-      twitterHandle
-      githubHandle
-      website
-      currency
-      settings
-      createdAt
-      isActive
-      isArchived
-      isDeletable
-      isHost
-      hostFeePercent
-      expensePolicy
-      stats {
-        id
-        yearlyBudget
-        balance
-        backers {
-          all
-        }
-        totalAmountSpent
-      }
-      tiers {
-        id
-        slug
-        type
-        name
-        description
-        amount
-        presets
-        interval
-        currency
-        maxQuantity
-      }
-      memberOf {
-        id
-        createdAt
-        role
-        stats {
-          totalDonations
-        }
-        tier {
-          id
-          name
-        }
-        collective {
-          id
-          type
-          slug
-          name
-          currency
-          description
-          settings
-          image
-          stats {
-            id
-            backers {
-              all
-            }
-            yearlyBudget
-          }
-        }
-      }
-      members(roles: ["ADMIN", "MEMBER", "HOST"]) {
-        id
-        createdAt
-        role
-        description
-        stats {
-          totalDonations
-        }
-        tier {
-          id
-          name
-        }
-        member {
-          id
-          name
-          image
-          slug
-          twitterHandle
-          description
-          ... on User {
-            email
-          }
-        }
-      }
-      paymentMethods(types: ["creditcard", "virtualcard", "prepaid"], hasBalanceAboveZero: true) {
-        id
-        uuid
-        name
-        data
-        monthlyLimitPerMember
-        service
-        type
-        balance
-        currency
-        expiryDate
-        orders(hasActiveSubscription: true) {
-          id
-        }
-      }
-      connectedAccounts {
-        id
-        service
-        username
-        createdAt
-        settings
-      }
+      ...CollectiveToEditFields
     }
   }
+  ${getCollectiveToEditQueryFields}
 `;
 
 const getCollectiveQuery = gql`

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -446,6 +446,7 @@
   "goal.description.label": "description",
   "goal.remove": "remove goal",
   "goal.title.label": "title",
+  "goal.title.placeholder": "Required if you want the goal to be displayed on the collective page",
   "goal.type.label": "type",
   "goal.yearlyBudget.label": "yearly budget",
   "home.activeCollectives": "Active collectives",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -446,6 +446,7 @@
   "goal.description.label": "description",
   "goal.remove": "remove goal",
   "goal.title.label": "title",
+  "goal.title.placeholder": "Required if you want the goal to be displayed on the collective page",
   "goal.type.label": "type",
   "goal.yearlyBudget.label": "yearly budget",
   "home.activeCollectives": "Active collectives",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -446,6 +446,7 @@
   "goal.description.label": "description",
   "goal.remove": "supprimer cet objectif",
   "goal.title.label": "titre",
+  "goal.title.placeholder": "Required if you want the goal to be displayed on the collective page",
   "goal.type.label": "type",
   "goal.yearlyBudget.label": "budget annuel",
   "home.activeCollectives": "Collectifs actifs",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -446,6 +446,7 @@
   "goal.description.label": "description",
   "goal.remove": "remove goal",
   "goal.title.label": "title",
+  "goal.title.placeholder": "Required if you want the goal to be displayed on the collective page",
   "goal.type.label": "type",
   "goal.yearlyBudget.label": "yearly budget",
   "home.activeCollectives": "Active collectives",


### PR DESCRIPTION
The main change of this PR is to put all `CollectiveToEditData` fields in a fragment so we can share them between the query and the mutation.

Together with https://github.com/opencollective/opencollective-api/pull/1838, it should resolve https://github.com/opencollective/opencollective/issues/1870. For example `settings` (that contains the goals) were not refetched when a mutation was sent.

Github diff for `src/graphql/queries.js` is not very pretty, but basically all fields from `CollectiveToEditData` have been preserved.