### PR TITLE
fix(SignInOrJoinFree): Remove props for redirect={Router.asPath}

### DIFF
--- a/src/components/AuthenticatedPage.js
+++ b/src/components/AuthenticatedPage.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Flex } from '@rebass/grid';
 
-import { Router } from '../server/pages';
 import { withUser } from './UserProvider';
 import Page from './Page';
 import Loading from './Loading';
@@ -51,7 +50,7 @@ class AuthenticatedPage extends React.Component {
                   defaultMessage="You need to be logged in to continue."
                 />
               </MessageBox>
-              <SignInOrJoinFree redirect={Router.asPath} />
+              <SignInOrJoinFree />
             </Flex>
           )}
         </Flex>

--- a/src/components/CreateCollective.js
+++ b/src/components/CreateCollective.js
@@ -213,7 +213,7 @@ class CreateCollective extends React.Component {
               </div>
             )}
 
-            {canApply && !LoggedInUser && <SignInOrJoinFree redirect={Router.asPath} />}
+            {canApply && !LoggedInUser && <SignInOrJoinFree />}
 
             {canApply && LoggedInUser && (
               <div>

--- a/src/components/CreateOrganization.js
+++ b/src/components/CreateOrganization.js
@@ -128,7 +128,7 @@ class CreateOrganization extends React.Component {
           <div className="content">
             {!LoggedInUser && (
               <div className="signin">
-                <SignInOrJoinFree redirect={Router.asPath} />
+                <SignInOrJoinFree />
               </div>
             )}
             {LoggedInUser && (

--- a/src/components/EditCollective.js
+++ b/src/components/EditCollective.js
@@ -12,7 +12,6 @@ import NotificationBar from './NotificationBar';
 import { defaultBackgroundImage } from '../constants/collectives';
 import withIntl from '../lib/withIntl';
 import Loading from './Loading';
-import { Router } from '../server/pages';
 
 class EditCollective extends React.Component {
   static propTypes = {
@@ -201,7 +200,7 @@ class EditCollective extends React.Component {
                   <br />
                   or as a core contributor of the {collective.name} collective.
                 </p>
-                <SignInOrJoinFree redirect={Router.asPath} />
+                <SignInOrJoinFree />
               </div>
             )}
             {canEditCollective && !loggedInEditDataLoaded && <Loading />}

--- a/src/components/expenses/CreateExpenseForm.js
+++ b/src/components/expenses/CreateExpenseForm.js
@@ -6,7 +6,6 @@ import { get } from 'lodash';
 
 import withIntl from '../../lib/withIntl';
 import { getCurrencySymbol } from '../../lib/utils';
-import { Router } from '../../server/pages';
 import categories from '../../constants/categories';
 
 import InputField from '../InputField';
@@ -506,7 +505,7 @@ class CreateExpenseForm extends React.Component {
           <P textAlign="center" mt={4} fontSize="LeadParagraph" lineHeight="LeadParagraph">
             <FormattedMessage id="expenses.create.login" defaultMessage="Sign up or login to submit an expense." />
           </P>
-          <SignInOrJoinFree redirect={Router.asPath} />
+          <SignInOrJoinFree />
         </div>
       );
     } else {

--- a/src/pages/action.js
+++ b/src/pages/action.js
@@ -5,7 +5,6 @@ import { graphql, compose } from 'react-apollo';
 import gql from 'graphql-tag';
 import { Flex } from '@rebass/grid';
 
-import { Router } from '../server/pages';
 import Header from '../components/Header';
 import Body from '../components/Body';
 import Footer from '../components/Footer';
@@ -70,7 +69,7 @@ class ActionPage extends React.Component {
     if (!LoggedInUser) {
       return (
         <Flex justifyContent="center" alignItems="center" className="content" px={2} py={5}>
-          <SignInOrJoinFree redirect={Router.asPath} />
+          <SignInOrJoinFree />
         </Flex>
       );
     } else {

--- a/src/pages/claimCollective.js
+++ b/src/pages/claimCollective.js
@@ -185,7 +185,7 @@ class ClaimCollectivePage extends React.Component {
         <Body>
           {(step === 'loading' || step === 'signin') && (
             <Flex id="content" flexDirection="column" alignItems="center" mt={6} mb={6} p={2}>
-              {loadingLoggedInUser ? <Loading /> : <SignInOrJoinFree redirect={Router.asPath} />}
+              {loadingLoggedInUser ? <Loading /> : <SignInOrJoinFree />}
             </Flex>
           )}
 

--- a/src/pages/completePledge.js
+++ b/src/pages/completePledge.js
@@ -93,7 +93,7 @@ class CompletePledgePage extends React.Component {
 
             {!loadingLoggedInUser && !LoggedInUser && (
               <Fragment>
-                <SignInOrJoinFree redirect={Router.asPath} />
+                <SignInOrJoinFree />
               </Fragment>
             )}
 

--- a/src/pages/createOrder.js
+++ b/src/pages/createOrder.js
@@ -822,7 +822,7 @@ class CreateOrderPage extends React.Component {
     const { LoggedInUser } = this.props;
 
     if (!LoggedInUser) {
-      return <SignInOrJoinFree redirect={Router.asPath} />;
+      return <SignInOrJoinFree />;
     }
 
     const isPaypal = get(this.state, 'stepPayment.paymentMethod.service') === 'paypal';

--- a/src/pages/openSourceApply.js
+++ b/src/pages/openSourceApply.js
@@ -86,7 +86,7 @@ class OpenSourceApplyPage extends Component {
     const { repositories } = this.state;
 
     if (!LoggedInUser) {
-      return <SignInOrJoinFree redirect={Router.asPath} />;
+      return <SignInOrJoinFree />;
     } else if (!token || repositories.length === 0) {
       return this.renderConnectGithubButton();
     } else {


### PR DESCRIPTION
Following up on https://github.com/opencollective/opencollective-frontend/pull/1960 and https://github.com/opencollective/opencollective-frontend/pull/1997

I got the error below in dev environment (wasn't able to reproduce on staging). As the component automatically adds a redirect, there's no need to use `Router.asPath`. The only case where we want to set the `redirect` prop is when the redirect URL is different from the current page, for example on `/signin`.

![2019-06-27_09:56:04](https://user-images.githubusercontent.com/1556356/60322637-3e347680-9980-11e9-9446-d7f4588ac243.png)
