### PR TITLE
Replace createOrder with addFundsToCollective for handling AddFund form.

### DIFF
--- a/src/components/host-dashboard/CollectivePickerWithData.js
+++ b/src/components/host-dashboard/CollectivePickerWithData.js
@@ -105,7 +105,8 @@ class CollectivePickerWithData extends React.Component {
       uuid: pm.uuid,
     };
     try {
-      await this.props.createOrder(order);
+      console.log(order);
+      await this.props.addFundsToCollective(order);
       this.setState({ showAddFunds: false, loading: false });
     } catch (e) {
       const error = e.message && e.message.replace(/GraphQL error:/, '');
@@ -355,9 +356,9 @@ class CollectivePickerWithData extends React.Component {
   }
 }
 
-const createOrderQuery = gql`
-  mutation createOrder($order: OrderInputType!) {
-    createOrder(order: $order) {
+const addFundsToCollectiveQuery = gql`
+  mutation addFundsToCollective($order: OrderInputType!) {
+    addFundsToCollective(order: $order) {
       id
       collective {
         id
@@ -370,9 +371,9 @@ const createOrderQuery = gql`
   }
 `;
 
-const addMutation = graphql(createOrderQuery, {
+const addMutation = graphql(addFundsToCollectiveQuery, {
   props: ({ mutate }) => ({
-    createOrder: async order => {
+    addFundsToCollective: async order => {
       return await mutate({ variables: { order } });
     },
   }),

--- a/src/components/host-dashboard/CollectivePickerWithData.js
+++ b/src/components/host-dashboard/CollectivePickerWithData.js
@@ -15,6 +15,9 @@ class CollectivePickerWithData extends React.Component {
   static propTypes = {
     host: PropTypes.object.isRequired,
     onChange: PropTypes.func,
+    LoggedInUser: PropTypes.object,
+    addFundsToCollective: PropTypes.func.isRequired,
+    intl: PropTypes.object.isRequired,
   };
 
   constructor(props) {

--- a/src/components/host-dashboard/CollectivePickerWithData.js
+++ b/src/components/host-dashboard/CollectivePickerWithData.js
@@ -105,7 +105,6 @@ class CollectivePickerWithData extends React.Component {
       uuid: pm.uuid,
     };
     try {
-      console.log(order);
       await this.props.addFundsToCollective(order);
       this.setState({ showAddFunds: false, loading: false });
     } catch (e) {

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1236,6 +1236,7 @@ type Mutation {
   ): Member
   createOrder(order: OrderInputType!): OrderType
   updateOrder(order: OrderInputType!): OrderType
+  addFundsToCollective(order: OrderInputType!): OrderType
 
   """
   Update the non-sensitive information of an order, like the public message


### PR DESCRIPTION
This PR follows up [#2044](https://github.com/opencollective/opencollective-api/pull/2044) to fix [#2042](https://github.com/opencollective/opencollective/issues/2042). Basically, `createOrder` is replaced with `addFundsToCollective` in `CollectivePickerWithData` component.

### Screen record
![Peek 2019-05-29 14-58](https://user-images.githubusercontent.com/15707013/58563558-4a170680-8223-11e9-8d78-30893d3dd84b.gif)
