### PR TITLE
Ignore new Collective prop if Apollo strips it

### DIFF
--- a/src/pages/editCollective.js
+++ b/src/pages/editCollective.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { compose } from 'react-apollo';
 import { FormattedMessage } from 'react-intl';
 import { Flex } from '@rebass/grid';
+import { get } from 'lodash';
 
 import Page from '../components/Page';
 import { withUser } from '../components/UserProvider';
@@ -37,8 +38,30 @@ class EditCollectivePage extends React.Component {
     deleteEventCollective: PropTypes.func.isRequired, // from addDeleteEventCollectiveMutation
   };
 
+  constructor(props) {
+    super(props);
+    this.state = { Collective: get(props, 'data.Collective') };
+  }
+
+  async componentDidMount() {
+    const collective = get(this.props, 'data.Collective');
+    this.setState({ Collective: collective || this.state.Collective });
+  }
+
+  componentDidUpdate(oldProps) {
+    // We store the component in state and update only if the next one is not
+    // null because of a bug in Apollo where it strips the `Collective` from data
+    // during re-hydratation.
+    // See https://github.com/opencollective/opencollective/issues/1872
+    const currentCollective = get(this.props, 'data.Collective');
+    if (currentCollective && get(oldProps, 'data.Collective') !== currentCollective) {
+      this.setState({ Collective: currentCollective });
+    }
+  }
+
   render() {
     const { data, editCollective, deleteEventCollective, LoggedInUser, loadingLoggedInUser } = this.props;
+    const collective = get(data, 'Collective') || this.state.Collective;
 
     if ((data && data.loading) || loadingLoggedInUser) {
       return (
@@ -48,7 +71,7 @@ class EditCollectivePage extends React.Component {
       );
     } else if (data && data.error) {
       return <ErrorPage data={data} />;
-    } else if (!LoggedInUser || !data || !data.Collective) {
+    } else if (!LoggedInUser || !collective) {
       return (
         <Page>
           <Flex justifyContent="center" p={5}>
@@ -67,7 +90,7 @@ class EditCollectivePage extends React.Component {
     return (
       <div>
         <EditCollective
-          collective={data.Collective}
+          collective={collective}
           LoggedInUser={LoggedInUser}
           editCollective={editCollective}
           deleteEventCollective={deleteEventCollective}


### PR DESCRIPTION
See https://github.com/opencollective/opencollective/issues/1872

This is more a hack than a fix and we should not mark https://github.com/opencollective/opencollective/issues/1872 as resolved before we find the root cause. It may be hard to find cause it may be an old issue on apollo .

This should already improve the situation with "Unexpected error" that users are facing on collective pages (edit, transactions...).