### PR TITLE
Edit user email UX improvements

### DIFF
--- a/cypress/integration/08-user.change-email.js
+++ b/cypress/integration/08-user.change-email.js
@@ -17,9 +17,6 @@ describe('Users can change their email address', () => {
 
     // Initial form should have current email in it
     cy.get('[data-cy=EditUserEmailForm] input[name=email]').should('have.value', user.email);
-    cy.get('[data-cy=EditUserEmailForm] input[name=email]').should('be.disabled');
-
-    cy.contains('[data-cy=EditUserEmailForm] button', 'Change email').click();
 
     // Submit disabled if value is incorrect
     cy.get('[data-cy=EditUserEmailForm] input[name=email]').type('{selectall}NotAValidEmail');
@@ -58,7 +55,6 @@ describe('Users can change their email address', () => {
     const emailForDoubleConfirmation = randomEmail();
 
     cy.login({ email: newEmail, redirect: `/${user.collective.slug}/edit/advanced` });
-    cy.contains('[data-cy=EditUserEmailForm] button', 'Change email').click();
     cy.get('[data-cy=EditUserEmailForm] input[name=email]').type(`{selectall}${emailForDoubleConfirmation}`);
     cy.contains('[data-cy=EditUserEmailForm] button', 'Confirm new email').click();
     cy.contains('[data-cy=EditUserEmailForm] button', 'Re-send confirmation').click();

--- a/src/components/EditCollectiveForm.js
+++ b/src/components/EditCollectiveForm.js
@@ -658,7 +658,7 @@ class EditCollectiveForm extends React.Component {
           <Flex flexDirection="column" css={{ flexGrow: 10, flexBasis: 600 }}>
             {this.state.section === 'advanced' && (
               <Box>
-                {collective.type === 'USER' && <EditUserEmailForm user={LoggedInUser} />}
+                {collective.type === 'USER' && <EditUserEmailForm />}
                 {emptyBalanceIsEnabled && collective.type === 'COLLECTIVE' && (
                   <EditCollectiveEmptyBalance collective={collective} LoggedInUser={LoggedInUser} />
                 )}

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -331,7 +331,6 @@
   "editCollective.menu.tiers": "Tiers",
   "editCollective.menu.virtualCards": "Gift Cards",
   "editCollective.notFound": "No collective data to edit",
-  "EditUserEmailForm.change": "Change email",
   "EditUserEmailForm.reSend": "Re-send confirmation",
   "EditUserEmailForm.submit": "Confirm new email",
   "EditUserEmailForm.success": "An email with a confirmation link has been sent to {email}.",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -331,7 +331,6 @@
   "editCollective.menu.tiers": "categorías",
   "editCollective.menu.virtualCards": "Tarjetas de regalo",
   "editCollective.notFound": "No collective data to edit",
-  "EditUserEmailForm.change": "Change email",
   "EditUserEmailForm.reSend": "Re-send confirmation",
   "EditUserEmailForm.submit": "Confirm new email",
   "EditUserEmailForm.success": "An email with a confirmation link has been sent to {email}.",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -331,7 +331,6 @@
   "editCollective.menu.tiers": "Tiers",
   "editCollective.menu.virtualCards": "Cartes Cadeaux",
   "editCollective.notFound": "No collective data to edit",
-  "EditUserEmailForm.change": "Change email",
   "EditUserEmailForm.reSend": "Re-send confirmation",
   "EditUserEmailForm.submit": "Confirm new email",
   "EditUserEmailForm.success": "An email with a confirmation link has been sent to {email}.",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -331,7 +331,6 @@
   "editCollective.menu.tiers": "Tier",
   "editCollective.menu.virtualCards": "ギフトカード",
   "editCollective.notFound": "編集するコレクティブのデータがありません",
-  "EditUserEmailForm.change": "Change email",
   "EditUserEmailForm.reSend": "Re-send confirmation",
   "EditUserEmailForm.submit": "Confirm new email",
   "EditUserEmailForm.success": "An email with a confirmation link has been sent to {email}.",


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/1711

Following @alannallama's feedback, this improves the UX on the edit user email. The input is not disabled anymore, we can directly set a value and click submit.

![Peek 15-04-2019 21-21](https://user-images.githubusercontent.com/1556356/56159274-8f111180-5fc4-11e9-831b-f636f9c2bc8d.gif)
