### PR TITLE
fix(ContributionFlow): Collectives are not allowed to use others PMs

### DIFF
--- a/src/components/Steps.js
+++ b/src/components/Steps.js
@@ -129,7 +129,7 @@ export default class Steps extends React.Component {
     const currentStep = this.getStepByName(this.props.currentStepName);
     if (!currentStep) {
       return false;
-    } else if (currentStep.isCompleted === false) {
+    } else if (currentStep.isCompleted === false && action !== 'prev') {
       return false;
     } else if (currentStep.validate) {
       this.setState({ isValidating: true });
@@ -160,6 +160,7 @@ export default class Steps extends React.Component {
 
   /** Go to previous step. Will be blocked if current step is not validated. */
   goBack = () => {
+    console.log('Go back');
     const currentStep = this.getStepByName(this.props.currentStepName);
     if (!currentStep || currentStep.index === 0) {
       return false;

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -263,6 +263,7 @@
   "contribute.newCard": "New: {name}",
   "contribute.newcreditcard": "New credit/debit card",
   "contribute.nextStep": "Next step",
+  "contribute.noPaymentMethod": "The balance of this collective is too low to make orders from it. Add funds to {collectiveName} by making a donation to it first.",
   "contribute.payment.label": "Choose a payment method:",
   "contribute.prevStep": "Previous step",
   "contribute.profile.label": "Contribute As:",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -263,6 +263,7 @@
   "contribute.newCard": "Nuevo: {name}",
   "contribute.newcreditcard": "Nueva tarjeta de crédito/débito",
   "contribute.nextStep": "Siguiente paso",
+  "contribute.noPaymentMethod": "The balance of this collective is too low to make orders from it. Add funds to {collectiveName} by making a donation to it first.",
   "contribute.payment.label": "Elige un método de pago:",
   "contribute.prevStep": "Paso anterior",
   "contribute.profile.label": "Contribuye:",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -263,6 +263,7 @@
   "contribute.newCard": "Nouveau : {name}",
   "contribute.newcreditcard": "Nouvelle carte de crédit/débit",
   "contribute.nextStep": "Étape suivante",
+  "contribute.noPaymentMethod": "The balance of this collective is too low to make orders from it. Add funds to {collectiveName} by making a donation to it first.",
   "contribute.payment.label": "Choisissez un moyen de paiement :",
   "contribute.prevStep": "Étape précédente",
   "contribute.profile.label": "Contribuer en tant que:",

--- a/src/lang/it.json
+++ b/src/lang/it.json
@@ -263,6 +263,7 @@
   "contribute.newCard": "New: {name}",
   "contribute.newcreditcard": "New credit/debit card",
   "contribute.nextStep": "Next step",
+  "contribute.noPaymentMethod": "The balance of this collective is too low to make orders from it. Add funds to {collectiveName} by making a donation to it first.",
   "contribute.payment.label": "Choose a payment method:",
   "contribute.prevStep": "Previous step",
   "contribute.profile.label": "Contribute As:",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -263,6 +263,7 @@
   "contribute.newCard": "新規: {name}",
   "contribute.newcreditcard": "新しいクレジットカード/デビットカード",
   "contribute.nextStep": "次のステップ",
+  "contribute.noPaymentMethod": "The balance of this collective is too low to make orders from it. Add funds to {collectiveName} by making a donation to it first.",
   "contribute.payment.label": "支払い方法を選択:",
   "contribute.prevStep": "1つ前のステップ",
   "contribute.profile.label": "コントリビュート:",

--- a/src/lang/pt.json
+++ b/src/lang/pt.json
@@ -263,6 +263,7 @@
   "contribute.newCard": "New: {name}",
   "contribute.newcreditcard": "New credit/debit card",
   "contribute.nextStep": "Next step",
+  "contribute.noPaymentMethod": "The balance of this collective is too low to make orders from it. Add funds to {collectiveName} by making a donation to it first.",
   "contribute.payment.label": "Choose a payment method:",
   "contribute.prevStep": "Previous step",
   "contribute.profile.label": "Contribute As:",

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -263,6 +263,7 @@
   "contribute.newCard": "Новый: {name}",
   "contribute.newcreditcard": "Новая кредитная или дебетовая карта",
   "contribute.nextStep": "Следующий шаг",
+  "contribute.noPaymentMethod": "The balance of this collective is too low to make orders from it. Add funds to {collectiveName} by making a donation to it first.",
   "contribute.payment.label": "Выберите метод оплаты:",
   "contribute.prevStep": "Предыдущий шаг",
   "contribute.profile.label": "Сделать вклад как:",

--- a/src/lang/zh.json
+++ b/src/lang/zh.json
@@ -263,6 +263,7 @@
   "contribute.newCard": "新：{name}",
   "contribute.newcreditcard": "New credit/debit card",
   "contribute.nextStep": "下一步",
+  "contribute.noPaymentMethod": "The balance of this collective is too low to make orders from it. Add funds to {collectiveName} by making a donation to it first.",
   "contribute.payment.label": "Choose a payment method:",
   "contribute.prevStep": "上一步",
   "contribute.profile.label": "Contribute As:",

--- a/src/pages/createOrder.js
+++ b/src/pages/createOrder.js
@@ -254,7 +254,10 @@ class CreateOrderPage extends React.Component {
     const { stepPayment } = this.state;
     const isFixedPriceTier = this.isFixedPriceTier();
 
-    if (this.getOrderMinAmount() === 0 && (isFixedPriceTier || !stepPayment)) {
+    if (action === 'prev') {
+      // Don't validate when going back
+      return true;
+    } else if (this.getOrderMinAmount() === 0 && (isFixedPriceTier || !stepPayment)) {
       // Always ignore payment method for free tiers
       return true;
     } else if (!stepPayment) {
@@ -262,8 +265,6 @@ class CreateOrderPage extends React.Component {
       return false;
     } else if (!stepPayment.isNew) {
       // No need to validate existing payment methods
-      return true;
-    } else if (action === 'prev' && stepPayment.isNew && (stepPayment.error || !stepPayment.data)) {
       return true;
     } else if (!stepPayment.data && get(stepPayment, 'paymentMethod.token')) {
       // New credit card - if no data, stripe token has already been exchanged
@@ -665,7 +666,7 @@ class CreateOrderPage extends React.Component {
   }
 
   renderStep(step) {
-    const { LoggedInUser, data } = this.props;
+    const { data } = this.props;
     const { stepDetails, stepPayment } = this.state;
     const [personal, profiles] = this.getProfiles();
     const tier = this.props.data.Tier;
@@ -768,7 +769,6 @@ class CreateOrderPage extends React.Component {
             </H5>
             <ContributePayment
               onChange={stepPayment => this.setState({ stepPayment })}
-              paymentMethods={get(LoggedInUser, 'collective.paymentMethods', [])}
               collective={this.state.stepProfile}
               defaultValue={stepPayment}
               onNewCardFormReady={({ stripe }) => this.setState({ stripe })}


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2131

---

Following a conversation with @znarf from this morning: donating from collective using something else than collective's balance is not playing nice with the ledger as we calculate balances by summing the transactions. So both the collective's balance and the credit card are debited. Thankfully this feature wasn't widely used, we only have 13 transactions to this day. 

This fix will make sure that we only display the collective payment method for collectives. As the API returns no payment method if the balance is null, I've also added a special message in case users try to donate with a collective that has an empty balance.

# Preview 

- Users/organizations PMs work as usual

![2019-07-01_11:46:25](https://user-images.githubusercontent.com/1556356/60433100-456bb680-9c04-11e9-93b0-aa0e44c95049.png)

![2019-07-01_12:18:31](https://user-images.githubusercontent.com/1556356/60433136-59171d00-9c04-11e9-9e05-7af93d2bc176.png)

- Collective PM is displayed when there is a balance

![image](https://user-images.githubusercontent.com/1556356/60433194-7b109f80-9c04-11e9-81cd-6ba5cd1b4d3c.png)

- Special message for empty balance

![image](https://user-images.githubusercontent.com/1556356/60433225-9085c980-9c04-11e9-8880-52ddda921b49.png)
 
