### PR TITLE
Tier page: HTMLEditor Dynamic loading

### DIFF
--- a/src/components/tier-page/index.js
+++ b/src/components/tier-page/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
+import dynamic from 'next/dynamic';
 import { Flex, Box } from '@rebass/grid';
 import styled from 'styled-components';
 import { themeGet } from 'styled-system';
@@ -17,13 +18,20 @@ import FormattedMoneyAmount from '../FormattedMoneyAmount';
 import StyledProgressBar from '../StyledProgressBar';
 import Avatar from '../Avatar';
 import LinkCollective from '../LinkCollective';
-import HTMLEditor from '../HTMLEditor';
 import InlineEditField from '../InlineEditField';
+import LoadingPlaceholder from '../LoadingPlaceholder';
 
 // Local tier page imports
 import { Dimensions } from './_constants';
 import ShareButtons from './ShareButtons';
 import BubblesSVG from './Bubbles.svg';
+
+// Dynamicly load HTMLEditor to download it only if user can edit the page
+const HTMLEditorLoadingPlaceholder = () => <LoadingPlaceholder height={400} />;
+const HTMLEditor = dynamic(() => import(/* webpackChunkName: 'HTMLEditor' */ '../HTMLEditor'), {
+  loading: HTMLEditorLoadingPlaceholder,
+  ssr: false,
+});
 
 /** The blured background image displayed under the tier description */
 const TierCover = styled(Container)`


### PR DESCRIPTION
With the new collective page we want things to load faster. According to [bundlephobia](https://bundlephobia.com/result?p=react-quill@1.3.3) `react-quill` is almost 60kb minified + gzipped, but there's no reason to load it if user cannot edit the content.

This PR uses NextJS dynamic load feature to only load the editor when it's being used. While loading, a `LoadingPlaceholder` is displayed in place of the editor.

# Preview

Preview below is generated with a hard throttling on the connection speed. On fast connections the component loads faster than this.

![Peek 03-06-2019 09-22](https://user-images.githubusercontent.com/1556356/58783480-47306300-85e1-11e9-8145-df17b0fcde96.gif)

