### PR TITLE
Add customFields to ContributionFlow

### DIFF
--- a/src/components/ContributeDetails.js
+++ b/src/components/ContributeDetails.js
@@ -59,6 +59,7 @@ const ContributeDetails = ({
   showInterval,
   customFields,
   onChange,
+  onCustomFieldsChange,
 }) => {
   const hasOptions = get(amountOptions, 'length', 0) > 0;
   const displayMap = amountOptions ? buildDisplayMap(amountOptions) : {};
@@ -189,7 +190,7 @@ const ContributeDetails = ({
       )}
       {customFields &&
         customFields.length > 0 &&
-        customFields.map(customField => {
+        customFields.map((customField, index) => {
           return (
             <StyledInputField mt={2} key={customField.name} htmlFor={customField.name} label={customField.label}>
               {fieldProps => (
@@ -198,7 +199,7 @@ const ContributeDetails = ({
                   {...fieldProps}
                   value={customField.value}
                   width={1}
-                  diabled={true}
+                  onChange={({ target }) => onCustomFieldsChange(index, target.value)}
                 />
               )}
             </StyledInputField>
@@ -238,6 +239,7 @@ ContributeDetails.propTypes = {
   showInterval: PropTypes.bool,
   /** Enable the customFields inputs */
   customFields: PropTypes.array,
+  onCustomFieldsChange: PropTypes.func,
 };
 
 ContributeDetails.defaultProps = {

--- a/src/components/ContributeDetails.js
+++ b/src/components/ContributeDetails.js
@@ -58,6 +58,7 @@ const ContributeDetails = ({
   showQuantity,
   showInterval,
   customFields,
+  customData,
   onChange,
   onCustomFieldsChange,
 }) => {
@@ -190,16 +191,16 @@ const ContributeDetails = ({
       )}
       {customFields &&
         customFields.length > 0 &&
-        customFields.map((customField, index) => {
+        customFields.map(customField => {
           return (
             <StyledInputField mt={2} key={customField.name} htmlFor={customField.name} label={customField.label}>
               {fieldProps => (
                 <StyledInput
                   type={customField.type}
                   {...fieldProps}
-                  value={customField.value}
+                  value={customData[customField.name]}
                   width={1}
-                  onChange={({ target }) => onCustomFieldsChange(index, target.value)}
+                  onChange={({ target }) => onCustomFieldsChange(customField.name, target.value)}
                 />
               )}
             </StyledInputField>
@@ -239,6 +240,7 @@ ContributeDetails.propTypes = {
   showInterval: PropTypes.bool,
   /** Enable the customFields inputs */
   customFields: PropTypes.array,
+  customData: PropTypes.object,
   onCustomFieldsChange: PropTypes.func,
 };
 

--- a/src/components/ContributeDetails.js
+++ b/src/components/ContributeDetails.js
@@ -57,6 +57,7 @@ const ContributeDetails = ({
   maxQuantity,
   showQuantity,
   showInterval,
+  customFields,
   onChange,
 }) => {
   const hasOptions = get(amountOptions, 'length', 0) > 0;
@@ -186,6 +187,23 @@ const ContributeDetails = ({
           )}
         </StyledInputField>
       )}
+      {customFields &&
+        customFields.length > 0 &&
+        customFields.map(customField => {
+          return (
+            <StyledInputField mt={2} key={customField.name} htmlFor={customField.name} label={customField.label}>
+              {fieldProps => (
+                <StyledInput
+                  type={customField.type}
+                  {...fieldProps}
+                  value={customField.value}
+                  width={1}
+                  diabled={true}
+                />
+              )}
+            </StyledInputField>
+          );
+        })}
     </Flex>
   );
 };
@@ -218,6 +236,8 @@ ContributeDetails.propTypes = {
   showQuantity: PropTypes.bool,
   /** Enable the interval input */
   showInterval: PropTypes.bool,
+  /** Enable the customFields inputs */
+  customFields: PropTypes.array,
 };
 
 ContributeDetails.defaultProps = {

--- a/src/components/ContributeDetails.js
+++ b/src/components/ContributeDetails.js
@@ -192,14 +192,16 @@ const ContributeDetails = ({
       {customFields &&
         customFields.length > 0 &&
         customFields.map(customField => {
+          const value = customData && customData[customField.name] ? customData[customField.name] : '';
           return (
             <StyledInputField mt={2} key={customField.name} htmlFor={customField.name} label={customField.label}>
               {fieldProps => (
                 <StyledInput
                   type={customField.type}
                   {...fieldProps}
-                  value={customData[customField.name]}
+                  value={value}
                   width={1}
+                  required={customField.required}
                   onChange={({ target }) => onCustomFieldsChange(customField.name, target.value)}
                 />
               )}

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1770,14 +1770,6 @@ enum OrderDirection {
   DESC
 }
 
-input CustomFieldsInputType {
-  type: String
-  label: String
-  name: String
-  required: Boolean
-  value: String
-}
-
 """
 Input type for OrderType
 """
@@ -1793,7 +1785,7 @@ input OrderInputType {
   publicMessage: String
   privateMessage: String
   paymentMethod: PaymentMethodInputType
-  customFields: [CustomFieldsInputType]
+  customData: JSON
 
   """
   The first part of the UUID of the PaymentMethod that can be used to match the donation
@@ -2551,6 +2543,16 @@ type Subscription {
 }
 
 """
+CustomFields Type
+"""
+type CustomFieldsType {
+  type: String
+  label: String
+  name: String
+  required: Boolean
+}
+
+"""
 This represents an Tier
 """
 type Tier {
@@ -2625,6 +2627,13 @@ type Tier {
   stats: TierStatsType
 }
 
+input CustomFieldsInputType {
+  type: String
+  label: String
+  name: String
+  required: Boolean
+}
+
 """
 Input type for TierType
 """
@@ -2661,6 +2670,11 @@ input TierInputType {
   """
   goal: Int
   password: String
+  customFields: [CustomFieldsInputType]
+
+  """
+  amount that you are trying to raise with this tier
+  """
   customFields: [CustomFieldsInputType]
 
   """

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1785,6 +1785,7 @@ input OrderInputType {
   publicMessage: String
   privateMessage: String
   paymentMethod: PaymentMethodInputType
+  customFields: JSON
 
   """
   The first part of the UUID of the PaymentMethod that can be used to match the donation
@@ -1858,6 +1859,7 @@ type OrderType {
   subscription: Subscription
   stats: StatsOrderType
   createdByUser: UserDetails
+  customFields: JSON
 
   """
   Description of the order that will show up in the invoice

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1770,6 +1770,14 @@ enum OrderDirection {
   DESC
 }
 
+input CustomFieldsInputType {
+  type: String
+  label: String
+  name: String
+  required: Boolean
+  value: String
+}
+
 """
 Input type for OrderType
 """
@@ -1785,7 +1793,7 @@ input OrderInputType {
   publicMessage: String
   privateMessage: String
   paymentMethod: PaymentMethodInputType
-  customFields: JSON
+  customFields: [CustomFieldsInputType]
 
   """
   The first part of the UUID of the PaymentMethod that can be used to match the donation
@@ -1859,7 +1867,6 @@ type OrderType {
   subscription: Subscription
   stats: StatsOrderType
   createdByUser: UserDetails
-  customFields: JSON
 
   """
   Description of the order that will show up in the invoice

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1,5 +1,5 @@
-# source: http://localhost:3000/api/graphql
-# timestamp: Thu Jul 04 2019 17:49:47 GMT+0200 (GMT+02:00)
+# source: https://opencollective.com/api/graphql
+# timestamp: Mon Jul 08 2019 10:28:18 GMT+0200 (Central European Summer Time)
 
 """
 Application model
@@ -1785,7 +1785,6 @@ input OrderInputType {
   publicMessage: String
   privateMessage: String
   paymentMethod: PaymentMethodInputType
-  customData: JSON
 
   """
   The first part of the UUID of the PaymentMethod that can be used to match the donation
@@ -2543,16 +2542,6 @@ type Subscription {
 }
 
 """
-CustomFields Type
-"""
-type CustomFieldsType {
-  type: String
-  label: String
-  name: String
-  required: Boolean
-}
-
-"""
 This represents an Tier
 """
 type Tier {
@@ -2627,13 +2616,6 @@ type Tier {
   stats: TierStatsType
 }
 
-input CustomFieldsInputType {
-  type: String
-  label: String
-  name: String
-  required: Boolean
-}
-
 """
 Input type for TierType
 """
@@ -2670,11 +2652,6 @@ input TierInputType {
   """
   goal: Int
   password: String
-  customFields: [CustomFieldsInputType]
-
-  """
-  amount that you are trying to raise with this tier
-  """
   customFields: [CustomFieldsInputType]
 
   """

--- a/src/pages/createOrder.js
+++ b/src/pages/createOrder.js
@@ -95,7 +95,7 @@ class CreateOrderPage extends React.Component {
       redeem: query.redeem,
       redirect: query.redirect,
       referral: query.referral,
-      customFieldsDefaultValues: query.data,
+      jsonUrl: query.jsonUrl,
     };
   }
 
@@ -111,7 +111,7 @@ class CreateOrderPage extends React.Component {
     description: PropTypes.string,
     verb: PropTypes.string,
     step: PropTypes.string,
-    customFieldsDefaultValues: PropTypes.object,
+    jsonUrl: PropTypes.string,
     redirect: PropTypes.string,
     referral: PropTypes.string,
     redeem: PropTypes.bool,
@@ -487,22 +487,12 @@ class CreateOrderPage extends React.Component {
 
   getDefaultCustomFields() {
     const { customFields } = this.state;
-    let { customFieldsDefaultValues } = this.props;
+    const { jsonUrl } = this.props;
 
-    try {
-      // `customFieldsDefaultValues` is from the url data querystring
-      // it is needed as an object hence the need to parse
-      customFieldsDefaultValues = JSON.parse(customFieldsDefaultValues);
-    } catch (err) {
-      console.error(err);
-    }
-
-    if (customFieldsDefaultValues) {
+    if (jsonUrl) {
       forEach(customFields, field => {
-        // if customFieldsDefaultValues from the url has a property whose key
-        // is a name in the customFields, set it's value as field value.
-        if (customFieldsDefaultValues[field.name]) {
-          field.value = customFieldsDefaultValues[field.name];
+        if (field.name === 'jsonUrl') {
+          field.value = jsonUrl;
         }
       });
     }

--- a/src/pages/createOrder.js
+++ b/src/pages/createOrder.js
@@ -605,8 +605,10 @@ class CreateOrderPage extends React.Component {
     const { customData } = this.state;
 
     this.setState({
-      ...customData,
-      [name]: value,
+      customData: {
+        ...customData,
+        [name]: value,
+      },
     });
   };
 

--- a/src/pages/createOrder.js
+++ b/src/pages/createOrder.js
@@ -683,7 +683,7 @@ class CreateOrderPage extends React.Component {
     const { stepDetails, stepPayment, customData } = this.state;
     const [personal, profiles] = this.getProfiles();
     const tier = this.props.data.Tier;
-    const customFields = tier.customFields || [];
+    const customFields = tier && tier.customFields ? tier.customFields : [];
     const defaultStepDetails = this.getDefaultStepDetails(tier);
     const interval = get(stepDetails, 'interval') || defaultStepDetails.interval;
 

--- a/src/pages/createOrder.js
+++ b/src/pages/createOrder.js
@@ -199,7 +199,7 @@ class CreateOrderPage extends React.Component {
       stepDetails: get(state.stepDetails, 'totalAmount')
         ? state.stepDetails
         : this.getDefaultStepDetails(this.props.data.Tier),
-      customData: this.props.customData, // May needs parsing with JSON.parse
+      customData: this.props.customData,
     }));
   }
 

--- a/src/pages/createOrder.js
+++ b/src/pages/createOrder.js
@@ -80,6 +80,14 @@ class CreateOrderPage extends React.Component {
       query.interval = null;
     }
 
+    if (query.data) {
+      try {
+        query.data = JSON.parse(query.data);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
     return {
       collectiveSlug: query.collectiveSlug,
       eventSlug: query.eventSlug,
@@ -111,7 +119,7 @@ class CreateOrderPage extends React.Component {
     description: PropTypes.string,
     verb: PropTypes.string,
     step: PropTypes.string,
-    customData: PropTypes.string,
+    customData: PropTypes.object,
     redirect: PropTypes.string,
     referral: PropTypes.string,
     redeem: PropTypes.bool,
@@ -364,7 +372,6 @@ class CreateOrderPage extends React.Component {
       description: decodeURIComponent(this.props.description || ''),
       customData,
     };
-    console.log(order);
 
     try {
       const res = await this.props.createOrder(order);


### PR DESCRIPTION
This PR follows up [#2128](https://github.com/opencollective/opencollective/issues/2128) frontend specification. While some of the expected behaviors are not fully clear now, will update the code as it is being reviewed.
![Screenshot from 2019-06-19 10-45-23](https://user-images.githubusercontent.com/15707013/59759789-c03de480-9288-11e9-9681-3725470d90b8.png)

The customField value is passed, through the url as `http://localhost:3000/brusselstogether/contribute/donor-121/checkout?jsonUrl=http://example/deps.json`.

One question bothering me while writing the code here was, should I tailor this to just expect `jsonUrl` in custom field? or make it flexible and expandable for other fields? doing the latter will add extra complexity and time to get right as no collective tier currently have `settings` but maybe json schema ([#issuecomment-503028059](https://github.com/opencollective/opencollective/issues/2128#issuecomment-503028059)) would make it easier.  Also I think there is a limit to url characters.