### PR TITLE
fix(NCP): About section not updated after saving

### DIFF
--- a/src/components/InlineEditField.js
+++ b/src/components/InlineEditField.js
@@ -3,7 +3,7 @@ import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import { Flex, Box } from '@rebass/grid';
 import { Mutation } from 'react-apollo';
-import { get, set, pick } from 'lodash';
+import { get, pick } from 'lodash';
 import styled from 'styled-components';
 
 import { PencilAlt } from 'styled-icons/fa-solid/PencilAlt';
@@ -55,6 +55,8 @@ class InlineEditField extends Component {
     mutation: PropTypes.object.isRequired,
     /** Can user edit the description */
     canEdit: PropTypes.bool,
+    /** Called to format the value before submitting */
+    formatBeforeSubmit: PropTypes.func,
     /** Set to false to disable edit icon even if user is allowed to edit */
     showEditIcon: PropTypes.bool,
     /** If given, this function will be used to render the field */
@@ -103,9 +105,9 @@ class InlineEditField extends Component {
       return <span>{value}</span>;
     }
   }
-
+  z;
   render() {
-    const { field, values, mutation, canEdit, showEditIcon, placeholder, children } = this.props;
+    const { field, values, mutation, canEdit, formatBeforeSubmit, showEditIcon, placeholder, children } = this.props;
     const { isEditing, draft } = this.state;
     const value = get(values, field);
     const touched = draft !== value;
@@ -167,7 +169,8 @@ class InlineEditField extends Component {
                     disabled={!touched}
                     data-cy="InlineEditField-Btn-Save"
                     onClick={() => {
-                      const variables = set(pick(values, ['id']), field, draft.trim());
+                      const variables = pick(values, ['id']);
+                      variables[field] = formatBeforeSubmit ? formatBeforeSubmit(draft) : draft;
                       updateField({ variables }).then(this.disableEditor);
                     }}
                   >

--- a/src/components/collective-page/SectionAbout.js
+++ b/src/components/collective-page/SectionAbout.js
@@ -59,6 +59,7 @@ const SectionAbout = ({ collective, canEdit, editMutation }) => {
           field="longDescription"
           canEdit={canEdit}
           showEditIcon={!isEmptyDescription}
+          formatBeforeSubmit={v => (isEmptyValue(v) ? null : v)}
         >
           {({ isEditing, value, setValue, enableEditor }) => {
             if (isEditing) {

--- a/src/pages/new-collective-page.js
+++ b/src/pages/new-collective-page.js
@@ -38,6 +38,7 @@ class NewCollectivePage extends React.Component {
   // See https://github.com/opencollective/opencollective/issues/1872
   shouldComponentUpdate(newProps) {
     if (get(this.props, 'data.Collective') && !get(newProps, 'data.Collective')) {
+      console.warn('Collective lost from props (#1872)');
       return false;
     } else {
       return true;
@@ -129,6 +130,7 @@ const getCollective = graphql(gql`
       currency
       settings
       stats {
+        id
         balance
         yearlyBudget
       }


### PR DESCRIPTION
The bug was because we missed an `id` for stats.