### PR TITLE
fix: Issue #2180 - Event form does not let you correct errors

### DIFF
--- a/components/CreateEvent.js
+++ b/components/CreateEvent.js
@@ -64,7 +64,7 @@ class CreateEvent extends React.Component {
       const errorMsg = err.graphQLErrors && err.graphQLErrors[0] ? err.graphQLErrors[0].message : err.message;
       this.setState({
         status: 'idle',
-        result: { error: errorMsg }
+        result: { error: errorMsg },
       });
       throw new Error(errorMsg);
     }

--- a/components/CreateEvent.js
+++ b/components/CreateEvent.js
@@ -62,7 +62,10 @@ class CreateEvent extends React.Component {
     } catch (err) {
       console.error('>>> createEvent error: ', JSON.stringify(err));
       const errorMsg = err.graphQLErrors && err.graphQLErrors[0] ? err.graphQLErrors[0].message : err.message;
-      this.setState({ result: { error: errorMsg } });
+      this.setState({
+        status: 'idle',
+        result: { error: errorMsg }
+      });
       throw new Error(errorMsg);
     }
   }


### PR DESCRIPTION
This pull request is aimed at fixing issue [2180](https://github.com/opencollective/opencollective/issues/2180) (Event form does not let you correct errors)

Issue statement and proposed solution has been made [here](https://github.com/opencollective/opencollective/issues/2180#issue-462348982)

Please find attached a short video of a working solution
![2180](https://user-images.githubusercontent.com/37955249/62813684-f3e6ff00-bac0-11e9-8ee7-879a4e5bb339.gif)

@Betree @znarf I am very open to feedback. Thanks!
