### PR TITLE
Fix moment.js warning with GraphQL API v1 date format

### DIFF
--- a/src/components/Moment.js
+++ b/src/components/Moment.js
@@ -4,11 +4,9 @@ import moment from 'moment';
 import { FormattedDate } from 'react-intl';
 
 const Moment = ({ value, relative }) => {
-  const date = new Date(value);
-  const formattedLongDateStr = moment(date).format('LLLL');
-  return (
-    <span title={formattedLongDateStr}>{relative ? moment(date).fromNow() : <FormattedDate value={value} />}</span>
-  );
+  const date = moment(new Date(value));
+  const formattedLongDateStr = date.format('LLLL');
+  return <span title={formattedLongDateStr}>{relative ? date.fromNow() : <FormattedDate value={value} />}</span>;
 };
 
 Moment.propTypes = {

--- a/src/components/Moment.js
+++ b/src/components/Moment.js
@@ -3,14 +3,11 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 import { FormattedDate } from 'react-intl';
 
-const formatDate = value => new Date(value).toISOString();
-
 const Moment = ({ value, relative }) => {
-  const formattedLongDateStr = moment(value).format('LLLL');
+  const date = new Date(value);
+  const formattedLongDateStr = moment(date).format('LLLL');
   return (
-    <span title={formattedLongDateStr}>
-      {relative ? moment(formatDate(value)).fromNow() : <FormattedDate value={value} />}
-    </span>
+    <span title={formattedLongDateStr}>{relative ? moment(date).fromNow() : <FormattedDate value={value} />}</span>
   );
 };
 


### PR DESCRIPTION
Avoid this kind of warnings.

`Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. moment construction falls back to js Date(), which is not reliable across all browsers and versions. Non RFC2822/ISO date formats are discouraged and will be removed in an upcoming major release. Please refer to http://momentjs.com/guides/#/warnings/js-date/ for more info.`
