### PR TITLE
Allow collective host admin to use refund button

### DIFF
--- a/src/apps/expenses/components/Transactions.js
+++ b/src/apps/expenses/components/Transactions.js
@@ -178,7 +178,7 @@ class Transactions extends React.Component {
                 collective={collective}
                 {...transaction}
                 isRefund={Boolean(transaction.refundTransaction)}
-                canRefund={LoggedInUser && LoggedInUser.isRoot()}
+                canRefund={LoggedInUser && (LoggedInUser.isRoot() || LoggedInUser.isHostAdmin(collective))}
                 canDownloadInvoice={this.canDownloadInvoice(transaction)}
                 dateDisplayType={this.props.dateDisplayType}
               />

--- a/src/classes/LoggedInUser.js
+++ b/src/classes/LoggedInUser.js
@@ -154,4 +154,8 @@ LoggedInUser.prototype.hostsUserIsAdminOf = function() {
   );
 };
 
+LoggedInUser.prototype.isHostAdmin = function(collective) {
+  return collective.isHost && intersection(this.roles[collective.slug], ['ADMIN']).length > 0;
+};
+
 export default LoggedInUser;


### PR DESCRIPTION
This PR enables collective host `admin`  to access "Refund" button by adding `isHostAdmin` method to `LoggedInUser` object. The method ensures the collective `isHost` property is `true` and `LoggedInUser`
has an admin role in the collective.

### Screenshot
![Screenshot from 2019-05-28 16-50-14](https://user-images.githubusercontent.com/15707013/58493495-fa750400-816a-11e9-820e-679fe86c5e3e.png)

Ref [#2070](https://github.com/opencollective/opencollective/issues/2070)
