### PR TITLE
Hero scroll behaviour and responsiveness

### DIFF
--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { backgroundImage, backgroundColor, borders, borderColor, size, themeGet } from 'styled-system';
 import tag from 'clean-tag';
 import { Flex } from '@rebass/grid';
@@ -25,6 +25,11 @@ export const StyledAvatar = styled(Flex)`
   overflow: hidden;
   flex-shrink: 0;
   ${size}
+  ${props =>
+    props.animationDuration &&
+    css`
+      transition: width ${props.animationDuration}ms, height ${props.animationDuration}ms;
+    `}
 `;
 
 StyledAvatar.defaultProps = {
@@ -53,6 +58,8 @@ Avatar.propTypes = {
   type: PropTypes.oneOf(['USER', 'COLLECTIVE', 'ORGANIZATION', 'CHAPTER', 'ANONYMOUS']),
   /** Avatar size */
   radius: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  /** Duration to transition size. Disabled if 0, null or undefined */
+  animationDuration: PropTypes.number,
 };
 
 export default withFallbackImage(Avatar);

--- a/src/components/AvatarWithHost.js
+++ b/src/components/AvatarWithHost.js
@@ -26,10 +26,11 @@ const HostLink = styled(LinkCollective)`
  * Same as `Avatar`, except this one also displays the host avatar on
  * the bottom right corner.
  */
-const AvatarWithHost = ({ collective, host, radius }) => {
+const AvatarWithHost = ({ collective, host, radius, animationDuration, onCollectiveClick }) => {
+  const hostAvatarRadius = radius <= 60 ? radius / 2 : radius / 4;
   return (
     <MainContainer>
-      <LinkCollective collective={collective}>
+      <LinkCollective collective={collective} onClick={onCollectiveClick} isNewVersion>
         <Avatar
           type={collective.type}
           src={collective.image}
@@ -37,17 +38,19 @@ const AvatarWithHost = ({ collective, host, radius }) => {
           border="1px solid #efefef"
           radius={radius}
           borderRadius={radius / 4}
+          animationDuration={animationDuration}
         />
       </LinkCollective>
       {host && (
-        <HostLink collective={host}>
+        <HostLink collective={host} isNewVersion>
           <Avatar
             type={host.type}
             src={host.image}
             border="1px solid #efefef"
-            radius={radius / 4}
-            borderRadius={radius / 16}
+            radius={hostAvatarRadius}
+            borderRadius={hostAvatarRadius / 4}
             title={host.name}
+            animationDuration={animationDuration}
           />
         </HostLink>
       )}
@@ -70,6 +73,12 @@ AvatarWithHost.propTypes = {
 
   /** Size of the main image in pixels. Should ideally be a multiple of 4. */
   radius: PropTypes.number,
+
+  /** Duration to transition size. Disabled if 0, null or undefined */
+  animationDuration: PropTypes.number,
+
+  /** Called when main collective picture is clicked */
+  onCollectiveClick: PropTypes.func,
 };
 
 export default withFallbackImage(AvatarWithHost);

--- a/src/components/Body.js
+++ b/src/components/Body.js
@@ -1,8 +1,30 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class Body extends React.Component {
+  static propTypes = {
+    withGlobalStyles: PropTypes.bool,
+    smoothScroll: PropTypes.bool,
+    children: PropTypes.node,
+  };
+
+  static defaultProps = {
+    withGlobalStyles: true,
+  };
+
   render() {
-    return (
+    return !this.props.withGlobalStyles ? (
+      <main>
+        {this.props.smoothScroll && (
+          <style jsx global>{`
+            html {
+              scroll-behavior: smooth;
+            }
+          `}</style>
+        )}
+        {this.props.children}
+      </main>
+    ) : (
       <main>
         <style jsx global>
           {`

--- a/src/components/Body.js
+++ b/src/components/Body.js
@@ -3,18 +3,11 @@ import PropTypes from 'prop-types';
 
 export default class Body extends React.Component {
   static propTypes = {
-    withGlobalStyles: PropTypes.bool,
     children: PropTypes.node,
   };
 
-  static defaultProps = {
-    withGlobalStyles: true,
-  };
-
   render() {
-    return !this.props.withGlobalStyles ? (
-      <main>{this.props.children}</main>
-    ) : (
+    return (
       <main>
         <style jsx global>
           {`

--- a/src/components/Body.js
+++ b/src/components/Body.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 export default class Body extends React.Component {
   static propTypes = {
     withGlobalStyles: PropTypes.bool,
-    smoothScroll: PropTypes.bool,
     children: PropTypes.node,
   };
 
@@ -14,16 +13,7 @@ export default class Body extends React.Component {
 
   render() {
     return !this.props.withGlobalStyles ? (
-      <main>
-        {this.props.smoothScroll && (
-          <style jsx global>{`
-            html {
-              scroll-behavior: smooth;
-            }
-          `}</style>
-        )}
-        {this.props.children}
-      </main>
+      <main>{this.props.children}</main>
     ) : (
       <main>
         <style jsx global>

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -12,6 +12,7 @@ class Link extends React.Component {
     animate: PropTypes.object,
     className: PropTypes.string,
     title: PropTypes.string,
+    onClick: PropTypes.func,
     children: PropTypes.node.isRequired,
   };
 

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -25,7 +25,7 @@ class Link extends React.Component {
   }
 
   render() {
-    const { route, params, children, className, title, ...otherProps } = this.props;
+    const { route, params, children, className, title, onClick, ...otherProps } = this.props;
     if (this.isHash) {
       const afterAnimate = () => {
         if (window.history) {
@@ -54,7 +54,7 @@ class Link extends React.Component {
     } else {
       return (
         <router.Link {...pick(this.props, ['route', 'params', 'href', 'scroll', 'passHref'])}>
-          <a className={className} title={title}>
+          <a className={className} title={title} onClick={onClick}>
             {children}
           </a>
         </router.Link>

--- a/src/components/LinkCollective.js
+++ b/src/components/LinkCollective.js
@@ -16,9 +16,9 @@ const getEventParentCollectiveSlug = parentCollective => {
  * Create a `Link` to the collective, properly switching between `event` and `collective`
  * routes based on collective type.
  */
-const LinkCollective = ({ collective: { type, slug, name, parentCollective }, children, ...props }) => {
+const LinkCollective = ({ collective: { type, slug, name, parentCollective }, children, isNewVersion, ...props }) => {
   return type !== 'EVENT' ? (
-    <Link route="collective" params={{ slug }} {...props}>
+    <Link route={isNewVersion ? 'new-collective-page' : 'collective'} params={{ slug }} {...props}>
       {children || name || slug}
     </Link>
   ) : (
@@ -44,6 +44,8 @@ LinkCollective.propTypes = {
   }).isRequired,
   /** If not given, will render the name of the collective */
   children: PropTypes.node,
+  /** Link to the new collective page */
+  isNewVersion: PropTypes.bool,
 };
 
 export default LinkCollective;

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -19,7 +19,6 @@ const Page = ({
   twitterHandle,
   showSearch,
   withGlobalStyles,
-  smoothScroll,
 }) => {
   if (data.error) {
     return <ErrorPage data={data} LoggedInUser={LoggedInUser} />;
@@ -36,7 +35,7 @@ const Page = ({
         description={description}
         image={image}
       />
-      <Body withGlobalStyles={withGlobalStyles} smoothScroll={smoothScroll}>
+      <Body withGlobalStyles={withGlobalStyles}>
         {typeof children === 'function' ? children(childProps) : children}
       </Body>
       <Footer />

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -54,7 +54,6 @@ Page.propTypes = {
   loadingLoggedInUser: PropTypes.bool,
   LoggedInUser: PropTypes.shape({}),
   showSearch: PropTypes.bool,
-  smoothScroll: PropTypes.bool,
   withGlobalStyles: PropTypes.bool,
   title: PropTypes.string,
   twitterHandle: PropTypes.string,

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -18,6 +18,8 @@ const Page = ({
   title,
   twitterHandle,
   showSearch,
+  withGlobalStyles,
+  smoothScroll,
 }) => {
   if (data.error) {
     return <ErrorPage data={data} LoggedInUser={LoggedInUser} />;
@@ -34,7 +36,9 @@ const Page = ({
         description={description}
         image={image}
       />
-      <Body>{typeof children === 'function' ? children(childProps) : children}</Body>
+      <Body withGlobalStyles={withGlobalStyles} smoothScroll={smoothScroll}>
+        {typeof children === 'function' ? children(childProps) : children}
+      </Body>
       <Footer />
     </Fragment>
   );
@@ -51,12 +55,15 @@ Page.propTypes = {
   loadingLoggedInUser: PropTypes.bool,
   LoggedInUser: PropTypes.shape({}),
   showSearch: PropTypes.bool,
+  smoothScroll: PropTypes.bool,
+  withGlobalStyles: PropTypes.bool,
   title: PropTypes.string,
   twitterHandle: PropTypes.string,
 };
 
 Page.defaultProps = {
   showSearch: true,
+  withGlobalStyles: true,
 };
 
 export default withUser(Page);

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -18,7 +18,6 @@ const Page = ({
   title,
   twitterHandle,
   showSearch,
-  withGlobalStyles,
 }) => {
   if (data.error) {
     return <ErrorPage data={data} LoggedInUser={LoggedInUser} />;
@@ -35,9 +34,7 @@ const Page = ({
         description={description}
         image={image}
       />
-      <Body withGlobalStyles={withGlobalStyles}>
-        {typeof children === 'function' ? children(childProps) : children}
-      </Body>
+      <Body>{typeof children === 'function' ? children(childProps) : children}</Body>
       <Footer />
     </Fragment>
   );
@@ -54,14 +51,12 @@ Page.propTypes = {
   loadingLoggedInUser: PropTypes.bool,
   LoggedInUser: PropTypes.shape({}),
   showSearch: PropTypes.bool,
-  withGlobalStyles: PropTypes.bool,
   title: PropTypes.string,
   twitterHandle: PropTypes.string,
 };
 
 Page.defaultProps = {
   showSearch: true,
-  withGlobalStyles: true,
 };
 
 export default withUser(Page);

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -14,6 +14,7 @@ import styled from 'styled-components';
 
 import { rotateMixin } from '../constants/animations';
 import { withUser } from './UserProvider';
+import theme from '../constants/theme';
 
 const Logo = styled.img.attrs({
   src: '/static/images/opencollective-icon.svg',
@@ -80,7 +81,7 @@ class TopBar extends React.Component {
         alignItems="center"
         flexDirection="row"
         justifyContent="space-around"
-        css={{ minHeight: 68 }}
+        css={{ height: theme.sizes.navbarHeight }}
       >
         <Link route="home" passHref>
           <Flex as="a" alignItems="center">

--- a/src/components/collective-page/Hero.js
+++ b/src/components/collective-page/Hero.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import styled, { css } from 'styled-components';
 import { Flex, Box } from '@rebass/grid';
 import { FormattedMessage, defineMessages } from 'react-intl';
 import { get } from 'lodash';
@@ -24,10 +25,32 @@ import I18nCollectiveTags from '../I18nCollectiveTags';
 import StyledTag from '../StyledTag';
 import DefinedTerm, { Terms } from '../DefinedTerm';
 import Link from '../Link';
+import LinkCollective from '../LinkCollective';
 
-import { AllSectionsNames, Dimensions } from './_constants';
+import { AllSectionsNames, Dimensions, AnimationsDurations } from './_constants';
 import NavBar from './NavBar';
 import HeroBackground from './HeroBackground';
+
+/**
+ * The main container that uses `sticky` to fix on top.
+ */
+const MainContainer = styled.div`
+  position: relative;
+  top: 0;
+  border-bottom: 1px solid #e6e8eb;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  transition: flex;
+
+  ${props =>
+    props.isFixed &&
+    css`
+      position: fixed;
+      width: 100%;
+      background: white;
+    `}
+`;
 
 /**
  * Collective's page Hero/Banner/Cover component. Also includes the NavBar
@@ -65,6 +88,15 @@ class Hero extends Component {
     /** The list of sections to be displayed by the NavBar */
     sections: PropTypes.arrayOf(PropTypes.oneOf(AllSectionsNames)),
 
+    /** The section currently selected */
+    selectedSection: PropTypes.string,
+
+    /** Called with the new section name when it changes */
+    onSectionClick: PropTypes.func.isRequired,
+
+    /** Called when the collective name or the logo is clicked */
+    onCollectiveClick: PropTypes.func.isRequired,
+
     /** Define if we need to display special actions like the "Edit collective" button */
     canEditCollective: PropTypes.bool,
 
@@ -84,92 +116,118 @@ class Hero extends Component {
   });
 
   render() {
-    const { collective, host, canEditCollective, intl } = this.props;
+    const { collective, host, canEditCollective, intl, isFixed, onCollectiveClick } = this.props;
     const { slug, twitterHandle, githubHandle, website } = this.props.collective;
     const { formatMessage } = intl;
 
     return (
-      <div>
+      <MainContainer isFixed={isFixed}>
         {/* Hero top */}
-        <Container position="relative" pb={4}>
-          <HeroBackground backgroundImage={collective.backgroundImage} />
+        <Container position="relative" pb={isFixed ? 0 : 4}>
+          {!isFixed && <HeroBackground backgroundImage={collective.backgroundImage} />}
           <Container maxWidth={Dimensions.MAX_SECTION_WIDTH} px={Dimensions.PADDING_X} margin="0 auto">
-            <Flex pt={40} flexWrap="wrap" width={1} justifyContent="center">
+            <Flex pt={isFixed ? 16 : 40} flexWrap="wrap" width={1} justifyContent="center">
               {/* Collective presentation (name, logo, description...) */}
-              <Box flex="1 1">
-                <Flex mb={2} justifyContent={['center', 'left']}>
-                  <AvatarWithHost collective={collective} host={host} radius={128} />
-                </Flex>
-                <Flex flexDirection="column" flex="1 1 400px">
-                  <H1 fontSize="H3" textAlign={['center', 'left']}>
-                    {collective.name || collective.slug}
-                  </H1>
-                  <Flex mb={[1, 2, 3]} alignItems="center" justifyContent={['center', 'flex-start']}>
-                    <StyledTag mr={2}>
-                      <I18nCollectiveTags tags={getCollectiveMainTag(get(collective, 'host.id'), collective.tags)} />
-                    </StyledTag>
-                    {host && (
-                      <Container ml={3} color="black.600">
-                        <FormattedMessage
-                          id="Collective.Hero.Host"
-                          defaultMessage="{FiscalHost}: {hostName}"
-                          values={{
-                            hostName: host.name,
-                            FiscalHost: <DefinedTerm term={Terms.FISCAL_HOST} />,
-                          }}
-                        />
-                      </Container>
-                    )}
-                  </Flex>
-                  <H2 mt={2} fontSize="LeadParagraph" lineHeight="24px" textAlign={['center', 'left']}>
-                    {collective.description}
-                  </H2>
-                </Flex>
-              </Box>
-              {/* Contact buttons */}
-              <Flex flexWrap="wrap" justifyContent="center" mt={48}>
-                <StyledButton disabled width={120} height={40} mb={3} mr={2} title="Coming soon">
-                  <Span mr={2}>
-                    <CheckCircle size="1em" />
-                  </Span>
-                  <FormattedMessage id="CollectivePage.Hero.Follow" defaultMessage="Follow" />
-                </StyledButton>
-                <Flex css={{ height: 40 }}>
-                  <a href={`mailto:hello@${slug}.opencollective.com`} title="Email">
-                    <StyledRoundButton size={40} mx={2}>
-                      <Mail size={14} />
-                    </StyledRoundButton>
-                  </a>
-                  {twitterHandle && (
-                    <ExternalLinkNewTab href={twitterProfileUrl(twitterHandle)} title="Twitter">
-                      <StyledRoundButton size={40} mx={2}>
-                        <Twitter size={14} />
-                      </StyledRoundButton>
-                    </ExternalLinkNewTab>
-                  )}
-                  {githubHandle && (
-                    <ExternalLinkNewTab href={githubProfileUrl(githubHandle)} title="Github">
-                      <StyledRoundButton size={40} mx={2}>
-                        <Github size={14} />
-                      </StyledRoundButton>
-                    </ExternalLinkNewTab>
-                  )}
-                  {website && (
-                    <ExternalLinkNewTab href={website} title={formatMessage(Hero.Translations.website)}>
-                      <StyledRoundButton size={40} mx={2}>
-                        <ExternalLink size={14} />
-                      </StyledRoundButton>
-                    </ExternalLinkNewTab>
-                  )}
-                  {canEditCollective && (
-                    <Link route="editCollective" params={{ slug }} title={formatMessage(Hero.Translations.settings)}>
-                      <StyledRoundButton size={40} mx={2}>
-                        <Settings size={14} />
-                      </StyledRoundButton>
-                    </Link>
+              <Flex
+                flex="1 1"
+                flexWrap="wrap"
+                justifyContent={isFixed ? 'left' : ['center', null, null, 'left', 'center']}
+                flexDirection={isFixed ? 'row' : ['column', null, null, 'row', 'column']}
+              >
+                <Box mb={isFixed ? 0 : 2} mr={isFixed ? 3 : [0, 4]}>
+                  <AvatarWithHost
+                    collective={collective}
+                    host={host}
+                    radius={isFixed ? 40 : 128}
+                    animationDuration={AnimationsDurations.HERO_COLLAPSE}
+                    onCollectiveClick={onCollectiveClick}
+                  />
+                </Box>
+                <Flex flexDirection="column" flex="1 1">
+                  <LinkCollective collective={collective} onClick={onCollectiveClick} isNewVersion>
+                    <H1
+                      mt={-2}
+                      color="black.800"
+                      fontSize={isFixed ? 'H5' : 'H3'}
+                      textAlign={isFixed ? 'left' : ['center', 'left']}
+                    >
+                      {collective.name || collective.slug}
+                    </H1>
+                  </LinkCollective>
+                  {!isFixed && (
+                    <React.Fragment>
+                      <Flex mb={[1, 2, 3]} alignItems="center" justifyContent={['center', 'flex-start']}>
+                        <StyledTag mr={2}>
+                          <I18nCollectiveTags
+                            tags={getCollectiveMainTag(get(collective, 'host.id'), collective.tags)}
+                          />
+                        </StyledTag>
+                        {host && (
+                          <Container ml={3} color="black.600">
+                            <FormattedMessage
+                              id="Collective.Hero.Host"
+                              defaultMessage="{FiscalHost}: {hostName}"
+                              values={{
+                                hostName: host.name,
+                                FiscalHost: <DefinedTerm term={Terms.FISCAL_HOST} />,
+                              }}
+                            />
+                          </Container>
+                        )}
+                      </Flex>
+                      <H2 mt={2} fontSize="LeadParagraph" lineHeight="24px" textAlign={['center', 'left']}>
+                        {collective.description}
+                      </H2>
+                    </React.Fragment>
                   )}
                 </Flex>
               </Flex>
+              {/* Contact buttons */}
+              {!isFixed && (
+                <Flex flexWrap="wrap" justifyContent="center" mt={48}>
+                  <StyledButton disabled width={120} height={40} mb={3} mr={2} title="Coming soon">
+                    <Span mr={2}>
+                      <CheckCircle size="1em" />
+                    </Span>
+                    <FormattedMessage id="CollectivePage.Hero.Follow" defaultMessage="Follow" />
+                  </StyledButton>
+                  <Flex css={{ height: 40 }}>
+                    <a href={`mailto:hello@${slug}.opencollective.com`} title="Email">
+                      <StyledRoundButton size={40} mx={2}>
+                        <Mail size={14} />
+                      </StyledRoundButton>
+                    </a>
+                    {twitterHandle && (
+                      <ExternalLinkNewTab href={twitterProfileUrl(twitterHandle)} title="Twitter">
+                        <StyledRoundButton size={40} mx={2}>
+                          <Twitter size={14} />
+                        </StyledRoundButton>
+                      </ExternalLinkNewTab>
+                    )}
+                    {githubHandle && (
+                      <ExternalLinkNewTab href={githubProfileUrl(githubHandle)} title="Github">
+                        <StyledRoundButton size={40} mx={2}>
+                          <Github size={14} />
+                        </StyledRoundButton>
+                      </ExternalLinkNewTab>
+                    )}
+                    {website && (
+                      <ExternalLinkNewTab href={website} title={formatMessage(Hero.Translations.website)}>
+                        <StyledRoundButton size={40} mx={2}>
+                          <ExternalLink size={14} />
+                        </StyledRoundButton>
+                      </ExternalLinkNewTab>
+                    )}
+                    {canEditCollective && (
+                      <Link route="editCollective" params={{ slug }} title={formatMessage(Hero.Translations.settings)}>
+                        <StyledRoundButton size={40} mx={2}>
+                          <Settings size={14} />
+                        </StyledRoundButton>
+                      </Link>
+                    )}
+                  </Flex>
+                </Flex>
+              )}
             </Flex>
           </Container>
         </Container>
@@ -179,21 +237,27 @@ class Hero extends Component {
           justifyContent="space-between"
           alignItems="center"
           maxWidth={Dimensions.MAX_SECTION_WIDTH}
-          px={Dimensions.PADDING_X}
+          px={[0, 15, null, null, 120]}
           margin="0 auto"
-          height={[56, null, null, 84]}
+          height={isFixed ? 56 : [56, null, null, 84]}
+          flexWrap="wrap"
+          width={1}
         >
-          <NavBar sections={this.props.sections} selected="join-us" onSectionClick={console.log} />
-          <Box py={2} ml={3}>
+          <NavBar
+            sections={this.props.sections}
+            selected={this.props.selectedSection}
+            onSectionClick={this.props.onSectionClick}
+          />
+          <Container py={2} ml={3} display={['none', null, null, 'block']}>
             <StyledButton mx={2}>
               <FormattedMessage id="Collective.Hero.SubmitExpenses" defaultMessage="Submit expenses" />
             </StyledButton>
             <StyledButton mx={2} buttonStyle="dark">
               <FormattedMessage id="Collective.Hero.Donate" defaultMessage="Donate" />
             </StyledButton>
-          </Box>
+          </Container>
         </Container>
-      </div>
+      </MainContainer>
     );
   }
 }

--- a/src/components/collective-page/HeroBackground.js
+++ b/src/components/collective-page/HeroBackground.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { PropTypes } from 'prop-types';
 import styled from 'styled-components';
 import { backgroundImage } from 'styled-system';
+import { fadeIn } from '../../constants/animations.js';
 
 import HeroBackgroundMask from './HeroBackgroundMask.svg';
 
@@ -13,6 +14,9 @@ const BackgroundContainer = styled.div`
   height: 100%;
   background: #145ecc;
   z-index: -1;
+  animation: ${fadeIn};
+  animation-duration: 0.3s;
+  animation-fill-mode: both;
 
   @supports (mask-size: contain) {
     ${backgroundImage}

--- a/src/components/collective-page/NavBar.js
+++ b/src/components/collective-page/NavBar.js
@@ -19,9 +19,11 @@ const MenuLink = styled(props => <a {...omit(props, ['isSelected'])} />)`
   line-height: 24px;
   letter-spacing: -0.2px;
   text-decoration: none;
+  white-space: nowrap;
 
   &:focus {
     color: #090a0a;
+    text-decoration: none;
   }
 
   &:hover {
@@ -69,13 +71,16 @@ const translations = defineMessages({
  */
 const NavBar = ({ sections, selected, onSectionClick, linkBuilder, intl }) => {
   return (
-    <Flex css={{ height: '100%' }}>
+    <Flex data-cy="CollectivePage.NavBar" css={{ height: '100%', overflowX: 'auto' }}>
       {sections.map(section => (
         <MenuLink
           key={section}
           href={linkBuilder(section)}
           isSelected={section === selected}
-          onClick={() => onSectionClick(section)}
+          onClick={e => {
+            onSectionClick(section);
+            e.preventDefault();
+          }}
         >
           {translations[section] ? intl.formatMessage(translations[section]) : section}
         </MenuLink>

--- a/src/components/collective-page/_constants.js
+++ b/src/components/collective-page/_constants.js
@@ -4,6 +4,14 @@
 export const Dimensions = {
   PADDING_X: [15, 30, null, null, 120],
   MAX_SECTION_WIDTH: 1700,
+  HERO_FIXED_HEIGHT: 120,
+};
+
+/**
+ * Durations for page animations
+ */
+export const AnimationsDurations = {
+  HERO_COLLAPSE: 250,
 };
 
 /**

--- a/src/components/collective-page/index.js
+++ b/src/components/collective-page/index.js
@@ -1,10 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Flex } from '@rebass/grid';
 
-import { AllSectionsNames } from './_constants';
-import Hero from './Hero';
+import theme from '../../constants/theme';
+import { debounceScroll } from '../../lib/ui-utils';
 import Container from '../Container';
+
+import { AllSectionsNames, Dimensions } from './_constants';
+import Hero from './Hero';
 
 /**
  * This is the collective page main layout, holding different blocks together
@@ -40,24 +42,101 @@ export default class CollectivePage extends Component {
     LoggedInUser: PropTypes.object,
   };
 
+  constructor(props) {
+    super(props);
+    this.sectionsRefs = {}; // This will store a map of sectionName => sectionRef
+    this.heroRef = React.createRef();
+    this.state = {
+      isFixed: false,
+      selectedSection: AllSectionsNames[0],
+    };
+  }
+
+  componentDidMount() {
+    window.addEventListener('scroll', this.onScroll);
+    this.onScroll(); // First tick in case scroll is restored when page loads
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('scroll', this.onScroll);
+  }
+
+  onScroll = debounceScroll(() => {
+    // Fixes the Hero when a certain scroll threshold is reached
+    if (window.scrollY >= theme.sizes.navbarHeight) {
+      if (!this.state.isFixed) {
+        this.setState({ isFixed: true });
+      }
+    } else if (this.state.isFixed) {
+      this.setState({ isFixed: false });
+    }
+
+    // Update selected section
+    const distanceThreshold = 200;
+    for (let i = AllSectionsNames.length - 1; i >= 0; i--) {
+      const sectionName = AllSectionsNames[i];
+      const sectionRef = this.sectionsRefs[sectionName];
+      const currentViewBottom = window.scrollY + window.innerHeight;
+      if (currentViewBottom - distanceThreshold > sectionRef.offsetTop) {
+        if (this.state.selectedSection !== sectionName) {
+          this.setState({ selectedSection: sectionName });
+        }
+        break;
+      }
+    }
+  });
+
+  onSectionClick = sectionName => {
+    window.location.hash = `section-${sectionName}`;
+    const sectionTop = this.sectionsRefs[sectionName].offsetTop;
+    if (this.state.isFixed) {
+      window.scrollTo(0, sectionTop);
+    } else {
+      // If not fixed, we have to acknowledge the fact that Hero is going to shrink, thus
+      // reducting the size of the navbar
+      const heroRect = this.heroRef.current.getBoundingClientRect();
+      window.scrollTo(0, sectionTop - heroRect.height + Dimensions.HERO_FIXED_HEIGHT);
+    }
+  };
+
+  onCollectiveClick = () => {
+    window.scrollTo(0, 0);
+  };
+
   render() {
     const { collective, host, LoggedInUser } = this.props;
+    const { isFixed, selectedSection } = this.state;
     const canEditCollective = LoggedInUser && LoggedInUser.canEditCollective(collective);
 
     return (
-      <Container borderTop="1px solid #E6E8EB">
-        <Container borderBottom="1px solid #E6E8EB">
-          <Hero collective={collective} host={host} sections={AllSectionsNames} canEditCollective={canEditCollective} />
+      <Container position="relative" borderTop="1px solid #E6E8EB">
+        <Container ref={this.heroRef} height={isFixed ? Dimensions.HERO_FIXED_HEIGHT : 'auto'}>
+          <Hero
+            collective={collective}
+            host={host}
+            sections={AllSectionsNames}
+            canEditCollective={canEditCollective}
+            isFixed={isFixed}
+            selectedSection={selectedSection}
+            onSectionClick={this.onSectionClick}
+            onCollectiveClick={this.onCollectiveClick}
+          />
         </Container>
 
         {/* Placeholders for sections not implemented yet */}
         {AllSectionsNames.map(section => (
-          <React.Fragment key={section}>
-            <Flex id={`section-${section}`} py={7} justifyContent="center">
-              [Section] {section}
-            </Flex>
-            <hr />
-          </React.Fragment>
+          <Container
+            ref={sectionRef => (this.sectionsRefs[section] = sectionRef)}
+            key={section}
+            id={`section-${section}`}
+            display="flex"
+            borderBottom="1px solid lightgrey"
+            py={8}
+            justifyContent="center"
+            fontSize={36}
+          >
+            [Section] {section}
+          </Container>
         ))}
       </Container>
     );

--- a/src/constants/animations.js
+++ b/src/constants/animations.js
@@ -5,6 +5,11 @@ export const rotate = keyframes`
   100%  { transform: rotate(360deg); }
 `;
 
+export const fadeIn = keyframes`
+  0%    { opacity: 0; }
+  100%  { opacity: 1; }
+`;
+
 export const rotateMixin = css`
   animation: ${rotate} 0.8s infinite linear;
 `;

--- a/src/constants/theme.js
+++ b/src/constants/theme.js
@@ -234,6 +234,9 @@ const theme = {
       color: colors.red[700],
     },
   },
+  sizes: {
+    navbarHeight: 68,
+  },
 };
 
 export const buttonStyle = variant({

--- a/src/lib/ui-utils.js
+++ b/src/lib/ui-utils.js
@@ -1,0 +1,17 @@
+/**
+ * A set of helpers to use for UI, rendering, or animations.
+ */
+
+import { debounce } from 'lodash';
+
+/**
+ * A debouncer for scroll functions. It is configured to trigger on trailing and
+ * leading calls with a max wait of 100 to ensure everything stays responsive.
+ */
+export const debounceScroll = func => {
+  return debounce(func, 200, {
+    maxWait: 100,
+    leading: true,
+    trailing: true,
+  });
+};

--- a/src/pages/new-collective-page.js
+++ b/src/pages/new-collective-page.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { graphql } from 'react-apollo';
 import gql from 'graphql-tag';
 import { get } from 'lodash';
+import { createGlobalStyle } from 'styled-components';
 
 import withIntl from '../lib/withIntl';
 import { withUser } from '../components/UserProvider';
@@ -10,6 +11,13 @@ import ErrorPage from '../components/ErrorPage';
 import Page from '../components/Page';
 import Loading from '../components/Loading';
 import CollectivePage from '../components/collective-page';
+
+/** Add global style to enable smooth scroll on the page */
+const GlobalStyles = createGlobalStyle`
+  html {
+    scroll-behavior: smooth;
+  }
+`;
 
 /**
  * The main page to display collectives. Wrap route parameters and GraphQL query
@@ -61,7 +69,10 @@ class NewCollectivePage extends React.Component {
         {data.loading || !data.Collective ? (
           <Loading />
         ) : (
-          <CollectivePage collective={data.Collective} host={data.Collective.host} LoggedInUser={LoggedInUser} />
+          <React.Fragment>
+            <GlobalStyles />
+            <CollectivePage collective={data.Collective} host={data.Collective.host} LoggedInUser={LoggedInUser} />
+          </React.Fragment>
         )}
       </Page>
     );

--- a/src/pages/new-collective-page.js
+++ b/src/pages/new-collective-page.js
@@ -65,7 +65,7 @@ class NewCollectivePage extends React.Component {
     return !data || data.error ? (
       <ErrorPage data={data} />
     ) : (
-      <Page {...this.getPageMetaData(data.collective)} withGlobalStyles={false} smoothScroll>
+      <Page {...this.getPageMetaData(data.collective)}>
         {data.loading || !data.Collective ? (
           <Loading />
         ) : (

--- a/src/pages/new-collective-page.js
+++ b/src/pages/new-collective-page.js
@@ -57,7 +57,7 @@ class NewCollectivePage extends React.Component {
     return !data || data.error ? (
       <ErrorPage data={data} />
     ) : (
-      <Page {...this.getPageMetaData(data.collective)}>
+      <Page {...this.getPageMetaData(data.collective)} withGlobalStyles={false} smoothScroll>
         {data.loading || !data.Collective ? (
           <Loading />
         ) : (


### PR DESCRIPTION
:deciduous_tree: See https://github.com/opencollective/opencollective/issues/1954
:art: Design: https://figma.com/file/e71tBo0Sr8J7R5n6iMkqI42d/09.-Collectives?node-id=2338%3A36062

---

There's still room for improvement and optimization for collapse animation but I wanted to propose a first version to start the conversation about it.

---

- [x] Fix Hero on scroll
- [x] Select active section
- [x] Smooth scroll on NavBar click
- [x] Hero responsiveness
- [x] Animate height transition

# Preview

- https://opencollective-frontend-ewfwnhdmun.now.sh/webpack/v2
- https://opencollective-frontend-ewfwnhdmun.now.sh/babel/v2
- https://opencollective-frontend-ewfwnhdmun.now.sh/captainfact_io/v2
- https://opencollective-frontend-ewfwnhdmun.now.sh/material-ui/v2
- https://opencollective-frontend-ewfwnhdmun.now.sh/wwcodeportland/v2

## Expend / Collapse

![Peek 13-05-2019 13-31](https://user-images.githubusercontent.com/1556356/57618366-770cbd80-7583-11e9-9a3f-e3be7e991b98.gif)

## Section watcher

![Peek 13-05-2019 13-38](https://user-images.githubusercontent.com/1556356/57618697-7163a780-7584-11e9-944e-cae4f37e2428.gif)
