### PR TITLE
Add amountType to Tier props

### DIFF
--- a/cypress/integration/22-collective.edit.test.js
+++ b/cypress/integration/22-collective.edit.test.js
@@ -4,6 +4,7 @@ const addTier = tier => {
   const fields = [
     { type: 'input', name: 'name' },
     { type: 'textarea', name: 'description' },
+    { type: 'select', name: 'amountType' },
     { type: 'input', name: 'maxQuantity' },
     { type: 'input', name: 'amount' },
     { type: 'select', name: 'interval' },
@@ -47,7 +48,7 @@ describe('edit collective', () => {
     cy.get('.EditTiers .tier:first .name.inputField input').type('{selectall}Backer edited');
     cy.get('.EditTiers .tier:first .description.inputField textarea').type('{selectall}New description for backers');
     cy.get('.EditTiers .tier:first .amount.inputField input').type('{selectall}5');
-    cy.get('.EditTiers .tier:first ._amountType.inputField select').select('flexible');
+    cy.get('.EditTiers .tier:first .amountType.inputField select').select('FLEXIBLE');
     cy.get('.EditTiers .tier:first .currency1.inputField input').type('{selectall}5');
     cy.get('.EditTiers .tier:first .currency2.inputField input').type('{selectall}10');
     cy.get('.EditTiers .tier:first .currency3.inputField input').type('{selectall}20');
@@ -57,6 +58,7 @@ describe('edit collective', () => {
       name: 'Donor (one time donation)',
       type: 'DONATION',
       amount: 500,
+      amountType: 'FIXED',
       interval: 'onetime',
       description: 'New description for donor',
     });
@@ -65,6 +67,7 @@ describe('edit collective', () => {
       name: 'Priority Support',
       description: 'Get priority support from the core contributors',
       amount: 1000,
+      amountType: 'FIXED',
       interval: 'month',
       maxQuantity: 10,
     });
@@ -110,8 +113,8 @@ describe('edit collective', () => {
     cy.visit('/testcollective/edit/tiers');
     cy.get('.EditTiers .tier')
       .first()
-      .find('._amountType select')
-      .select('fixed');
+      .find('.amountType select')
+      .select('FIXED');
     cy.get('.EditTiers .tier')
       .last()
       .find('.removeTier')

--- a/src/components/EditCollective.js
+++ b/src/components/EditCollective.js
@@ -108,10 +108,9 @@ class EditCollective extends React.Component {
       resetAttributes.map(attr => {
         cleanTier[attr] = null;
       });
-      if (tier._amountType === 'fixed') {
+      if (tier.amountType === 'FIXED') {
         cleanTier.presets = null;
       }
-      delete cleanTier._amountType;
       return cleanTier;
     });
   }

--- a/src/components/EditCollective.js
+++ b/src/components/EditCollective.js
@@ -125,7 +125,7 @@ class EditCollective extends React.Component {
     this.setState({ status: 'loading' });
     try {
       await this.props.editCollective(CollectiveInputType);
-      this.setState({ status: 'saved' });
+      this.setState({ status: 'saved', result: { error: null } });
       setTimeout(() => {
         this.setState({ status: null });
       }, 3000);
@@ -133,7 +133,6 @@ class EditCollective extends React.Component {
       console.error('>>> editCollective error:', JSON.stringify(err));
       const errorMsg = err.graphQLErrors && err.graphQLErrors[0] ? err.graphQLErrors[0].message : err.message;
       this.setState({ status: null, result: { error: errorMsg } });
-      throw new Error(errorMsg);
     }
   }
 

--- a/src/components/EditTiers.js
+++ b/src/components/EditTiers.js
@@ -171,7 +171,7 @@ class EditTiers extends React.Component {
         label: intl.formatMessage(this.messages['description.label']),
       },
       {
-        name: '_amountType',
+        name: 'amountType',
         type: 'select',
         options: getOptions(['FIXED', 'FLEXIBLE']),
         label: intl.formatMessage(this.messages['amountType.label']),
@@ -182,7 +182,7 @@ class EditTiers extends React.Component {
         pre: getCurrencySymbol(props.currency),
         type: 'currency',
         label: intl.formatMessage(this.messages['amount.label']),
-        when: tier => tier._amountType === 'FIXED',
+        when: tier => tier.amountType === 'FIXED',
       },
       {
         name: 'presets',
@@ -191,7 +191,7 @@ class EditTiers extends React.Component {
         options: { step: 1 },
         component: InputFieldPresets,
         label: intl.formatMessage(this.messages['presets.label']),
-        when: tier => tier._amountType === 'FLEXIBLE',
+        when: tier => tier.amountType === 'FLEXIBLE',
       },
       {
         name: 'amount',
@@ -199,7 +199,7 @@ class EditTiers extends React.Component {
         type: 'currency',
         options: { step: 1 },
         label: intl.formatMessage(this.messages['defaultAmount.label']),
-        when: tier => tier._amountType === 'FLEXIBLE',
+        when: tier => tier.amountType === 'FLEXIBLE',
       },
       {
         name: 'minimumAmount',
@@ -207,7 +207,7 @@ class EditTiers extends React.Component {
         type: 'currency',
         options: { step: 1 },
         label: intl.formatMessage(this.messages['minimumAmount.label']),
-        when: tier => tier._amountType === 'FLEXIBLE',
+        when: tier => tier.amountType === 'FLEXIBLE',
       },
       {
         name: 'interval',
@@ -291,6 +291,7 @@ class EditTiers extends React.Component {
     const defaultValues = {
       ...tier,
       type: tier.type || this.defaultType,
+      amountType: tier.amountType || (tier.presets ? 'FLEXIBLE' : 'FIXED'),
     };
 
     return (

--- a/src/components/EditTiers.js
+++ b/src/components/EditTiers.js
@@ -111,8 +111,8 @@ class EditTiers extends React.Component {
         id: 'tier.interval.label',
         defaultMessage: 'interval',
       },
-      fixed: { id: 'tier.amountType.fixed', defaultMessage: 'fixed amount' },
-      flexible: {
+      FIXED: { id: 'tier.amountType.fixed', defaultMessage: 'fixed amount' },
+      FLEXIBLE: {
         id: 'tier.amountType.flexible',
         defaultMessage: 'flexible amount',
       },
@@ -173,7 +173,7 @@ class EditTiers extends React.Component {
       {
         name: '_amountType',
         type: 'select',
-        options: getOptions(['fixed', 'flexible']),
+        options: getOptions(['FIXED', 'FLEXIBLE']),
         label: intl.formatMessage(this.messages['amountType.label']),
         when: tier => ['DONATION', 'TIER'].indexOf(tier.type) !== -1,
       },
@@ -182,7 +182,7 @@ class EditTiers extends React.Component {
         pre: getCurrencySymbol(props.currency),
         type: 'currency',
         label: intl.formatMessage(this.messages['amount.label']),
-        when: tier => tier._amountType === 'fixed',
+        when: tier => tier._amountType === 'FIXED',
       },
       {
         name: 'presets',
@@ -191,7 +191,7 @@ class EditTiers extends React.Component {
         options: { step: 1 },
         component: InputFieldPresets,
         label: intl.formatMessage(this.messages['presets.label']),
-        when: tier => tier._amountType === 'flexible',
+        when: tier => tier._amountType === 'FLEXIBLE',
       },
       {
         name: 'amount',
@@ -199,7 +199,7 @@ class EditTiers extends React.Component {
         type: 'currency',
         options: { step: 1 },
         label: intl.formatMessage(this.messages['defaultAmount.label']),
-        when: tier => tier._amountType === 'flexible',
+        when: tier => tier._amountType === 'FLEXIBLE',
       },
       {
         name: 'minimumAmount',
@@ -207,7 +207,7 @@ class EditTiers extends React.Component {
         type: 'currency',
         options: { step: 1 },
         label: intl.formatMessage(this.messages['minimumAmount.label']),
-        when: tier => tier._amountType === 'flexible',
+        when: tier => tier._amountType === 'FLEXIBLE',
       },
       {
         name: 'interval',
@@ -291,7 +291,6 @@ class EditTiers extends React.Component {
     const defaultValues = {
       ...tier,
       type: tier.type || this.defaultType,
-      _amountType: tier._amountType || (tier.presets ? 'flexible' : 'fixed'),
     };
 
     return (

--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -349,6 +349,7 @@ export const addEditCollectiveMutation = graphql(editCollectiveQuery, {
             'description',
             'longDescription',
             'amount',
+            'amountType',
             'interval',
             'maxQuantity',
             'maxQuantityPerUser',

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -163,6 +163,7 @@ const getTiersQuery = gql`
         name
         description
         amount
+        amountType
         minimumAmount
         currency
         interval
@@ -250,6 +251,7 @@ export const getCollectiveToEditQueryFields = `
     longDescription
     amount
     presets
+    amountType
     minimumAmount
     goal
     interval
@@ -409,6 +411,7 @@ const getCollectiveQuery = gql`
         description
         button
         amount
+        amountType
         minimumAmount
         presets
         interval
@@ -562,6 +565,7 @@ const getEventCollectiveQuery = gql`
         name
         description
         amount
+        amountType
         minimumAmount
         presets
         currency

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1782,6 +1782,7 @@ input TierInputType {
 
   """amount in the lowest unit of the currency of the host (ie. in cents)"""
   amount: Int
+  amountType: String
   currency: String
   presets: [Int]
   interval: String

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1748,6 +1748,7 @@ type Tier {
   longDescription: String
   button: String
   amount: Int
+  amountType: String
   minimumAmount: Int
   currency: String
   interval: String


### PR DESCRIPTION
This PR follows [#2009](https://github.com/opencollective/opencollective-api/pull/2009):
 
-  Adds `amountType` to graphql queries & mutations, updates
-  Update `EditTiers` component to use `amountType`
 - Update `editCollective`  mutation props error handling to show validation message from the API. 