### PR TITLE
chore(ContributorsGrid): Truncate names more aggressively

### DIFF
--- a/src/components/ContributorsGrid.js
+++ b/src/components/ContributorsGrid.js
@@ -181,7 +181,7 @@ class ContributorCard extends React.PureComponent {
         <Container display="flex" textAlign="center" flexDirection="column" justifyContent="center">
           {withCollectiveLink(
             <P fontSize="Paragraph" fontWeight="bold" lineHeight="Caption" color="black.900" title={name}>
-              {truncate(name, { length: 40 })}
+              {truncate(name, { length: 18 })}
             </P>,
           )}
           <P fontSize="Tiny" lineHeight="Caption" color="black.500">


### PR DESCRIPTION
To ensure they always fit one online (card is small, we can't afford more).

![image](https://user-images.githubusercontent.com/1556356/60977305-7ef0a000-a32f-11e9-8e53-537751399773.png)
