### PR TITLE
Fix input fields overflow style

### DIFF
--- a/src/components/InputField.js
+++ b/src/components/InputField.js
@@ -573,7 +573,6 @@ class InputField extends React.Component {
               width: 100%;
             }
             .inputField {
-              overflow: auto;
               margin: 1rem 0;
             }
             .inputField,


### PR DESCRIPTION
Fixes a bug where scrollbars would appear on input fields.

This `overflow: auto` was added so the input fields would take the correct space but there are too many placed where the styles have been adapted to deal with this and there's no clear path to update them.