### PR TITLE
Ignore crowdin branch in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,8 @@
 version: 2
 
 aliases:
+  crowdin_branch: &crowdin_branch /i18n\/crowdin.*/
+
   restore_npm_cache: &restore_npm_cache
     restore_cache:
       name: Restore npm cache
@@ -233,20 +235,27 @@ workflows:
   version: 2
   lint-build-test:
     jobs:
-      - lint
-      - jest
       - update-langs
-      - build
-      - build-api
+      - lint:
+          filters: { branches: { ignore: [*crowdin_branch] } }
+      - jest:
+          filters: { branches: { ignore: [*crowdin_branch] } }
+      - build:
+          filters: { branches: { ignore: [*crowdin_branch] } }
+      - build-api:
+          filters: { branches: { ignore: [*crowdin_branch] } }
       - test-e2e-0:
+          filters: { branches: { ignore: [*crowdin_branch] } }
           requires:
             - build
             - build-api
       - test-e2e-1:
+          filters: { branches: { ignore: [*crowdin_branch] } }
           requires:
             - build
             - build-api
       - test-e2e-2:
+          filters: { branches: { ignore: [*crowdin_branch] } }
           requires:
             - build
             - build-api


### PR DESCRIPTION
Only left `update-langs` as I sometimes edit the translations directly on the crowdin branch. It's also a security if for any reason Crowdin goes wrong and starts messing up with the translation files.

I didn't tried to remove Now because it can be useful to review translations in their context.