### PR TITLE
NCP + contributors grid: hide scrollbar when not hovered

### DIFF
--- a/src/components/ContributorsGrid.js
+++ b/src/components/ContributorsGrid.js
@@ -28,6 +28,17 @@ const COLLECTIVE_CARD_FULL_WIDTH = COLLECTIVE_CARD_WIDTH + COLLECTIVE_CARD_MARGI
 /** Adds custom scrollbar for Chrome */
 const StyledGridContainer = styled.div`
   ${CustomScrollbarCSS}
+
+  /** Hide scrollbar when not hovered */
+  &:not(:hover) {
+    &::-webkit-scrollbar-thumb {
+      background: white;
+    }
+
+    &::-webkit-scrollbar-track {
+      background: white;
+    }
+  }
 `;
 
 /**

--- a/src/components/collective-page/ContributeCardsContainer.js
+++ b/src/components/collective-page/ContributeCardsContainer.js
@@ -10,6 +10,17 @@ const ContributeCardsContainer = styled.div`
 
   ${CustomScrollbarCSS}
 
+  /** Hide scrollbar when not hovered */
+  &:not(:hover) {
+    &::-webkit-scrollbar-thumb {
+      background: white;
+    }
+
+    &::-webkit-scrollbar-track {
+      background: white;
+    }
+  }
+
   /** Respect left margin / center cards on widescreens */
   @media (min-width: 1500px) {
     padding-left: calc((100% - 1500px) / 2);


### PR DESCRIPTION
:deciduous_tree: Resolve https://github.com/opencollective/opencollective/issues/2224
:warning: Only for webkit (chrome + safari)

---

The fix is a little bit hacky, we just set the background color of the scrollbar to white when not hovered. The reason is that we can't use things like opacity on this one and we don't want to miss with the height as it will impact the whole layout. Anyway, it works.

![Peek 09-07-2019 16-59](https://user-images.githubusercontent.com/1556356/60900754-04f7e280-a26d-11e9-80f0-d8c69e47d687.gif)
