### PR TITLE
AddFundsForm: Default platform fee

### DIFF
--- a/components/AddFundsForm.js
+++ b/components/AddFundsForm.js
@@ -35,6 +35,7 @@ class AddFundsForm extends React.Component {
       form: {
         totalAmount: 0,
         hostFeePercent: get(props, 'collective.hostFeePercent'),
+        platformFeePercent: 0,
       },
       result: {},
     };
@@ -134,6 +135,7 @@ class AddFundsForm extends React.Component {
       {
         name: 'hostFeePercent',
         when: () => !this.isAddFundsToOrg,
+        defaultValue: props.collective.hostFeePercent,
         type: 'number',
         post: '%',
       },
@@ -182,13 +184,14 @@ class AddFundsForm extends React.Component {
     const { host } = this.props;
 
     const newState = { ...this.state };
+
     if (value !== undefined) {
       newState[obj][attr] = value;
     } else {
       newState[obj] = Object.assign({}, this.state[obj], attr);
     }
 
-    if (attr === 'FromCollectiveId') {
+    if (attr === 'FromCollectiveId' && value !== 'other') {
       value = Number(value);
       if (host && value !== host.id) {
         newState[obj].hostFeePercent = this.props.collective.hostFeePercent;
@@ -198,7 +201,6 @@ class AddFundsForm extends React.Component {
            receiving funds and the right host must be pulled from
            GraphQL when the user chooses an option in the combo. */
         newState[obj].hostFeePercent = await this.retrieveHostFeePercent(value);
-        newState[obj].platformFeePercent = 5;
       }
     }
 
@@ -365,7 +367,7 @@ class AddFundsForm extends React.Component {
                               <td className="amount">{hostFeeAmount}</td>
                             </tr>
                           )}
-                          {platformFeePercent > 0 && !this.isAddFundsToOrg && (
+                          {!this.isAddFundsToOrg && (
                             <tr>
                               <td>
                                 <FormattedMessage

--- a/components/AddFundsSourcePicker.js
+++ b/components/AddFundsSourcePicker.js
@@ -87,13 +87,15 @@ class AddFundsSourcePicker extends React.Component {
 
   render() {
     const { intl, host, data } = this.props;
+    const options = this.getSelectOptions(intl, host, data.PaymentMethod);
 
     return (
       <StyledSelect
         id="sourcePicker"
         isLoading={data.loading}
         disabled={!data.PaymentMethod}
-        options={this.getSelectOptions(intl, host, data.PaymentMethod)}
+        options={options}
+        defaultValue={options[0]}
         onChange={this.onChange}
         maxMenuHeight={200}
       />

--- a/components/__tests__/__snapshots__/AddFundsSourcePicker.test.js.snap
+++ b/components/__tests__/__snapshots__/AddFundsSourcePicker.test.js.snap
@@ -132,9 +132,9 @@ exports[`AddFundsSourcePicker component renders fromCollectives by type in optgr
       className=" css-1hwfws3"
     >
       <div
-        className=" css-1wa3eu0-placeholder"
+        className=" css-1uccc91-singleValue"
       >
-        No selection
+        Host ()
       </div>
       <div
         className="css-1g6gooi"


### PR DESCRIPTION
Fix a bug in `AddFunds` that would add platform fees when changing source and a regression introduced in https://github.com/opencollective/opencollective-frontend/pull/2265 that would add 5% platform fees per default if not specified.

Resolve https://opencollective.freshdesk.com/a/tickets/1059
