### PR TITLE
Fix customData in createOrder

### DIFF
--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -206,7 +206,7 @@ class CreateOrderPage extends React.Component {
       step: stepName === 'contributeAs' ? undefined : stepName,
       totalAmount: this.props.fixedAmount ? this.props.fixedAmount.toString() : undefined,
       interval: this.props.fixedInterval || undefined,
-      ...pick(this.props, ['interval', 'description', 'redirect', 'eventSlug']),
+      ...pick(this.props, ['interval', 'description', 'redirect']),
       ...routeParams,
     };
 

--- a/pages/createOrder.js
+++ b/pages/createOrder.js
@@ -143,6 +143,7 @@ class CreateOrderPage extends React.Component {
           defaultQuantity={quantity}
           fixedInterval={interval}
           fixedAmount={totalAmount}
+          customData={this.props.customData}
         />
       );
     }

--- a/pages/createOrder.js
+++ b/pages/createOrder.js
@@ -51,11 +51,9 @@ class CreateOrderPage extends React.Component {
 
     return {
       collectiveSlug: query.eventSlug || query.collectiveSlug,
-      eventSlug: query.eventSlug,
       totalAmount: parseInt(query.amount) * 100 || parseInt(query.totalAmount) || null,
       step: query.step || 'contributeAs',
       tierId: parseInt(query.tierId) || null,
-      tierSlug: query.tierSlug,
       quantity: parseInt(query.quantity) || 1,
       description: query.description ? decodeURIComponent(query.description) : undefined,
       interval: query.interval,
@@ -68,8 +66,6 @@ class CreateOrderPage extends React.Component {
 
   static propTypes = {
     collectiveSlug: PropTypes.string, // for addData
-    eventSlug: PropTypes.string, // for addData
-    tierSlug: PropTypes.string,
     tierId: PropTypes.number,
     quantity: PropTypes.number,
     totalAmount: PropTypes.number,
@@ -82,11 +78,6 @@ class CreateOrderPage extends React.Component {
     referral: PropTypes.string,
     data: PropTypes.object.isRequired, // from withData
     intl: PropTypes.object.isRequired, // from injectIntl
-    loadStripe: PropTypes.func.isRequired, // from withStripeLoader
-    LoggedInUser: PropTypes.object, // from withUser
-    loadingLoggedInUser: PropTypes.bool, // from withUser
-    createCollective: PropTypes.func,
-    refetchLoggedInUser: PropTypes.func,
   };
 
   getPageMetadata() {
@@ -129,20 +120,19 @@ class CreateOrderPage extends React.Component {
         </Flex>
       );
     } else {
-      const { verb, step, referral, redirect, description, quantity, interval, totalAmount } = this.props;
       return (
         <ContributionFlow
           collective={data.Collective}
           host={data.Collective.host}
           tier={data.Tier}
-          verb={verb}
-          step={step}
-          referral={referral}
-          redirect={redirect}
-          description={description}
-          defaultQuantity={quantity}
-          fixedInterval={interval}
-          fixedAmount={totalAmount}
+          verb={this.props.verb}
+          step={this.props.step}
+          referral={this.props.referral}
+          redirect={this.props.redirect}
+          description={this.props.description}
+          defaultQuantity={this.props.quantity}
+          fixedInterval={this.props.interval}
+          fixedAmount={this.props.totalAmount}
           customData={this.props.customData}
         />
       );


### PR DESCRIPTION
This was broken in  https://github.com/opencollective/opencollective-frontend/pull/2281 
This PR also removes props/proptypes that were not used anymore.

![Peek 08-08-2019 13-15](https://user-images.githubusercontent.com/1556356/62698905-911d3700-b9de-11e9-88ff-b7ce09db76ae.gif)
