### PR TITLE
Add locale prop to Stripe Element component

### DIFF
--- a/src/components/ContributePayment.js
+++ b/src/components/ContributePayment.js
@@ -227,6 +227,8 @@ class ContributePayment extends React.Component {
 
   render() {
     const { paymentMethodsOptions, errors } = this.state;
+    const { intl } = this.props;
+    const locale = intl.locale;
 
     return (
       <StyledCard width={1} maxWidth={500} mx="auto">
@@ -274,6 +276,7 @@ class ContributePayment extends React.Component {
                     onChange={this.onChange}
                     onReady={this.props.onNewCardFormReady}
                     hidePostalCode={this.props.hideCreditCardPostalCode}
+                    locale={locale}
                   />
                 </Box>
               )}

--- a/src/components/NewCreditCardForm.js
+++ b/src/components/NewCreditCardForm.js
@@ -78,9 +78,13 @@ class NewCreditCardFormWithoutStripe extends React.Component {
 const NewCreditCardFormWithStripe = injectStripe(NewCreditCardFormWithoutStripe);
 
 const NewCreditCardForm = props => (
-  <Elements>
+  <Elements locale={props.locale}>
     <NewCreditCardFormWithStripe {...props} />
   </Elements>
 );
+
+NewCreditCardForm.propTypes = {
+  locale: PropTypes.string,
+};
 
 export default NewCreditCardForm;


### PR DESCRIPTION
This PR adds `locale` to stripe `Element` component prop, enables stripe error messages to be the current `locale`.

Ref([#1971](https://github.com/opencollective/opencollective/issues/1971))