### PR TITLE
fix(StyledModal): Example in styleguidist

### DIFF
--- a/src/components/StyledModal.js
+++ b/src/components/StyledModal.js
@@ -124,4 +124,5 @@ Modal.propTypes = {
   onClose: PropTypes.func.isRequired,
 };
 
+/** @component */
 export default Modal;

--- a/styleguide/examples/StyledModal.md
+++ b/styleguide/examples/StyledModal.md
@@ -1,19 +1,32 @@
+```jsx noeditor
+// See https://github.com/styleguidist/react-styleguidist/issues/1278
+import Modal, { ModalBody, ModalHeader, ModalFooter } from 'components/StyledModal';
+import StyledButton from 'components/StyledButton';
+```
+
 ```js
-import Modal, { ModalBody, ModalHeader, ModalFooter } from '../../../src/components/StyledModal';
-import StyledButton from '../../../src/components/StyledButton';
+import Modal, { ModalBody, ModalHeader, ModalFooter } from 'components/StyledModal';
+import StyledButton from 'components/StyledButton';
 
-const initalState = { show: true }
+initialState = { show: false };
 
-<Modal show={state.show} onClose={() => setState({ show: false }) } height="300px">
-  <ModalHeader>
-    Modal title goes here
-  </ModalHeader>
-  <ModalBody>
-    Contents of the modal goes here. There will be different content types but for noew lerts use this simple version. Are you ok to use this version for now?
-  </ModalBody>
-  <ModalFooter>
-    <StyledButton mx={20}>Cancel</StyledButton>
-    <StyledButton buttonStyle="primary">Go with this version</StyledButton>
-  </ModalFooter>
-</Modal>
+<React.Fragment>
+  {state.show ? (
+    <Modal show onClose={() => setState({ show: false })} height="300px">
+      <ModalHeader>Modal title goes here</ModalHeader>
+      <ModalBody>
+        Contents of the modal goes here. There will be different content types but for noew lerts use this simple
+        version. Are you ok to use this version for now?
+      </ModalBody>
+      <ModalFooter>
+        <StyledButton mx={20}>Cancel</StyledButton>
+        <StyledButton buttonStyle="primary">Go with this version</StyledButton>
+      </ModalFooter>
+    </Modal>
+  ) : (
+    <StyledButton buttonSize="large" buttonStyle="primary" onClick={() => setState({ show: true })}>
+      Show modal
+    </StyledButton>
+  )}
+</React.Fragment>;
 ```


### PR DESCRIPTION
The example was not implemented correctly and was showing an error:

![2019-05-17_01:03:03](https://user-images.githubusercontent.com/1556356/57893098-ee6f7500-7841-11e9-86e1-c17707a54781.png)

@flickz to try the examples in styleguide the easiest is to `npm run styleguide:dev`. It's also useful when developing to click on `Open isolated` to have a fast page reloading:

![image](https://user-images.githubusercontent.com/1556356/57910282-32379e00-7885-11e9-8b86-85c143170ead.png)
