### PR TITLE
deps: Remove clean-tag dependency

### DIFF
--- a/components/Container.js
+++ b/components/Container.js
@@ -1,10 +1,9 @@
 import styled from 'styled-components';
-import tag from 'clean-tag';
 import { background, border, flexbox, shadow, color, position, layout, space, typography } from 'styled-system';
 import { cursor, clear, float, overflow, pointerEvents, whiteSpace } from '../lib/styled_system_custom';
 import propTypes from '@styled-system/prop-types';
 
-const Container = styled(tag)`
+const Container = styled.div`
   box-sizing: border-box;
 
   ${flexbox}

--- a/components/DeprecatedStyledSelect.js
+++ b/components/DeprecatedStyledSelect.js
@@ -5,7 +5,6 @@ import styled, { css } from 'styled-components';
 import themeGet from '@styled-system/theme-get';
 import { CaretDown } from 'styled-icons/fa-solid/CaretDown';
 import { Box } from '@rebass/grid';
-import tag from 'clean-tag';
 
 import { getInputBorderColor } from '../lib/styled_components_utils';
 import Container from './Container';
@@ -84,10 +83,6 @@ const SelectContainer = styled(Container)`
         `}
 `;
 
-SelectContainer.defaultProps = {
-  omitProps: tag.defaultProps.omitProps.concat('mode'),
-};
-
 const SelectPopupContainer = styled(Container)`
   position: absolute;
   z-index: 10;
@@ -95,7 +90,7 @@ const SelectPopupContainer = styled(Container)`
   box-shadow: 0px 4px 14px rgba(20, 20, 20, 0.16);
 `;
 
-const StyledListItem = styled(tag.li)`
+const StyledListItem = styled.li`
   list-style: none;
   cursor: pointer;
   padding: 8px;
@@ -122,10 +117,6 @@ const StyledListItem = styled(tag.li)`
     }
   }}
 `;
-
-StyledListItem.defaultProps = {
-  omitProps: tag.defaultProps.omitProps.concat('isHighlighted', 'isSelected'),
-};
 
 const Icon = styled(CaretDown)`
   color: ${themeGet('colors.black.400')};

--- a/components/Hide.js
+++ b/components/Hide.js
@@ -41,10 +41,6 @@ const Hide = styled(Box)`
   ${top}
 `;
 
-Hide.defaultProps = {
-  omitProps: ['xs', 'sm', 'md', 'lg'],
-};
-
 Hide.propTypes = {
   xs: PropTypes.bool,
   sm: PropTypes.bool,

--- a/components/MessageBox.js
+++ b/components/MessageBox.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { display, height, maxHeight, maxWidth, minHeight, minWidth, typography, shadow } from 'styled-system';
+import { display, layout, space, typography, shadow, color, flexbox } from 'styled-system';
 import themeGet from '@styled-system/theme-get';
-import tag from 'clean-tag';
-import { Box } from '@rebass/grid';
 
 import { InfoCircle } from 'styled-icons/fa-solid/InfoCircle';
 import { CheckCircle } from 'styled-icons/fa-solid/CheckCircle';
@@ -16,19 +14,18 @@ import { Span } from './Text';
 import StyledCard from './StyledCard';
 import StyledSpinner from './StyledSpinner';
 
-const Message = styled(Box)`
+const Message = styled.div`
   border: 1px solid;
   border-radius: 8px;
   padding: ${themeGet('space.3')}px;
 
   ${shadow}
   ${display}
-  ${height}
-  ${maxHeight}
-  ${maxWidth}
-  ${minHeight}
-  ${minWidth}
+  ${layout}
+  ${space}
   ${typography}
+  ${color}
+  ${flexbox}
 
   ${messageType}
 `;
@@ -63,8 +60,6 @@ const MessageBox = ({ withIcon, isLoading, children, ...props }) => {
 };
 
 MessageBox.propTypes = {
-  /** @ignore */
-  omitProps: PropTypes.arrayOf(PropTypes.string),
   /** Type of the message */
   type: PropTypes.oneOf(['white', 'dark', 'info', 'success', 'warning', 'error']),
   /** Weither icon should be hidden. Icons are only set for info, success, warning and error messages. */
@@ -80,7 +75,6 @@ MessageBox.propTypes = {
 MessageBox.defaultProps = {
   type: 'white',
   withIcon: false,
-  omitProps: tag.defaultProps.omitProps.concat('type'),
 };
 
 export default MessageBox;

--- a/components/StyledButton.js
+++ b/components/StyledButton.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
-import tag from 'clean-tag';
 import { border, color, layout, typography, space } from 'styled-system';
 import themeGet from '@styled-system/theme-get';
 
@@ -14,7 +13,7 @@ import StyledSpinner from './StyledSpinner';
  *
  * @see See [styled-system docs](https://github.com/jxnblk/styled-system/blob/master/docs/api.md) for usage of those props
  */
-const StyledButtonContent = styled(tag.button)`
+const StyledButtonContent = styled.button`
   appearance: none;
   border: none;
   cursor: pointer;
@@ -58,8 +57,6 @@ const StyledButton = ({ loading, ...props }) =>
   );
 
 StyledButton.propTypes = {
-  /** @ignore */
-  omitProps: PropTypes.arrayOf(PropTypes.string),
   /**
    * Based on the design system theme
    */
@@ -106,7 +103,6 @@ StyledButton.propTypes = {
 };
 
 StyledButton.defaultProps = {
-  omitProps: tag.defaultProps.omitProps.concat('buttonStyle', 'buttonSize', 'asLink', 'textTransform'),
   buttonSize: 'medium',
   buttonStyle: 'standard',
   loading: false,

--- a/components/StyledButtonSet.js
+++ b/components/StyledButtonSet.js
@@ -40,10 +40,6 @@ StyledButtonItem.propTypes = {
   combo: PropTypes.bool,
 };
 
-StyledButtonItem.defaultProps = {
-  omitProps: StyledButton.defaultProps.omitProps.concat('combo'),
-};
-
 const StyledButtonSet = ({
   size,
   items,

--- a/components/StyledHr.js
+++ b/components/StyledHr.js
@@ -1,10 +1,12 @@
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { space, layout, shadow, border } from 'styled-system';
 import themeGet from '@styled-system/theme-get';
-import tag from 'clean-tag';
+import propTypes from '@styled-system/prop-types';
 
-const StyledHr = styled(tag.hr)`
+/**
+ * An horizontal line. Control the color and size using border properties.
+ */
+const StyledHr = styled.hr`
   border: 0;
   border-top: 1px solid ${themeGet('colors.black.400')};
   margin: 0;
@@ -17,26 +19,10 @@ const StyledHr = styled(tag.hr)`
 `;
 
 StyledHr.propTypes = {
-  /** styled-system prop: accepts any css 'border-color' value or theme color */
-  borderColor: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
-  /** accepts any css 'border-style' value */
-  borderStyle: PropTypes.string,
-  /** styled-system prop: accepts any css 'box-shadow' value */
-  boxShadow: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
-  /** styled-system prop: accepts any css 'max-width' value */
-  maxWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
-  /** styled-system prop: accepts any css 'min-width' value */
-  minWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
-  /**
-   * styled-system prop: adds margin & padding props
-   * see: https://github.com/jxnblk/styled-system/blob/master/docs/api.md#space
-   */
-  space: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
-};
-
-StyledHr.defaultProps = {
-  /** @ignore */
-  omitProps: tag.defaultProps.omitProps.concat('borderStyle'),
+  ...propTypes.border,
+  ...propTypes.layout,
+  ...propTypes.shadow,
+  ...propTypes.space,
 };
 
 /** @component */

--- a/components/StyledInput.js
+++ b/components/StyledInput.js
@@ -2,9 +2,9 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { background, border, color, layout, flexbox, space, typography } from 'styled-system';
 import themeGet from '@styled-system/theme-get';
-import tag from 'clean-tag';
 import { overflow } from '../lib/styled_system_custom';
 import { buttonSize, buttonStyle } from '../lib/constants/theme';
+import propTypes from '@styled-system/prop-types';
 
 const getBorderColor = ({ error, success }) => {
   if (error) {
@@ -23,7 +23,7 @@ const getBorderColor = ({ error, success }) => {
  *
  * @see See [styled-system docs](https://github.com/jxnblk/styled-system/blob/master/docs/api.md) for usage of those props
  */
-const StyledInput = styled(tag.input)`
+const StyledInput = styled.input`
   ${background}
   ${border}
   ${color}
@@ -53,43 +53,23 @@ const StyledInput = styled(tag.input)`
 `;
 
 StyledInput.propTypes = {
-  /** @ignore */
-  omitProps: PropTypes.arrayOf(PropTypes.string),
-  /** true to hide styled borders */
-  bare: PropTypes.bool,
-  /** styled-system prop: accepts any css 'border' value */
-  border: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
-  /** styled-system prop: accepts any css 'border-color' value */
-  borderColor: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
-  /** styled-system prop: accepts any css 'border-radius' value */
-  borderRadius: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
-  /** Show disabled state for field */
-  disabled: PropTypes.bool,
-  /** Show error state for field */
-  error: PropTypes.bool,
-  /** styled-system prop: accepts any css 'font-size' value */
-  fontSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
-  /** styled-system prop: accepts any css 'min-width' value */
-  maxWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
-  /** styled-system prop: accepts any css 'max-width' value */
-  minWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
-  /** @ignore */
-  px: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
-  /** @ignore */
-  py: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
-  /**
-   * styled-system prop: adds margin & padding props
-   * see: https://github.com/jxnblk/styled-system/blob/master/docs/api.md#space
-   */
-  space: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
   /** Show success state for field */
   success: PropTypes.bool,
-  /** styled-system prop: accepts any css 'width' value */
-  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
+  /** true to hide styled borders */
+  bare: PropTypes.bool,
+  /** Scroll overflow */
+  overflow: PropTypes.oneOf(['auto', 'hidden', 'scroll']),
+  // Styled-system proptypes
+  ...propTypes.background,
+  ...propTypes.border,
+  ...propTypes.color,
+  ...propTypes.flexbox,
+  ...propTypes.layout,
+  ...propTypes.space,
+  ...propTypes.typography,
 };
 
 StyledInput.defaultProps = {
-  omitProps: tag.defaultProps.omitProps.concat('buttonStyle', 'buttonSize', 'bare', 'error'),
   border: '1px solid',
   borderColor: 'black.300',
   borderRadius: '4px',
@@ -112,7 +92,6 @@ export const SubmitInput = styled(StyledInput)`
 `;
 
 SubmitInput.defaultProps = {
-  omitProps: tag.defaultProps.omitProps.concat('buttonStyle', 'buttonSize', 'bare'),
   buttonStyle: 'primary',
   buttonSize: 'large',
   fontWeight: 'bold',

--- a/components/StyledLink.js
+++ b/components/StyledLink.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { border, color, layout, space, typography } from 'styled-system';
 import themeGet from '@styled-system/theme-get';
-import tag from 'clean-tag';
 import { whiteSpace, textDecoration } from '../lib/styled_system_custom';
 import { buttonSize, buttonStyle } from '../lib/constants/theme';
 
@@ -11,7 +10,7 @@ import { buttonSize, buttonStyle } from '../lib/constants/theme';
  *
  * @see See [styled-system docs](https://github.com/jxnblk/styled-system/blob/master/docs/api.md) for usage of those props
  */
-const StyledLink = styled(tag.a)`
+const StyledLink = styled.a`
   color: ${themeGet('colors.primary.500')};
 
   &:hover {
@@ -38,8 +37,6 @@ const StyledLink = styled(tag.a)`
 `;
 
 StyledLink.propTypes = {
-  /** @ignore */
-  omitProps: PropTypes.arrayOf(PropTypes.string),
   /**
    * Based on the design system theme
    */
@@ -71,10 +68,6 @@ StyledLink.propTypes = {
   textDecoration: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
   /** Disable the link, make it unclickable */
   disabled: PropTypes.bool,
-};
-
-StyledLink.defaultProps = {
-  omitProps: tag.defaultProps.omitProps.concat('buttonStyle', 'buttonSize', 'whiteSpace'),
 };
 
 /** @component */

--- a/components/StyledTag.js
+++ b/components/StyledTag.js
@@ -1,9 +1,8 @@
-import tag from 'clean-tag';
 import styled from 'styled-components';
 import { background, borderRadius, color, space, border, fontSize, fontWeight, lineHeight } from 'styled-system';
 
 /** Simple tag to display a short string */
-const StyledTag = styled(tag.span)`
+const StyledTag = styled.span`
   border-radius: 4px;
   padding: 8px 6px;
   font-size: 8px;

--- a/components/Text.js
+++ b/components/Text.js
@@ -1,10 +1,9 @@
 import styled from 'styled-components';
 import { color, display, space, typography } from 'styled-system';
-import tag from 'clean-tag';
 
 import { textTransform, whiteSpace, wordBreak, cursor } from '../lib/styled_system_custom';
 
-export const P = styled(tag.p).attrs(props => ({
+export const P = styled.p.attrs(props => ({
   // Overrides default margin Y to avoid global styles
   mb: props.mb || props.my || props.m || 0,
   mt: props.mt || props.my || props.m || 0,
@@ -20,13 +19,12 @@ export const P = styled(tag.p).attrs(props => ({
 `;
 
 P.defaultProps = {
-  omitProps: tag.defaultProps.omitProps.concat(['textTransform', 'whiteSpace', 'wordBreak', 'cursor']),
   fontSize: 'Paragraph',
   letterSpacing: '-0.2px',
   lineHeight: 'Paragraph',
 };
 
-export const Span = P.withComponent(tag.span);
+export const Span = P.withComponent('span');
 
 Span.defaultProps = {
   ...P.defaultProps,
@@ -34,7 +32,7 @@ Span.defaultProps = {
   lineHeight: 'inherit',
 };
 
-export const H1 = P.withComponent(tag.h1);
+export const H1 = P.withComponent('h1');
 
 H1.defaultProps = {
   ...P.defaultProps,
@@ -44,7 +42,7 @@ H1.defaultProps = {
   lineHeight: 'H1',
 };
 
-export const H2 = P.withComponent(tag.h2);
+export const H2 = P.withComponent('h2');
 
 H2.defaultProps = {
   ...P.defaultProps,
@@ -54,7 +52,7 @@ H2.defaultProps = {
   lineHeight: 'H2',
 };
 
-export const H3 = P.withComponent(tag.h3);
+export const H3 = P.withComponent('h3');
 
 H3.defaultProps = {
   ...P.defaultProps,
@@ -64,7 +62,7 @@ H3.defaultProps = {
   lineHeight: 'H3',
 };
 
-export const H4 = P.withComponent(tag.h4);
+export const H4 = P.withComponent('h4');
 
 H4.defaultProps = {
   ...P.defaultProps,
@@ -74,7 +72,7 @@ H4.defaultProps = {
   lineHeight: 'H4',
 };
 
-export const H5 = P.withComponent(tag.h5);
+export const H5 = P.withComponent('h5');
 
 H5.defaultProps = {
   ...P.defaultProps,

--- a/components/icons/CustomStyledIcon.js
+++ b/components/icons/CustomStyledIcon.js
@@ -2,11 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { alignSelf, height, width } from 'styled-system';
-import tag from 'clean-tag';
 
 import { cursor } from '../../lib/styled_system_custom';
 
-const StyledSVG = styled(tag.svg)`
+const StyledSVG = styled.svg`
   display: inline-block;
   vertical-align: middle;
   overflow: hidden;
@@ -16,10 +15,6 @@ const StyledSVG = styled(tag.svg)`
   ${width};
   ${cursor};
 `;
-
-StyledSVG.defaultProps = {
-  omitProps: tag.defaultProps.omitProps.concat('cursor'),
-};
 
 /**
  * A simple wrapper to export custom icons as styled icons. It mostly mimics the

--- a/package-lock.json
+++ b/package-lock.json
@@ -5719,35 +5719,6 @@
         }
       }
     },
-    "clean-tag": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/clean-tag/-/clean-tag-3.1.0.tgz",
-      "integrity": "sha512-UvkRzFThxcNbvMywy4llq1LOUEKlONpNbeGSQr6kO5n2l4ehOOq7izYkxEnXDGBKm0u+768GQKZ/3sgH7YX38w==",
-      "requires": {
-        "html-tags": "^2.0.0",
-        "react": "^16.8.5",
-        "styled-system": "^3.2.1"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.4.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
-          "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          }
-        },
-        "styled-system": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-3.2.1.tgz",
-          "integrity": "sha512-ag0Yp7UeVHHc3t+1uM3jvlljaZYzwqpbJ8hMrFvpaKfUd8xsB9JeQXLwMpEsz8iLx8Lz/+9j0coWFZjmw8MogQ==",
-          "requires": {
-            "@babel/runtime": "^7.1.2",
-            "prop-types": "^15.6.2"
-          }
-        }
-      }
-    },
     "clean-webpack-plugin": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-1.0.1.tgz",
@@ -9263,13 +9234,13 @@
       "dependencies": {
         "colors": {
           "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "resolved": "http://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
           "dev": true
         },
         "commander": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
           "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
           "dev": true
         }
@@ -10189,7 +10160,7 @@
         },
         "node-fetch": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
           "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
           "dev": true
         }
@@ -10554,11 +10525,6 @@
       "requires": {
         "phantomjs-prebuilt": "^2.1.4"
       }
-    },
-    "html-tags": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-2.0.0.tgz",
-      "integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos="
     },
     "html-to-react": {
       "version": "1.3.4",
@@ -19373,7 +19339,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
@@ -20410,7 +20376,7 @@
         },
         "globby": {
           "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
           "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
           "dev": true,
           "requires": {
@@ -24184,7 +24150,7 @@
       "dependencies": {
         "ast-types": {
           "version": "0.7.8",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
+          "resolved": "http://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
           "integrity": "sha1-kC0uDWDQcb3NRtwRXhgJ7RHBOKk=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "bluebird": "3.5.5",
     "bootstrap": "3.4.1",
     "classnames": "2.2.6",
-    "clean-tag": "3.1.0",
     "cloudflare-ip": "0.0.7",
     "cookie-parser": "1.4.4",
     "copy-to-clipboard": "3.2.0",

--- a/pages/orderSuccess.js
+++ b/pages/orderSuccess.js
@@ -51,7 +51,6 @@ ShareLink.defaultProps = {
   mx: 2,
   mb: 2,
   target: '_blank',
-  omitProps: StyledLink.defaultProps.omitProps,
 };
 
 const GetOrderQuery = gql`


### PR DESCRIPTION
`clean-tag` is no longer maintained (see https://github.com/styled-system/extras/tree/master/packages/clean-tag). 

Moreover, it's not needed anymore because `styled-components` now strips the non-html tags so we just need to be careful when naming our custom props. As per https://www.styled-components.com/docs/basics#passed-props:

> If the styled target is a simple element (e.g. styled.div), styled-components passes through any known HTML attribute to the DOM. If it is a custom React component (e.g. styled(MyComponent)), styled-components passes through all props.