### PR TITLE
deps(rebass/grid): Fix regression from 6.0.0-7 migration

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -20,7 +20,7 @@
         "messagesDir": "./dist/messages/"
       }
     ],
-    "styled-components"
+    "babel-plugin-styled-components"
   ],
   "env": {
     "development": {


### PR DESCRIPTION
https://github.com/opencollective/opencollective-frontend/pull/1778 introduced a regression. It seems that `6.0.0` didn't support `css` prop.

This made the `flexGrow` innefective on Edit Collective (see screenshots below).

Anyway dependabot shouldn't have triggered the update, last version is `6.0.0-7` - not `6.0.0`. @znarf is that correct?

---

### With 6.0.0

![With_6 0 0](https://user-images.githubusercontent.com/1556356/57695811-8c4f1e00-764f-11e9-991c-bdfe2588b751.png)

### With 6.0.0-7

![With_6 0 0-7](https://user-images.githubusercontent.com/1556356/57695897-c02a4380-764f-11e9-843d-73a5c8a3064a.png)

