### PR TITLE
Use hasLongDescription field on tiers page

### DIFF
--- a/src/components/TierCard.js
+++ b/src/components/TierCard.js
@@ -258,7 +258,7 @@ class TierCard extends React.Component {
           `}
         </style>
         <div className="name">
-          {!tier.longDescription ? (
+          {!tier.hasLongDescription ? (
             tier.name
           ) : (
             <Link
@@ -308,7 +308,7 @@ class TierCard extends React.Component {
               />
             </p>
           )}
-          {tier.longDescription && (
+          {tier.hasLongDescription && (
             <Link
               route="tier"
               params={{ collectiveSlug: collective.slug, tierId: tier.id, tierSlug: tier.slug, verb: 'contribute' }}

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -410,7 +410,7 @@ export const getCollectiveQuery = gql`
         type
         name
         description
-        longDescription
+        hasLongDescription
         button
         amount
         amountType


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-api/pull/2112

Tier's long description can be quite heavy (it's HTML content). On the tiers page  we display a `Read More` link towards the tier page if there is a long description but we actually don't need the full content, we just need to know if it exists.