### PR TITLE
NCP: Improve Hero collapse/expand behaviour

### DIFF
--- a/src/components/collective-page/Hero.js
+++ b/src/components/collective-page/Hero.js
@@ -36,19 +36,15 @@ import HeroBackground from './HeroBackground';
  */
 const MainContainer = styled.div`
   position: relative;
+  width: 100%;
   top: 0;
   border-bottom: 1px solid #e6e8eb;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  transition: flex;
   z-index: 999;
 
   ${props =>
     props.isFixed &&
     css`
       position: fixed;
-      width: 100%;
       background: white;
     `}
 `;

--- a/src/components/collective-page/_constants.js
+++ b/src/components/collective-page/_constants.js
@@ -5,13 +5,14 @@ export const Dimensions = {
   PADDING_X: [15, 30, null, null, 120],
   MAX_SECTION_WIDTH: 1700,
   HERO_FIXED_HEIGHT: 120,
+  HERO_PLACEHOLDER_HEIGHT: [550, 500, 450],
 };
 
 /**
  * Durations for page animations
  */
 export const AnimationsDurations = {
-  HERO_COLLAPSE: 250,
+  HERO_COLLAPSE: 150,
 };
 
 /**

--- a/src/components/collective-page/index.js
+++ b/src/components/collective-page/index.js
@@ -77,7 +77,6 @@ export default class CollectivePage extends Component {
   constructor(props) {
     super(props);
     this.sectionsRefs = {}; // This will store a map of sectionName => sectionRef
-    this.heroRef = React.createRef();
     this.state = {
       isFixed: false,
       selectedSection: AllSectionsNames[0],
@@ -95,7 +94,7 @@ export default class CollectivePage extends Component {
 
   onScroll = debounceScroll(() => {
     // Fixes the Hero when a certain scroll threshold is reached
-    if (window.scrollY >= theme.sizes.navbarHeight) {
+    if (window.scrollY >= theme.sizes.navbarHeight + Dimensions.HERO_FIXED_HEIGHT) {
       if (!this.state.isFixed) {
         this.setState({ isFixed: true });
       }
@@ -105,11 +104,11 @@ export default class CollectivePage extends Component {
 
     // Update selected section
     const distanceThreshold = 200;
+    const currentViewBottom = window.scrollY + window.innerHeight;
     for (let i = AllSectionsNames.length - 1; i >= 0; i--) {
       const sectionName = AllSectionsNames[i];
       const sectionRef = this.sectionsRefs[sectionName];
-      const currentViewBottom = window.scrollY + window.innerHeight;
-      if (currentViewBottom - distanceThreshold > sectionRef.offsetTop) {
+      if (sectionRef && currentViewBottom - distanceThreshold > sectionRef.offsetTop) {
         if (this.state.selectedSection !== sectionName) {
           this.setState({ selectedSection: sectionName });
         }
@@ -121,14 +120,7 @@ export default class CollectivePage extends Component {
   onSectionClick = sectionName => {
     window.location.hash = `section-${sectionName}`;
     const sectionTop = this.sectionsRefs[sectionName].offsetTop;
-    if (this.state.isFixed) {
-      window.scrollTo(0, sectionTop);
-    } else {
-      // If not fixed, we have to acknowledge the fact that Hero is going to shrink, thus
-      // reducting the size of the navbar
-      const heroRect = this.heroRef.current.getBoundingClientRect();
-      window.scrollTo(0, sectionTop - heroRect.height + Dimensions.HERO_FIXED_HEIGHT);
-    }
+    window.scrollTo(0, sectionTop - Dimensions.HERO_FIXED_HEIGHT);
   };
 
   onCollectiveClick = () => {
@@ -162,8 +154,8 @@ export default class CollectivePage extends Component {
     const canEditCollective = LoggedInUser && LoggedInUser.canEditCollective(collective);
 
     return (
-      <Container position="relative" borderTop="1px solid #E6E8EB">
-        <Container ref={this.heroRef} height={isFixed ? Dimensions.HERO_FIXED_HEIGHT : 'auto'}>
+      <Container borderTop="1px solid #E6E8EB">
+        <Container height={Dimensions.HERO_PLACEHOLDER_HEIGHT}>
           <Hero
             collective={collective}
             host={host}

--- a/src/lib/ui-utils.js
+++ b/src/lib/ui-utils.js
@@ -10,7 +10,7 @@ import { debounce } from 'lodash';
  */
 export const debounceScroll = func => {
   return debounce(func, 200, {
-    maxWait: 100,
+    maxWait: 50,
     leading: true,
     trailing: true,
   });


### PR DESCRIPTION
By using a fixed placeholder height, we avoid the "jumping" issue when hero is collapsing.

![Peek 11-06-2019 13-47](https://user-images.githubusercontent.com/1556356/59270912-f230c480-8c52-11e9-9dd3-b9656348991e.gif)
