### PR TITLE
fix(AddFundsForm): Correct fees amount for orgs

### DIFF
--- a/components/AddFundsForm.js
+++ b/components/AddFundsForm.js
@@ -9,6 +9,8 @@ import { get } from 'lodash';
 import { getCurrencySymbol, formatCurrency } from '../lib/utils';
 import InputField from './InputField';
 import { AddFundsSourcePickerWithData, AddFundsSourcePickerForUserWithData } from './AddFundsSourcePicker';
+import { CollectiveType } from '../lib/constants/collectives';
+import { OC_FEE_PERCENT } from '../lib/constants/transactions';
 
 class AddFundsForm extends React.Component {
   static propTypes = {
@@ -35,7 +37,6 @@ class AddFundsForm extends React.Component {
       form: {
         totalAmount: 0,
         hostFeePercent: get(props, 'collective.hostFeePercent'),
-        platformFeePercent: 0,
       },
       result: {},
     };
@@ -216,11 +217,21 @@ class AddFundsForm extends React.Component {
     return false;
   }
 
+  getPlatformFee() {
+    if (this.state.form.platformFeePercent !== undefined) {
+      return this.state.form.platformFeePercent;
+    } else if (this.props.collective.type === CollectiveType.ORGANIZATION) {
+      return OC_FEE_PERCENT;
+    } else {
+      return 0;
+    }
+  }
+
   render() {
     const { loading } = this.props;
 
     const hostFeePercent = this.state.form.hostFeePercent || 0;
-    const platformFeePercent = this.state.form.platformFeePercent || 0;
+    const platformFeePercent = this.getPlatformFee();
 
     const hostFeeAmount = formatCurrency(
       (hostFeePercent / 100) * this.state.form.totalAmount,
@@ -398,8 +409,11 @@ class AddFundsForm extends React.Component {
                       <div>
                         {showAddFundsToOrgDetails && (
                           <div className="note">
-                            Please put aside {hostFeePercent}% ({hostFeeAmount}) for your host fees and 5% (
-                            {platformFeeAmount}) for platform fees.
+                            <FormattedMessage
+                              id="AddFundsForm.PutAside"
+                              defaultMessage="Please put aside {hostFeePercent}% ({hostFeeAmount}) for your host fees and {platformFeePercent}% ({platformFeeAmount}) for platform fees."
+                              values={{ hostFeePercent, hostFeeAmount, platformFeePercent, platformFeeAmount }}
+                            />
                           </div>
                         )}
                       </div>

--- a/lang/de.json
+++ b/lang/de.json
@@ -30,6 +30,7 @@
   "addfunds.submit": "Githaben hinzufügen",
   "addfunds.title": "Guthaben zu {collective} hinzufügen",
   "addfunds.totalAmount": "Finanzierungsbetrag",
+  "AddFundsForm.PutAside": "Please put aside {hostFeePercent}% ({hostFeeAmount}) for your host fees and {platformFeePercent}% ({platformFeeAmount}) for platform fees.",
   "addfundstoorg.FromCollectiveId.label": "Host",
   "Amount": "{amount} {currencyCode}",
   "amount.free": "kostenlos",

--- a/lang/en.json
+++ b/lang/en.json
@@ -30,6 +30,7 @@
   "addfunds.submit": "Add Funds",
   "addfunds.title": "Add Funds to {collective}",
   "addfunds.totalAmount": "Funding amount",
+  "AddFundsForm.PutAside": "Please put aside {hostFeePercent}% ({hostFeeAmount}) for your host fees and {platformFeePercent}% ({platformFeeAmount}) for platform fees.",
   "addfundstoorg.FromCollectiveId.label": "host",
   "Amount": "{amount} {currencyCode}",
   "amount.free": "free",

--- a/lang/es.json
+++ b/lang/es.json
@@ -30,6 +30,7 @@
   "addfunds.submit": "Añadir Fondos",
   "addfunds.title": "Añadir fondos a {collective}",
   "addfunds.totalAmount": "Cantidad de fondos",
+  "AddFundsForm.PutAside": "Please put aside {hostFeePercent}% ({hostFeeAmount}) for your host fees and {platformFeePercent}% ({platformFeeAmount}) for platform fees.",
   "addfundstoorg.FromCollectiveId.label": "host",
   "Amount": "{amount} {currencyCode}",
   "amount.free": "gratuito",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -30,6 +30,7 @@
   "addfunds.submit": "Ajouter des fonds",
   "addfunds.title": "Ajouter des fonds à {collective}",
   "addfunds.totalAmount": "Montant",
+  "AddFundsForm.PutAside": "Please put aside {hostFeePercent}% ({hostFeeAmount}) for your host fees and {platformFeePercent}% ({platformFeeAmount}) for platform fees.",
   "addfundstoorg.FromCollectiveId.label": "hôte",
   "Amount": "{amount} {currencyCode}",
   "amount.free": "gratuit",

--- a/lang/it.json
+++ b/lang/it.json
@@ -30,6 +30,7 @@
   "addfunds.submit": "Aggiungi fondi",
   "addfunds.title": "Aggiungi fondi a {collective}",
   "addfunds.totalAmount": "Importo finanziamento",
+  "AddFundsForm.PutAside": "Please put aside {hostFeePercent}% ({hostFeeAmount}) for your host fees and {platformFeePercent}% ({platformFeeAmount}) for platform fees.",
   "addfundstoorg.FromCollectiveId.label": "organizzatore",
   "Amount": "{amount} {currencyCode}",
   "amount.free": "gratis",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -30,6 +30,7 @@
   "addfunds.submit": "資金を追加",
   "addfunds.title": "{collective} に資金を追加します",
   "addfunds.totalAmount": "資金額",
+  "AddFundsForm.PutAside": "Please put aside {hostFeePercent}% ({hostFeeAmount}) for your host fees and {platformFeePercent}% ({platformFeeAmount}) for platform fees.",
   "addfundstoorg.FromCollectiveId.label": "ホスト",
   "Amount": "{amount} {currencyCode}",
   "amount.free": "無料",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -30,6 +30,7 @@
   "addfunds.submit": "Voeg geld toe",
   "addfunds.title": "Voeg geld toe aan {collective}",
   "addfunds.totalAmount": "Totaal vermogen",
+  "AddFundsForm.PutAside": "Please put aside {hostFeePercent}% ({hostFeeAmount}) for your host fees and {platformFeePercent}% ({platformFeeAmount}) for platform fees.",
   "addfundstoorg.FromCollectiveId.label": "beheerder",
   "Amount": "{amount} {currencyCode}",
   "amount.free": "beschikbaar",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -30,6 +30,7 @@
   "addfunds.submit": "Adicionar Fundos",
   "addfunds.title": "Adicionar Fundos à {collective}",
   "addfunds.totalAmount": "Quantia financiada",
+  "AddFundsForm.PutAside": "Please put aside {hostFeePercent}% ({hostFeeAmount}) for your host fees and {platformFeePercent}% ({platformFeeAmount}) for platform fees.",
   "addfundstoorg.FromCollectiveId.label": "organizador",
   "Amount": "{amount} {currencyCode}",
   "amount.free": "grátis",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -30,6 +30,7 @@
   "addfunds.submit": "Добавить средства",
   "addfunds.title": "Добавить средства {collective}",
   "addfunds.totalAmount": "Сумма финансирования",
+  "AddFundsForm.PutAside": "Please put aside {hostFeePercent}% ({hostFeeAmount}) for your host fees and {platformFeePercent}% ({platformFeeAmount}) for platform fees.",
   "addfundstoorg.FromCollectiveId.label": "представитель",
   "Amount": "{amount} {currencyCode}",
   "amount.free": "бесплатно",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -30,6 +30,7 @@
   "addfunds.submit": "Add Funds",
   "addfunds.title": "Add Funds to {collective}",
   "addfunds.totalAmount": "Funding amount",
+  "AddFundsForm.PutAside": "Please put aside {hostFeePercent}% ({hostFeeAmount}) for your host fees and {platformFeePercent}% ({platformFeeAmount}) for platform fees.",
   "addfundstoorg.FromCollectiveId.label": "host",
   "Amount": "{amount} {currencyCode}",
   "amount.free": "免费",

--- a/lib/constants/transactions.js
+++ b/lib/constants/transactions.js
@@ -1,0 +1,13 @@
+/** @module constants/transactions */
+
+/** Percentage that Open Collective charges per transaction: 5% */
+export const OC_FEE_PERCENT = 5;
+
+/** Default per transaction host fee percentage */
+export const HOST_FEE_PERCENT = 5;
+
+/** Types of Transactions */
+export const TransactionTypes = {
+  CREDIT: 'CREDIT',
+  DEBIT: 'DEBIT',
+};


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/2311
Bug introduced in https://github.com/opencollective/opencollective-frontend/pull/2291

The implemented behavior is:
- There should not be any platform fees when adding funds to a collective
- There should be a 5% platform fee when adding funds to an organization

![image](https://user-images.githubusercontent.com/1556356/63357443-ba887c00-c369-11e9-8822-8f5caee1ffbe.png)
