### PR TITLE
Move NCP and tier pages to the new contributors endpoints

### DIFF
--- a/src/components/collective-page/index.js
+++ b/src/components/collective-page/index.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 
 // OC Frontend imports
-import roles from '../../constants/roles';
-import { CollectiveType } from '../../constants/collectives';
 import theme from '../../constants/theme';
 import { debounceScroll } from '../../lib/ui-utils';
 import Container from '../Container';
@@ -56,20 +54,8 @@ export default class CollectivePage extends Component {
       image: PropTypes.string,
     }),
 
-    /** Collective members */
-    members: PropTypes.arrayOf(
-      PropTypes.shape({
-        id: PropTypes.number.isRequired,
-        role: PropTypes.oneOf(Object.values(roles)).isRequired,
-        collective: PropTypes.shape({
-          id: PropTypes.number.isRequired,
-          type: PropTypes.oneOf(Object.values(CollectiveType)).isRequired,
-          slug: PropTypes.string.isRequired,
-          name: PropTypes.string,
-          image: PropTypes.string,
-        }).isRequired,
-      }),
-    ),
+    /** Collective contributors */
+    contributors: PropTypes.arrayOf(PropTypes.object),
 
     /** Collective tiers */
     tiers: PropTypes.arrayOf(
@@ -142,12 +128,12 @@ export default class CollectivePage extends Component {
   };
 
   renderSection(section, canEdit) {
-    const { collective, members, tiers, events } = this.props;
+    const { collective, contributors, tiers, events } = this.props;
 
     if (section === Sections.ABOUT) {
       return <SectionAbout collective={collective} canEdit={canEdit} editMutation={EditCollectiveMutation} />;
     } else if (section === Sections.CONTRIBUTORS) {
-      return <SectionContributors collectiveName={collective.name} members={members} />;
+      return <SectionContributors collectiveName={collective.name} contributors={contributors} />;
     } else if (section === Sections.CONTRIBUTE) {
       return <SectionContribute collective={collective} tiers={tiers} events={events} />;
     }

--- a/src/components/tier-page/index.js
+++ b/src/components/tier-page/index.js
@@ -8,8 +8,6 @@ import { withRouter } from 'next/router';
 import gql from 'graphql-tag';
 
 // Open Collective Frontend imports
-import roles from '../../constants/roles';
-import { CollectiveType } from '../../constants/collectives';
 import { getWebsiteUrl } from '../../lib/utils';
 import { P, H1, H3 } from '../Text';
 import StyledButton from '../StyledButton';
@@ -96,23 +94,11 @@ class TierPage extends Component {
       videoUrl: PropTypes.string,
     }).isRequired,
 
-    /** The members that contribute to this tier */
-    members: PropTypes.arrayOf(
-      PropTypes.shape({
-        id: PropTypes.number.isRequired,
-        role: PropTypes.oneOf(Object.values(roles)).isRequired,
-        collective: PropTypes.shape({
-          id: PropTypes.number.isRequired,
-          type: PropTypes.oneOf(Object.values(CollectiveType)).isRequired,
-          slug: PropTypes.string.isRequired,
-          name: PropTypes.string,
-          image: PropTypes.string,
-        }).isRequired,
-      }),
-    ),
+    /** The contributors for this tier */
+    contributors: PropTypes.arrayOf(PropTypes.object),
 
     /** Some statistics about this tier */
-    membersStats: PropTypes.shape({
+    contributorsStats: PropTypes.shape({
       all: PropTypes.number.isRequired,
       collectives: PropTypes.number.isRequired,
       organizations: PropTypes.number.isRequired,
@@ -139,7 +125,7 @@ class TierPage extends Component {
   }
 
   render() {
-    const { collective, tier, members, membersStats, LoggedInUser } = this.props;
+    const { collective, tier, contributors, contributorsStats, LoggedInUser } = this.props;
     const canEdit = LoggedInUser && LoggedInUser.canEditCollective(collective);
     const amountRaised = tier.interval ? tier.stats.totalRecurringDonations : tier.stats.totalDonated;
     const shareBlock = this.renderShareBlock();
@@ -345,7 +331,13 @@ class TierPage extends Component {
             </Container>
           </Flex>
         </Flex>
-        <TierContributors collectiveName={collective.name} members={members} membersStats={membersStats} />
+        {contributors && contributors.length > 0 && (
+          <TierContributors
+            collectiveName={collective.name}
+            contributors={contributors}
+            contributorsStats={contributorsStats}
+          />
+        )}
       </Container>
     );
   }

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:3000/api/graphql
-# timestamp: Thu Jun 13 2019 17:47:32 GMT+0200 (GMT+02:00)
+# timestamp: Thu Jun 20 2019 14:54:01 GMT+0200 (GMT+02:00)
 
 """
 Application model
@@ -152,6 +152,11 @@ type Collective implements CollectiveInterface {
     role: String
     roles: [String]
   ): [Member]
+
+  """
+  All the persons and entities that contribute to this organization
+  """
+  contributors(limit: Int = 1000): [Contributor]
   collectives(
     orderBy: CollectiveOrderField = name
     orderDirection: OrderDirection = ASC
@@ -374,6 +379,11 @@ interface CollectiveInterface {
   ): [Member]
 
   """
+  All the persons and entities that contribute to this organization
+  """
+  contributors(limit: Int = 1000): [Contributor]
+
+  """
   List of all collectives hosted by this collective
   """
   collectives(
@@ -407,7 +417,20 @@ interface CollectiveInterface {
   githubHandle: String
   website: String
   updates(limit: Int, offset: Int): [Event]
-  events(limit: Int, offset: Int): [Event]
+  events(
+    limit: Int
+    offset: Int
+
+    """
+    Include past events
+    """
+    includePastEvents: Boolean = false
+
+    """
+    Include inactive events
+    """
+    includeInactive: Boolean = false
+  ): [Event]
   paymentMethods(
     service: String
     limit: Int
@@ -650,6 +673,117 @@ type ConnectedAccountType {
   updatedAt: DateString
 }
 
+"""
+A person or an entity that contributes financially or by any other mean to the mission
+of the collective. While "Member" is dedicated to permissions, this type is meant
+to surface all the public contributors.
+"""
+type Contributor {
+  """
+  A unique identifier for this member
+  """
+  id: String!
+
+  """
+  Name of the contributor
+  """
+  name: String!
+
+  """
+  All the roles for a given contributor
+  """
+  roles: [ContributorRole]
+
+  """
+  True if the contributor is a core contributor (admin)
+  """
+  isCore: Boolean!
+
+  """
+  True if the contributor is a financial contributor
+  """
+  isBacker: Boolean!
+
+  """
+  True if the contributor is a core contributor (admin)
+  """
+  isFundraiser: Boolean!
+
+  """
+  Member join date
+  """
+  since: IsoDateString!
+
+  """
+  How much money the user has contributed for this (in cents, using collective currency)
+  """
+  totalAmountDonated: Int!
+
+  """
+  Description of how the member contribute. Will usually be a tier name, or "design" or "code".
+  """
+  description: String
+
+  """
+  If the contributor has a page on Open Collective, this is the slug to link to it
+  """
+  collectiveSlug: String
+
+  """
+  Contributor avatar or logo
+  """
+  image: String
+
+  """
+  A public message from contributors to describe their contributions
+  """
+  publicMessage: String
+}
+
+"""
+Possible roles for a contributor. Extends `Member.Role`.
+"""
+enum ContributorRole {
+  HOST
+  ADMIN
+  MEMBER
+  CONTRIBUTOR
+  BACKER
+  FUNDRAISER
+  ATTENDEE
+  FOLLOWER
+}
+
+"""
+Breakdown of contributors per type (ANY/USER/ORGANIZATION/COLLECTIVE)
+"""
+type ContributorsStats {
+  """
+  We always have to return an id for apollo's caching
+  """
+  id: String!
+
+  """
+  Total number of contributors
+  """
+  all: Int
+
+  """
+  Number of individuals
+  """
+  users: Int
+
+  """
+  Number of organizations
+  """
+  organizations: Int
+
+  """
+  Number of collectives
+  """
+  collectives: Int
+}
+
 type CreateUserResult {
   user: UserDetails
   organization: CollectiveInterface
@@ -751,6 +885,11 @@ type Event implements CollectiveInterface {
     role: String
     roles: [String]
   ): [Member]
+
+  """
+  All the persons and entities that contribute to this organization
+  """
+  contributors(limit: Int = 1000): [Contributor]
   collectives(
     orderBy: CollectiveOrderField = name
     orderDirection: OrderDirection = ASC
@@ -1855,6 +1994,11 @@ type Organization implements CollectiveInterface {
     role: String
     roles: [String]
   ): [Member]
+
+  """
+  All the persons and entities that contribute to this organization
+  """
+  contributors(limit: Int = 1000): [Contributor]
   collectives(
     orderBy: CollectiveOrderField = name
     orderDirection: OrderDirection = ASC
@@ -2416,6 +2560,19 @@ type Tier {
     """
     limit: Int = 5000
   ): [Member]
+    @deprecated(
+      reason: "\n          2019/06/20 - This endpoint was used for the new tier page and has been replaced\n          by \"contributors\". It can be deleted as soon as the migration's completed\n          as well as the \"members.findByTierId\" loader.\n        "
+    )
+
+  """
+  Returns a list of all the contributors for this tier
+  """
+  contributors(
+    """
+    Maximum number of entries to return
+    """
+    limit: Int = 3000
+  ): [Contributor]
   stats: TierStatsType
 }
 
@@ -2477,6 +2634,14 @@ type TierStatsType {
   Breakdown of all the members that belongs to this tier.
   """
   members: MembersStatsType
+    @deprecated(
+      reason: "\n          2019/06/20 - This endpoint was used for the new tier page and has been replaced\n          by \"contributors\". It can be deleted as soon as the migration's completed\n          as well as the \"members.findByTierId\" loader.\n        "
+    )
+
+  """
+  Breakdown of all the contributors that belongs to this tier.
+  """
+  contributors: ContributorsStats
 
   """
   total number of individual orders
@@ -2747,6 +2912,11 @@ type User implements CollectiveInterface {
     role: String
     roles: [String]
   ): [Member]
+
+  """
+  All the persons and entities that contribute to this organization
+  """
+  contributors(limit: Int = 1000): [Contributor]
   collectives(
     orderBy: CollectiveOrderField = name
     orderDirection: OrderDirection = ASC

--- a/src/pages/new-collective-page.js
+++ b/src/pages/new-collective-page.js
@@ -74,7 +74,7 @@ class NewCollectivePage extends React.Component {
             <CollectivePage
               collective={data.Collective}
               host={data.Collective.host}
-              members={data.Collective.members}
+              contributors={data.Collective.contributors}
               tiers={data.Collective.tiers}
               events={data.Collective.events}
               LoggedInUser={LoggedInUser}
@@ -115,16 +115,18 @@ const getCollective = graphql(gql`
         image
         type
       }
-      members {
+      contributors {
         id
-        role
-        collective: member {
-          id
-          type
-          slug
-          name
-          image
-        }
+        name
+        roles
+        isCore
+        isBacker
+        isFundraiser
+        since
+        description
+        collectiveSlug
+        totalAmountDonated
+        image
       }
       tiers {
         id

--- a/src/pages/tier.js
+++ b/src/pages/tier.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from 'react-apollo';
 import gql from 'graphql-tag';
-import { get, uniqBy } from 'lodash';
+import { get } from 'lodash';
 import { createGlobalStyle } from 'styled-components';
 
 import withIntl from '../lib/withIntl';
@@ -11,7 +11,6 @@ import ErrorPage from '../components/ErrorPage';
 import Page from '../components/Page';
 import Loading from '../components/Loading';
 import TierPageContent from '../components/tier-page';
-import { CollectiveType } from '../constants/collectives';
 
 /** Overrides global styles for this page */
 const GlobalStyles = createGlobalStyle`
@@ -34,8 +33,8 @@ class TierPage extends React.Component {
     tierSlug: PropTypes.string,
   };
 
-  static getInitialProps({ query: { tierId, tierSlug } }) {
-    return { tierId: Number(tierId), tierSlug };
+  static getInitialProps({ query: { collectiveSlug, tierId, tierSlug } }) {
+    return { collectiveSlug, tierId: Number(tierId), tierSlug };
   }
 
   // See https://github.com/opencollective/opencollective/issues/1872
@@ -66,20 +65,6 @@ class TierPage extends React.Component {
     }
   }
 
-  /**
-   * As we also count the collective admins among tier contributors, we must add this
-   * to the tier stats.
-   */
-  getMembersStats = (baseStats, admins) => {
-    const countAdminType = type => admins.filter(m => m.collective.type === type).length;
-    return {
-      all: baseStats.all + admins.length,
-      collectives: baseStats.collectives + countAdminType(CollectiveType.COLLECTIVE),
-      organizations: baseStats.organizations + countAdminType(CollectiveType.ORGANIZATION),
-      users: baseStats.users + countAdminType(CollectiveType.USER),
-    };
-  };
-
   render() {
     const { data, LoggedInUser } = this.props;
 
@@ -96,8 +81,8 @@ class TierPage extends React.Component {
               LoggedInUser={LoggedInUser}
               collective={data.Tier.collective}
               tier={data.Tier}
-              members={uniqBy([...data.Tier.collective.admins, ...data.Tier.members], 'collective.id')}
-              membersStats={this.getMembersStats(data.Tier.stats.members, data.Tier.collective.admins)}
+              contributors={data.Tier.contributors}
+              contributorsStats={data.Tier.stats.contributors}
             />
           </React.Fragment>
         )}
@@ -123,7 +108,7 @@ const getCollective = graphql(gql`
         id
         totalDonated
         totalRecurringDonations
-        members {
+        contributors {
           id
           all
           collectives
@@ -157,16 +142,17 @@ const getCollective = graphql(gql`
         }
       }
 
-      members {
+      contributors {
         id
-        role
-        collective: member {
-          id
-          type
-          slug
-          name
-          image
-        }
+        name
+        roles
+        isCore
+        isBacker
+        isFundraiser
+        since
+        description
+        collectiveSlug
+        image
       }
     }
   }


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-api/pull/2127
Resolve opencollective/opencollective#2102

---

- [x] New collective page
  - [x] Contributors grid
  - Top contributors => Will follow up in https://github.com/opencollective/opencollective-frontend/pull/1968
- [x] Tier page
  - [x] Contributors grid
  - [x] Stats
- [x] Add contributor's description (tier name) on contributors cards - see design