### PR TITLE
fix(withViewport): Use innerWidth rather than screen.availWidth

### DIFF
--- a/src/lib/withViewport.js
+++ b/src/lib/withViewport.js
@@ -90,8 +90,8 @@ const withViewport = (ChildComponent, options) => {
     /** Must only be called on client side */
     onResize = debounce(
       () => {
-        const viewport = getViewportFromWidth(window.screen.availWidth);
-        const state = buildState(window.screen.availWidth, window.screen.availHeight, viewport);
+        const viewport = getViewportFromWidth(window.innerWidth);
+        const state = buildState(window.innerWidth, window.innerHeight, viewport);
         this.setState(state);
       },
       500,


### PR DESCRIPTION
Using `screen.availWidth` works with mobile landscape/portrait switch but not with desktop window resize