### PR TITLE
Add PREPAID Tier to EditCollective 

### DIFF
--- a/src/components/EditCollectiveForm.js
+++ b/src/components/EditCollectiveForm.js
@@ -720,7 +720,7 @@ class EditCollectiveForm extends React.Component {
               {this.state.section === 'tiers' && (
                 <EditTiers
                   title="Tiers"
-                  types={['TIER', 'MEMBERSHIP', 'SERVICE', 'PRODUCT', 'DONATION']}
+                  types={['TIER', 'MEMBERSHIP', 'SERVICE', 'PRODUCT', 'DONATION', 'PREPAID']}
                   tiers={this.state.tiers}
                   collective={collective}
                   currency={collective.currency}

--- a/src/components/EditTiers.js
+++ b/src/components/EditTiers.js
@@ -51,6 +51,7 @@ class EditTiers extends React.Component {
         defaultMessage: 'product (e.g. t-shirt)',
       },
       DONATION: { id: 'tier.type.donation', defaultMessage: 'donation (gift)' },
+      PREPAID: { id: 'tier.type.prepaid', defaultMessage: 'prepaid (card)' },
       TICKET: {
         id: 'tier.type.ticket',
         defaultMessage: 'ticket (allow multiple tickets per order)',
@@ -215,7 +216,7 @@ class EditTiers extends React.Component {
         type: 'select',
         options: getOptions(['onetime', 'month', 'year']),
         label: intl.formatMessage(this.messages['interval.label']),
-        when: tier => !tier || ['DONATION', 'MEMBERSHIP', 'TIER', 'SERVICE'].indexOf(tier.type) !== -1,
+        when: tier => !tier || ['DONATION', 'MEMBERSHIP', 'TIER', 'SERVICE', 'PREPAID'].indexOf(tier.type) !== -1,
       },
       {
         name: 'maxQuantity',

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1,5 +1,5 @@
-# source: https://opencollective.com/api/graphql
-# timestamp: Mon Jul 08 2019 10:28:18 GMT+0200 (Central European Summer Time)
+# source: http://localhost:3000/api/graphql
+# timestamp: Wed Jul 17 2019 11:13:17 GMT+0100 (West Africa Standard Time)
 
 """
 Application model
@@ -1119,6 +1119,7 @@ type ExpenseType {
   payoutMethod: String
   privateMessage: String
   attachment: String
+  userTaxFormRequiredBeforePayment: Boolean
   user: UserDetails
   fromCollective: CollectiveInterface
   comments(limit: Int, offset: Int): CommentListType
@@ -1451,6 +1452,7 @@ type Mutation {
   """
   editMembership(id: Int!, publicMessage: String): Member
   createOrder(order: OrderInputType!): OrderType
+  createOrderForDispatch(order: OrderInputType!): OrderType
   addFundsToCollective(order: OrderInputType!): OrderType
   updateOrder(order: OrderInputType!): OrderType
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -974,6 +974,7 @@
   "tier.type.donation": "donation (gift)",
   "tier.type.label": "type",
   "tier.type.membership": "membership (recurring)",
+  "tier.type.prepaid": "prepaid (card)",
   "tier.type.product": "product (e.g. t-shirt)",
   "tier.type.service": "service (e.g. support)",
   "tier.type.sponsor.add": "add another tier",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -974,6 +974,7 @@
   "tier.type.donation": "donación (regalo)",
   "tier.type.label": "tipo",
   "tier.type.membership": "membership (recurring)",
+  "tier.type.prepaid": "prepaid (card)",
   "tier.type.product": "producto (ej. camiseta)",
   "tier.type.service": "servicio (ej. soporte)",
   "tier.type.sponsor.add": "sumar otra categoría",

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -974,6 +974,7 @@
   "tier.type.donation": "don (sans contrepartie)",
   "tier.type.label": "type",
   "tier.type.membership": "membre (récurrent)",
+  "tier.type.prepaid": "prepaid (card)",
   "tier.type.product": "produit (e.g. t-shirt)",
   "tier.type.service": "service (ex. support)",
   "tier.type.sponsor.add": "ajouter un autre tier",

--- a/src/lang/it.json
+++ b/src/lang/it.json
@@ -974,6 +974,7 @@
   "tier.type.donation": "donation (gift)",
   "tier.type.label": "type",
   "tier.type.membership": "membership (recurring)",
+  "tier.type.prepaid": "prepaid (card)",
   "tier.type.product": "product (e.g. t-shirt)",
   "tier.type.service": "service (e.g. support)",
   "tier.type.sponsor.add": "add another tier",

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -974,6 +974,7 @@
   "tier.type.donation": "寄付 (ギフト)",
   "tier.type.label": "タイプ",
   "tier.type.membership": "メンバーシップ (定期)",
+  "tier.type.prepaid": "prepaid (card)",
   "tier.type.product": "プロダクト (例: Tシャツ)",
   "tier.type.service": "サービス (例: サポート)",
   "tier.type.sponsor.add": "ほかの Tier を追加",

--- a/src/lang/pt.json
+++ b/src/lang/pt.json
@@ -974,6 +974,7 @@
   "tier.type.donation": "donation (gift)",
   "tier.type.label": "type",
   "tier.type.membership": "membership (recurring)",
+  "tier.type.prepaid": "prepaid (card)",
   "tier.type.product": "product (e.g. t-shirt)",
   "tier.type.service": "service (e.g. support)",
   "tier.type.sponsor.add": "add another tier",

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -974,6 +974,7 @@
   "tier.type.donation": "donation (gift)",
   "tier.type.label": "тип",
   "tier.type.membership": "membership (recurring)",
+  "tier.type.prepaid": "prepaid (card)",
   "tier.type.product": "продукт (например, майка)",
   "tier.type.service": "услуга (например, тех. поддержка)",
   "tier.type.sponsor.add": "добавить уровень",

--- a/src/lang/zh.json
+++ b/src/lang/zh.json
@@ -974,6 +974,7 @@
   "tier.type.donation": "donation (gift)",
   "tier.type.label": "类型",
   "tier.type.membership": "membership (recurring)",
+  "tier.type.prepaid": "prepaid (card)",
   "tier.type.product": "product (e.g. t-shirt)",
   "tier.type.service": "service (e.g. support)",
   "tier.type.sponsor.add": "add another tier",


### PR DESCRIPTION
This PR follows up [#2153](https://github.com/opencollective/opencollective-api/pull/2153), does the following: 
- adds `createOrderForDispatch` mutation to `createOrder` page
- adds `PREPAID` to tier type in `EditCollective`

TODO:
- Make `PREPAID` tier only available for `hostCollectives` (`opensource` hostCollectives only fornow ) 
- Enable `customFields` in `EditTiers` where tier is `PREPAID` type