### PR TITLE
Update language files when defaults change

### DIFF
--- a/scripts/translate.js
+++ b/scripts/translate.js
@@ -1,10 +1,11 @@
 import * as fs from 'fs';
 import { sync as globSync } from 'glob';
 import { sync as mkdirpSync } from 'mkdirp';
-import { orderBy } from 'lodash';
+import { orderBy, difference, has } from 'lodash';
 
 const MESSAGES_PATTERN = './dist/messages/**/*.json';
 const LANG_DIR = './src/lang/';
+const DEFAULT_TRANSLATIONS_FILE = `${LANG_DIR}en.json`;
 
 // Aggregates the default messages that were extracted from the app's
 // React components via the React Intl Babel plugin. An error will be thrown if
@@ -30,37 +31,77 @@ const defaultMessages = globSync(MESSAGES_PATTERN)
 /**
  * Store new keys in translation file without overwritting the existing ones.
  */
-const translatedMessages = locale => {
+const translatedMessages = (locale, defaultMessages, updatedKeys) => {
   const filename = `${LANG_DIR}${locale}.json`;
   const file = fs.readFileSync(filename, 'utf8');
   const json = JSON.parse(file);
-
-  // Check if there are unused keys in the translation file
-  Object.keys(json).map(id => {
-    if (!defaultMessages.hasOwnProperty(id)) {
-      console.info(`🗑️ Removing unused ${id} from ${filename}`);
-    }
-  });
 
   // Do translate
   return Object.keys(defaultMessages)
     .map(id => [id, defaultMessages[id]])
     .reduce((collection, [id, defaultMessage]) => {
-      collection[id] = json[id] || defaultMessage;
+      if (updatedKeys.includes(id)) {
+        // If default message was updated, override the translation
+        collection[id] = defaultMessage;
+      } else {
+        // Otherwise we only save the default message if there's no translation yet
+        collection[id] = json[id] || defaultMessage;
+      }
+
       return collection;
     }, {});
+};
+
+/**
+ * Sort translation object's keys alphabetically
+ */
+const sortKeys = i18nKeys => {
+  return orderBy(i18nKeys, [key => key.toLowerCase()]);
+};
+
+/**
+ * Get the diff between two translations objects.
+ */
+const getDiff = (base, newDefaults) => {
+  const sortedOldKeys = sortKeys(Object.keys(base));
+  const sortedNewKeys = sortKeys(Object.keys(newDefaults));
+  return {
+    removed: difference(sortedOldKeys, sortedNewKeys),
+    created: difference(sortedNewKeys, sortedOldKeys),
+    updated: sortedNewKeys.filter(key => {
+      return has(base, key) && has(newDefaults, key) && base[key] !== newDefaults[key];
+    }),
+  };
 };
 
 /**
  * Convert to JSON and ensure that the keys are sorted properly.
  */
 const convertToJSON = obj => {
-  return `${JSON.stringify(obj, orderBy(Object.keys(obj), [key => key.toLowerCase()]), 2)}\n`;
+  return `${JSON.stringify(obj, sortKeys(Object.keys(obj)), 2)}\n`;
 };
 
+/**
+ * Update the keys for locale and save the file
+ */
+const translate = (locale, defaultMessages, updatedKeys) => {
+  const translations = convertToJSON(translatedMessages(locale, defaultMessages, updatedKeys));
+  fs.writeFileSync(`${LANG_DIR}${locale}.json`, translations);
+};
+
+// Load existing translations, check what changed
+const existingTranslationsObj = JSON.parse(fs.readFileSync(DEFAULT_TRANSLATIONS_FILE, 'utf8'));
+const diff = getDiff(existingTranslationsObj, defaultMessages);
+
+// Display changes
+diff.removed.forEach(key => console.info(`🗑️   [REMOVE] "${key}"`));
+diff.created.forEach(key => console.info(`🆕  [CREATE] "${key}"`));
+diff.updated.forEach(key => console.info(`📥  [UPDATE] "${key}"`));
+
+// Save translations
 mkdirpSync(LANG_DIR);
-fs.writeFileSync(`${LANG_DIR}en.json`, convertToJSON(defaultMessages));
-fs.writeFileSync(`${LANG_DIR}fr.json`, convertToJSON(translatedMessages('fr')));
-fs.writeFileSync(`${LANG_DIR}es.json`, convertToJSON(translatedMessages('es')));
-fs.writeFileSync(`${LANG_DIR}ja.json`, convertToJSON(translatedMessages('ja')));
-fs.writeFileSync(`${LANG_DIR}ru.json`, convertToJSON(translatedMessages('ru')));
+fs.writeFileSync(DEFAULT_TRANSLATIONS_FILE, convertToJSON(defaultMessages));
+translate('fr', defaultMessages, diff.updated);
+translate('es', defaultMessages, diff.updated);
+translate('ja', defaultMessages, diff.updated);
+translate('ru', defaultMessages, diff.updated);


### PR DESCRIPTION
With this PR, any change made to the default translation (`defaultMessage`) will update all the languages files with the new default.

This will protect us from cases where we decide to update a default translation to add a parameter and we forget to add this parameter to all translations.

This will also displays more info about what changed when running `npm run build:langs`:

```
🗑️  [REMOVE] "ConnectPaypal.expired"
🆕  [CREATE] "ConnectPaypal.NewTranslation"
🆕  [CREATE] "ConnectPaypal.NewTranslation2"
📥  [UPDATE] "ConnectPaypal.expireSoon"
```