### PR TITLE
Move discover page to graphql

### DIFF
--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -46,7 +46,7 @@ Page.propTypes = {
   data: PropTypes.shape({
     error: PropTypes.shape({}),
   }),
-  children: PropTypes.node,
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   description: PropTypes.string,
   image: PropTypes.string,
   loadingLoggedInUser: PropTypes.bool,

--- a/src/pages/discover.js
+++ b/src/pages/discover.js
@@ -1,13 +1,11 @@
-import React, { Fragment, useState, useEffect } from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import fetch from 'node-fetch';
-import { pick } from 'lodash';
+import { get } from 'lodash';
+import { Query } from 'react-apollo';
+import gql from 'graphql-tag';
 
 import { withRouter } from 'next/router';
 import withIntl from '../lib/withIntl';
-
-import { getBaseApiUrl } from '../lib/utils';
-import { queryString } from '../lib/api';
 
 import { Box, Flex } from '@rebass/grid';
 import CollectiveCard from '../components/CollectiveCard';
@@ -16,53 +14,72 @@ import Page from '../components/Page';
 import { H1, P } from '../components/Text';
 import LoadingGrid from '../components/LoadingGrid';
 import Pagination from '../components/Pagination';
+import MessageBox from '../components/MessageBox';
 
-const _transformData = collective => ({
-  ...collective,
-  stats: {
-    backers: {
-      all: collective.backersCount,
-    },
-    yearlyBudget: collective.yearlyIncome,
-  },
-  type: 'COLLECTIVE',
-});
-
-function useCollectives(query) {
-  const [state, setState] = useState({ error: null });
-  const params = {
-    offset: query.offset || 0,
-    show: query.show || 'all',
-    sort: query.sort || 'most popular',
-  };
-
-  const fetchDiscoverData = async () => {
-    try {
-      const endpoints = [`/discover?${queryString(params)}`, '/groups/tags'];
-      const [data, tags] = await Promise.all(endpoints.map(e => fetch(`${getBaseApiUrl()}${e}`).then(r => r.json())));
-      setState({
-        ...pick(data, ['offset', 'total']),
-        ...params,
-        tags,
-        collectives: data.collectives.map(_transformData),
-      });
-    } catch (error) {
-      setState({ error });
+const DiscoverPageDataQuery = gql`
+  query DiscoverPageDataQuery($offset: Int, $tags: [String], $orderBy: CollectiveOrderField, $limit: Int) {
+    allCollectiveTags
+    allCollectives(
+      type: COLLECTIVE
+      orderBy: $orderBy
+      orderDirection: DESC
+      offset: $offset
+      tags: $tags
+      limit: $limit
+    ) {
+      limit
+      offset
+      total
+      collectives {
+        id
+        backgroundImage
+        currency
+        description
+        longDescription
+        image
+        name
+        settings
+        slug
+        type
+        website
+        stats {
+          yearlyBudget
+          backers {
+            all
+          }
+        }
+        memberOf {
+          id
+        }
+        parentCollective {
+          id
+          slug
+          settings
+          backgroundImage
+        }
+        pledges: orders(status: PENDING) {
+          id
+          totalAmount
+          currency
+        }
+      }
     }
-  };
+  }
+`;
 
-  useEffect(() => {
-    fetchDiscoverData();
-  }, [query]);
-
-  return state;
-}
+const prepareTags = tags => {
+  return ['all'].concat(tags.map(tag => tag.toLowerCase()).sort());
+};
 
 const DiscoverPage = ({ router }) => {
   const { query } = router;
-  const { collectives, offset, total, show, sort, tags = [] } = useCollectives(query);
-  const tagOptions = ['all'].concat(tags.map(tag => tag.toLowerCase()).sort());
-  const limit = 12;
+
+  const params = {
+    offset: Number(query.offset) || 0,
+    tags: !query.show || query.show === 'all' ? undefined : [query.show],
+    orderBy: query.sort === 'newest' ? 'createdAt' : 'totalDonations',
+    limit: 12,
+  };
 
   const onChange = event => {
     const { name, value } = event.target;
@@ -75,86 +92,101 @@ const DiscoverPage = ({ router }) => {
   return (
     <Page title="Discover">
       {({ LoggedInUser }) => (
-        <Fragment>
-          <Container
-            alignItems="center"
-            backgroundImage="url(/static/images/discover-bg.svg)"
-            backgroundPosition="center top"
-            backgroundSize="cover"
-            backgroundRepeat="no-repeat"
-            display="flex"
-            flexDirection="column"
-            height={560}
-            justifyContent="center"
-            textAlign="center"
-          >
-            <H1 color="white.full" fontSize={['H3', null, 'H2']} lineHeight={['H3', null, 'H2']}>
-              Discover awesome collectives to support
-            </H1>
-            <P color="white.full" fontSize="H4" lineHeight="H4" mt={4}>
-              Let&apos;s make great things together.
-            </P>
-          </Container>
-          <Container
-            alignItems="center"
-            display="flex"
-            flexDirection="column"
-            justifyContent="center"
-            maxWidth={1200}
-            mx="auto"
-            position="relative"
-            px={2}
-            top={-120}
-            width={1}
-          >
-            <Flex width={[1, 0.8, 0.6]} justifyContent="space-evenly" flexWrap="wrap" mb={4}>
-              <Flex width={[1, null, 0.5]} justifyContent="center" alignItems="center" mb={[3, null, 0]}>
-                <P as="label" htmlFor="sort" color="white.full" fontSize="LeadParagraph" pr={2}>
-                  Sort By
+        <Query query={DiscoverPageDataQuery} variables={params}>
+          {({ data, error, loading }) => (
+            <Fragment>
+              <Container
+                alignItems="center"
+                backgroundImage="url(/static/images/discover-bg.svg)"
+                backgroundPosition="center top"
+                backgroundSize="cover"
+                backgroundRepeat="no-repeat"
+                display="flex"
+                flexDirection="column"
+                height={560}
+                justifyContent="center"
+                textAlign="center"
+              >
+                <H1 color="white.full" fontSize={['H3', null, 'H2']} lineHeight={['H3', null, 'H2']}>
+                  Discover awesome collectives to support
+                </H1>
+                <P color="white.full" fontSize="H4" lineHeight="H4" mt={4}>
+                  Let&apos;s make great things together.
                 </P>
-                <select name="sort" id="sort" value={sort} onChange={onChange}>
-                  <option value="most popular">Most Popular</option>
-                  <option value="newest">Newest</option>
-                </select>
-              </Flex>
-
-              <Flex width={[1, null, 0.5]} justifyContent="center" alignItems="center">
-                <P as="label" htmlFor="show" color="white.full" fontSize="LeadParagraph" pr={2}>
-                  Show
-                </P>
-                <select name="show" id="show" value={show} onChange={onChange}>
-                  {tagOptions.map(tag => (
-                    <option key={tag} value={tag}>
-                      {tag}
-                    </option>
-                  ))}
-                </select>
-              </Flex>
-            </Flex>
-
-            {collectives && (
-              <Fragment>
-                <Flex flexWrap="wrap" width={1} justifyContent="center">
-                  {collectives.map(c => (
-                    <Flex key={c.id} width={[1, 1 / 2, 1 / 4]} mb={3} justifyContent="center">
-                      <CollectiveCard collective={c} LoggedInUser={LoggedInUser} />
-                    </Flex>
-                  ))}
-                </Flex>
-                {total > limit && (
-                  <Flex justifyContent="center" mt={3}>
-                    <Pagination offset={Number(offset)} total={total} limit={limit} />
+              </Container>
+              <Container
+                alignItems="center"
+                display="flex"
+                flexDirection="column"
+                justifyContent="center"
+                maxWidth={1200}
+                mx="auto"
+                position="relative"
+                px={2}
+                top={-120}
+                width={1}
+              >
+                <Flex width={[1, 0.8, 0.6]} justifyContent="space-evenly" flexWrap="wrap" mb={4}>
+                  <Flex width={[1, null, 0.5]} justifyContent="center" alignItems="center" mb={[3, null, 0]}>
+                    <P as="label" htmlFor="sort" color="white.full" fontSize="LeadParagraph" pr={2}>
+                      Sort By
+                    </P>
+                    <select name="sort" id="sort" value={query.sort || 'totalDonations'} onChange={onChange}>
+                      <option value="totalDonations">Most Popular</option>
+                      <option value="newest">Newest</option>
+                    </select>
                   </Flex>
+
+                  <Flex width={[1, null, 0.5]} justifyContent="center" alignItems="center">
+                    <P as="label" htmlFor="show" color="white.full" fontSize="LeadParagraph" pr={2}>
+                      Show
+                    </P>
+                    <select name="show" id="show" value={params.tags} onChange={onChange}>
+                      {prepareTags(get(data, 'allCollectiveTags', [])).map(tag => (
+                        <option key={tag} value={tag}>
+                          {tag}
+                        </option>
+                      ))}
+                    </select>
+                  </Flex>
+                </Flex>
+
+                {loading && (
+                  <Box pt={6}>
+                    <LoadingGrid />
+                  </Box>
                 )}
-              </Fragment>
-            )}
-            {!collectives && (
-              <Box pt={6}>
-                <LoadingGrid />
-              </Box>
-            )}
-          </Container>
-        </Fragment>
+
+                {error && (
+                  <MessageBox type="error" withIcon mt={6}>
+                    {error.message}
+                  </MessageBox>
+                )}
+
+                {!error && !loading && data && data.allCollectives && (
+                  <Fragment>
+                    <Flex flexWrap="wrap" width={1} justifyContent="center">
+                      {get(data, 'allCollectives.collectives', []).map(c => (
+                        <Flex key={c.id} width={[1, 1 / 2, 1 / 4]} mb={3} justifyContent="center">
+                          <CollectiveCard collective={c} LoggedInUser={LoggedInUser} />
+                        </Flex>
+                      ))}
+                    </Flex>
+                    {data.allCollectives.total > data.allCollectives.limit && (
+                      <Flex justifyContent="center" mt={3}>
+                        <Pagination
+                          offset={data.allCollectives.offset}
+                          total={data.allCollectives.total}
+                          limit={data.allCollectives.limit}
+                        />
+                      </Flex>
+                    )}
+                  </Fragment>
+                )}
+              </Container>
+            </Fragment>
+          )}
+        </Query>
       )}
     </Page>
   );


### PR DESCRIPTION
Provide the basis for https://github.com/opencollective/opencollective/issues/2036
Provide the basis for https://github.com/opencollective/opencollective-api/pull/2017
Will help for https://github.com/opencollective/opencollective/issues/1387
Require https://github.com/opencollective/opencollective-api/pull/2016

Move discover page to GraphQL instead of using the legacy REST endpoints.

- [x] Use GraphQL for component's data
- [x] Implement `most popular` filter on API
