### PR TITLE
Refactory: set defaultValues for tier

### DIFF
--- a/src/components/EditTiers.js
+++ b/src/components/EditTiers.js
@@ -288,11 +288,19 @@ class EditTiers extends React.Component {
       get(collective, 'location.country') || get(collective, 'parentCollective.location.country');
     const vatOriginCountry = getVatOriginCountry(tier.type, hostCountry, collectiveCountry);
     const vatPercentage = getStandardVatRate(tier.type, vatOriginCountry);
+    if (!tier.amountType) {
+      tier.amountType = tier.presets ? 'FLEXIBLE' : 'FIXED';
+    }
+
+    // Set the default value of preset
+    if (tier.amountType === 'FLEXIBLE' && !tier.presets) {
+      tier.presets = [1000];
+    }
 
     const defaultValues = {
       ...tier,
       type: tier.type || this.defaultType,
-      amountType: tier.amountType || (tier.presets ? 'FLEXIBLE' : 'FIXED'),
+      amountType: tier.amountType,
     };
 
     return (


### PR DESCRIPTION
This PR follows up [#2060](https://github.com/opencollective/opencollective-api/pull/2060), setting the default values of tiers for `flexible` and `fixed` `amountType`.