### PR TITLE
Activate new collective page as default for some collectives

### DIFF
--- a/server/pages.js
+++ b/server/pages.js
@@ -148,7 +148,11 @@ pages.add(
 
 // New collective page
 pages.add('new-collective-page', '/:slug/v2');
+// Hardcode some collectives for the beta program
+const collectivesBeta = process.env.NCP_BETA_COLLECTIVES || 'betree';
+pages.add('new-collective-page-beta', `/:slug(${collectivesBeta})`, 'new-collective-page');
 
+// Normal collective page
 pages.add('collective', '/:slug');
 
 export default pages;


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective/issues/2217

---

I've dropped the GraphQL approach that was way too complex, error prone, and had a significant impact on performance.

Hardcoding collectives in route like it's done here has the following benefits:
- It's damn simple
- It's performant
- Can work both ways (opt-in and opt-out)

Main drawback is that we have to deploy a new version to add pr remove collectives from the beta program list.

---

For this first version, we'll be onboarding only collectives managed by members of the Open Collective team.