### PR TITLE
Update collective page section title fontsize

### DIFF
--- a/src/components/SectionTitle.js
+++ b/src/components/SectionTitle.js
@@ -7,11 +7,15 @@ import withIntl from '../lib/withIntl';
 import { defineMessages } from 'react-intl';
 import Link from './Link';
 import Container from './Container';
-import { H1 } from './Text';
+import { H2 } from './Text';
 
 const LinkAction = styled(Link)`
   text-align: center;
   color: #090a0a;
+`;
+
+const Title = styled(H2)`
+  font-size: 4rem !important;
 `;
 
 const Subtitle = styled(Container)`
@@ -150,7 +154,7 @@ class SectionTitle extends React.Component {
 
         <Container className="content">
           <Box mt={2} mb={3}>
-            <H1>{title}</H1>
+            <Title>{title}</Title>
           </Box>
           {action && (
             <LinkAction route={action.href} className="action" scroll={false}>


### PR DESCRIPTION
This PR replaces section title from `H1` tag to `H2` and sets the fontSize value to `4rem`.

Before:
![Screenshot from 2019-06-14 16-37-43](https://user-images.githubusercontent.com/15707013/59520880-da5f7780-8ec2-11e9-87ba-c80223b0e874.png)

After:
![Screenshot from 2019-06-14 16-35-29](https://user-images.githubusercontent.com/15707013/59520884-e0555880-8ec2-11e9-9ff8-4ab735662f73.png)

