### PR TITLE
Display collectives related to an hostCollective

### DIFF
--- a/src/components/Collective.js
+++ b/src/components/Collective.js
@@ -287,7 +287,41 @@ class Collective extends React.Component {
                 </div>
               </div>
 
-              {get(collective, 'stats.collectives.memberOf') > 0 && (
+              {get(collective, 'settings.isHostCollective') && (
+                <section id="members" className="clear">
+                  <div className="content">
+                    <SectionTitle
+                      title={
+                        <FormattedMessage
+                          id="hostCollective.host.collectives.title"
+                          defaultMessage={'Hosted by the organization'}
+                        />
+                      }
+                      subtitle={
+                        <FormattedMessage
+                          id="hostCollective.host.collectives.subtitle"
+                          values={{ n: collective.stats.collectives.memberOf }}
+                          defaultMessage={
+                            '{n, plural, one {this collective is} other {{n} collectives are}} hosted by the linked organization'
+                          }
+                        />
+                      }
+                    />
+
+                    <div className="cardsList">
+                      <CollectivesWithData
+                        HostCollectiveId={collective.host.id}
+                        orderBy="balance"
+                        type="COLLECTIVE"
+                        orderDirection="DESC"
+                        limit={20}
+                      />
+                    </div>
+                  </div>
+                </section>
+              )}
+
+              {!get(collective, 'settings.isHostCollective') && get(collective, 'stats.collectives.memberOf') > 0 && (
                 <section id="members" className="clear">
                   <div className="content">
                     <SectionTitle

--- a/src/components/Collective.js
+++ b/src/components/Collective.js
@@ -300,10 +300,7 @@ class Collective extends React.Component {
                       subtitle={
                         <FormattedMessage
                           id="hostCollective.host.collectives.subtitle"
-                          values={{ n: collective.stats.collectives.memberOf }}
-                          defaultMessage={
-                            '{n, plural, one {this collective is} other {{n} collectives are}} hosted by the linked organization'
-                          }
+                          defaultMessage={'Collectives hosted by the linked organization'}
                         />
                       }
                     />

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -594,6 +594,8 @@
   "host.types.organization.label": "an organization",
   "host.types.user.description": "ou will receive the funds on behalf of the collective under your own name. Please check with your local fiscal authorities the allowance below which you don't have to report the donations as taxable income.",
   "host.types.user.label": "an individual",
+  "hostCollective.host.collectives.subtitle": "{n, plural, one {this collective is} other {{n} collectives are}} hosted by the linked organization",
+  "hostCollective.host.collectives.title": "Hosted by the organization",
   "hosts.description": "Hosts are legal entities that collect money on behalf of open collectives so that they don't have to worry about accounting, taxes, etc. Some also provide extra services. {findOutMoreLink}",
   "hosts.description.findOutMoreLink": "Find out more about becoming an Open Collective Host.",
   "hosts.title": "Open Collective Hosts",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -594,7 +594,7 @@
   "host.types.organization.label": "an organization",
   "host.types.user.description": "ou will receive the funds on behalf of the collective under your own name. Please check with your local fiscal authorities the allowance below which you don't have to report the donations as taxable income.",
   "host.types.user.label": "an individual",
-  "hostCollective.host.collectives.subtitle": "{n, plural, one {this collective is} other {{n} collectives are}} hosted by the linked organization",
+  "hostCollective.host.collectives.subtitle": "Collectives hosted by the linked organization",
   "hostCollective.host.collectives.title": "Hosted by the organization",
   "hosts.description": "Hosts are legal entities that collect money on behalf of open collectives so that they don't have to worry about accounting, taxes, etc. Some also provide extra services. {findOutMoreLink}",
   "hosts.description.findOutMoreLink": "Find out more about becoming an Open Collective Host.",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -594,7 +594,7 @@
   "host.types.organization.label": "an organization",
   "host.types.user.description": "ou will receive the funds on behalf of the collective under your own name. Please check with your local fiscal authorities the allowance below which you don't have to report the donations as taxable income.",
   "host.types.user.label": "an individual",
-  "hostCollective.host.collectives.subtitle": "{n, plural, one {this collective is} other {{n} collectives are}} hosted by the linked organization",
+  "hostCollective.host.collectives.subtitle": "Collectives hosted by the linked organization",
   "hostCollective.host.collectives.title": "Hosted by the organization",
   "hosts.description": "Hosts are legal entities that collect money on behalf of open collectives so that they don't have to worry about accounting, taxes, etc. Some also provide extra services.",
   "hosts.description.findOutMoreLink": "Find out more about becoming an Open Collective Host.",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -594,6 +594,8 @@
   "host.types.organization.label": "an organization",
   "host.types.user.description": "ou will receive the funds on behalf of the collective under your own name. Please check with your local fiscal authorities the allowance below which you don't have to report the donations as taxable income.",
   "host.types.user.label": "an individual",
+  "hostCollective.host.collectives.subtitle": "{n, plural, one {this collective is} other {{n} collectives are}} hosted by the linked organization",
+  "hostCollective.host.collectives.title": "Hosted by the organization",
   "hosts.description": "Hosts are legal entities that collect money on behalf of open collectives so that they don't have to worry about accounting, taxes, etc. Some also provide extra services.",
   "hosts.description.findOutMoreLink": "Find out more about becoming an Open Collective Host.",
   "hosts.title": "Open Collective Hosts",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -594,7 +594,7 @@
   "host.types.organization.label": "une entreprise",
   "host.types.user.description": "Vous recevrez les fonds du collectif sous votre propre nom. Merci de vérifier avec les autorités fiscales locales que vous n’avez pas à déclarer les dons comme revenu imposable.",
   "host.types.user.label": "un individu",
-  "hostCollective.host.collectives.subtitle": "{n, plural, one {this collective is} other {{n} collectives are}} hosted by the linked organization",
+  "hostCollective.host.collectives.subtitle": "Collectives hosted by the linked organization",
   "hostCollective.host.collectives.title": "Hosted by the organization",
   "hosts.description": "Les hôtes sont des entitées légales qui récoltent l'argent au nom de collectifs ouverts, leur permettant ainsi d'opérer en toute légalité sans devoir se soucier de toute la paperasserie administrative, la comptabilité, etc. Certains hôtes offrent également des services complémentaires.",
   "hosts.description.findOutMoreLink": "Plus d'information sur comment devenir un hôte de collectifs ouverts.",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -594,6 +594,8 @@
   "host.types.organization.label": "une entreprise",
   "host.types.user.description": "Vous recevrez les fonds du collectif sous votre propre nom. Merci de vérifier avec les autorités fiscales locales que vous n’avez pas à déclarer les dons comme revenu imposable.",
   "host.types.user.label": "un individu",
+  "hostCollective.host.collectives.subtitle": "{n, plural, one {this collective is} other {{n} collectives are}} hosted by the linked organization",
+  "hostCollective.host.collectives.title": "Hosted by the organization",
   "hosts.description": "Les hôtes sont des entitées légales qui récoltent l'argent au nom de collectifs ouverts, leur permettant ainsi d'opérer en toute légalité sans devoir se soucier de toute la paperasserie administrative, la comptabilité, etc. Certains hôtes offrent également des services complémentaires.",
   "hosts.description.findOutMoreLink": "Plus d'information sur comment devenir un hôte de collectifs ouverts.",
   "hosts.title": "Hôtes d'Open Collective",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -594,6 +594,8 @@
   "host.types.organization.label": "組織",
   "host.types.user.description": "ou will receive the funds on behalf of the collective under your own name. Please check with your local fiscal authorities the allowance below which you don't have to report the donations as taxable income.",
   "host.types.user.label": "個人",
+  "hostCollective.host.collectives.subtitle": "{n, plural, one {this collective is} other {{n} collectives are}} hosted by the linked organization",
+  "hostCollective.host.collectives.title": "Hosted by the organization",
   "hosts.description": "ホストはオープンコレクティブの代わりにお金を集める法人です。経理や税金などについて心配する必要はありません。追加のサービスを提供する人もいます。{findOutMoreLink}",
   "hosts.description.findOutMoreLink": "Find out more about becoming an Open Collective Host.",
   "hosts.title": "Open Collective ホスト",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -594,7 +594,7 @@
   "host.types.organization.label": "組織",
   "host.types.user.description": "ou will receive the funds on behalf of the collective under your own name. Please check with your local fiscal authorities the allowance below which you don't have to report the donations as taxable income.",
   "host.types.user.label": "個人",
-  "hostCollective.host.collectives.subtitle": "{n, plural, one {this collective is} other {{n} collectives are}} hosted by the linked organization",
+  "hostCollective.host.collectives.subtitle": "Collectives hosted by the linked organization",
   "hostCollective.host.collectives.title": "Hosted by the organization",
   "hosts.description": "ホストはオープンコレクティブの代わりにお金を集める法人です。経理や税金などについて心配する必要はありません。追加のサービスを提供する人もいます。{findOutMoreLink}",
   "hosts.description.findOutMoreLink": "Find out more about becoming an Open Collective Host.",

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -594,6 +594,8 @@
   "host.types.organization.label": "организация",
   "host.types.user.description": "ou will receive the funds on behalf of the collective under your own name. Please check with your local fiscal authorities the allowance below which you don't have to report the donations as taxable income.",
   "host.types.user.label": "частное лицо",
+  "hostCollective.host.collectives.subtitle": "{n, plural, one {this collective is} other {{n} collectives are}} hosted by the linked organization",
+  "hostCollective.host.collectives.title": "Hosted by the organization",
   "hosts.description": "Представители являются юридическими лицами, которые собирают деньги от лица открытых коллективов, чтобы им не пришлом думать об учёте, налогах, и т. д. Некоторые представители также предоставляют дополнительные услуги. {findOutMoreLink}",
   "hosts.description.findOutMoreLink": "Узнайте больше о том, как стать Представителем Open Collective.",
   "hosts.title": "Представители Open Collective",

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -594,7 +594,7 @@
   "host.types.organization.label": "организация",
   "host.types.user.description": "ou will receive the funds on behalf of the collective under your own name. Please check with your local fiscal authorities the allowance below which you don't have to report the donations as taxable income.",
   "host.types.user.label": "частное лицо",
-  "hostCollective.host.collectives.subtitle": "{n, plural, one {this collective is} other {{n} collectives are}} hosted by the linked organization",
+  "hostCollective.host.collectives.subtitle": "Collectives hosted by the linked organization",
   "hostCollective.host.collectives.title": "Hosted by the organization",
   "hosts.description": "Представители являются юридическими лицами, которые собирают деньги от лица открытых коллективов, чтобы им не пришлом думать об учёте, налогах, и т. д. Некоторые представители также предоставляют дополнительные услуги. {findOutMoreLink}",
   "hosts.description.findOutMoreLink": "Узнайте больше о том, как стать Представителем Open Collective.",


### PR DESCRIPTION
If a collective is an "hostCollective" (`settings.hostCollective: true`), we display the collectives hosted by the organization.

Replace the old functionnality relying on `ParentCollectiveId`.

### Before

![Capture d’écran 2019-06-14 à 11 48 10](https://user-images.githubusercontent.com/806/59500714-50031d80-8e9a-11e9-9d41-272dd6df4b79.png)

### After

![Capture d’écran 2019-06-14 à 11 32 45](https://user-images.githubusercontent.com/806/59500083-02d27c00-8e99-11e9-9783-3c0455638bd8.png)
