### PR TITLE
NCP/ContributorsGrid: No padding left if grid is full, better center cards

### DIFF
--- a/src/components/ContributorsGrid.js
+++ b/src/components/ContributorsGrid.js
@@ -210,8 +210,9 @@ const ContributorsGrid = ({ intl, contributors, width, maxNbRowsForViewports, vi
 
   // Preload more items when viewport width is unknown to avoid displaying blank spaces on SSR
   const viewWidth = viewport === VIEWPORTS.UNKNOWN ? width * 3 : width;
-  const paddingLeft = getPaddingLeft ? getPaddingLeft({ width, nbRows }) : 0;
-  const hasScroll = nbCols * COLLECTIVE_CARD_FULL_WIDTH + paddingLeft > width;
+  const rowWidth = nbCols * COLLECTIVE_CARD_FULL_WIDTH + COLLECTIVE_CARD_MARGIN_X;
+  const paddingLeft = getPaddingLeft ? getPaddingLeft({ width, rowWidth, nbRows }) : 0;
+  const hasScroll = rowWidth + paddingLeft > width;
 
   return (
     <FixedSizeGrid

--- a/src/components/collective-page/SectionContributors.js
+++ b/src/components/collective-page/SectionContributors.js
@@ -102,13 +102,18 @@ export default class SectionContributors extends React.PureComponent {
         <Box mb={4}>
           <ContributorsGrid
             contributors={filteredContributors}
-            getPaddingLeft={({ width, nbRows }) => {
+            getPaddingLeft={({ width, rowWidth, nbRows }) => {
               if (width < Dimensions.MAX_SECTION_WIDTH) {
                 // No need for padding on screens small enough so they don't have padding
                 return 0;
               } else if (nbRows > 1) {
-                // If multiline, center contributors cards
-                return (width - Dimensions.MAX_SECTION_WIDTH) / 8;
+                if (rowWidth <= width) {
+                  // If multiline and possible center contributors cards
+                  return (width - rowWidth) / 2;
+                } else {
+                  // Otherwise if multiline and the grid is full, just use the full screen
+                  return 0;
+                }
               } else {
                 // Otherwise add a normal section padding on the left
                 return (width - Dimensions.MAX_SECTION_WIDTH) / 2;


### PR DESCRIPTION
Based on feedback from https://github.com/opencollective/opencollective/issues/2225

![Peek 11-07-2019 15-40](https://user-images.githubusercontent.com/1556356/61055639-449c0700-a3f2-11e9-9625-ec205ad1bca8.gif)
