### PR TITLE
feat(TierPage): Show collective bar

### DIFF
--- a/src/components/tier-page/index.js
+++ b/src/components/tier-page/index.js
@@ -8,12 +8,14 @@ import { withRouter } from 'next/router';
 
 // Open Collective Frontend imports
 import { getWebsiteUrl } from '../../lib/utils';
-import { P } from '../Text';
+import { P, H1 } from '../Text';
 import StyledButton from '../StyledButton';
 import Container from '../Container';
 import Link from '../Link';
 import FormattedMoneyAmount from '../FormattedMoneyAmount';
 import StyledProgressBar from '../StyledProgressBar';
+import Avatar from '../Avatar';
+import LinkCollective from '../LinkCollective';
 
 // Local tier page imports
 import { Dimensions } from './_constants';
@@ -60,6 +62,7 @@ class TierPage extends Component {
     collective: PropTypes.shape({
       id: PropTypes.number.isRequired,
       slug: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
       type: PropTypes.string.isRequired,
     }).isRequired,
 
@@ -98,6 +101,37 @@ class TierPage extends Component {
 
     return (
       <Container borderTop="1px solid #E6E8EB">
+        <Container
+          display="flex"
+          alignItems="center"
+          position="sticky"
+          top={0}
+          px={[3, 4]}
+          height={[70, 90]}
+          zIndex={999}
+          background="white"
+          borderBottom="1px solid #E6E8EB"
+        >
+          <Container flex="1" maxWidth={1440} m="0 auto">
+            <Flex alignItems="center">
+              <LinkCollective collective={collective}>
+                <Avatar
+                  type={collective.type}
+                  src={collective.image}
+                  backgroundColor="#EBEBEB"
+                  border="1px solid #efefef"
+                  radius={40}
+                  borderRadius={10}
+                />
+              </LinkCollective>
+              <LinkCollective collective={collective}>
+                <H1 color="black.800" fontSize={'H5'} ml={3}>
+                  {collective.name || collective.slug}
+                </H1>
+              </LinkCollective>
+            </Flex>
+          </Container>
+        </Container>
         <Container position="relative">
           <Container position="absolute" width={1} zIndex={-1} overflow="hidden">
             <TierCover

--- a/src/pages/tier.js
+++ b/src/pages/tier.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { graphql } from 'react-apollo';
 import gql from 'graphql-tag';
 import { get } from 'lodash';
+import { createGlobalStyle } from 'styled-components';
 
 import withIntl from '../lib/withIntl';
 import { withUser } from '../components/UserProvider';
@@ -10,6 +11,14 @@ import ErrorPage from '../components/ErrorPage';
 import Page from '../components/Page';
 import Loading from '../components/Loading';
 import TierPageContent from '../components/tier-page';
+
+/** Overrides global styles for this page */
+const GlobalStyles = createGlobalStyle`
+  main {
+    /** The "overflow: hidden" set in Body prevents from using position sticky */
+    overflow-x: inherit !important;
+  }
+`;
 
 /**
  * The main page to display collectives. Wrap route parameters and GraphQL query
@@ -62,7 +71,10 @@ class TierPage extends React.Component {
         {data.loading || !data.Tier || !data.Tier.collective ? (
           <Loading />
         ) : (
-          <TierPageContent collective={data.Tier.collective} tier={data.Tier} LoggedInUser={LoggedInUser} />
+          <React.Fragment>
+            <GlobalStyles />
+            <TierPageContent collective={data.Tier.collective} tier={data.Tier} LoggedInUser={LoggedInUser} />
+          </React.Fragment>
         )}
       </Page>
     );


### PR DESCRIPTION
Linked to https://github.com/opencollective/opencollective/issues/1982

A first implementation that lacks the collective NavBar but will at least show the collective name/logo on the tier page.

Disabled `overflow-x: hidden` on `main` for this page because it prevents us from using `position: sticky`.

---

![Peek 27-05-2019 10-01](https://user-images.githubusercontent.com/1556356/58405110-fa8bdb80-8066-11e9-9148-59837e314ec2.gif)
