### PR TITLE
Improve message in applying open source

### DIFF
--- a/src/pages/openSourceApply.js
+++ b/src/pages/openSourceApply.js
@@ -69,7 +69,7 @@ class OpenSourceApplyPage extends Component {
       } else {
         this.setState({
           loadingRepos: false,
-          result: { type: 'info', mesg: 'Info: No Repository found' },
+          result: { type: 'info', mesg: "We couldn't find any repositories (with >= 100 stars) linked to the account" },
         });
       }
     } catch (error) {


### PR DESCRIPTION
This improves message in applying open source repositories. This message is shown when connecting GitHub is success and there're no repos met a condition so I changed wording.

The message is based on https://github.com/opencollective/opencollective/issues/1939.

(Off-Topic: When running `npm install`, I found some vulnerabilities. These will be fixed by greenkeeper but it seems anybody doesn't merge the PRs... I understand we need to confirm if upgrading dependencies is ok and it takes time to review. I'd like to solve this problem...)