### PR TITLE
fix(deps): babel-plugin-styled-components in dev env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,14 +13,14 @@
     ]
   ],
   "plugins": [
+    "babel-plugin-styled-components",
     "lodash",
     [
       "react-intl",
       {
         "messagesDir": "./dist/messages/"
       }
-    ],
-    "babel-plugin-styled-components"
+    ]
   ],
   "env": {
     "development": {


### PR DESCRIPTION
Somehow the fact that `babel-plugin-styled-components` was not in first position for the plugins list broke some of the `css` props that we use around the site, for example on the Contribution flow (see below). This bug only affected local env.

### Before

![2019-05-17_00:57:30](https://user-images.githubusercontent.com/1556356/57892461-3c36ae00-783f-11e9-93e7-462e2ff92015.png)

### After

![2019-05-17_01:00:32](https://user-images.githubusercontent.com/1556356/57892460-3b9e1780-783f-11e9-8b85-3c5dd4e302c4.png)
