### PR TITLE
ContributionFlow: fix previous button functionality in payment step

### DIFF
--- a/src/components/Steps.js
+++ b/src/components/Steps.js
@@ -176,7 +176,7 @@ export default class Steps extends React.Component {
    */
   goToStep = async (step, opts = {}) => {
     const currentStep = this.getStepByName(this.props.currentStepName);
-    if (currentStep.isLastStep && step.index < currentStep.index) {
+    if (step.index < currentStep.index) {
       opts.action = 'prev';
     }
 

--- a/src/components/Steps.js
+++ b/src/components/Steps.js
@@ -125,7 +125,7 @@ export default class Steps extends React.Component {
     return this.getStepByIndex(this.props.steps.findIndex(s => s.name === stepName));
   }
 
-  validateCurrentStep = async () => {
+  validateCurrentStep = async (action = null) => {
     const currentStep = this.getStepByName(this.props.currentStepName);
     if (!currentStep) {
       return false;
@@ -133,7 +133,7 @@ export default class Steps extends React.Component {
       return false;
     } else if (currentStep.validate) {
       this.setState({ isValidating: true });
-      const result = await currentStep.validate();
+      const result = await currentStep.validate(action);
       this.setState({ isValidating: false });
       if (!result) {
         return false;
@@ -175,7 +175,12 @@ export default class Steps extends React.Component {
    * if `opts.ignoreValidation` is true.
    */
   goToStep = async (step, opts = {}) => {
-    if (!opts.ignoreValidation && !(await this.validateCurrentStep())) {
+    const currentStep = this.getStepByName(this.props.currentStepName);
+    if (currentStep.isLastStep && step.index < currentStep.index) {
+      opts.action = 'prev';
+    }
+
+    if (!opts.ignoreValidation && !(await this.validateCurrentStep(opts.action))) {
       return false;
     }
 

--- a/src/pages/createOrder.js
+++ b/src/pages/createOrder.js
@@ -241,7 +241,7 @@ class CreateOrderPage extends React.Component {
   };
 
   /** Validate step payment, loading data from stripe for new credit cards */
-  validateStepPayment = async () => {
+  validateStepPayment = async action => {
     const { stepPayment } = this.state;
     const isFixedPriceTier = this.isFixedPriceTier();
 
@@ -253,6 +253,8 @@ class CreateOrderPage extends React.Component {
       return false;
     } else if (!stepPayment.isNew) {
       // No need to validate existing payment methods
+      return true;
+    } else if (action === 'prev' && stepPayment.isNew && (stepPayment.error || !stepPayment.data)) {
       return true;
     } else if (!stepPayment.data && get(stepPayment, 'paymentMethod.token')) {
       // New credit card - if no data, stripe token has already been exchanged


### PR DESCRIPTION
This PR adds `stepsPayment` state to `Steps` component uses the information to skip validation when the user attempts to goBack or jump to previous step from payment step.

#### Screen record. 

![Peek 2019-05-04 16-51](https://user-images.githubusercontent.com/15707013/57181570-7ee6a680-6e8d-11e9-943c-a5698640ca8d.gif)

Ref([#1970](https://github.com/opencollective/opencollective/issues/1970))