### PR TITLE
feat(TierPage): Add inline editable video

### DIFF
--- a/src/components/HTMLContent.js
+++ b/src/components/HTMLContent.js
@@ -37,6 +37,8 @@ const HTMLContent = styled(({ content, ...props }) => {
   return content ? <div dangerouslySetInnerHTML={{ __html: content }} {...props} /> : <div {...props} />;
 })`
   /** Override global styles to match what we have in the editor */
+  width: 100%;
+
   h1,
   h2,
   h3 {

--- a/src/components/InlineEditField.js
+++ b/src/components/InlineEditField.js
@@ -33,6 +33,7 @@ const FormButton = styled(StyledButton).attrs({
   buttonSize: 'large',
 })`
   width: 35%;
+  font-weight: normal;
   min-width: 185px;
   text-transform: capitalize;
   margin: 0 8px;

--- a/src/components/LoadingPlaceholder.js
+++ b/src/components/LoadingPlaceholder.js
@@ -17,6 +17,7 @@ const LoadingPlaceholder = styled.div`
   background: linear-gradient(to right, #eee 2%, #ddd 18%, #eee 33%);
   background-size: 200%;
   border-radius: 15px;
+  width: 100%;
 
   ${height}
 `;

--- a/src/components/StyledKeyframes.js
+++ b/src/components/StyledKeyframes.js
@@ -22,6 +22,17 @@ export const fadeIn = keyframes`
   }
 `;
 
+export const fadeInUp = keyframes`
+  from {
+    opacity: 0;
+    transform: translate3d(0,40px,0);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0,0,0);
+  }
+`;
+
 export const flicker = ({ minOpacity = 0 }) => keyframes`
   0%   { opacity: 1; }
   50%  { opacity: ${minOpacity}; }

--- a/src/components/VideoLinkerBox.js
+++ b/src/components/VideoLinkerBox.js
@@ -1,0 +1,120 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled, { css } from 'styled-components';
+import { FormattedMessage } from 'react-intl';
+import { themeGet } from 'styled-system';
+import { Box } from '@rebass/grid';
+
+import { VideoPlus } from 'styled-icons/boxicons-regular/VideoPlus';
+import { ArrowUpCircle } from 'styled-icons/feather/ArrowUpCircle';
+
+import { fadeInUp } from './StyledKeyframes';
+import { P } from './Text';
+import StyledInput from './StyledInput';
+import VideoPlayer, { supportedVideoProviders } from './VideoPlayer';
+import Container from './Container';
+
+const VideoPlaceholder = styled(({ children, ...props }) => (
+  <div {...props}>
+    <div>{children}</div>
+  </div>
+))`
+  /** Main-container, sized with padding-bottom to be 16:9 */
+  position: relative;
+  width: 100%;
+  padding-bottom: 56.25%; // 16:9 aspect ratio equivalant (9/16 === 0.5625)
+  background: #f7f8fa;
+  color: #dcdee0;
+
+  /** Flex container to center the content */
+  & > div {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 16px;
+  }
+
+  ${props =>
+    props.onClick &&
+    css`
+      cursor: pointer;
+      &:hover {
+        color: ${themeGet('colors.black.400')};
+        & > div {
+          transform: scale(1.05);
+          transition: transform 0.2s;
+        }
+      }
+    `}
+`;
+
+/** A container for the form used to animate the different inputs */
+const MainFormContainer = styled.div`
+  input {
+    box-shadow: 0px 2px 7px -6px #696969;
+    animation: ${fadeInUp} 0.3s;
+  }
+`;
+
+/**
+ * A video placeholder that user can click on to upload a new video.
+ * This component doesn't provide save and cancel buttons, nor
+ * does it manages internal state.
+ *
+ * A good way to use it is to wrap it with `InlineEditField`. You can
+ * check `src/components/tier-page/TierVideo.js` for an example.
+ */
+const VideoLinkerBox = ({ url, onChange, isEditing, setEditing }) => {
+  return !isEditing ? (
+    <VideoPlaceholder onClick={() => setEditing(true)}>
+      <VideoPlus size="50%" />
+      <P fontWeight="bold" fontSize="LeadParagraph">
+        <FormattedMessage id="VideoLinkerBox.AddVideo" defaultMessage="Add a video" />
+      </P>
+    </VideoPlaceholder>
+  ) : (
+    <MainFormContainer>
+      <Container position="absolute" width={1} top={-45}>
+        <StyledInput
+          type="url"
+          placeholder="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+          value={url || ''}
+          onChange={e => onChange(e.target.value)}
+          width={1}
+          mb={2}
+          autoFocus
+        />
+      </Container>
+      <Box width={1} maxHeight={400} mb={2}>
+        <VideoPlayer
+          url={url}
+          placeholder={
+            <VideoPlaceholder>
+              <ArrowUpCircle size="50%" />
+              <P fontWeight="bold" fontSize="LeadParagraph" textAlign="center" color="black.400" mt={2}>
+                <FormattedMessage
+                  id="VideoLinkerBox.SetUrl"
+                  defaultMessage="Set the video URL above. We support the following platforms: {supportedVideoProviders}"
+                  values={{ supportedVideoProviders: supportedVideoProviders.join(', ') }}
+                />
+              </P>
+            </VideoPlaceholder>
+          }
+        />
+      </Box>
+    </MainFormContainer>
+  );
+};
+
+VideoLinkerBox.propTypes = {
+  url: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  isEditing: PropTypes.bool,
+  setEditing: PropTypes.func.isRequired,
+};
+
+export default VideoLinkerBox;

--- a/src/components/VideoPlayer.js
+++ b/src/components/VideoPlayer.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+// A map of provider name => regex
+const ProvidersRegexs = {
+  YouTube: /(?:youtube\.com\/(?:[^/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?/ ]{11})/i,
+  Vimeo: /:\/\/(www\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/([^/]*)\/videos\/|)(\d+)(?:|\/\?)/i,
+};
+
+/** A list of supported video provider names */
+export const supportedVideoProviders = Object.keys(ProvidersRegexs);
+
+/** Get provider name, or returns null if URL is null or not supported */
+export const getProvider = url => {
+  if (!url) {
+    return null;
+  }
+
+  return supportedVideoProviders.find(providerName => {
+    return ProvidersRegexs[providerName].test(url);
+  });
+};
+
+/** An iframe that groes with its content */
+const ResponsiveIframe = styled(({ src, ...props }) => (
+  <div {...props}>
+    <iframe src={src} allowFullScreen frameBorder="0" allow="fullscreen" />
+  </div>
+))`
+  position: relative;
+  width: 100%;
+  padding-bottom: 56.25%; // 16:9 aspect ratio equivalant (9/16 === 0.5625)
+  background: black;
+
+  iframe {
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
+  }
+`;
+
+/**
+ * A video player that supports YouTube and Vimeo.
+ * Implemented as a pure component to avoir re-checking the URL and re-rendering
+ * the iframe on each update.
+ */
+const VideoPlayer = React.memo(({ url, placeholder }) => {
+  const provider = getProvider(url);
+
+  if (provider === 'YouTube') {
+    const youtubeId = ProvidersRegexs.YouTube.exec(url)[1];
+    if (youtubeId) {
+      // youtube-nocookie is a special enpoint that don't send any cookie to the
+      // users until they actually start playing the video. It's better for privacy
+      // and lighter for users. The service is officially supported by Google.
+      // See https://support.google.com/youtube/answer/171780?hl=en > "Turn on privacy-enhanced mode"
+      return <ResponsiveIframe src={`https://www.youtube-nocookie.com/embed/${youtubeId}`} />;
+    }
+  } else if (provider === 'Vimeo') {
+    const vimeoId = ProvidersRegexs.Vimeo.exec(url)[3];
+    if (vimeoId) {
+      return <ResponsiveIframe src={`https://player.vimeo.com/video/${vimeoId}?color=145ECC/`} />;
+    }
+  }
+
+  return placeholder;
+});
+
+VideoPlayer.displayName = 'VideoPlayer';
+
+VideoPlayer.propTypes = {
+  /** URL of the video */
+  url: PropTypes.string,
+  /** Rendered when the video is not supported. */
+  placeholder: PropTypes.node,
+};
+
+VideoPlayer.defaultProps = {
+  placeholder: null,
+};
+
+export default VideoPlayer;

--- a/src/components/tier-page/TierVideo.js
+++ b/src/components/tier-page/TierVideo.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import dynamic from 'next/dynamic';
+import InlineEditField from '../InlineEditField';
+
+import VideoPlayer from '../VideoPlayer';
+
+// Dynamicly load heavy inputs only if user can edit the page
+const VideoLinkerBox = dynamic(() => import(/* webpackChunkName: 'VideoLinkerBox' */ '../VideoLinkerBox'));
+
+/**
+ * Displays the video on the page, with an optional form to edit it
+ * if user is allowed to do so.
+ */
+const TierVideo = ({ tier, editMutation, canEdit }) => {
+  return (
+    <InlineEditField
+      field="videoUrl"
+      values={tier}
+      mutation={editMutation}
+      canEdit={canEdit}
+      showEditIcon={Boolean(tier.videoUrl)}
+    >
+      {({ isEditing, value, setValue, enableEditor, disableEditor }) => {
+        if (isEditing || (!value && canEdit)) {
+          return (
+            <VideoLinkerBox
+              url={value}
+              onChange={setValue}
+              isEditing={isEditing}
+              setEditing={isEditing ? disableEditor : enableEditor}
+            />
+          );
+        } else {
+          return value ? <VideoPlayer url={value} /> : null;
+        }
+      }}
+    </InlineEditField>
+  );
+};
+
+TierVideo.propTypes = {
+  tier: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    videoUrl: PropTypes.string,
+  }).isRequired,
+  editMutation: PropTypes.object,
+  canEdit: PropTypes.bool,
+};
+
+export default TierVideo;

--- a/src/components/tier-page/index.js
+++ b/src/components/tier-page/index.js
@@ -238,43 +238,46 @@ class TierPage extends Component {
                     }
                   />
                 </H3>
-                <Container display="flex" position="relative" flexWrap="wrap">
-                  <InlineEditField
-                    mutation={EditTierMutation}
-                    values={tier}
-                    field="longDescription"
-                    canEdit={canEditTier}
-                  >
-                    {({ isEditing, value, setValue, enableEditor }) => {
-                      if (isEditing) {
-                        return (
-                          <HTMLContent>
-                            <HTMLEditor
-                              defaultValue={value}
-                              onChange={setValue}
-                              allowedHeaders={[false, 2, 3]} /** Disable H1 */
-                            />
-                          </HTMLContent>
-                        );
-                      } else if (isEmptyValue(tier.longDescription)) {
-                        return !canEditTier ? null : (
-                          <StyledButton buttonSize="large" onClick={enableEditor} data-cy="Btn-Add-longDescription">
-                            <FormattedMessage
-                              id="TierPage.AddLongDescription"
-                              defaultMessage="Add a rich description"
-                            />
-                          </StyledButton>
-                        );
-                      } else {
-                        return <HTMLContent content={tier.longDescription} data-cy="longDescription" />;
-                      }
-                    }}
-                  </InlineEditField>
+                <Container display="flex" flexDirection="column-reverse" position="relative" flexWrap="wrap">
+                  <div>
+                    <InlineEditField
+                      mutation={EditTierMutation}
+                      values={tier}
+                      field="longDescription"
+                      canEdit={canEditTier}
+                    >
+                      {({ isEditing, value, setValue, enableEditor }) => {
+                        if (isEditing) {
+                          return (
+                            <HTMLContent>
+                              <HTMLEditor
+                                defaultValue={value}
+                                onChange={setValue}
+                                allowedHeaders={[false, 2, 3]} /** Disable H1 */
+                              />
+                            </HTMLContent>
+                          );
+                        } else if (isEmptyValue(tier.longDescription)) {
+                          return !canEditTier ? null : (
+                            <StyledButton buttonSize="large" onClick={enableEditor} data-cy="Btn-Add-longDescription">
+                              <FormattedMessage
+                                id="TierPage.AddLongDescription"
+                                defaultMessage="Add a rich description"
+                              />
+                            </StyledButton>
+                          );
+                        } else {
+                          return <HTMLContent content={tier.longDescription} data-cy="longDescription" />;
+                        }
+                      }}
+                    </InlineEditField>
+                  </div>
                   <Container
                     position={['relative', null, null, 'absolute']}
-                    right={[null, null, null, -485]}
-                    width={['100%', null, null, 472]}
-                    mt={[3, null, null, 0]}
+                    right={[null, null, null, -390, -490]}
+                    width={['100%', null, null, 380, 472]}
+                    mb={[4, 5]}
+                    top={0}
                   >
                     <TierVideo tier={tier} editMutation={EditTierMutation} canEdit={canEditTier} />
                   </Container>

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:3000/api/graphql
-# timestamp: Tue Jun 04 2019 13:28:54 GMT+0200 (GMT+02:00)
+# timestamp: Fri Jun 07 2019 12:22:19 GMT+0200 (GMT+02:00)
 
 """
 Application model
@@ -309,6 +309,11 @@ interface CollectiveInterface {
   backgroundImage: String
   backgroundImageUrl(height: Int, format: ImageFormat): String
   settings: JSON
+
+  """
+  Defines if a collective is pledged
+  """
+  isPledged: Boolean
   data: JSON
   slug: String
   path: String
@@ -455,6 +460,11 @@ enum CollectiveOrderField {
   Order collectives by updated time.
   """
   updatedAt
+
+  """
+  Order collectives by total donations.
+  """
+  totalDonations
 }
 
 """
@@ -2323,6 +2333,11 @@ type Tier {
   A long, html-formatted description.
   """
   longDescription: String
+
+  """
+  Link to a video (YouTube, Vimeo).
+  """
+  videoUrl: String
   button: String
   amount: Int
   minimumAmount: Int
@@ -2373,6 +2388,11 @@ input TierInputType {
   A long, html-formatted description.
   """
   longDescription: String
+
+  """
+  Link to a video (YouTube, Vimeo).
+  """
+  videoUrl: String
 
   """
   amount in the lowest unit of the currency of the host (ie. in cents)

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1036,6 +1036,8 @@
   "user.website.description": "If any",
   "user.website.label": "website",
   "usercollective.since": "since {year}",
+  "VideoLinkerBox.AddVideo": "Add a video",
+  "VideoLinkerBox.SetUrl": "Set the video URL above. We support the following platforms: {supportedVideoProviders}",
   "viewYourProfile": "View your profile",
   "virtualCards.balance": "Balance: {balance}",
   "virtualCards.claimedBy": "claimed by {user}",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -1036,6 +1036,8 @@
   "user.website.description": "If any",
   "user.website.label": "sitio web",
   "usercollective.since": "Establecido in {year}",
+  "VideoLinkerBox.AddVideo": "Add a video",
+  "VideoLinkerBox.SetUrl": "Set the video URL above. We support the following platforms: {supportedVideoProviders}",
   "viewYourProfile": "Ver tu perfil",
   "virtualCards.balance": "Balance: {balance}",
   "virtualCards.claimedBy": "reclamado por {user}",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -1036,6 +1036,8 @@
   "user.website.description": "(si vous avez un site Internet)",
   "user.website.label": "site Internet",
   "usercollective.since": "depuis {year}",
+  "VideoLinkerBox.AddVideo": "Add a video",
+  "VideoLinkerBox.SetUrl": "Set the video URL above. We support the following platforms: {supportedVideoProviders}",
   "viewYourProfile": "Voir votre profil",
   "virtualCards.balance": "Solde : {balance}",
   "virtualCards.claimedBy": "réclamé par {user}",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -1036,6 +1036,8 @@
   "user.website.description": "あれば",
   "user.website.label": "ウェブサイト",
   "usercollective.since": "{year}年から",
+  "VideoLinkerBox.AddVideo": "Add a video",
+  "VideoLinkerBox.SetUrl": "Set the video URL above. We support the following platforms: {supportedVideoProviders}",
   "viewYourProfile": "プロフィールを表示",
   "virtualCards.balance": "残高: {balance}",
   "virtualCards.claimedBy": "{user} が請求",

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -1036,6 +1036,8 @@
   "user.website.description": "If any",
   "user.website.label": "сайт",
   "usercollective.since": "с {year}",
+  "VideoLinkerBox.AddVideo": "Add a video",
+  "VideoLinkerBox.SetUrl": "Set the video URL above. We support the following platforms: {supportedVideoProviders}",
   "viewYourProfile": "Открыть профиль",
   "virtualCards.balance": "Остаток: {balance}",
   "virtualCards.claimedBy": "claimed by {user}",

--- a/src/pages/tier.js
+++ b/src/pages/tier.js
@@ -110,6 +110,7 @@ const getCollective = graphql(gql`
       slug
       description
       longDescription
+      videoUrl
       goal
       currency
       interval


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-api/pull/2090

Adds the ability for collective admins to add a video on the tier page. The player currently supports YouTube and Vimeo.

This PR also includes improvements to make `InlineEditField` more generic and to have a background on the edit icon so it is always visible no matter how the parent looks.

# Preview

## Form

### Flow

![Peek 07-06-2019 12-37](https://user-images.githubusercontent.com/1556356/59098641-1de53f00-8921-11e9-8837-956e9eca088a.gif)

## Page

### Desktop 

<details>

![localhost_3000_open-potatoes_tiers_to-the-moon-2807 (6)](https://user-images.githubusercontent.com/1556356/59099321-13c44000-8923-11e9-8283-1d93f99e2fa8.png)

</details>

### Tablet

<details>

![localhost_3000_open-potatoes_tiers_to-the-moon-2807 (7)](https://user-images.githubusercontent.com/1556356/59099363-26d71000-8923-11e9-9a60-0ea203d6e718.png)

</details>

### Mobile

<details>

![localhost_3000_open-potatoes_tiers_to-the-moon-2807 (8)](https://user-images.githubusercontent.com/1556356/59099378-35bdc280-8923-11e9-87ff-0f685a6162b6.png)

</details>
