### PR TITLE
chore(NCP): Page index is not responsible for proptypes shapes

### DIFF
--- a/src/components/collective-page/index.js
+++ b/src/components/collective-page/index.js
@@ -35,58 +35,17 @@ const EditCollectiveMutation = gql`
  */
 export default class CollectivePage extends Component {
   static propTypes = {
-    /** The collective to display */
-    collective: PropTypes.shape({
-      id: PropTypes.number.isRequired,
-      name: PropTypes.string.isRequired,
-      slug: PropTypes.string.isRequired,
-      image: PropTypes.string,
-      backgroundImage: PropTypes.string,
-      twitterHandle: PropTypes.string,
-      githubHandle: PropTypes.string,
-      website: PropTypes.string,
-      description: PropTypes.string,
-      tags: PropTypes.arrayOf(PropTypes.string),
-      settings: PropTypes.object,
-    }).isRequired,
-
-    /** Collective's host */
-    host: PropTypes.shape({
-      id: PropTypes.number.isRequired,
-      name: PropTypes.string.isRequired,
-      slug: PropTypes.string.isRequired,
-      image: PropTypes.string,
-    }),
-
-    /** Collective contributors */
+    collective: PropTypes.object.isRequired,
+    host: PropTypes.object,
     contributors: PropTypes.arrayOf(PropTypes.object),
     topOrganizations: PropTypes.arrayOf(PropTypes.object),
     topIndividuals: PropTypes.arrayOf(PropTypes.object),
-
-    /** Collective tiers */
-    tiers: PropTypes.arrayOf(
-      PropTypes.shape({
-        id: PropTypes.number.isRequired,
-        name: PropTypes.string.isRequired,
-        slug: PropTypes.string.isRequired,
-        description: PropTypes.string,
-      }),
-    ),
-
-    /** Collective transactions & expenses */
+    tiers: PropTypes.arrayOf(PropTypes.object),
     transactions: PropTypes.arrayOf(PropTypes.object),
     expenses: PropTypes.arrayOf(PropTypes.object),
-
-    /** Updates / announcements */
     updates: PropTypes.arrayOf(PropTypes.object),
-
-    /** Collective stats */
     stats: PropTypes.object,
-
-    /** Collective events */
     events: PropTypes.arrayOf(PropTypes.object),
-
-    /** The logged in user */
     LoggedInUser: PropTypes.object,
   };
 


### PR DESCRIPTION
It's up to each component to define the shape of the data based on what they use.

Index page is only passing the props down so it shouldn't know about everything the object contains. Otherwise we need to update the PropTypes in multiple places when we update a subcomponent - a tedious process that doesn't bring anymore safety.

Also removed the redundant jsdocs.