### PR TITLE
NCP: Improve users avatars rounding

### DIFF
--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -18,7 +18,7 @@ const StyledAvatar = styled(Flex).attrs(props => ({
   background-position: center center;
   background-repeat: no-repeat;
   background-size: cover;
-  border-radius: ${({ type }) => (type === 'USER' ? '100px' : '25%')};
+  border-radius: ${({ type }) => (type === 'USER' ? '50%' : '25%')};
   ${border}
   color: ${themeGet('colors.black.400')};
   font-weight: bold;

--- a/src/components/Avatar.js
+++ b/src/components/Avatar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { color, border, space, layout } from 'styled-system';
 import themeGet from '@styled-system/theme-get';
 import { Flex } from '@rebass/grid';
@@ -27,11 +27,6 @@ const StyledAvatar = styled(Flex).attrs(props => ({
   flex-shrink: 0;
   ${space}
   ${layout}
-  ${props =>
-    props.animationDuration &&
-    css`
-      transition: width ${props.animationDuration}ms, height ${props.animationDuration}ms;
-    `}
 `;
 
 const Avatar = ({ collective, src, type = 'USER', radius, name, ...styleProps }) => {

--- a/src/components/collective-page/TopContributors.js
+++ b/src/components/collective-page/TopContributors.js
@@ -92,7 +92,7 @@ const ContributorsBlock = ({ title, contributors, totalNbContributors, currency,
               <AvatarWithRank>
                 <span>{idx + 1}</span>
                 <Link route={route} params={{ slug: contributor.collectiveSlug }}>
-                  <ContributorAvatar contributor={contributor} radius={28} borderRadius="25%" />
+                  <ContributorAvatar contributor={contributor} radius={32} />
                 </Link>
               </AvatarWithRank>
               <div>


### PR DESCRIPTION
- Disable opt-in CSS height animation (was used initially to animate hero, no more needed)

- Disable custom rounding for user's avatars (also made them slightly bigger)

**Before**
![image](https://user-images.githubusercontent.com/1556356/61370590-05a6ff00-a893-11e9-8166-ef0df0da2a86.png)

**After**
![image](https://user-images.githubusercontent.com/1556356/61370547-ead48a80-a892-11e9-8454-26dee1f261db.png)
