### PR TITLE
WIP: Tier forms validation.

### DIFF
--- a/src/components/EditCollectiveForm.js
+++ b/src/components/EditCollectiveForm.js
@@ -285,6 +285,13 @@ class EditCollectiveForm extends React.Component {
     window.state = this.state;
   }
 
+  handleTierChange = tierObj => {
+    this.setState({
+      ...tierObj,
+      modified: tierObj.tierHasError ? false : true,
+    });
+  };
+
   async handleSubmit() {
     const collective = {
       ...this.state.collective,
@@ -712,7 +719,7 @@ class EditCollectiveForm extends React.Component {
                   tiers={this.state.tiers}
                   collective={collective}
                   currency={collective.currency}
-                  onChange={this.handleObjectChange}
+                  onChange={this.handleTierChange}
                   defaultType={this.defaultTierType}
                 />
               )}

--- a/src/components/InputField.js
+++ b/src/components/InputField.js
@@ -98,6 +98,7 @@ class InputField extends React.Component {
     className: PropTypes.string,
     type: PropTypes.string,
     onChange: PropTypes.func.isRequired,
+    onBlur: PropTypes.func,
     required: PropTypes.bool,
     style: PropTypes.object,
   };
@@ -155,6 +156,19 @@ class InputField extends React.Component {
 
     this.setState({ value });
     this.props.onChange(value);
+  }
+
+  handleOnBlur(value) {
+    const { type } = this.props;
+    if (type === 'number') {
+      value = parseInt(value) || null;
+    } else if (type === 'currency') {
+      value = this.roundCurrencyValue(value);
+    }
+
+    if (this.props.onBlur) {
+      this.props.onBlur(value);
+    }
   }
 
   render() {
@@ -403,6 +417,9 @@ class InputField extends React.Component {
             className={`currency ${field.className}`}
             onFocus={event => event.target.select()}
             value={value}
+            onBlur={event => {
+              return this.handleOnBlur(event.target.value.length === 0 ? null : Math.round(event.target.value * 100));
+            }}
           />
         );
         break;
@@ -545,6 +562,7 @@ class InputField extends React.Component {
         this.input = (
           <FieldGroup
             onChange={event => this.handleChange(event.target.value)}
+            onBlur={event => this.handleOnBlur(event.target.value)}
             type={field.type}
             pre={field.pre}
             post={field.post}


### PR DESCRIPTION
Currently, we have no validation for tier forms, this PR adds validation ensuring:

- Tier name is required
- Tier amount is required when `amountType` is `fixed`
- The "default amount" (amount) is one of the presets when the amount type is "flexible amount"
- There is no presets smaller than the "minimum amount" (minimum_amount)
- Proper validation messages are shown on each respective input fields.

As shown in the screen record  below:
![Tier validation](https://user-images.githubusercontent.com/15707013/58000886-078e5500-7ad2-11e9-8256-0d52d5320e3c.gif)

### Few To-dos:

- [x] Re-validate from `API` & display validation message from the `API`  around affected tiers

- [ ] Add error messages to localization files.

Ref ([#1905](https://github.com/opencollective/opencollective/issues/1905))

NB: The error messages and styling can be better, I'd appreciate suggestions.
