### PR TITLE
Fix i18n: Ensure English is the default locale

### DIFF
--- a/scripts/translate.js
+++ b/scripts/translate.js
@@ -108,3 +108,5 @@ translate('ja', defaultMessages, diff.updated);
 translate('pt', defaultMessages, diff.updated);
 translate('ru', defaultMessages, diff.updated);
 translate('zh', defaultMessages, diff.updated);
+translate('nl', defaultMessages, diff.updated);
+translate('de', defaultMessages, diff.updated);

--- a/server/intl.js
+++ b/server/intl.js
@@ -11,7 +11,13 @@ import glob from 'glob';
 import { logger } from './logger';
 
 // Get the supported languages by looking for translations in the `lang/` dir.
-export const languages = glob.sync(path.join(__dirname, '../lang/*.json')).map(f => path.basename(f, '.json'));
+export const languages = [
+  'en', // Ensure English is always first in the list
+  ...glob
+    .sync(path.join(__dirname, '../lang/*.json'))
+    .map(f => path.basename(f, '.json'))
+    .filter(locale => locale !== 'en'),
+];
 
 logger.info(`loading languages: ${JSON.stringify(languages)}`);
 


### PR DESCRIPTION
CI was using `de` as the default language because we recently added German language files and the language list started with it (['de', 'en', ...]`).

However the headers sent by Cypress **doesn't** include `de` in the supported languages so there's definitely something wrong with `accept.language` in https://github.com/opencollective/opencollective-frontend/blob/7a19d5e85e765c3f333fadc7888b6fc2ad84c501/server/index.js#L43

I've forced `en` as the first locale to quickly fix the issue but I'm going to work on a better fix for the long-term