### PR TITLE
Display event year

### DIFF
--- a/components/CollectiveCover.js
+++ b/components/CollectiveCover.js
@@ -137,6 +137,7 @@ class CollectiveCover extends React.Component {
                   weekday="short"
                   day="numeric"
                   month="long"
+                  year="numeric"
                 />
                 , &nbsp;
                 <FormattedTime value={props.collective.endsAt} timeZone={props.collective.timezone} />
@@ -201,12 +202,15 @@ ${description}`;
     let cta;
     if (this.props.cta) {
       if (this.props.cta.href) {
-        const label = this.props.cta.label;
-        cta = (
-          <ContributeLink href={this.props.cta.href}>
-            {this.messages[label] ? intl.formatMessage(this.messages[label]) : label}
-          </ContributeLink>
-        );
+        const isDatePassed = Date.now() > Date.parse(this.props.collective.endsAt);
+        if (!isDatePassed) {
+          const label = this.props.cta.label;
+          cta = (
+            <ContributeLink href={this.props.cta.href}>
+              {this.messages[label] ? intl.formatMessage(this.messages[label]) : label}
+            </ContributeLink>
+          );
+        }
       } else {
         cta = this.props.cta;
       }

--- a/components/CollectiveCover.js
+++ b/components/CollectiveCover.js
@@ -202,15 +202,12 @@ ${description}`;
     let cta;
     if (this.props.cta) {
       if (this.props.cta.href) {
-        const isDatePassed = Date.now() > Date.parse(this.props.collective.endsAt);
-        if (!isDatePassed) {
-          const label = this.props.cta.label;
-          cta = (
-            <ContributeLink href={this.props.cta.href}>
-              {this.messages[label] ? intl.formatMessage(this.messages[label]) : label}
-            </ContributeLink>
-          );
-        }
+        const label = this.props.cta.label;
+        cta = (
+          <ContributeLink href={this.props.cta.href}>
+            {this.messages[label] ? intl.formatMessage(this.messages[label]) : label}
+          </ContributeLink>
+        );
       } else {
         cta = this.props.cta;
       }

--- a/components/Event.js
+++ b/components/Event.js
@@ -256,7 +256,7 @@ class Event extends React.Component {
                   <div className="eventDescription">
                     <Markdown source={event.longDescription || event.description} escapeHtml={false} />
                   </div>
-                  {isEventOver && event.endsAt ? null : (
+                  {!isEventOver && !event.endsAt ? (
                     <section id="tickets">
                       <SectionTitle
                         section="tickets"
@@ -282,7 +282,7 @@ class Event extends React.Component {
                         ))}
                       </div>
                     </section>
-                  )}
+                  ) : null}
                 </div>
 
                 {get(event, 'location.name') && <Location location={event.location} />}

--- a/components/Event.js
+++ b/components/Event.js
@@ -256,7 +256,7 @@ class Event extends React.Component {
                   <div className="eventDescription">
                     <Markdown source={event.longDescription || event.description} escapeHtml={false} />
                   </div>
-                  {isEventOver ? null : (
+                  {isEventOver && event.endsAt ? null : (
                     <section id="tickets">
                       <SectionTitle
                         section="tickets"

--- a/components/Event.js
+++ b/components/Event.js
@@ -259,31 +259,33 @@ class Event extends React.Component {
                   <div className="eventDescription">
                     <Markdown source={event.longDescription || event.description} escapeHtml={false} />
                   </div>
-                  <section id="tickets" className={isEventOver && event.endsAt ? 'hide' : ''}>
-                    <SectionTitle
-                      section="tickets"
-                      action={
-                        LoggedInUser && LoggedInUser.canEditCollective(event)
-                          ? {
-                              label: intl.formatMessage(this.messages['event.tickets.edit']),
-                              href: `${event.path}/edit#tiers`,
-                            }
-                          : null
-                      }
-                    />
+                  {isEventOver && event.endsAt ? null : (
+                    <section id="tickets">
+                      <SectionTitle
+                        section="tickets"
+                        action={
+                          LoggedInUser && LoggedInUser.canEditCollective(event)
+                            ? {
+                                label: intl.formatMessage(this.messages['event.tickets.edit']),
+                                href: `${event.path}/edit#tiers`,
+                              }
+                            : null
+                        }
+                      />
 
-                    <div className="ticketsGrid">
-                      {event.tiers.map(tier => (
-                        <Tier
-                          key={tier.id}
-                          tier={tier}
-                          values={this.state.tierInfo[tier.id] || {}}
-                          onChange={response => this.updateOrder(response)}
-                          onClick={response => this.handleOrderTier(response)}
-                        />
-                      ))}
-                    </div>
-                  </section>
+                      <div className="ticketsGrid">
+                        {event.tiers.map(tier => (
+                          <Tier
+                            key={tier.id}
+                            tier={tier}
+                            values={this.state.tierInfo[tier.id] || {}}
+                            onChange={response => this.updateOrder(response)}
+                            onClick={response => this.handleOrderTier(response)}
+                          />
+                        ))}
+                      </div>
+                    </section>
+                  )}
                 </div>
 
                 {get(event, 'location.name') && <Location location={event.location} />}

--- a/components/Event.js
+++ b/components/Event.js
@@ -1,5 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Markdown from 'react-markdown';
+import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
+import { uniqBy, get, union } from 'lodash';
 import Header from './Header';
 import Body from './Body';
 import Footer from './Footer';
@@ -10,9 +13,7 @@ import NotificationBar from './NotificationBar';
 import Sponsors from './Sponsors';
 import Responses from './Responses';
 import { filterCollection, trimObject } from '../lib/utils';
-import Markdown from 'react-markdown';
-import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
-import { uniqBy, get, union } from 'lodash';
+import { canOrderTicketsFromEvent, moneyCanMoveFromEvent } from '../lib/events';
 import { Router } from '../server/pages';
 import { addEventMutations } from '../lib/graphql/mutations';
 import { exportRSVPs } from '../lib/export_file';
@@ -120,8 +121,7 @@ class Event extends React.Component {
 
     const canEditEvent = LoggedInUser && LoggedInUser.canEditEvent(event);
     const responses = { sponsors: [] };
-
-    const isEventOver = new Date(event.endsAt).getTime() < new Date().getTime();
+    const canOrderTickets = canOrderTicketsFromEvent(event);
 
     const guests = {};
     guests.interested = [];
@@ -163,7 +163,7 @@ class Event extends React.Component {
 
     let notification = {};
     // If event is over and has a positive balance, we ask the admins if they want to move the money to the parent collective
-    if (isEventOver && get(this.props.event, 'stats.balance') > 0 && canEditEvent) {
+    if (canEditEvent && moneyCanMoveFromEvent(event)) {
       notification = {
         title: intl.formatMessage(this.messages['event.over.sendMoneyToParent.title']),
         description: intl.formatMessage(this.messages['event.over.sendMoneyToParent.description'], {
@@ -251,7 +251,7 @@ class Event extends React.Component {
                 collective={event}
                 title={event.name}
                 LoggedInUser={LoggedInUser}
-                cta={{ label: 'tickets', href: '#tickets' }}
+                cta={canOrderTickets ? { label: 'tickets', href: '#tickets' } : null}
               />
 
               <div>
@@ -259,12 +259,12 @@ class Event extends React.Component {
                   <div className="eventDescription">
                     <Markdown source={event.longDescription || event.description} escapeHtml={false} />
                   </div>
-                  {isEventOver && event.endsAt ? null : (
+                  {!canOrderTickets ? null : (
                     <section id="tickets">
                       <SectionTitle
                         section="tickets"
                         action={
-                          LoggedInUser && LoggedInUser.canEditCollective(event)
+                          canEditEvent
                             ? {
                                 label: intl.formatMessage(this.messages['event.tickets.edit']),
                                 href: `${event.path}/edit#tiers`,

--- a/components/Event.js
+++ b/components/Event.js
@@ -256,32 +256,33 @@ class Event extends React.Component {
                   <div className="eventDescription">
                     <Markdown source={event.longDescription || event.description} escapeHtml={false} />
                   </div>
+                  {isEventOver ? null : (
+                    <section id="tickets">
+                      <SectionTitle
+                        section="tickets"
+                        action={
+                          LoggedInUser && LoggedInUser.canEditCollective(event)
+                            ? {
+                                label: intl.formatMessage(this.messages['event.tickets.edit']),
+                                href: `${event.path}/edit#tiers`,
+                              }
+                            : null
+                        }
+                      />
 
-                  <section id="tickets">
-                    <SectionTitle
-                      section="tickets"
-                      action={
-                        LoggedInUser && LoggedInUser.canEditCollective(event)
-                          ? {
-                              label: intl.formatMessage(this.messages['event.tickets.edit']),
-                              href: `${event.path}/edit#tiers`,
-                            }
-                          : null
-                      }
-                    />
-
-                    <div className="ticketsGrid">
-                      {event.tiers.map(tier => (
-                        <Tier
-                          key={tier.id}
-                          tier={tier}
-                          values={this.state.tierInfo[tier.id] || {}}
-                          onChange={response => this.updateOrder(response)}
-                          onClick={response => this.handleOrderTier(response)}
-                        />
-                      ))}
-                    </div>
-                  </section>
+                      <div className="ticketsGrid">
+                        {event.tiers.map(tier => (
+                          <Tier
+                            key={tier.id}
+                            tier={tier}
+                            values={this.state.tierInfo[tier.id] || {}}
+                            onChange={response => this.updateOrder(response)}
+                            onClick={response => this.handleOrderTier(response)}
+                          />
+                        ))}
+                      </div>
+                    </section>
+                  )}
                 </div>
 
                 {get(event, 'location.name') && <Location location={event.location} />}

--- a/components/Event.js
+++ b/components/Event.js
@@ -221,6 +221,9 @@ class Event extends React.Component {
             .ticketsGrid :global(.tier) {
               margin: 2rem auto;
             }
+            .hide {
+              display: none;
+            }
           `}
         </style>
 
@@ -256,33 +259,31 @@ class Event extends React.Component {
                   <div className="eventDescription">
                     <Markdown source={event.longDescription || event.description} escapeHtml={false} />
                   </div>
-                  {!isEventOver && !event.endsAt ? (
-                    <section id="tickets">
-                      <SectionTitle
-                        section="tickets"
-                        action={
-                          LoggedInUser && LoggedInUser.canEditCollective(event)
-                            ? {
-                                label: intl.formatMessage(this.messages['event.tickets.edit']),
-                                href: `${event.path}/edit#tiers`,
-                              }
-                            : null
-                        }
-                      />
+                  <section id="tickets" className={isEventOver && event.endsAt ? 'hide' : ''}>
+                    <SectionTitle
+                      section="tickets"
+                      action={
+                        LoggedInUser && LoggedInUser.canEditCollective(event)
+                          ? {
+                              label: intl.formatMessage(this.messages['event.tickets.edit']),
+                              href: `${event.path}/edit#tiers`,
+                            }
+                          : null
+                      }
+                    />
 
-                      <div className="ticketsGrid">
-                        {event.tiers.map(tier => (
-                          <Tier
-                            key={tier.id}
-                            tier={tier}
-                            values={this.state.tierInfo[tier.id] || {}}
-                            onChange={response => this.updateOrder(response)}
-                            onClick={response => this.handleOrderTier(response)}
-                          />
-                        ))}
-                      </div>
-                    </section>
-                  ) : null}
+                    <div className="ticketsGrid">
+                      {event.tiers.map(tier => (
+                        <Tier
+                          key={tier.id}
+                          tier={tier}
+                          values={this.state.tierInfo[tier.id] || {}}
+                          onChange={response => this.updateOrder(response)}
+                          onClick={response => this.handleOrderTier(response)}
+                        />
+                      ))}
+                    </div>
+                  </section>
                 </div>
 
                 {get(event, 'location.name') && <Location location={event.location} />}

--- a/components/EventsWithData.js
+++ b/components/EventsWithData.js
@@ -63,7 +63,8 @@ class EventsWithData extends React.Component {
         {!event.startsAt && console.warn(`EventsWithData: event.startsAt should not be empty. event.id: ${event.id}`)}
         {event.startsAt && (
           <React.Fragment>
-            <FormattedDate value={event.startsAt} timeZone={event.timezone} day="numeric" month="long" />, &nbsp;
+            <FormattedDate value={event.startsAt} timeZone={event.timezone} day="numeric" month="long" year="numeric" />
+            , &nbsp;
           </React.Fragment>
         )}
         {event.location.name}

--- a/lib/events.js
+++ b/lib/events.js
@@ -1,0 +1,27 @@
+import { get } from 'lodash';
+
+/**
+ * Check if the given event is over. Ideally we would just rely on the date, but
+ * as there can be timezones differences we add an additional security by keeping
+ * tickets up to 24h after the event is over.
+ */
+export const canOrderTicketsFromEvent = event => {
+  if (!event.endsAt) {
+    return true;
+  }
+
+  const oneDay = 24 * 60 * 60 * 1000;
+  const isOverSince = new Date().getTime() - new Date(event.endsAt).getTime();
+  return isOverSince < oneDay;
+};
+
+/**
+ * Can only withraw the money from event if it's over.
+ */
+export const moneyCanMoveFromEvent = event => {
+  if (get(event, 'stats.balance', 0) <= 0) {
+    return false;
+  }
+
+  return new Date().getTime() >= new Date(event.endsAt).getTime();
+};

--- a/test/cypress/integration/24-event.createOrder.test.js
+++ b/test/cypress/integration/24-event.createOrder.test.js
@@ -1,9 +1,17 @@
 describe('event.createOrder page', () => {
+  it("can't order if the event is over", () => {
+    cy.visit('/opensource/events/webpack-webinar');
+    cy.contains('Webinar: How Webpack Reached $400K+/year in Sponsorship & Crowdfunding');
+    cy.get('.cover .cta').should('not.exist');
+    cy.get('#tickets').should('not.exist');
+  });
+
   it('makes an order for a free ticket as an existing user', () => {
+    cy.clock(Date.parse('2017/10/01')); // Go back in time when the event was not over yet
     cy.login({ redirect: '/opensource/events/webpack-webinar' });
     cy.get('#free.tier .btn.increase').click();
     cy.get('#free.tier .ctabtn').click();
-    cy.location().should(location => {
+    cy.location({ timeout: 15000 }).should(location => {
       expect(location.pathname).to.eq('/opensource/events/webpack-webinar/order/78');
       expect(location.search).to.eq('?quantity=2&totalAmount=0');
     });
@@ -31,10 +39,11 @@ describe('event.createOrder page', () => {
   });
 
   it('makes an order for a paying ticket as an existing user', () => {
+    cy.clock(Date.parse('2017/10/01')); // Go back in time when the event was not over yet
     cy.signup({ redirect: '/opensource/events/webpack-webinar' });
     cy.get('#silver-sponsor.tier .btn.increase').click();
     cy.get('#silver-sponsor.tier .ctabtn').click();
-    cy.location().should(location => {
+    cy.location({ timeout: 15000 }).should(location => {
       expect(location.pathname).to.eq('/opensource/events/webpack-webinar/order/77');
       expect(location.search).to.eq('?quantity=2&totalAmount=50000');
     });


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/2200

![image](https://user-images.githubusercontent.com/30627428/62411963-2a210c00-b5f3-11e9-9e0e-bbf07e0fe9e6.png)
#### Show year on event's cover for endsAt

![image](https://user-images.githubusercontent.com/30627428/62412005-ce0ab780-b5f3-11e9-9479-d225d2e06768.png)
#### Hide tickets button on the event's cover if the event is passed already

![image](https://user-images.githubusercontent.com/30627428/62411967-373dfb00-b5f3-11e9-90aa-127abf89dc1e.png)
#### In EventsWithData, show the year of the event 