### PR TITLE
fix(widgets): Ignore .babelrc when building

### DIFF
--- a/server/templates/.babelrc
+++ b/server/templates/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["@babel/preset-env"],
+  "plugins": []
+}


### PR DESCRIPTION
Fix for https://github.com/opencollective/opencollective/issues/2275

---

Widgets templates were built using our `.babelrc` configuration. As a consequence, the following code was prepended to each template:

```es6
"use strict";

var _interopRequireDefault = require("@babel/runtime-corejs2/helpers/interopRequireDefault");

var _parseInt2 = _interopRequireDefault(require("@babel/runtime-corejs2/core-js/parse-int"));
``` 

I'm not sure when this changed, but it made the scripts for button and widget crash with:

> Uncaught ReferenceError: require is not defined at button.js:3

The proposed fix is to add a custom `.babelrc` in the templates folder which overrides the default presets and plugins.