### PR TITLE
Remove collective double fetch

### DIFF
--- a/src/pages/collective.js
+++ b/src/pages/collective.js
@@ -36,15 +36,7 @@ class CollectivePage extends React.Component {
   }
 
   async componentDidMount() {
-    const { LoggedInUser, query, data = {} } = this.props;
-    window.OC = window.OC || {};
-    window.OC.LoggedInUser = LoggedInUser;
-
-    if (query.refetch && data.refetch) {
-      data.refetch();
-    }
-
-    const Collective = data.Collective || this.state.collective;
+    const Collective = get(this.props.data, 'Collective') || this.state.collective;
     this.setState({ Collective });
   }
 


### PR DESCRIPTION
This `refetch` was done in https://github.com/opencollective/opencollective-frontend/commit/f87d3339429aaf489a4f5e317850d07638b840a4 and merged in https://github.com/opencollective/opencollective-frontend/pull/946 probably to bypass cloudflare's cache. Since https://github.com/opencollective/opencollective-api/pull/1838 we have a more clever way to do that and we should use it.

:warning: We should properly test and QA the pledge process before merging