### PR TITLE
i18n: Enable NL as supported language

### DIFF
--- a/lib/constants/locales.js
+++ b/lib/constants/locales.js
@@ -1,7 +1,16 @@
+/**
+ * Define the languages that can be activated by users on Open Collective based
+ * on https://crowdin.com/project/opencollective.
+ *
+ * Only languages completed with 20%+ are currently activated.
+ */
+
+// Please keep English at the top, and sort other entries by `completion`.
 export default {
   en: { name: 'English' },
-  fr: { name: 'French', nativeName: 'Français', completion: '66%' },
-  ja: { name: 'Japanese', nativeName: '日本語', completion: '37%' },
-  es: { name: 'Spanish', nativeName: 'Español', completion: '23%' },
-  ru: { name: 'Russian', nativeName: 'Русский', completion: '10%' },
+  fr: { name: 'French', nativeName: 'Français', completion: '80%' },
+  es: { name: 'Spanish', nativeName: 'Español', completion: '32%' },
+  nl: { name: 'Dutch', nativeName: 'Niederländisch', completion: '29%' },
+  ja: { name: 'Japanese', nativeName: '日本語', completion: '25%' },
+  ru: { name: 'Russian', nativeName: 'Русский', completion: '23%' },
 };


### PR DESCRIPTION
Dutch has been completed to **29%**, it's now safe to enable it in the footer.

Also updated the completion percentages.