### PR TITLE
NCP/Updates: Limit max image width

### DIFF
--- a/components/collective-page/SectionUpdates.js
+++ b/components/collective-page/SectionUpdates.js
@@ -18,6 +18,7 @@ import StyledCard from '../StyledCard';
 import Link from '../Link';
 import Avatar from '../Avatar';
 import StyledButton from '../StyledButton';
+import HTMLContent from '../HTMLContent';
 
 import ContainerSectionContent from './ContainerSectionContent';
 import { UpdatesFieldsFragment } from './fragments';
@@ -150,7 +151,7 @@ class SectionUpdates extends React.PureComponent {
                       </P>
                     </Link>
                     {update.userCanSeeUpdate ? (
-                      <P color="black.700" dangerouslySetInnerHTML={{ __html: update.summary }} />
+                      <HTMLContent content={update.summary} />
                     ) : (
                       <PrivateUpdateMesgBox type="info" data-cy="mesgBox">
                         <FormattedMessage


### PR DESCRIPTION
Fix by using the `HTMLContent`, which as a result will also applies custom theme to updates preview.

![image](https://user-images.githubusercontent.com/1556356/63789615-030ae100-c8f8-11e9-98f7-9fdd4aec205f.png)
