### PR TITLE
Update API GraphQL to v14

### DIFF
--- a/src/pages/action.js
+++ b/src/pages/action.js
@@ -24,13 +24,13 @@ import withIntl from '../lib/withIntl';
  */
 class ActionPage extends React.Component {
   static getInitialProps({ query: { action, table, id } }) {
-    return { action, table, id, ssr: false };
+    return { action, table, id: Number(id), ssr: false };
   }
 
   static propTypes = {
     action: PropTypes.string,
     table: PropTypes.string,
-    id: PropTypes.string,
+    id: PropTypes.number,
     ssr: PropTypes.bool,
     LoggedInUser: PropTypes.object, // from withUser,
     loadingLoggedInUser: PropTypes.bool.isRequired, // from withUser

--- a/src/pages/tier.js
+++ b/src/pages/tier.js
@@ -17,13 +17,13 @@ import TierPageContent from '../components/tier-page';
  */
 class TierPage extends React.Component {
   static propTypes = {
-    tierId: PropTypes.string.isRequired,
+    tierId: PropTypes.number.isRequired,
     data: PropTypes.object.isRequired, // from withData
     LoggedInUser: PropTypes.object, // from withUser
   };
 
   static getInitialProps({ query: { tierId } }) {
-    return { tierId };
+    return { tierId: Number(tierId) };
   }
 
   // See https://github.com/opencollective/opencollective/issues/1872


### PR DESCRIPTION
With the pending update of Graphql to v14 on the API, a[ breaking change](https://github.com/graphql/graphql-js/pull/1382) is that variable coercion is no longer performed by the server. Hence, `Int` types have to be sent as `Ints` etc, whereas previously they could be sent as `Strings`, and coerced by the server.

Related: https://github.com/opencollective/opencollective-api/pull/2019
Ref: https://github.com/opencollective/opencollective/issues/1658