### PR TITLE
Added end time to events

### DIFF
--- a/src/components/CollectiveCover.js
+++ b/src/components/CollectiveCover.js
@@ -70,6 +70,20 @@ class CollectiveCover extends React.Component {
                 &nbsp; - &nbsp;
               </React.Fragment>
             )}
+            {props.collective.endsAt && (
+              <React.Fragment>
+                <FormattedDate
+                  value={props.collective.endsAt}
+                  timeZone={props.collective.timezone}
+                  weekday="short"
+                  day="numeric"
+                  month="long"
+                />
+                , &nbsp;
+                <FormattedTime value={props.collective.endsAt} timeZone={props.collective.timezone} />
+                &nbsp; - &nbsp;
+              </React.Fragment>
+            )}
             {get(props.collective, 'location.name')}
           </Link>
         </div>


### PR DESCRIPTION
Event end times were not being displayed. This fixes that, and allows event end times to be seen by users.

This addresses this issue: https://github.com/opencollective/opencollective/issues/1966

Hopefully this goes live soon, so my supporters can know about my event times!