### PR TITLE
Set a tier.name defaultValue for Tier model to validate

### DIFF
--- a/src/components/EditTiers.js
+++ b/src/components/EditTiers.js
@@ -297,6 +297,10 @@ class EditTiers extends React.Component {
       tier.presets = [1000];
     }
 
+    if (!tier.name) {
+      tier.name = '';
+    }
+
     const defaultValues = {
       ...tier,
       type: tier.type || this.defaultType,


### PR DESCRIPTION
This PR follows up [#1880](https://github.com/opencollective/opencollective-frontend/pull/1880) & [#2181](https://github.com/opencollective/opencollective-api/pull/2181). 

After opening this PR [#2181](https://github.com/opencollective/opencollective-api/pull/2181), noticed when you create a new tier without name, `tier.name` is not set, making the value `undefined`, Sequelize handles this because in `name` field `allowNull: false` is set but this unhelpful error message is reported instead:
![Screenshot from 2019-06-28 12-34-33](https://user-images.githubusercontent.com/15707013/60340460-84e79800-99a3-11e9-9916-1a543d65b62d.png)
 
Having an empty string set as default value of tier.name instead prevents this and allows our custom name validation to run, throwing this error message instead: 
![Screenshot from 2019-06-28 12-36-10](https://user-images.githubusercontent.com/15707013/60340572-e1e34e00-99a3-11e9-962b-2aa72b7e0c1f.png)

Basically 
```js
if (!tier.name) {
      tier.name = '';
 }
```

