### PR TITLE
Delete account: fix breaking test for delete user account

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,6 +229,19 @@ jobs:
       CYPRESS_TEST_FILES: 2*.js
     <<: *e2e_steps
 
+  test-e2e-3:
+    docker:
+      - image: circleci/node:11.8.0
+      - image: circleci/postgres:9.6.8-alpine-postgis-ram
+      - image: circleci/redis
+      - image: memcached
+    environment:
+      NODE_ENV: circleci
+      # E2E_TEST will be checked by the API to tweak its behavior in CIRCLECI environment
+      E2E_TEST: 1
+      CYPRESS_TEST_FILES: 3*.js
+    <<: *e2e_steps
+
 workflows:
   version: 2
   lint-build-test:

--- a/cypress/integration/32-account-deletion.test.js
+++ b/cypress/integration/32-account-deletion.test.js
@@ -26,11 +26,13 @@ describe('Account Deletion', () => {
   it('Should delete user', () => {
     const userParams = { firstName: 'New', lastName: 'Tester' };
     const visitParams = { onBeforeLoad: mockRecaptcha };
-    cy.signup({ user: userParams, visitParams }).then(user => {
-      cy.visit(`/${user.slug}/edit`);
-      cy.wait(1000);
+    cy.signup({ user: userParams, visitParams }).then(() => {
+      cy.wait(2000);
+      cy.get('.LoginTopBarProfileButton-name').click();
+      cy.contains('a', 'Profile').click();
+      cy.contains('button', 'edit profile').click();
       cy.contains('a', 'Advanced').click();
-      cy.contains('button', 'Delete this account.').click();
+      cy.contains('button', 'Delete this account').click();
       cy.get('.confirm-deleteCollective').should('exist');
       cy.get('.confirm-deleteCollective')
         .contains('button', 'Delete')


### PR DESCRIPTION
This PR adds missing job for 3* tests on CI and fixes `32-account-deletion.test.js`.

Ref ([#1901](https://github.com/opencollective/opencollective/issues/1901))
