### PR TITLE
ArchiveCollective: Remove "Apply to*" button from an archived host organization 

### DIFF
--- a/src/components/UserCollective.js
+++ b/src/components/UserCollective.js
@@ -218,7 +218,7 @@ class UserCollective extends React.Component {
     const canEditCollective = LoggedInUser && LoggedInUser.canEditCollective(collective);
     const type = collective.type.toLowerCase();
     let cta;
-    if (collective.canApply) {
+    if (collective.canApply && !collective.isArchived) {
       cta = <ApplyToHostBtn LoggedInUser={LoggedInUser} host={collective} sticky={false} />;
     }
 


### PR DESCRIPTION
Currently, users can still apply to host a collective in an archived organization, this PR removes that button.

Before
![Screenshot from 2019-04-10 09-24-56](https://user-images.githubusercontent.com/15707013/55864233-fddd0d80-5b73-11e9-8678-831b6b53ce15.png)

After
![Screenshot from 2019-04-10 09-26-11](https://user-images.githubusercontent.com/15707013/55864138-ca01e800-5b73-11e9-9b9a-23dba9f6357d.png)
