### PR TITLE
Use data-cy property for e2e selectors

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -31,7 +31,8 @@
             "removeImport": true
           }
         ],
-        "transform-styled-components-remove-prop-types"
+        "transform-styled-components-remove-prop-types",
+        ["react-remove-properties", { "properties": ["data-cy"] }]
       ]
     }
   }

--- a/cypress/integration/14-contributionFlow.success.test.js
+++ b/cypress/integration/14-contributionFlow.success.test.js
@@ -24,7 +24,7 @@ describe('Contribution Flow: Order success', () => {
     const publicMessage = "Wow such an amazing project 💙 Let's take it to the moon!!! 🚀";
 
     // Public message popup
-    cy.contains('.public-message-popup', 'Leave a public message (Optional)');
+    cy.contains('[data-cy=public-message-popup]', 'Leave a public message (Optional)');
 
     // Limited to 140 characters
     cy.get('textarea[name=publicMessage]').type('.'.repeat(142), { delay: 1 });
@@ -36,11 +36,11 @@ describe('Contribution Flow: Order success', () => {
     cy.contains('button', 'Submit').click();
 
     // Card should be updated with the message, can be edited on click
-    cy.get('.public-message-popup').should('not.exist');
+    cy.get('[data-cy=public-message-popup]').should('not.exist');
     cy.get('.collective-card')
       .contains(`“${publicMessage}”`)
       .click();
-    cy.contains('.public-message-popup', 'Leave a public message (Optional)');
+    cy.contains('[data-cy=public-message-popup]', 'Leave a public message (Optional)');
     cy.get('textarea[name=publicMessage]').should('have.value', publicMessage);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3093,6 +3093,12 @@
         "mkdirp": "^0.5.1"
       }
     },
+    "babel-plugin-react-remove-properties": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-remove-properties/-/babel-plugin-react-remove-properties-0.3.0.tgz",
+      "integrity": "sha512-vbxegtXGyVcUkCvayLzftU95vuvpYFV85pRpeMpohMHeEY46Qe0VNWfkVVcCbaZ12CXHzDFOj0esumATcW83ng==",
+      "dev": true
+    },
     "babel-plugin-react-require": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-react-require/-/babel-plugin-react-require-3.0.0.tgz",
@@ -7289,13 +7295,13 @@
       "dependencies": {
         "colors": {
           "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "resolved": "http://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
           "dev": true
         },
         "commander": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
           "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
           "dev": true
         }
@@ -19052,7 +19058,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         }
@@ -19810,7 +19816,7 @@
         },
         "globby": {
           "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
           "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
           "dev": true,
           "requires": {
@@ -23524,7 +23530,7 @@
       "dependencies": {
         "ast-types": {
           "version": "0.7.8",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
+          "resolved": "http://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
           "integrity": "sha1-kC0uDWDQcb3NRtwRXhgJ7RHBOKk=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "babel-eslint": "^10.0.1",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-react-intl": "^3.0.1",
+    "babel-plugin-react-remove-properties": "0.3.0",
     "babel-plugin-styled-components": "1.8.0",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
     "babel-plugin-transform-styled-components-remove-prop-types": "0.0.5",

--- a/src/pages/orderSuccess.js
+++ b/src/pages/orderSuccess.js
@@ -102,10 +102,6 @@ const PublicMessagePopup = styled.div`
   }
 `;
 
-PublicMessagePopup.defaultProps = {
-  className: 'public-message-popup',
-};
-
 const SpeechCaret = styled(SpeechTriangle)`
   position: absolute;
   left: -26px;
@@ -404,7 +400,7 @@ class OrderSuccessPage extends React.Component {
               </Flex>
             </StyledCollectiveCard>
             {this.state.hasPublicMessagePopup && (
-              <PublicMessagePopup>
+              <PublicMessagePopup data-cy="public-message-popup">
                 <Flex justifyContent="flex-end">
                   <Times
                     size="1em"


### PR DESCRIPTION
This PR adds the required configuration to use the `data-cy` property specified in https://github.com/opencollective/opencollective/issues/1882 and migrates a single test as a proof of concept (see https://github.com/opencollective/opencollective-frontend/pull/1616/commits/63294b8a27dee05159042a3694e9ce9e5438df17).

In the future we should avoid adding unnecessary classes to prefer this `data-cy` approach. See [Cypress documentation's note](https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements) about selecting elements for details.

---

*Proof that prop is correctly stripped*

![image](https://user-images.githubusercontent.com/1556356/55350305-a83d9c80-54b3-11e9-9f60-d474053c170e.png)
