### PR TITLE
Enhancement: Fiscal Host admin can enable or disable applications from new Collectives

### DIFF
--- a/components/EditCollective.js
+++ b/components/EditCollective.js
@@ -73,12 +73,14 @@ class EditCollective extends React.Component {
       goals: CollectiveInputType.goals,
       editor: CollectiveInputType.markdown ? 'markdown' : 'html',
       sendInvoiceByEmail: CollectiveInputType.sendInvoiceByEmail,
+      apply: CollectiveInputType.application,
       tos: CollectiveInputType.tos,
     };
     delete CollectiveInputType.goals;
     delete CollectiveInputType.markdown;
     delete CollectiveInputType.sendInvoiceByEmail;
     delete CollectiveInputType.tos;
+    delete CollectiveInputType.application;
 
     return CollectiveInputType;
   }

--- a/components/EditCollectiveForm.js
+++ b/components/EditCollectiveForm.js
@@ -72,6 +72,7 @@ class EditCollectiveForm extends React.Component {
     collective.slug = collective.slug ? collective.slug.replace(/.*\//, '') : '';
     collective.tos = get(collective, 'settings.tos');
     collective.sendInvoiceByEmail = get(collective, 'settings.sendInvoiceByEmail');
+    collective.application = get(collective, 'settings.apply');
     collective.goals = get(collective, 'settings.goals');
     collective.markdown = get(collective, 'settings.markdown');
 
@@ -191,6 +192,14 @@ class EditCollectiveForm extends React.Component {
       'sendInvoiceByEmail.description': {
         id: 'collective.sendInvoiceByEmail.description',
         defaultMessage: 'Automatically attach the PDF of your receipts to the monthly report email',
+      },
+      'application.label': {
+        id: 'collective.application.label',
+        defaultMessage: 'Application',
+      },
+      'application.description': {
+        id: 'collective.application.description',
+        defaultMessage: 'Enable application from collectives',
       },
       'hostFeePercent.label': {
         id: 'collective.hostFeePercent.label',
@@ -515,6 +524,13 @@ class EditCollectiveForm extends React.Component {
         },
       ],
       advanced: [
+        {
+          name: 'application',
+          className: 'horizontal',
+          type: 'switch',
+          defaultValue: get(this.state.collective, 'settings.apply'),
+          when: () => this.state.section === 'advanced' && collective.isHost,
+        },
         {
           name: 'sendInvoiceByEmail',
           className: 'horizontal',

--- a/lang/en.json
+++ b/lang/en.json
@@ -50,6 +50,8 @@
   "collective.addHostBtn": "Add a host",
   "collective.address.label": "Address",
   "collective.amount.label": "amount",
+  "collective.application.description": "Enable application from collectives",
+  "collective.application.label": "Application",
   "collective.archive.archivedConfirmMessage": "{message}.",
   "collective.archive.availableBalance": "Only Collectives with a balance of zero can be archived. To pay out the funds, submit an expense, donate to another Collective, or send the funds to your fiscal host using the 'empty balance' option.",
   "collective.archive.button": "Archive this {type}",

--- a/lang/es.json
+++ b/lang/es.json
@@ -50,6 +50,8 @@
   "collective.addHostBtn": "Añade un host",
   "collective.address.label": "Dirección",
   "collective.amount.label": "monto",
+  "collective.application.description": "Enable application from collectives",
+  "collective.application.label": "Application",
   "collective.archive.archivedConfirmMessage": "{message}.",
   "collective.archive.availableBalance": "Solo se pueden archivar los Colectivos con balance igual a cero. Para pagar los fondos, envíe un gasto, done su remanente a otro Colectivo o envíe fondos a su anfitrión fiscal utilizando la opción 'saldo vacío'.",
   "collective.archive.button": "Archive esto {type}",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -50,6 +50,8 @@
   "collective.addHostBtn": "Ajoutez un hôte",
   "collective.address.label": "Adresse",
   "collective.amount.label": "montant",
+  "collective.application.description": "Enable application from collectives",
+  "collective.application.label": "Application",
   "collective.archive.archivedConfirmMessage": "{message}.",
   "collective.archive.availableBalance": "Seuls les collectifs avec un solde à zéro peuvent être archivés. Pour avoir un solde à zéro, soumettez une dépense, donnez à un autre collectif ou envoyez les fonds à votre hôte fiscal en utilisant la fonctionnalité \"Solder le compte\".",
   "collective.archive.button": "Archiver ce {type}",

--- a/lang/it.json
+++ b/lang/it.json
@@ -50,6 +50,8 @@
   "collective.addHostBtn": "Aggiungi organizzatore",
   "collective.address.label": "Indirizzo",
   "collective.amount.label": "ammontare",
+  "collective.application.description": "Enable application from collectives",
+  "collective.application.label": "Application",
   "collective.archive.archivedConfirmMessage": "{message}.",
   "collective.archive.availableBalance": "Only Collectives with a balance of zero can be archived. To pay out the funds, submit an expense, donate to another Collective, or send the funds to your fiscal host using the 'empty balance' option.",
   "collective.archive.button": "Archivia questo {type}",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -50,6 +50,8 @@
   "collective.addHostBtn": "ホストを追加",
   "collective.address.label": "アドレス",
   "collective.amount.label": "金額",
+  "collective.application.description": "Enable application from collectives",
+  "collective.application.label": "Application",
   "collective.archive.archivedConfirmMessage": "{message}。",
   "collective.archive.availableBalance": "Only Collectives with a balance of zero can be archived. To pay out the funds, submit an expense, donate to another Collective, or send the funds to your fiscal host using the 'empty balance' option.",
   "collective.archive.button": "{type} をアーカイブ",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -50,6 +50,8 @@
   "collective.addHostBtn": "Adicionar um organizador",
   "collective.address.label": "Endereço",
   "collective.amount.label": "quantia",
+  "collective.application.description": "Enable application from collectives",
+  "collective.application.label": "Application",
   "collective.archive.archivedConfirmMessage": "{message}.",
   "collective.archive.availableBalance": "Only Collectives with a balance of zero can be archived. To pay out the funds, submit an expense, donate to another Collective, or send the funds to your fiscal host using the 'empty balance' option.",
   "collective.archive.button": "Arquive esse {type}",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -50,6 +50,8 @@
   "collective.addHostBtn": "Добавить представителя",
   "collective.address.label": "Адрес",
   "collective.amount.label": "сумма",
+  "collective.application.description": "Enable application from collectives",
+  "collective.application.label": "Application",
   "collective.archive.archivedConfirmMessage": "{message}.",
   "collective.archive.availableBalance": "Only Collectives with a balance of zero can be archived. To pay out the funds, submit an expense, donate to another Collective, or send the funds to your fiscal host using the 'empty balance' option.",
   "collective.archive.button": "Архивировать этот {type}",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -50,6 +50,8 @@
   "collective.addHostBtn": "Add a host",
   "collective.address.label": "地址",
   "collective.amount.label": "数量",
+  "collective.application.description": "Enable application from collectives",
+  "collective.application.label": "Application",
   "collective.archive.archivedConfirmMessage": "{message}。",
   "collective.archive.availableBalance": "Only Collectives with a balance of zero can be archived. To pay out the funds, submit an expense, donate to another Collective, or send the funds to your fiscal host using the 'empty balance' option.",
   "collective.archive.button": "存档此 {type}",


### PR DESCRIPTION
This PR follows up [#2165](https://github.com/opencollective/opencollective/issues/2165), to allow fiscal host admin enable or disable application from new collectives as shown in the screenshot below. The toggle switch is only available in `EditCollectiveForm` -> `Advanced` section, provided the collective is a fiscal host.

![screenshot (7)](https://user-images.githubusercontent.com/15707013/62533529-cdb22c80-b83e-11e9-8662-df949d4d58f6.png)
