### PR TITLE
Move archive/delete and change email above

### DIFF
--- a/src/components/EditCollectiveForm.js
+++ b/src/components/EditCollectiveForm.js
@@ -652,6 +652,14 @@ class EditCollectiveForm extends React.Component {
           </Flex>
 
           <Flex flexDirection="column" css={{ flexGrow: 10, flexBasis: 600 }}>
+            {this.state.section === 'advanced' && (
+              <Box>
+                {collective.type === 'USER' && <EditUserEmailForm user={LoggedInUser} />}
+                {archiveIsEnabled && collective.type !== 'USER' && <ArchiveCollective collective={collective} />}
+                {deleteIsEnabled && collective.type !== 'EVENT' && <DeleteCollective collective={collective} />}
+                <hr />
+              </Box>
+            )}
             <div className="FormInputs">
               {Object.keys(this.fields).map(
                 section =>
@@ -740,13 +748,6 @@ class EditCollectiveForm extends React.Component {
               )}
               {this.state.section === 'connected-accounts' && (
                 <EditConnectedAccounts collective={collective} connectedAccounts={collective.connectedAccounts} />
-              )}
-              {this.state.section === 'advanced' && (
-                <Box>
-                  {collective.type === 'USER' && <EditUserEmailForm user={LoggedInUser} />}
-                  {archiveIsEnabled && collective.type !== 'USER' && <ArchiveCollective collective={collective} />}
-                  {deleteIsEnabled && collective.type !== 'EVENT' && <DeleteCollective collective={collective} />}
-                </Box>
               )}
               {this.state.section === 'export' && <ExportData collective={collective} />}
             </div>

--- a/src/components/EditUserEmailForm.js
+++ b/src/components/EditUserEmailForm.js
@@ -18,7 +18,7 @@ const EditUserEmailForm = ({ user, updateUserEmail }) => {
   const isDone = step === 'already-sent' || step === 'success';
 
   return (
-    <Box my={4} data-cy="EditUserEmailForm">
+    <Box mb={4} data-cy="EditUserEmailForm">
       <H2>
         <FormattedMessage id="EditUserEmailForm.title" defaultMessage="Email address" />
       </H2>


### PR DESCRIPTION
The save button for the old fields (invoice/default editor) is at the bottom of the page so it makes no sense to have them at the top.

I'm also afraid that this "Save" button can be confusing: how can the user know which fields it applies to?

**Before**
![localhost_3000_test43wow_edit_advanced (1)](https://user-images.githubusercontent.com/1556356/55909626-d4a49780-5bdc-11e9-874a-019087fb58b6.png)


**After**
![localhost_3000_test43wow_edit_advanced](https://user-images.githubusercontent.com/1556356/55909630-d8d0b500-5bdc-11e9-9448-1dd66286b5f5.png)

