### PR TITLE
Downgrade babel-plugin-styled-components to 1.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4314,9 +4314,9 @@
       "integrity": "sha1-Lk57RJa5OmVKHIAEInbeTk7rIOM="
     },
     "babel-plugin-styled-components": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.4.tgz",
-      "integrity": "sha512-LI4xaSF//yp9+CWG+TkAIbH1Xt50ptMY04WQgzi27184JyHVt4D3biCfDppJg+FJ4cOAtuuvdLXpFNoOWSEpQQ==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.2.tgz",
+      "integrity": "sha512-gA67BkMbddFPkTjD2bBe7zE6NNEUNK/7A4uDxwSigA3h1+sL2b6mWhxPu9a5DKf+3TvmdoxvtJ4me2NE7k66Ng==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-module-imports": "^7.0.0",
@@ -8647,6 +8647,7 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
       "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
+      "optional": true,
       "requires": {
         "minipass": "^2.2.1"
       }
@@ -13745,6 +13746,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -13754,6 +13756,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
       "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "optional": true,
       "requires": {
         "minipass": "^2.2.1"
       }
@@ -14388,9 +14391,9 @@
       "integrity": "sha512-t5oCENZJl8TGusJKoCJm7+asaSsPuNmK6+iEjrZ5TyBj2f02brCRsd4c83hwtu+e5d4LCSBZ0uoDlMjBo+A8yA=="
     },
     "npm": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.9.0.tgz",
-      "integrity": "sha512-91V+zB5hDxO+Jyp2sUKS7juHlIM95dGQxTeQtmZI1nAI/7kjWXFipPrtwwKjhyKmV4GsS2LzJhrxRjGWsU9z/w==",
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.9.2.tgz",
+      "integrity": "sha512-b0sEGRYrVdcV/DedLrqV4VMpdMHJbvpt9bopivh4K9RisHFMbj+G6RNbB6lRdr9rpYIoqHG9YP9CYmxdI9k81g==",
       "requires": {
         "JSONStream": "^1.3.5",
         "abbrev": "~1.1.1",
@@ -14480,21 +14483,21 @@
         "path-is-inside": "~1.0.2",
         "promise-inflight": "~1.0.1",
         "qrcode-terminal": "^0.12.0",
-        "query-string": "^6.2.0",
+        "query-string": "^6.4.0",
         "qw": "~1.0.1",
         "read": "~1.0.7",
         "read-cmd-shim": "~1.0.1",
         "read-installed": "~4.0.3",
         "read-package-json": "^2.0.13",
         "read-package-tree": "^5.2.2",
-        "readable-stream": "^3.1.1",
+        "readable-stream": "^3.2.0",
         "readdir-scoped-modules": "*",
         "request": "^2.88.0",
         "retry": "^0.12.0",
         "rimraf": "^2.6.3",
         "safe-buffer": "^5.1.2",
         "semver": "^5.6.0",
-        "sha": "~2.0.1",
+        "sha": "^3.0.0",
         "slide": "~1.1.6",
         "sorted-object": "~2.0.1",
         "sorted-union-stream": "~2.1.3",
@@ -16189,26 +16192,12 @@
               "bundled": true
             },
             "tar": {
-              "version": "2.2.2",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
-              "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+              "version": "2.2.1",
+              "bundled": true,
               "requires": {
                 "block-stream": "*",
-                "fstream": "^1.0.12",
+                "fstream": "^1.0.2",
                 "inherits": "2"
-              },
-              "dependencies": {
-                "fstream": {
-                  "version": "1.0.12",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-                  "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-                  "requires": {
-                    "graceful-fs": "^4.1.2",
-                    "inherits": "~2.0.0",
-                    "mkdirp": ">=0.5 0",
-                    "rimraf": "2"
-                  }
-                }
               }
             }
           }
@@ -16639,7 +16628,7 @@
           "bundled": true
         },
         "query-string": {
-          "version": "6.2.0",
+          "version": "6.4.0",
           "bundled": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
@@ -16716,7 +16705,7 @@
           }
         },
         "readable-stream": {
-          "version": "3.1.1",
+          "version": "3.2.0",
           "bundled": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -16835,33 +16824,10 @@
           "bundled": true
         },
         "sha": {
-          "version": "2.0.1",
+          "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "readable-stream": "^2.0.2"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.3.6",
-              "bundled": true,
-              "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.1.0"
-              }
-            }
+            "graceful-fs": "^4.1.2"
           }
         },
         "shebang-command": {
@@ -17095,6 +17061,37 @@
           "bundled": true,
           "requires": {
             "has-flag": "^3.0.0"
+          }
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          },
+          "dependencies": {
+            "chownr": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "minipass": {
+              "version": "2.3.5",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "yallist": {
+              "version": "3.0.3",
+              "bundled": true
+            }
           }
         },
         "term-size": {
@@ -22146,6 +22143,7 @@
       "version": "4.4.9",
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.9.tgz",
       "integrity": "sha512-xisFa7Q2i3HOgfn+nmnWLGHD6Tm23hxjkx6wwGmgxkJFr6wxwXnJOdJYcZjL453PSdF0+bemO03+flAzkIdLBQ==",
+      "optional": true,
       "requires": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
@@ -22159,7 +22157,8 @@
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-react-intl": "^3.3.3",
     "babel-plugin-react-remove-properties": "0.3.0",
-    "babel-plugin-styled-components": "1.10.4",
+    "babel-plugin-styled-components": "1.10.2",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
     "babel-plugin-transform-styled-components-remove-prop-types": "0.0.5",
     "commitizen": "^3.1.1",


### PR DESCRIPTION
Something in 1.10.3 is making our dev environment unusable (stuck on "compiling ...").