### PR TITLE
refactor(paymentMethodSelect): migrate from deprecatedStyledSheet to …

### DIFF
--- a/components/PaymentMethodSelect.js
+++ b/components/PaymentMethodSelect.js
@@ -1,31 +1,46 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl } from 'react-intl';
 
-import StyledSelect from './DeprecatedStyledSelect';
+import StyledSelect from './StyledSelect';
 import { paymentMethodLabelWithIcon } from '../lib/payment_method_label';
 
-const PaymentMethodSelect = ({ intl, paymentMethods, defaultPaymentMethod, ...props }) => {
-  return (
-    <StyledSelect
-      name="paymentMethod"
-      options={paymentMethods}
-      keyGetter="id"
-      defaultValue={defaultPaymentMethod}
-      {...props}
-    >
-      {({ value: pm }) => <div>{paymentMethodLabelWithIcon(intl, pm)}</div>}
-    </StyledSelect>
-  );
-};
+class PaymentMethodSelect extends Component {
+  static propTypes = {
+    onChange: PropTypes.func.isRequired,
+    /** To control the component state */
+    value: PropTypes.object,
+    /** The payment methods to display. **Cannot be empty !** */
+    paymentMethods: PropTypes.arrayOf(PropTypes.object).isRequired,
+    /** The default payment method. Will use the first one if not provided. */
+    defaultPaymentMethod: PropTypes.object,
+    /** @ignore Provided by injectIntl */
+    intl: PropTypes.object,
+  };
 
-PaymentMethodSelect.propTypes = {
-  /** The payment methods to display. **Cannot be empty !** */
-  paymentMethods: PropTypes.arrayOf(PropTypes.object).isRequired,
-  /** The default payment method. Will use the first one if not provided. */
-  defaultPaymentMethod: PropTypes.object,
-  /** @ignore Provided by injectIntl */
-  intl: PropTypes.object,
-};
+  paymentMethodValueAndLabel = (intl, paymentMethod) => {
+    return {
+      value: paymentMethod.id,
+      label: paymentMethodLabelWithIcon(intl, paymentMethod),
+    };
+  };
+
+  render() {
+    const { intl, paymentMethods, defaultPaymentMethod, value, onChange, ...props } = this.props;
+
+    const options = paymentMethods.map(paymentMethod => this.paymentMethodValueAndLabel(intl, paymentMethod));
+
+    return (
+      <StyledSelect
+        name="paymentMethod"
+        options={options}
+        onChange={({ value }) => onChange(value)}
+        value={value ? this.paymentMethodValueAndLabel(intl, value) : undefined}
+        defaultValue={defaultPaymentMethod ? this.paymentMethodValueAndLabel(intl, defaultPaymentMethod) : options[0]}
+        {...props}
+      />
+    );
+  }
+}
 
 export default injectIntl(PaymentMethodSelect);


### PR DESCRIPTION
…new StyledSheet

BREAKING CHANGE: onChange prop is required for paymentMetohodSelect component

fix #2294