### PR TITLE
fix(opensource): make sure we use the github flow

### DIFF
--- a/src/components/ApplyToHostBtnLoggedIn.js
+++ b/src/components/ApplyToHostBtnLoggedIn.js
@@ -77,17 +77,17 @@ class ApplyToHostBtnLoggedIn extends React.Component {
   render() {
     const { host, data } = this.props;
 
-    if (host.slug === 'opensource') {
+    if (data.loading) {
       return (
-        <Button className="blue" href={`/${host.slug}/apply`}>
+        <Button className="blue" disabled>
           <FormattedMessage id="host.apply.create.btn" defaultMessage="Apply to create a collective" />
         </Button>
       );
     }
 
-    if (data.loading) {
+    if (host && host.slug === 'opensource') {
       return (
-        <Button className="blue" disabled>
+        <Button className="blue" href={`/${host.slug}/apply`}>
           <FormattedMessage id="host.apply.create.btn" defaultMessage="Apply to create a collective" />
         </Button>
       );

--- a/src/components/ApplyToHostBtnLoggedIn.js
+++ b/src/components/ApplyToHostBtnLoggedIn.js
@@ -76,6 +76,15 @@ class ApplyToHostBtnLoggedIn extends React.Component {
 
   render() {
     const { host, data } = this.props;
+
+    if (host.slug === 'opensource') {
+      return (
+        <Button className="blue" href={`/${host.slug}/apply`}>
+          <FormattedMessage id="host.apply.create.btn" defaultMessage="Apply to create a collective" />
+        </Button>
+      );
+    }
+
     if (data.loading) {
       return (
         <Button className="blue" disabled>


### PR DESCRIPTION
This makes sure that we use the dedicated flow for open source project on the "apply to create an open collective" button on https://opencollective.com/opensource (now that this links to the organization and not the collective).

If people want to apply to the open source collective 501c6 without going through the github flow, they can create the collective and then in the /edit, apply to the open source host.

Related to https://github.com/opencollective/opencollective/issues/2182