### PR TITLE
fix(EditCollectiveForm): Ensure we don't loose settings

### DIFF
--- a/components/EditCollectiveForm.js
+++ b/components/EditCollectiveForm.js
@@ -70,6 +70,10 @@ class EditCollectiveForm extends React.Component {
 
     const collective = { ...(props.collective || {}) };
     collective.slug = collective.slug ? collective.slug.replace(/.*\//, '') : '';
+    collective.tos = get(collective, 'settings.tos');
+    collective.sendInvoiceByEmail = get(collective, 'settings.sendInvoiceByEmail');
+    collective.goals = get(collective, 'settings.goals');
+    collective.markdown = get(collective, 'settings.markdown');
 
     this.state = {
       modified: false,


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/2256

---

Before this PR editing something that belongs to `settings` (goals, editor, sendInvoiceByEmail, tos) could strip the other settings. The proper fix should be to revamp this `/edit` because the way we handle this state is too hacky.