### PR TITLE
Makes tax form warning work when viewing single expense.

### DIFF
--- a/components/expenses/ExpenseWithData.js
+++ b/components/expenses/ExpenseWithData.js
@@ -89,6 +89,7 @@ const getExpenseQuery = gql`
       currency
       payoutMethod
       privateMessage
+      userTaxFormRequiredBeforePayment
       attachment
       collective {
         id


### PR DESCRIPTION
We accidentally broke the tax form warning badge on the single expense view when we changed to using the `ExpensesWithData` component to query about missing tax forms. 

Easy fix tho :)



