### PR TITLE
Fix datetime picker issues

### DIFF
--- a/components/CreateCollectiveForm.js
+++ b/components/CreateCollectiveForm.js
@@ -316,7 +316,7 @@ class CreateCollectiveForm extends React.Component {
             .FormInputs {
               max-width: 700px;
               margin: 0 auto;
-              overflow: hidden;
+              overflow-x: hidden;
             }
 
             .actions {

--- a/components/DateTime.js
+++ b/components/DateTime.js
@@ -15,7 +15,7 @@ class DateTime extends React.Component {
     const { date, timezone } = props;
     const value = momentTimezone.tz(new Date(date), timezone);
 
-    return <ReactDateTime value={value} {...props} />;
+    return <ReactDateTime value={value} utc={timezone === 'utc'} {...props} />;
   }
 }
 

--- a/components/EditCollectiveForm.js
+++ b/components/EditCollectiveForm.js
@@ -488,7 +488,7 @@ class EditCollectiveForm extends React.Component {
             }
 
             .FormInputs {
-              overflow: hidden;
+              overflow-x: hidden;
             }
 
             .EditCollectiveForm :global(textarea[name='longDescription']) {


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/2161

- Don't convert string to UTC, which fixes:

>  when I tried to type in 04/01/2017 it kept jumping to 03/31/2017

- Allow overflow-y for the form so we can scroll the picker. Not the best, but it will fix the issue for now

![Peek 22-07-2019 12-10](https://user-images.githubusercontent.com/1556356/61625026-1338fc00-ac7a-11e9-90fa-3455b499cd27.gif)
