### PR TITLE
WIP: fix(src/graphql/mutations.js): make pledge appear after submitting #1962

### DIFF
--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -2,7 +2,7 @@ import { graphql, compose } from 'react-apollo';
 import gql from 'graphql-tag';
 import { pick, isArray } from 'lodash';
 
-import { getLoggedInUserQuery, getCollectiveToEditQueryFields, getMutatedCollective } from './queries';
+import { getLoggedInUserQuery, getCollectiveToEditQueryFields, getCollectiveQuery } from './queries';
 
 const createOrderQuery = gql`
   mutation createOrder($order: OrderInputType!) {
@@ -226,16 +226,11 @@ export const addCreateOrderMutation = graphql(createOrderQuery, {
         variables: { order },
         update: (cache, { data: { createOrder } }) => {
           const data = cache.readQuery({
-            query: getMutatedCollective,
+            query: getCollectiveQuery,
             variables: { slug: createOrder.collective.slug },
           });
-          data.Collective.orders.push({
-            fromCollective: createOrder.fromCollective,
-            id: createOrder.id,
-            status: createOrder.status,
-            __typename: createOrder.__typename,
-          });
-          cache.writeQuery({ query: getMutatedCollective, data });
+          data.Collective.pledges.push({ createOrder });
+          cache.writeQuery({ query: getCollectiveQuery, data });
         },
       });
     },

--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -2,32 +2,7 @@ import { graphql, compose } from 'react-apollo';
 import gql from 'graphql-tag';
 import { pick, isArray } from 'lodash';
 
-import { getLoggedInUserQuery, getCollectiveToEditQueryFields, getCollectiveQuery } from './queries';
-
-const createOrderQuery = gql`
-  mutation createOrder($order: OrderInputType!) {
-    createOrder(order: $order) {
-      id
-      createdAt
-      status
-      createdByUser {
-        id
-      }
-      fromCollective {
-        id
-        slug
-      }
-      collective {
-        id
-        slug
-      }
-      transactions(type: "CREDIT") {
-        id
-        uuid
-      }
-    }
-  }
-`;
+import { getLoggedInUserQuery, getCollectiveToEditQueryFields } from './queries';
 
 export const createUserQuery = gql`
   mutation createUser($user: UserInputType!, $organization: CollectiveInputType, $redirect: String) {
@@ -219,24 +194,6 @@ export const createVirtualCardsMutationQuery = gql`
   }
 `;
 
-export const addCreateOrderMutation = graphql(createOrderQuery, {
-  props: ({ mutate }) => ({
-    createOrder: async order => {
-      return await mutate({
-        variables: { order },
-        update: (cache, { data: { createOrder } }) => {
-          const data = cache.readQuery({
-            query: getCollectiveQuery,
-            variables: { slug: createOrder.collective.slug },
-          });
-          data.Collective.pledges.push({ createOrder });
-          cache.writeQuery({ query: getCollectiveQuery, data });
-        },
-      });
-    },
-  }),
-});
-
 export const addCreateMemberMutation = graphql(createMemberQuery, {
   props: ({ mutate }) => ({
     createMember: (member, collective, role) => mutate({ variables: { member, collective, role } }),
@@ -250,7 +207,6 @@ export const addRemoveMemberMutation = graphql(removeMemberQuery, {
 });
 
 export const addEventMutations = compose(
-  addCreateOrderMutation,
   addCreateMemberMutation,
   addRemoveMemberMutation,
 );

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -341,7 +341,7 @@ const getCollectiveToEditQuery = gql`
 `;
 /* eslint-enable graphql/template-strings, graphql/no-deprecated-fields, graphql/capitalized-type-name, graphql/named-operations */
 
-const getCollectiveQuery = gql`
+export const getCollectiveQuery = gql`
   query Collective($slug: String) {
     Collective(slug: $slug) {
       id
@@ -912,29 +912,6 @@ export const getCollectiveSourcePaymentMethodsQuery = gql`
         balance
         currency
         expiryDate
-      }
-    }
-  }
-`;
-
-export const getMutatedCollective = gql`
-  query getMutatedCollective($slug: String) {
-    Collective(slug: $slug) {
-      id
-      slug
-      name
-      orders(status: PENDING) {
-        id
-        interval
-        publicMessage
-        status
-        totalAmount
-        fromCollective {
-          name
-          image
-          slug
-          type
-        }
       }
     }
   }

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -917,6 +917,29 @@ export const getCollectiveSourcePaymentMethodsQuery = gql`
   }
 `;
 
+export const getMutatedCollective = gql`
+  query getMutatedCollective($slug: String) {
+    Collective(slug: $slug) {
+      id
+      slug
+      name
+      orders(status: PENDING) {
+        id
+        interval
+        publicMessage
+        status
+        totalAmount
+        fromCollective {
+          name
+          image
+          slug
+          type
+        }
+      }
+    }
+  }
+`;
+
 export const addCollectiveData = graphql(getCollectiveQuery);
 export const addCollectiveCoverData = (component, options) => {
   return graphql(getCollectiveCoverQuery, options)(component);


### PR DESCRIPTION
This change makes new pledges made to a collective with existing pledges. 

Update mutation for creation of order (pledge) to include changes to the collective information in
Apollo cache that is newly out of sync with GraphQL server, to include new pledge to show in the UI.
This is done via the update function provided by the Mutation API
https://www.apollographql.com/docs/react/essentials/mutations#update. Also, added a new query to
retrieve the collective currently in cache.

BREAKING CHANGE: For an unknown reason, the Collective data seems to be stripped away during
re-hydration. Similar to https://github.com/opencollective/opencollective/issues/1872

---

*Edit: Fix https://github.com/opencollective/opencollective/issues/1962*