### PR TITLE
Add query string to redirect url in authentication flow.

### DIFF
--- a/src/components/SignInOrJoinFree.js
+++ b/src/components/SignInOrJoinFree.js
@@ -49,7 +49,11 @@ class SignInOrJoinFree extends React.Component {
   };
 
   getRedirectURL() {
-    return encodeURIComponent(this.props.redirect || window.location.pathname || '/');
+    let currentPath = window.location.pathname;
+    if (window.location.search) {
+      currentPath = currentPath + window.location.search;
+    }
+    return encodeURIComponent(this.props.redirect || currentPath || '/');
   }
 
   signIn = async email => {


### PR DESCRIPTION
This PR adds `windows.location.search` if available  to the redirect URL path during authentication. 