### PR TITLE
Show error when removing a payment method with active subscriptions

### DIFF
--- a/src/components/EditPaymentMethod.js
+++ b/src/components/EditPaymentMethod.js
@@ -14,7 +14,11 @@ import StyledLink from './StyledLink';
 
 class EditPaymentMethod extends React.Component {
   static propTypes = {
-    paymentMethod: PropTypes.object.isRequired,
+    paymentMethod: PropTypes.shape({
+      service: PropTypes.string.isRequired,
+      type: PropTypes.string.isRequired,
+    }).isRequired,
+    subscriptions: PropTypes.arrayOf(PropTypes.any).isRequired,
     onRemove: PropTypes.func.isRequired,
     onSave: PropTypes.func.isRequired,
     collectiveSlug: PropTypes.string.isRequired,
@@ -78,13 +82,13 @@ class EditPaymentMethod extends React.Component {
   };
 
   render() {
-    const { intl, paymentMethod, currency, isSaving } = this.props;
-    const { service, type, orders } = paymentMethod;
-    const hasOrders = orders && orders.length > 0;
+    const { intl, paymentMethod, currency, isSaving, subscriptions } = this.props;
+    const { service, type } = paymentMethod;
+    const hasSubscriptions = subscriptions && subscriptions.length > 0;
     const isStripeCreditCard = service === 'stripe' && type === 'creditcard';
-    const canRemove = !hasOrders && isStripeCreditCard;
+    const canRemove = !hasSubscriptions && isStripeCreditCard;
     const saved = this.state.paymentMethod.monthlyLimitPerMember === paymentMethod.monthlyLimitPerMember;
-    const hasActions = !saved || canRemove || hasOrders;
+    const hasActions = !saved || canRemove || hasSubscriptions;
 
     return (
       <div className="EditPaymentMethod">
@@ -107,12 +111,12 @@ class EditPaymentMethod extends React.Component {
             </Box>
             <Box>
               <div className="name col">{paymentMethodLabelWithIcon(intl, paymentMethod)}</div>
-              {hasOrders && (
+              {hasSubscriptions && (
                 <div className="actions">
                   <FormattedMessage
                     id="paymentMethod.activeSubscriptions"
                     defaultMessage="{n} active {n, plural, one {subscription} other {subscriptions}}"
-                    values={{ n: orders.length }}
+                    values={{ n: subscriptions.length }}
                   />
                 </div>
               )}
@@ -137,7 +141,7 @@ class EditPaymentMethod extends React.Component {
                   <FormattedMessage id="save" defaultMessage="save" />
                 </StyledButton>
               )}
-              {hasOrders && (
+              {hasSubscriptions && (
                 <Link route="subscriptions" params={{ collectiveSlug: this.props.collectiveSlug }} passHref>
                   <StyledLink buttonStyle="standard" buttonSize="medium" mx={1} disabled={isSaving}>
                     {intl.formatMessage(this.messages['paymentMethod.editSubscriptions'])}

--- a/src/components/EditPaymentMethods.js
+++ b/src/components/EditPaymentMethods.js
@@ -129,11 +129,11 @@ class EditPaymentMethods extends React.Component {
   renderError(error) {
     if (typeof error === 'string') {
       return error;
-    } else if (error.id === 'pm_remove_has_active_subscriptions') {
+    } else if (error.id === 'PM.Remove.HasActiveSubscriptions') {
       return (
         <React.Fragment>
           <FormattedMessage
-            id="errors.pm_remove_has_active_subscriptions"
+            id="errors.PM.Remove.HasActiveSubscriptions"
             defaultMessage="This payment method cannot be removed because it has active subscriptions."
           />{' '}
           <Link route="subscriptions" params={{ collectiveSlug: this.props.collectiveSlug }}>
@@ -231,6 +231,7 @@ class EditPaymentMethods extends React.Component {
             >
               <EditPaymentMethod
                 paymentMethod={pm}
+                subscriptions={pm.subscriptions}
                 hasMonthlyLimitPerMember={Collective.type === 'ORGANIZATION' && pm.type !== 'prepaid'}
                 currency={pm.currency || Collective.currency}
                 collectiveSlug={Collective.slug}
@@ -264,7 +265,7 @@ const getPaymentMethods = graphql(gql`
         balance
         currency
         expiryDate
-        orders(hasActiveSubscription: true) {
+        subscriptions: orders(hasActiveSubscription: true) {
           id
         }
       }

--- a/src/components/EditPaymentMethods.js
+++ b/src/components/EditPaymentMethods.js
@@ -10,7 +10,8 @@ import { Add } from 'styled-icons/material/Add';
 
 import withIntl from '../lib/withIntl';
 import { paymentMethodLabel } from '../lib/payment_method_label';
-import { H3 } from './Text';
+import { H3, Span } from './Text';
+import Link from './Link';
 import Loading from './Loading';
 import EditPaymentMethod from './EditPaymentMethod';
 import StyledButton from './StyledButton';
@@ -19,6 +20,7 @@ import { withStripeLoader } from './StripeProvider';
 import NewCreditCardForm from './NewCreditCardForm';
 import MessageBox from './MessageBox';
 import { stripeTokenToPaymentMethod } from '../lib/stripe';
+import { getErrorFromGraphqlException } from '../lib/utils';
 
 class EditPaymentMethods extends React.Component {
   static propTypes = {
@@ -91,7 +93,8 @@ class EditPaymentMethods extends React.Component {
       await this.props.data.refetch();
       this.setState({ savingId: null });
     } catch (e) {
-      this.setState({ error: e.message, savingId: null });
+      this.showError(e.message);
+      this.setState({ savingId: null });
     }
   };
 
@@ -105,10 +108,15 @@ class EditPaymentMethods extends React.Component {
         this.setState({ error: null });
         await this.props.data.refetch();
       } catch (e) {
-        this.setState({ error: e.message });
+        this.showError(getErrorFromGraphqlException(e));
       }
     }
     this.setState({ removedId: null });
+  };
+
+  showError = error => {
+    this.setState({ error });
+    window.scrollTo(0, 0);
   };
 
   getPaymentMethodsToDisplay() {
@@ -116,6 +124,28 @@ class EditPaymentMethods extends React.Component {
       pm => pm.balance > 0 || (pm.type === 'virtualcard' && pm.monthlyLimitPerMember),
     );
     return sortBy(paymentMethods, ['type', 'id']);
+  }
+
+  renderError(error) {
+    if (typeof error === 'string') {
+      return error;
+    } else if (error.id === 'pm_remove_has_active_subscriptions') {
+      return (
+        <React.Fragment>
+          <FormattedMessage
+            id="errors.pm_remove_has_active_subscriptions"
+            defaultMessage="This payment method cannot be removed because it has active subscriptions."
+          />{' '}
+          <Link route="subscriptions" params={{ collectiveSlug: this.props.collectiveSlug }}>
+            <Span textTransform="capitalize">
+              <FormattedMessage id="paymentMethod.editSubscriptions" defaultMessage="edit subscriptions" />
+            </Span>
+          </Link>
+        </React.Fragment>
+      );
+    } else {
+      return error.message;
+    }
   }
 
   render() {
@@ -127,37 +157,8 @@ class EditPaymentMethods extends React.Component {
       <Loading />
     ) : (
       <Flex className="EditPaymentMethods" flexDirection="column">
-        <Flex className="paymentMethods" flexDirection="column" mb={2}>
-          {paymentMethods.map(pm => (
-            <Container
-              className="paymentMethod"
-              key={pm.id}
-              mb={4}
-              p={3}
-              border="1px solid #dedede"
-              boxShadow="0px 3px 18px #eaeaea"
-              borderRadius={4}
-              style={{ filter: pm.id === removedId ? 'blur(1px)' : 'none' }}
-            >
-              <EditPaymentMethod
-                paymentMethod={pm}
-                hasMonthlyLimitPerMember={Collective.type === 'ORGANIZATION' && pm.type !== 'prepaid'}
-                currency={pm.currency || Collective.currency}
-                collectiveSlug={Collective.slug}
-                onSave={pm => this.updatePaymentMethod(pm)}
-                onRemove={pm => this.removePaymentMethod(pm)}
-                isSaving={pm.id === savingId}
-              />
-            </Container>
-          ))}
-        </Flex>
-        {error && (
-          <MessageBox type="error" withIcon>
-            {error}
-          </MessageBox>
-        )}
         {!hasForm ? (
-          <Flex justifyContent="center" mx={3} mt={3} mb={4}>
+          <Flex justifyContent="center" mx={3} my={4}>
             <Box>
               <StyledButton buttonStyle="standard" buttonSize="large" onClick={() => this.setState({ hasForm: true })}>
                 <Add size="1em" />
@@ -171,8 +172,7 @@ class EditPaymentMethods extends React.Component {
             display="flex"
             alignItems="center"
             flexWrap="wrap"
-            mt={2}
-            mb={3}
+            my={4}
             px={3}
             py={1}
             borderRadius={4}
@@ -212,6 +212,35 @@ class EditPaymentMethods extends React.Component {
             </Box>
           </Container>
         )}
+        {error && (
+          <MessageBox type="error" withIcon mb={4}>
+            {this.renderError(error)}
+          </MessageBox>
+        )}
+        <Flex className="paymentMethods" flexDirection="column" my={2}>
+          {paymentMethods.map(pm => (
+            <Container
+              className="paymentMethod"
+              key={pm.id}
+              mb={4}
+              p={3}
+              border="1px solid #dedede"
+              boxShadow="0px 3px 18px #eaeaea"
+              borderRadius={4}
+              style={{ filter: pm.id === removedId ? 'blur(1px)' : 'none' }}
+            >
+              <EditPaymentMethod
+                paymentMethod={pm}
+                hasMonthlyLimitPerMember={Collective.type === 'ORGANIZATION' && pm.type !== 'prepaid'}
+                currency={pm.currency || Collective.currency}
+                collectiveSlug={Collective.slug}
+                onSave={pm => this.updatePaymentMethod(pm)}
+                onRemove={pm => this.removePaymentMethod(pm)}
+                isSaving={pm.id === savingId}
+              />
+            </Container>
+          ))}
+        </Flex>
       </Flex>
     );
   }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -344,6 +344,7 @@
   "error.reload": "Reload the page",
   "error.unexpected": "Ooops, an unexpected error seems to have occurred",
   "errorMsg": "Error: {error}",
+  "errors.PM.Remove.HasActiveSubscriptions": "This payment method cannot be removed because it has active subscriptions.",
   "event.amount.label": "amount",
   "event.create.btn": "Create Event",
   "event.description.label": "Short description",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -344,6 +344,7 @@
   "error.reload": "Reload the page",
   "error.unexpected": "Ooops, an unexpected error seems to have occurred",
   "errorMsg": "Error: {error}",
+  "errors.PM.Remove.HasActiveSubscriptions": "This payment method cannot be removed because it has active subscriptions.",
   "event.amount.label": "monto",
   "event.create.btn": "Create Event",
   "event.description.label": "Short description",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -344,6 +344,7 @@
   "error.reload": "Recharger la page",
   "error.unexpected": "Oups, une erreur inattendue est survenue",
   "errorMsg": "Erreur : {error}",
+  "errors.PM.Remove.HasActiveSubscriptions": "This payment method cannot be removed because it has active subscriptions.",
   "event.amount.label": "montant",
   "event.create.btn": "Créer un événement",
   "event.description.label": "Courte description",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -344,6 +344,7 @@
   "error.reload": "ページをリロード",
   "error.unexpected": "予期しないエラーが発生しました",
   "errorMsg": "エラー: {error}",
+  "errors.PM.Remove.HasActiveSubscriptions": "This payment method cannot be removed because it has active subscriptions.",
   "event.amount.label": "金額",
   "event.create.btn": "イベントを作成",
   "event.description.label": "短い説明",

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -260,6 +260,30 @@ export const getGraphqlUrl = () => {
   return `${getBaseApiUrl()}/graphql${apiKey ? `?api_key=${apiKey}` : ''}`;
 };
 
+/**
+ * From a GraphQL error exception, returns an object like:
+ *
+ * @returns {
+ *   id: 'Unique id of the error, can be null if not provided by the API',
+ *   message: 'A user-friendly error message',
+ * }
+ */
+export const getErrorFromGraphqlException = exception => {
+  const firstError = get(exception, 'graphQLErrors.0') || get(exception, 'networkError.result.errors.0');
+
+  if (!firstError) {
+    return {
+      id: 'unknown',
+      message: 'An unknown error occured',
+    };
+  }
+
+  return {
+    id: get(firstError, 'data.errorId'),
+    message: firstError.message,
+  };
+};
+
 export const translateApiUrl = url => {
   const withoutParams = getBaseApiUrl({ internal: true }) + url.replace('/api/', '/');
   const hasParams = `${url}`.match(/\?/);


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/1894
Require https://github.com/opencollective/opencollective-api/pull/1877

Normally we don't display the `Remove` button if payment method has active subscriptions. With https://github.com/opencollective/opencollective-api/pull/1877 this check is also done in the backend and this PR ensure that we properly display the error message, with a link to directly edit subscriptions.

![image](https://user-images.githubusercontent.com/1556356/55879690-7a391600-5b9f-11e9-808d-81787864d683.png)
