### PR TITLE
Consolidated yearly invoice #1783 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7829,11 +7829,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7846,15 +7848,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7957,7 +7962,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7967,6 +7973,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7979,17 +7986,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -8006,6 +8016,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8078,7 +8089,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8088,6 +8100,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8193,6 +8206,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/apps/expenses/components/DownloadInvoicesPopOver.js
+++ b/src/apps/expenses/components/DownloadInvoicesPopOver.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import { FormattedMessage } from 'react-intl';
@@ -23,8 +24,12 @@ class Overlay extends React.Component {
   constructor(props) {
     super(props);
     this.renderMonth = this.renderMonth.bind(this);
+    this.renderYear = this.renderYear.bind(this);
     this.renderInvoice = this.renderInvoice.bind(this);
-    this.state = { year: new Date().getFullYear() };
+    this.state = {
+      year: new Date().getFullYear(),
+      isDisplayYearly: false,
+    };
   }
 
   arrayToFormOptions(arr) {
@@ -35,8 +40,7 @@ class Overlay extends React.Component {
     });
   }
 
-  renderInvoiceLabel(invoice, isLoading) {
-    const { totalAmount, currency, host } = invoice;
+  renderInvoiceLabel(isLoading, totalAmount, currency, host) {
     const formattedAmount = formatCurrency(totalAmount, currency, { precision: 0 });
     const image = isLoading
       ? '/static/images/loading.gif'
@@ -48,7 +52,7 @@ class Overlay extends React.Component {
     );
   }
 
-  renderInvoice(invoice) {
+  renderInvoice(invoice, dateFrom, dateTo, totalAmount) {
     return (
       <div className="invoice" key={invoice.slug}>
         <style jsx>
@@ -63,13 +67,38 @@ class Overlay extends React.Component {
         </style>
         <InvoiceDownloadLink
           type="invoice"
-          fromCollectiveSlug={this.props.fromCollectiveSlug}
+          fromCollectiveSlug={invoice.fromCollective.slug}
+          toCollectiveSlug={invoice.host.slug}
+          dateFrom={dateFrom}
+          dateTo={dateTo}
           invoice={invoice}
-          viewLoading={() => this.renderInvoiceLabel(invoice, true)}
+          viewLoading={() => this.renderInvoiceLabel(true, totalAmount, invoice.currency, invoice.host)}
         >
-          {this.renderInvoiceLabel(invoice, false)}
+          {this.renderInvoiceLabel(false, totalAmount, invoice.currency, invoice.host)}
         </InvoiceDownloadLink>
       </div>
+    );
+  }
+  renderYear(year) {
+    const invoices = this.props.data.allInvoices.filter(i => Number(i.year) === Number(year));
+
+    const total = invoices.reduce((sum, invoice) => sum + invoice.totalAmount, 0);
+    const dateFrom = moment(year, 'YYYY').toISOString();
+    const dateTo = moment(year + 1, 'YYYY').toISOString();
+    return (
+      invoices.length > 0 && (
+        <div key={`${this.state.year}-${year}`}>
+          <style jsx>
+            {`
+              h2 {
+                font-size: 1.8rem;
+              }
+            `}
+          </style>
+          <h2>{year}</h2>
+          {this.renderInvoice(invoices[0], dateFrom, dateTo, total)}
+        </div>
+      )
     );
   }
 
@@ -77,19 +106,23 @@ class Overlay extends React.Component {
     const invoices = this.props.data.allInvoices.filter(
       i => Number(i.year) === Number(this.state.year) && Number(i.month) === Number(month),
     );
+    const dateFrom = moment(`${this.state.year}${month}`, 'YYYYMM').toISOString();
+    const dateTo = moment(`${this.state.year}${month + 1}`, 'YYYYMM').toISOString();
     const month2digit = month < 10 ? `0${month}` : month;
     return (
-      <div key={`${this.state.year}-${month}`}>
-        <style jsx>
-          {`
-            h2 {
-              font-size: 1.8rem;
-            }
-          `}
-        </style>
-        <h2>{moment(new Date(`${this.state.year}-${month2digit}-01`)).format('MMMM')}</h2>
-        {invoices.map(this.renderInvoice)}
-      </div>
+      invoices.length > 0 && (
+        <div key={`${this.state.year}-${month}`}>
+          <style jsx>
+            {`
+              h2 {
+                font-size: 1.8rem;
+              }
+            `}
+          </style>
+          <h2>{moment(new Date(`${this.state.year}-${month2digit}-01`)).format('MMMM')}</h2>
+          {this.renderInvoice(invoices[0], dateFrom, dateTo, invoices[0].totalAmount)}
+        </div>
+      )
     );
   }
 
@@ -113,15 +146,30 @@ class Overlay extends React.Component {
 
     return (
       <Popover id="downloadInvoicesPopover" title="Download invoices" {...forwardedProps}>
-        {years.length > 1 && (
+        <ul className="nav nav-tabs">
+          <li
+            role="presentation"
+            onClick={() => this.setState({ isDisplayYearly: false })}
+            className={classnames({ active: !this.state.isDisplayYearly })}
+          >
+            <a>Monthly</a>
+          </li>
+          <li
+            role="presentation"
+            onClick={() => this.setState({ isDisplayYearly: true })}
+            className={classnames({ active: this.state.isDisplayYearly })}
+          >
+            <a>Yearly</a>
+          </li>
+        </ul>
+        {this.state.isDisplayYearly && years.length > 1 && (
           <InputField
             type="select"
             options={this.arrayToFormOptions(years)}
             onChange={year => this.setState({ year })}
           />
         )}
-
-        <div>{months.map(this.renderMonth)}</div>
+        <div>{this.state.isDisplayYearly ? years.map(this.renderYear) : months.map(this.renderMonth)}</div>
       </Popover>
     );
   }
@@ -135,11 +183,11 @@ const getInvoicesQuery = gql`
       month
       totalAmount
       currency
-      host {
-        id
+      fromCollective {
         slug
-        name
-        image
+      }
+      host {
+        slug
       }
     }
   }

--- a/src/apps/expenses/components/InvoiceDownloadLink.js
+++ b/src/apps/expenses/components/InvoiceDownloadLink.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import * as api from '../../../lib/api';
 import { saveAs } from 'file-saver';
+import moment from 'moment';
 
 import { collectiveInvoiceURL, invoiceServiceURL, transactionInvoiceURL } from '../../../lib/url_helpers';
 import { Span } from '../../../components/Text';
@@ -17,9 +18,16 @@ export default class InvoiceDownloadLink extends Component {
     type: PropTypes.oneOf(['transaction', 'invoice']).isRequired,
     /** Transaction UUID, only used if type if set to `transaction` */
     transactionUuid: PropTypes.string,
-    /** Collective for which invoice is generated, only used if type is set to `invoice` */
+    /** Collective that is paying money, only used if type is set to `invoice` */
     fromCollectiveSlug: PropTypes.string,
+    /** Collective that is receiving money, only used if type is set to `invoice` */
+    toCollectiveSlug: PropTypes.string,
     /** Invoice data, only used if type is set to `invoice` */
+    dateFrom: PropTypes.string,
+    /** Invoice date from */
+
+    dateTo: PropTypes.string,
+    /** Invoice  date to  */
     invoice: PropTypes.object,
   };
 
@@ -29,15 +37,20 @@ export default class InvoiceDownloadLink extends Component {
   }
 
   getInvoiceUrl() {
+    const { fromCollectiveSlug, toCollectiveSlug, dateFrom, dateTo } = this.props;
     return this.props.type === 'transaction'
       ? transactionInvoiceURL(this.props.transactionUuid)
-      : collectiveInvoiceURL(this.props.fromCollectiveSlug, this.props.invoice.slug, 'pdf');
+      : collectiveInvoiceURL(fromCollectiveSlug, toCollectiveSlug, encodeURI(dateFrom), encodeURI(dateTo), 'pdf');
   }
 
   getFilename() {
+    const { fromCollectiveSlug, toCollectiveSlug, dateFrom, dateTo } = this.props;
+    const fromString = moment(dateFrom).format('YYYYMMDD');
+    const toString = moment(dateTo).format('YYYYMMDD');
+
     return this.props.type === 'transaction'
       ? `transaction-${this.props.transactionUuid}.pdf`
-      : `${this.props.invoice.slug}.pdf`;
+      : `${fromCollectiveSlug}_${toCollectiveSlug}_${fromString}-${toString}.pdf`;
   }
 
   async download() {

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -734,6 +734,8 @@ type InvoiceType {
   Title for the invoice. Depending on the type of legal entity, a host should issue an Invoice or a Receipt.
   """
   title: String
+  dateFrom: String
+  dateTo: String
   year: Int
   month: Int
   day: Int

--- a/src/lib/url_helpers.js
+++ b/src/lib/url_helpers.js
@@ -32,8 +32,8 @@ export const objectToQueryString = options => {
 
 // ---- Routes to other Open Collective services ----
 
-export const collectiveInvoiceURL = (collectiveSlug, invoiceSlug, format) => {
-  return `${invoiceServiceURL}/collectives/${collectiveSlug}/${invoiceSlug}.${format}`;
+export const collectiveInvoiceURL = (collectiveSlug, hostSlug, startDate, endDate, format) => {
+  return `${invoiceServiceURL}/collectives/${collectiveSlug}/${hostSlug}/${startDate}/${endDate}.${format}`;
 };
 
 export const transactionInvoiceURL = transactionUUID => {


### PR DESCRIPTION
# [Consolidated yearly invoice](https://github.com/opencollective/opencollective/issues/1783)

This PR adds Monthly / Yearly tabs to the `DownloadInvoicesPopover` component.

Monthly and Yearly invoices now use a new route on the invoices server that looks like:
```
'/collectives/:fromCollectiveSlug/:toCollectiveSlug/:isoStartDate/:isoEndDate.:format(html|pdf|json)',
```

