### PR TITLE
Improve responsiveness on redeem(ed) pages

### DIFF
--- a/src/components/GiftCard.js
+++ b/src/components/GiftCard.js
@@ -54,7 +54,9 @@ class GiftCard extends React.Component {
   static propTypes = {
     amount: PropTypes.number.isRequired,
     currency: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired,
+    collective: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+    }),
     emitter: PropTypes.shape({
       slug: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,

--- a/src/components/StyledButton.js
+++ b/src/components/StyledButton.js
@@ -19,6 +19,8 @@ import {
   width,
   themeGet,
 } from 'styled-system';
+
+import { textTransform } from '../lib/styled_system_custom';
 import { buttonSize, buttonStyle } from '../constants/theme';
 import StyledSpinner from './StyledSpinner';
 
@@ -67,6 +69,7 @@ const StyledButtonContent = styled(tag.button)`
   ${textAlign}
   ${width}
   ${height}
+  ${textTransform}
 `;
 
 const StyledButton = ({ loading, ...props }) =>
@@ -127,7 +130,7 @@ StyledButton.propTypes = {
 };
 
 StyledButton.defaultProps = {
-  omitProps: tag.defaultProps.omitProps.concat('buttonStyle', 'buttonSize', 'asLink'),
+  omitProps: tag.defaultProps.omitProps.concat('buttonStyle', 'buttonSize', 'asLink', 'textTransform'),
   buttonSize: 'medium',
   buttonStyle: 'standard',
   loading: false,

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -734,7 +734,7 @@
   "redeem.card.success.instructions": "We’ve sent an email to {email} with instructions to verify your new Open Collective account and credit it with the amount of your gift card.",
   "redeem.card.success.title": "You are one step away from supporting open collectives.",
   "redeem.form.code.label": "Gift card code",
-  "redeem.form.redeem.btn": "reclamar",
+  "redeem.form.redeem.btn": "redeem",
   "redeem.subtitle.line1": "Open Collective helps communities - like open source projects, meetups and social movements - raise funds spend them transparently.",
   "redeemed.backyourstack": "or discover the open source projects that your organization is depending on and that need funding on {link}",
   "redeemed.findCollectives": "Find open collectives to support.",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -734,7 +734,7 @@
   "redeem.card.success.instructions": "Nous avons envoyé un e-mail à {email} avec des instructions pour vérifier votre nouveau compte Open Collective et le créditer avec le montant de votre carte cadeau.",
   "redeem.card.success.title": "Vous n'êtes qu'à un pas de soutenir des initiatives d'Open Collective !",
   "redeem.form.code.label": "Code de carte cadeau",
-  "redeem.form.redeem.btn": "confirmer",
+  "redeem.form.redeem.btn": "redeem",
   "redeem.subtitle.line1": "Open Collective aide des communautés - projets open-source, meetups etc - à collecter de l’argent et à opérer de façon transparente.",
   "redeemed.backyourstack": "ou découvrez les projets open source dont dépend votre entreprise et qui cherchent des dons {link}",
   "redeemed.findCollectives": "Trouver et soutenir de nouveaux collectifs.",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -734,7 +734,7 @@
   "redeem.card.success.instructions": "We’ve sent an email to {email} with instructions to verify your new Open Collective account and credit it with the amount of your gift card.",
   "redeem.card.success.title": "You are one step away from supporting open collectives.",
   "redeem.form.code.label": "ギフトカードコード",
-  "redeem.form.redeem.btn": "引き換え",
+  "redeem.form.redeem.btn": "redeem",
   "redeem.subtitle.line1": "Open Collective helps communities - like open source projects, meetups and social movements - raise funds spend them transparently.",
   "redeemed.backyourstack": "or discover the open source projects that your organization is depending on and that need funding on {link}",
   "redeemed.findCollectives": "サポートするオープンコレクティブを探す",

--- a/src/pages/redeem.js
+++ b/src/pages/redeem.js
@@ -25,32 +25,10 @@ import { isValidEmail } from '../lib/utils';
 
 import withData from '../lib/withData';
 import withIntl from '../lib/withIntl';
+import StyledButton from '../components/StyledButton';
 
 const Error = styled(P)`
   color: red;
-`;
-
-const BlueButton = styled.button`
-  --webkit-appearance: none;
-  width: 336px;
-  height: 56px;
-  border: none;
-  background: #3385ff;
-  border-radius: 100px;
-  color: white;
-  font-size: 1.6rem;
-  line-height: 5.2rem;
-  text-align: center;
-  margin: 16px;
-  &&:hover {
-    background: #66a3ff;
-  }
-  &&:active {
-    background: #145ecc;
-  }
-  &&:disabled {
-    background: #e0edff;
-  }
 `;
 
 const ShadowBox = styled(Box)`
@@ -64,6 +42,8 @@ const Title = styled(H1)`
 
 const Subtitle = styled(H5)`
   color: white;
+  text-align: center;
+  margin: 0 auto;
   ${fontSize};
   ${maxWidth};
 `;
@@ -206,7 +186,7 @@ class RedeemPage extends React.Component {
 
                 <Box mt={[4, 5]}>
                   <Flex justifyContent="center" flexDirection="column">
-                    <Container background="white" borderRadius="16px" width="400px">
+                    <Container background="white" borderRadius="16px" maxWidth="400px">
                       <ShadowBox py="24px" px="32px">
                         {this.state.view === 'form' && (
                           <RedeemForm
@@ -221,16 +201,25 @@ class RedeemPage extends React.Component {
                       </ShadowBox>
                     </Container>
                     {this.state.view === 'form' && (
-                      <Box my={3} align="center">
-                        <BlueButton onClick={this.handleSubmit} disabled={this.state.loading}>
+                      <Flex my={4} px={2} flexDirection="column" alignItems="center">
+                        <StyledButton
+                          buttonStyle="primary"
+                          buttonSize="large"
+                          onClick={this.handleSubmit}
+                          loading={this.state.loading}
+                          mb={2}
+                          maxWidth={335}
+                          width={1}
+                          textTransform="capitalize"
+                        >
                           {this.state.loading ? (
                             <FormattedMessage id="form.processing" defaultMessage="processing" />
                           ) : (
                             <FormattedMessage id="redeem.form.redeem.btn" defaultMessage="redeem" />
                           )}
-                        </BlueButton>
+                        </StyledButton>
                         {this.state.error && <Error>{this.state.error}</Error>}
-                      </Box>
+                      </Flex>
                     )}
                   </Flex>
                 </Box>

--- a/src/pages/redeemed.js
+++ b/src/pages/redeemed.js
@@ -50,6 +50,7 @@ const Title = styled(H1)`
 
 const Subtitle = styled(H5)`
   color: white;
+  margin: 0 auto;
   ${fontSize};
   ${maxWidth};
 `;


### PR DESCRIPTION
With the upcoming Maintainerati event there's good changes that some people are going to validate their gift cards on mobile. This improves responsiveness to make their experience smoother.

## Redeem page

### Before

![localhost_3000_redeem_5e54d194(iPhone 5_SE)](https://user-images.githubusercontent.com/1556356/57680143-408b7d00-762d-11e9-8370-b2d6e260beaa.png)

### After

![localhost_3000_redeem_42(iPhone 5_SE)](https://user-images.githubusercontent.com/1556356/57680638-5baabc80-762e-11e9-8ecc-a189dd638cd5.png)

## Redeemed page

Just center align the subtitle.

### Before

![localhost_3000_brusselstogetherasbl_edit_gift-cards(iPhone 5_SE)](https://user-images.githubusercontent.com/1556356/57680318-a1b35080-762d-11e9-9614-410b43a39e3c.png)

### After

![localhost_3000_redeemed_39a1a2ab(iPhone 5_SE)](https://user-images.githubusercontent.com/1556356/57680460-f6ef6200-762d-11e9-9084-355fa65a4203.png)
