### PR TITLE
Improve the look of "Top Contributors" when it's not full

### DIFF
--- a/src/components/collective-page/SectionContribute.js
+++ b/src/components/collective-page/SectionContribute.js
@@ -226,8 +226,8 @@ class SectionContribute extends React.PureComponent {
         </ContainerSectionContent>
         {(topOrganizations.length !== 0 || topIndividuals.length !== 0) && (
           <TopContributors
-            topOrganizations={topOrganizations}
-            topIndividuals={topIndividuals}
+            organizations={topOrganizations}
+            individuals={topIndividuals}
             currency={collective.currency}
           />
         )}

--- a/src/components/collective-page/SectionContribute.js
+++ b/src/components/collective-page/SectionContribute.js
@@ -150,11 +150,8 @@ class SectionContribute extends React.PureComponent {
   });
 
   getTopContributors = memoizeOne(contributors => {
-    const nbMaxInTop = 10;
     const topOrgs = [];
     const topIndividuals = [];
-    let doneWithOrgs = false;
-    let doneWithIndividuals = false;
 
     for (const contributor of contributors) {
       // We only care about financial contributors that donated $$$
@@ -163,27 +160,31 @@ class SectionContribute extends React.PureComponent {
       }
 
       // Put contributors in the array corresponding to their types
-      if (!doneWithIndividuals && contributor.type === CollectiveType.USER) {
+      if (contributor.type === CollectiveType.USER) {
         topIndividuals.push(contributor);
-        if (topIndividuals.length === nbMaxInTop) {
-          doneWithIndividuals = true;
-        }
-      } else if (
-        (!doneWithOrgs && contributor.type === CollectiveType.ORGANIZATION) ||
-        contributor.type === CollectiveType.COLLECTIVE
-      ) {
+      } else if (contributor.type === CollectiveType.ORGANIZATION || contributor.type === CollectiveType.COLLECTIVE) {
         topOrgs.push(contributor);
-        if (topOrgs.length === nbMaxInTop) {
-          doneWithOrgs = true;
-        }
       }
 
-      if (doneWithOrgs && doneWithIndividuals) {
+      if (topIndividuals.length >= 10 && topOrgs.length >= 10) {
         break;
       }
     }
 
-    return [topOrgs, topIndividuals];
+    // If one of the two categories is not filled, complete with more contributors from the other
+    const nbColsPerCategory = 2;
+    const nbFreeColsFromOrgs = nbColsPerCategory - Math.ceil(topOrgs.length / 5);
+    const nbFreeColsFromIndividuals = nbColsPerCategory - Math.ceil(topOrgs.length / 5);
+    let takeNbOrgs = 10;
+    let takeNbIndividuals = 10;
+
+    if (nbFreeColsFromOrgs > 0) {
+      takeNbIndividuals += nbFreeColsFromOrgs * 5;
+    } else if (nbFreeColsFromIndividuals) {
+      takeNbOrgs += nbFreeColsFromIndividuals * 5;
+    }
+
+    return [topOrgs.slice(0, takeNbOrgs), topIndividuals.slice(0, takeNbIndividuals)];
   });
 
   render() {

--- a/src/components/collective-page/TopContributors.js
+++ b/src/components/collective-page/TopContributors.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import { FormattedMessage, FormattedDate } from 'react-intl';
 import PropTypes from 'prop-types';
-import { Flex } from '@rebass/grid';
+import { Flex, Box } from '@rebass/grid';
 import styled from 'styled-components';
-import { layout } from 'styled-system';
-import { truncate } from 'lodash';
+import { truncate, size } from 'lodash';
 
 import { CollectiveType } from '../../constants/collectives';
 import { formatCurrency } from '../../lib/utils';
@@ -13,8 +12,8 @@ import Link from '../Link';
 import { H4, P, Span } from '../Text';
 import { ContributorAvatar } from '../Avatar';
 
-import TopContributorsBackgroundSVG from './TopContributorsBackground.svg';
 import ContainerSectionContent from './ContainerSectionContent';
+import TopContributorsBackgroundSVG from './TopContributorsBackground.svg';
 
 /** The container for Top Contributors view */
 const TopContributorsContainer = styled.div`
@@ -24,12 +23,24 @@ const TopContributorsContainer = styled.div`
   background-color: #f5f7fa;
 `;
 
-const ContributorsList = styled.div`
-  display: flex;
-  flex-direction: column;
+const ContributorsList = styled(Flex)`
   flex-wrap: wrap;
-  max-height: 400px;
-  ${layout}
+  margin-bottom: 16px;
+  flex-direction: row;
+
+  @media (max-width: 52em) {
+    // Only show 5 contributors on mobile/tablet
+    & > *:nth-child(1n + 6) {
+      display: none;
+    }
+  }
+
+  @media (max-width: 64em) {
+    // Only show 10 contributors on mobile/tablet
+    & > *:nth-child(1n + 11) {
+      display: none;
+    }
+  }
 `;
 
 const AvatarWithRank = styled.div`
@@ -45,106 +56,124 @@ const AvatarWithRank = styled.div`
   border-radius: 32px;
 `;
 
-const ContributorRow = ({ rank, currency, contributor }) => {
-  const route = contributor.type === CollectiveType.COLLECTIVE ? 'new-collective-page' : 'collective';
-
-  return (
-    <Flex my={3} mr={3}>
-      <AvatarWithRank>
-        <span>{rank}</span>
-        <Link route={route} params={{ slug: contributor.collectiveSlug }}>
-          <ContributorAvatar contributor={contributor} radius={38} borderRadius="25%" />
-        </Link>
-      </AvatarWithRank>
-      <div>
-        <Link route={route} params={{ slug: contributor.collectiveSlug }}>
-          <P fontWeight="bold" color="black.700">
-            {truncate(contributor.name, { length: 20 })}
-          </P>
-        </Link>
-        <P color="black.500">
-          <FormattedMessage
-            id="TotalDonatedSince"
-            defaultMessage="{totalDonated} since {date}"
-            values={{
-              totalDonated: <Span fontWeight="bold">{formatCurrency(contributor.totalAmountDonated, currency)}</Span>,
-              date: <FormattedDate value={contributor.since} month="long" year="numeric" />,
-            }}
-          />
-        </P>
-      </div>
-    </Flex>
-  );
+/**
+ * Returns the flex-basis as a string in `px` based on the percentage of
+ * contributors that belongs in this column.
+ */
+const getFlexBasisForCol = (nbContributors, totalContributors) => {
+  const baseSpace = 0.1;
+  return `${Math.trunc((nbContributors / totalContributors - baseSpace) * 100)}%`;
 };
 
-ContributorRow.propTypes = {
-  rank: PropTypes.number.isRequired,
+/**
+ * Shows a list of contributors with the section title. Auto-size based on number
+ * of contributors.
+ */
+const ContributorsBlock = ({ title, contributors, totalNbContributors, currency, showTitle }) => (
+  <Box flex="50% 1 3" style={{ flexBasis: getFlexBasisForCol(contributors.length, totalNbContributors) }}>
+    {showTitle && <P fontSize="LeadParagraph">{title}</P>}
+    <ContributorsList>
+      {contributors.map((contributor, idx) => {
+        const route = contributor.type === CollectiveType.COLLECTIVE ? 'new-collective-page' : 'collective';
+        return (
+          <Flex my={3} mr={3} css={{ width: 300 }} key={contributor.id}>
+            <AvatarWithRank>
+              <span>{idx + 1}</span>
+              <Link route={route} params={{ slug: contributor.collectiveSlug }}>
+                <ContributorAvatar contributor={contributor} radius={38} borderRadius="25%" />
+              </Link>
+            </AvatarWithRank>
+            <div>
+              <Link route={route} params={{ slug: contributor.collectiveSlug }}>
+                <P fontWeight="bold" color="black.700">
+                  {truncate(contributor.name, { length: 20 })}
+                </P>
+              </Link>
+              <P color="black.500">
+                <FormattedMessage
+                  id="TotalDonatedSince"
+                  defaultMessage="{totalDonated} since {date}"
+                  values={{
+                    totalDonated: (
+                      <Span fontWeight="bold">{formatCurrency(contributor.totalAmountDonated, currency)}</Span>
+                    ),
+                    date: <FormattedDate value={contributor.since} month="long" year="numeric" />,
+                  }}
+                />
+              </P>
+            </div>
+          </Flex>
+        );
+      })}
+    </ContributorsList>
+  </Box>
+);
+
+ContributorsBlock.propTypes = {
   currency: PropTypes.string.isRequired,
-  contributor: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired,
-    type: PropTypes.oneOf(Object.values(CollectiveType)).isRequired,
-    collectiveSlug: PropTypes.string.isRequired,
-    totalAmountDonated: PropTypes.number.isRequired,
-    since: PropTypes.string.isRequired,
-  }).isRequired,
+  totalNbContributors: PropTypes.number,
+  title: PropTypes.node.isRequired,
+  showTitle: PropTypes.bool.isRequired,
+  contributors: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+      type: PropTypes.oneOf(Object.values(CollectiveType)).isRequired,
+      collectiveSlug: PropTypes.string.isRequired,
+      totalAmountDonated: PropTypes.number.isRequired,
+      since: PropTypes.string.isRequired,
+    }).isRequired,
+  ),
 };
 
 /**
  * Shows two columns as leaderboards for organizations and individuals
  * financial contributions.
  */
-const TopContributors = ({ topOrganizations, topIndividuals, currency }) => {
-  const hasBothTypes = Boolean(topOrganizations.length && topIndividuals.length);
+const TopContributors = ({ organizations, individuals, currency }) => {
+  const nbOrgs = size(organizations);
+  const nbIndividuals = size(individuals);
+  const totalNbContributors = nbOrgs + nbIndividuals;
+  const hasBothTypes = Boolean(nbOrgs && nbIndividuals);
+
+  // Nothing to render if there's no one to show
+  if (!totalNbContributors) {
+    return null;
+  }
+
+  // Build the individual blocks in variables so we can sort them later
+  const BlockIndividuals = nbIndividuals > 0 && (
+    <ContributorsBlock
+      currency={currency}
+      contributors={individuals}
+      totalNbContributors={totalNbContributors}
+      title={<FormattedMessage id="TopContributors.Individuals" defaultMessage="Individuals" />}
+      showTitle={hasBothTypes}
+    />
+  );
+
+  const BlockOrgs = nbOrgs > 0 && (
+    <ContributorsBlock
+      currency={currency}
+      contributors={organizations}
+      totalNbContributors={totalNbContributors}
+      title={<FormattedMessage id="TopContributors.Organizations" defaultMessage="Organizations" />}
+      showTitle={hasBothTypes}
+    />
+  );
+
+  // Put the blocks with the most contributors first. If equals, default is to show orgs first.
+  const Blocks = nbIndividuals > nbOrgs ? [BlockIndividuals, BlockOrgs] : [BlockOrgs, BlockIndividuals];
+
   return (
     <TopContributorsContainer>
-      <ContainerSectionContent m="0 auto">
+      <ContainerSectionContent>
         <H4 fontWeight="normal" mb={3}>
           <FormattedMessage id="SectionContribute.TopContributors" defaultMessage="Top Contributors" />
         </H4>
-        <Flex mt={2} justifyContent="space-between" flexWrap="wrap">
-          {topOrganizations && topOrganizations.length > 0 && (
-            <div>
-              {hasBothTypes && (
-                <P fontSize="LeadParagraph">
-                  <FormattedMessage id="TopContributors.Organizations" defaultMessage="Organizations" />
-                </P>
-              )}
-              <Flex>
-                <ContributorsList>
-                  {topOrganizations.slice(0, 5).map((contributor, idx) => (
-                    <ContributorRow key={contributor.id} rank={idx + 1} contributor={contributor} currency={currency} />
-                  ))}
-                </ContributorsList>
-                <ContributorsList display={['none', null, 'flex']}>
-                  {topOrganizations.slice(5, 10).map((contributor, idx) => (
-                    <ContributorRow key={contributor.id} rank={idx + 6} contributor={contributor} currency={currency} />
-                  ))}
-                </ContributorsList>
-              </Flex>
-            </div>
-          )}
-          {topIndividuals && topIndividuals.length > 0 && (
-            <div>
-              {hasBothTypes && (
-                <P fontSize="LeadParagraph">
-                  <FormattedMessage id="TopContributors.Individuals" defaultMessage="Individuals" />
-                </P>
-              )}
-              <Flex>
-                <ContributorsList>
-                  {topIndividuals.slice(0, 5).map((contributor, idx) => (
-                    <ContributorRow key={contributor.id} rank={idx + 1} contributor={contributor} currency={currency} />
-                  ))}
-                </ContributorsList>
-                <ContributorsList display={['none', null, 'flex']}>
-                  {topIndividuals.slice(5, 10).map((contributor, idx) => (
-                    <ContributorRow key={contributor.id} rank={idx + 6} contributor={contributor} currency={currency} />
-                  ))}
-                </ContributorsList>
-              </Flex>
-            </div>
-          )}
+        <Flex mt={2} flexWrap="wrap" justify-content="space-between">
+          {Blocks[0]}
+          {Blocks[1]}
         </Flex>
       </ContainerSectionContent>
     </TopContributorsContainer>
@@ -153,8 +182,8 @@ const TopContributors = ({ topOrganizations, topIndividuals, currency }) => {
 
 TopContributors.propTypes = {
   currency: PropTypes.string.isRequired,
-  topOrganizations: PropTypes.arrayOf(PropTypes.object).isRequired,
-  topIndividuals: PropTypes.arrayOf(PropTypes.object).isRequired,
+  organizations: PropTypes.arrayOf(PropTypes.object),
+  individuals: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default withViewport(TopContributors);

--- a/src/components/collective-page/TopContributors.js
+++ b/src/components/collective-page/TopContributors.js
@@ -18,7 +18,6 @@ import ContainerSectionContent from './ContainerSectionContent';
 
 /** The container for Top Contributors view */
 const TopContributorsContainer = styled.div`
-  min-height: 425px;
   padding: 32px 16px;
   margin-top: 48px;
   background: url(${TopContributorsBackgroundSVG}) no-repeat center;
@@ -96,6 +95,7 @@ ContributorRow.propTypes = {
  * financial contributions.
  */
 const TopContributors = ({ topOrganizations, topIndividuals, currency }) => {
+  const hasBothTypes = Boolean(topOrganizations.length && topIndividuals.length);
   return (
     <TopContributorsContainer>
       <ContainerSectionContent m="0 auto">
@@ -105,9 +105,11 @@ const TopContributors = ({ topOrganizations, topIndividuals, currency }) => {
         <Flex mt={2} justifyContent="space-between" flexWrap="wrap">
           {topOrganizations && topOrganizations.length > 0 && (
             <div>
-              <P fontSize="LeadParagraph">
-                <FormattedMessage id="TopContributors.Organizations" defaultMessage="Organizations" />
-              </P>
+              {hasBothTypes && (
+                <P fontSize="LeadParagraph">
+                  <FormattedMessage id="TopContributors.Organizations" defaultMessage="Organizations" />
+                </P>
+              )}
               <Flex>
                 <ContributorsList>
                   {topOrganizations.slice(0, 5).map((contributor, idx) => (
@@ -124,9 +126,11 @@ const TopContributors = ({ topOrganizations, topIndividuals, currency }) => {
           )}
           {topIndividuals && topIndividuals.length > 0 && (
             <div>
-              <P fontSize="LeadParagraph">
-                <FormattedMessage id="TopContributors.Individuals" defaultMessage="Individuals" />
-              </P>
+              {hasBothTypes && (
+                <P fontSize="LeadParagraph">
+                  <FormattedMessage id="TopContributors.Individuals" defaultMessage="Individuals" />
+                </P>
+              )}
               <Flex>
                 <ContributorsList>
                   {topIndividuals.slice(0, 5).map((contributor, idx) => (
@@ -149,8 +153,8 @@ const TopContributors = ({ topOrganizations, topIndividuals, currency }) => {
 
 TopContributors.propTypes = {
   currency: PropTypes.string.isRequired,
-  topOrganizations: PropTypes.arrayOf(PropTypes.object),
-  topIndividuals: PropTypes.arrayOf(PropTypes.object),
+  topOrganizations: PropTypes.arrayOf(PropTypes.object).isRequired,
+  topIndividuals: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 
 export default withViewport(TopContributors);


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2212

---

This PR tries to minimize blank spaces as much as possible. It should not change anything for collectives with the max number of contributors in `Top Contributors` but should greatly improve things for collectives that have no orgs / no individuals contributing

# Preview

- Use rows instead of columns when the grid is not full
- Hide `Individuals` / `Organizations` labels when there's only one type

![image](https://user-images.githubusercontent.com/1556356/60909493-a76c9180-a27e-11e9-8e36-8fda853e4208.png)

- Show the column that has the most contributors first

![image](https://user-images.githubusercontent.com/1556356/60909385-67a5aa00-a27e-11e9-90e0-cdb2a39a5183.png)

- Complete empty spaces by showing more orgs or individuals to always have a full grid if we can

![image](https://user-images.githubusercontent.com/1556356/60914220-62019180-a289-11e9-9f06-8c30b2877143.png)
