### PR TITLE
CreateOrder EventDetails: Hide event box if there's nothing to show in it

### DIFF
--- a/src/components/EventDetails.js
+++ b/src/components/EventDetails.js
@@ -16,7 +16,8 @@ const EventDetails = ({ event, tier }) => {
   const description = event.longDescription || event.description;
   const truncatedDescription =
     isExpended || !description ? description : truncate(description, { length: TruncatedLength });
-  return (
+
+  return !tier.maxQuantity && !description ? null : (
     <StyledCard p={3}>
       {tier.maxQuantity > 0 && (
         <Box mb={2}>


### PR DESCRIPTION
We used to display an empty box when event has no tickets limit and not description:

![2019-04-01_11:41:52](https://user-images.githubusercontent.com/1556356/55322310-e5823a00-5473-11e9-993b-9bd0da8571c4.png)
