### PR TITLE
Allow collective host admin to use refund button

### DIFF
--- a/src/classes/LoggedInUser.js
+++ b/src/classes/LoggedInUser.js
@@ -155,7 +155,7 @@ LoggedInUser.prototype.hostsUserIsAdminOf = function() {
 };
 
 LoggedInUser.prototype.isHostAdmin = function(collective) {
-  return collective.isHost && intersection(this.roles[collective.slug], ['ADMIN']).length > 0;
+  return intersection(this.roles[collective.host.slug], ['ADMIN']).length > 0;
 };
 
 export default LoggedInUser;

--- a/src/classes/LoggedInUser.js
+++ b/src/classes/LoggedInUser.js
@@ -155,7 +155,7 @@ LoggedInUser.prototype.hostsUserIsAdminOf = function() {
 };
 
 LoggedInUser.prototype.isHostAdmin = function(collective) {
-  return intersection(this.roles[collective.host.slug], ['ADMIN']).length > 0;
+  return collective.host && intersection(this.roles[collective.host.slug], ['ADMIN']).length > 0;
 };
 
 export default LoggedInUser;


### PR DESCRIPTION
This PR follows up [#2070](https://github.com/opencollective/opencollective/issues/2070#issuecomment-499392855) by updating the logic to show refund button for collective host admin.