### PR TITLE
Disable payment method select when submitting

### DIFF
--- a/src/components/ContributePayment.js
+++ b/src/components/ContributePayment.js
@@ -28,7 +28,6 @@ import NewCreditCardForm from './NewCreditCardForm';
 const PaymentEntryContainer = styled(Container)`
   display: flex;
   flex-direction: column;
-  cursor: pointer;
   background: ${themeGet('colors.white.full')};
   &:hover {
     background: ${themeGet('colors.black.50')};
@@ -238,6 +237,7 @@ class ContributePayment extends React.Component {
           options={paymentMethodsOptions}
           onChange={this.onChange}
           defaultValue={this.state.selectedOption.key}
+          disabled={this.props.disabled}
         >
           {({ radio, checked, index, value: { key, title, subtitle, icon, data } }) => (
             <PaymentEntryContainer
@@ -246,6 +246,7 @@ class ContributePayment extends React.Component {
               borderBottom={index !== paymentMethodsOptions.length - 1 ? '1px solid' : 'none'}
               bg="white.full"
               borderColor="black.200"
+              cursor={this.props.disabled ? 'not-allowed' : 'pointer'}
             >
               <Flex alignItems="center">
                 <Box as="span" mr={[2, 21]} flexWrap="wrap">
@@ -316,6 +317,8 @@ ContributePayment.propTypes = {
    * Wether we should ask for postal code in Credit Card form
    */
   hideCreditCardPostalCode: PropTypes.bool,
+  /** If true, user won't be able to interact with the element */
+  disabled: PropTypes.bool,
 };
 
 ContributePayment.defaultProps = {

--- a/src/components/StyledRadioList.js
+++ b/src/components/StyledRadioList.js
@@ -9,7 +9,7 @@ import Container from './Container';
 /**
  * Component for controlling a list of radio inputs
  */
-const StyledRadioList = ({ children, id, name, onChange, options, keyGetter, ...props }) => {
+const StyledRadioList = ({ children, id, name, onChange, options, keyGetter, disabled, ...props }) => {
   const [selected, setSelected] = useState(props.defaultValue);
   const keyExtractor = getKeyExtractor(options, keyGetter);
   const items = getItems(options, keyExtractor);
@@ -44,6 +44,7 @@ const StyledRadioList = ({ children, id, name, onChange, options, keyGetter, ...
                 id={id && key + id}
                 value={key}
                 defaultChecked={props.defaultValue !== undefined && defaultValueStr === key}
+                disabled={disabled}
               />
             ),
           })}
@@ -78,6 +79,8 @@ StyledRadioList.propTypes = {
   ]).isRequired,
   /** A key name of a getter function to extract the unique key from option */
   keyGetter: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  /** If true, user won't be able to interact with the element */
+  disabled: PropTypes.bool,
 };
 
 const defaultChild = ({ value, radio }) => (

--- a/src/pages/createOrder.js
+++ b/src/pages/createOrder.js
@@ -758,6 +758,7 @@ class CreateOrderPage extends React.Component {
               manual={this.getManualPaymentMethod()}
               hideCreditCardPostalCode={this.shouldHideCreditCardPostalCode()}
               margins="0 auto"
+              disabled={this.state.submitting || this.state.submitted}
             />
           </Flex>
           {this.isFixedPriceTier() ? this.renderTierDetails(tier) : <Box width={[0, null, null, 1 / 5]} />}

--- a/styleguide/examples/ContributePayment.md
+++ b/styleguide/examples/ContributePayment.md
@@ -7,14 +7,26 @@ import paymentMethods from '../mocks/payment_methods';
 
 ```js
 import paymentMethods from '../mocks/payment_methods';
-<ContributePayment
-  withPaypal
-  onChange={console.log}
-  paymentMethods={paymentMethods}
-  manual={{
-    title: 'Bank transfer',
-    instructions:
-      'Please make a bank transfer for the amount of $42.00 to the bank account: IBAN: BE11 4242 4242 4242 with the following communication: "fzappa order 125238". Please note that it will take a few days to process your payment.',
-  }}
-/>;
+
+initialState = { disabled: false, values: null };
+<div>
+  <ContributePayment
+    withPaypal
+    disabled={state.disabled}
+    onChange={values => setState({ values })}
+    paymentMethods={paymentMethods}
+    manual={{
+      title: 'Bank transfer',
+      instructions:
+        'Please make a bank transfer for the amount of $42.00 to the bank account: IBAN: BE11 4242 4242 4242 with the following communication: "fzappa order 125238". Please note that it will take a few days to process your payment.',
+    }}
+  />
+  <br />
+  <br />
+  <button onClick={() => setState({ disabled: !state.disabled })}>{state.disabled ? 'Enable' : 'Disable'}</button>
+  <hr />
+  <br />
+  <label>State</label>
+  <pre style={{ whiteSpace: 'pre-wrap' }}>{JSON.stringify(state.values, null, 2)}</pre>
+</div>;
 ```


### PR DESCRIPTION
User shouldn't be able to change payment method after `Make contribution` has been clicked. This PR disable the select while form is submitting or after it has been successfully submitted.

![Peek 10-04-2019 17-03](https://user-images.githubusercontent.com/1556356/55890204-91353380-5bb2-11e9-910d-487fb5513367.gif)
