### PR TITLE
Fix ContributionFlow free tiers validation

### DIFF
--- a/components/Steps.js
+++ b/components/Steps.js
@@ -160,7 +160,6 @@ export default class Steps extends React.Component {
 
   /** Go to previous step. Will be blocked if current step is not validated. */
   goBack = () => {
-    console.log('Go back');
     const currentStep = this.getStepByName(this.props.currentStepName);
     if (!currentStep || currentStep.index === 0) {
       return false;

--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -11,6 +11,7 @@ import uuid from 'uuid/v4';
 import * as LibTaxes from '@opencollective/taxes';
 
 import { OPENSOURCE_COLLECTIVE_ID } from '../../lib/constants/collectives';
+import { AmountTypes } from '../../lib/constants/tiers-types';
 import { VAT_OPTIONS } from '../../lib/constants/vat';
 import { Router } from '../../server/pages';
 import { stripeTokenToPaymentMethod } from '../../lib/stripe';
@@ -95,7 +96,16 @@ class CreateOrderPage extends React.Component {
       location: PropTypes.shape({ country: PropTypes.string }),
       settings: PropTypes.object,
     }).isRequired,
-    tier: PropTypes.shape(),
+    tier: PropTypes.shape({
+      id: PropTypes.number,
+      slug: PropTypes.string,
+      type: PropTypes.string,
+      amount: PropTypes.number,
+      minimumAmount: PropTypes.number,
+      amountType: PropTypes.string,
+      presets: PropTypes.arrayOf(PropTypes.string),
+      customFields: PropTypes.object,
+    }),
     verb: PropTypes.string.isRequired,
     step: PropTypes.string,
     referral: PropTypes.string,
@@ -432,17 +442,14 @@ class CreateOrderPage extends React.Component {
   getOrderMinAmount() {
     const tier = this.props.tier;
 
-    // When making a donation, min amount is $1
     if (!tier) {
+      // When making a donation, min amount is $1
       return 100;
+    } else if (tier.amountType === AmountTypes.FIXED) {
+      return tier.amount || 0;
+    } else {
+      return tier.minimumAmount || 0;
     }
-
-    // If the tier has not amount and no preset, it's a free tier
-    if (isNil(tier.amount) && isNil(tier.presets)) {
-      return 0;
-    }
-
-    return tier.minimumAmount;
   }
 
   getDefaultAmount() {

--- a/lib/constants/tiers-types.js
+++ b/lib/constants/tiers-types.js
@@ -1,1 +1,5 @@
 export default ['TIER', 'TICKET', 'MEMBERSHIP', 'SERVICE', 'PRODUCT', 'DONATION'];
+export const AmountTypes = {
+  FIXED: 'FIXED',
+  FLEXIBLE: 'FLEXIBLE',
+};

--- a/pages/createOrder.js
+++ b/pages/createOrder.js
@@ -207,6 +207,7 @@ const CollectiveWithTierDataQuery = gql`
       slug
       description
       amount
+      amountType
       minimumAmount
       currency
       interval


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2352

Probably broken in https://github.com/opencollective/opencollective-frontend/pull/1699, I haven't been able to go back that far but I can confirm that the bug is at least one month old and for sure prior to https://github.com/opencollective/opencollective-frontend/pull/2281 (I initially suspected it to be the cause of this issue).

@flickz @znarf It seems strange to me that we don't check the `amountType` to see if it's `FIXED` or `FLEXIBLE` in the contribution flow, was it intended?

