### PR TITLE
Replace `.eslintrc` with `.eslintrc.json`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,18 +1,13 @@
 {
-  "extends": [
-    "opencollective"
-  ],
+  "extends": ["opencollective"],
   "env": {
     "jest": true
   },
-  "plugins": [
-    "graphql",
-    "react-hooks"
-  ],
+  "plugins": ["graphql", "react-hooks"],
   "rules": {
     "no-console": "warn",
     "react/jsx-closing-bracket-location": ["warn", "tag-aligned"],
-    "graphql/template-strings": ["error", {"env": "apollo"}],
+    "graphql/template-strings": ["error", { "env": "apollo" }],
     "graphql/named-operations": ["error"],
     "graphql/capitalized-type-name": ["error"],
     "graphql/no-deprecated-fields": ["error"],

--- a/cypress/.eslintrc.json
+++ b/cypress/.eslintrc.json
@@ -2,7 +2,5 @@
   "env": {
     "cypress/globals": true
   },
-  "plugins": [
-    "cypress"
-  ]
+  "plugins": ["cypress"]
 }


### PR DESCRIPTION
@znarf pointed out the problem about `.eslintrc` (see https://github.com/opencollective/opencollective-frontend/pull/1712#issuecomment-487459520).

So I replaced them with `.eslintrc.json` (it seems that this format is popular).
