### PR TITLE
Remove unnecessary parameter from applications link

### DIFF
--- a/src/components/TopBarProfileMenu.js
+++ b/src/components/TopBarProfileMenu.js
@@ -275,7 +275,7 @@ class TopBarProfileMenu extends React.Component {
               </Link>
             </ListItem>
             <ListItem py={1}>
-              <Link route="applications" params={{ collectiveSlug: LoggedInUser.username }} passHref>
+              <Link route="applications" passHref>
                 <StyledLink color="#494D52" fontSize="1.2rem" fontFamily="montserratlight, arial">
                   {capitalize(intl.formatMessage(this.messages['menu.applications']))}
                 </StyledLink>


### PR DESCRIPTION
See https://github.com/opencollective/opencollective/issues/2013
Following https://github.com/opencollective/opencollective-frontend/pull/1749

Link was working but added an unnecessary `collectiveSlug` parameter