### PR TITLE
NCP: Add Submit Expense CTA and simplify usage

### DIFF
--- a/components/CollectiveCallsToAction.js
+++ b/components/CollectiveCallsToAction.js
@@ -19,11 +19,7 @@ const ApplyToHostBtn = dynamic(() => import(/* webpackChunkName: 'ApplyToHostBtn
  */
 const CollectiveCallsToAction = ({
   collective,
-  hasSubmitExpense,
-  hasContact,
-  hasApply,
-  hasDashboard,
-  hasManageSubscriptions,
+  callsToAction: { hasSubmitExpense, hasContact, hasApply, hasDashboard, hasManageSubscriptions },
   ...props
 }) => {
   return (
@@ -71,14 +67,22 @@ CollectiveCallsToAction.propTypes = {
   collective: PropTypes.shape({
     slug: PropTypes.string.isRequired,
   }),
-  hasContact: PropTypes.bool,
-  hasSubmitExpense: PropTypes.bool,
-  /** Hosts "Apply" button */
-  hasApply: PropTypes.bool,
-  /** Hosts "Dashboard" button */
-  hasDashboard: PropTypes.bool,
-  /** Link to edit subscriptions */
-  hasManageSubscriptions: PropTypes.bool,
+  callsToAction: PropTypes.shape({
+    /** Button to contact the collective */
+    hasContact: PropTypes.bool,
+    /** Submit new expense button */
+    hasSubmitExpense: PropTypes.bool,
+    /** Hosts "Apply" button */
+    hasApply: PropTypes.bool,
+    /** Hosts "Dashboard" button */
+    hasDashboard: PropTypes.bool,
+    /** Link to edit subscriptions */
+    hasManageSubscriptions: PropTypes.bool,
+  }).isRequired,
+};
+
+CollectiveCallsToAction.defaultProps = {
+  callsToAction: {},
 };
 
 export default CollectiveCallsToAction;

--- a/components/CollectiveCover.js
+++ b/components/CollectiveCover.js
@@ -178,7 +178,12 @@ ${description}`;
     if (useNewCollectiveNavbar) {
       return (
         <Container borderTop="1px solid #E6E8EB" mb={4}>
-          <CollectiveNavbar collective={collective} isAdmin={canEdit} showEdit {...this.props.callsToAction} />
+          <CollectiveNavbar
+            collective={collective}
+            isAdmin={canEdit}
+            showEdit
+            callsToAction={this.props.callsToAction}
+          />
         </Container>
       );
     }

--- a/components/CollectiveNavbar.js
+++ b/components/CollectiveNavbar.js
@@ -268,14 +268,10 @@ const CollectiveNavbar = ({
   sections,
   selected,
   LinkComponent,
+  callsToAction,
   onCollectiveClick,
   onSectionClick,
   hideInfos,
-  hasSubmitExpense,
-  hasContact,
-  hasApply,
-  hasManageSubscriptions,
-  hasDashboard,
   isAnimated,
   intl,
 }) => {
@@ -341,21 +337,21 @@ const CollectiveNavbar = ({
               />
             </MenuLinkContainer>
           ))}
-          {hasSubmitExpense && (
+          {callsToAction.hasSubmitExpense && (
             <MenuLinkContainer mobileOnly>
               <MenuLink as={Link} route="createExpense" params={{ collectiveSlug: collective.slug }}>
                 <FormattedMessage id="menu.submitExpense" defaultMessage="Submit Expense" />
               </MenuLink>
             </MenuLinkContainer>
           )}
-          {hasContact && (
+          {callsToAction.hasContact && (
             <MenuLinkContainer mobileOnly>
               <MenuLink href={`mailto:hello@${collective.slug}.opencollective.com`}>
                 <ExternalLinkAlt size="1em" /> <FormattedMessage id="Contact" defaultMessage="Contact" />
               </MenuLink>
             </MenuLinkContainer>
           )}
-          {hasDashboard && (
+          {callsToAction.hasDashboard && (
             <MenuLinkContainer mobileOnly>
               <MenuLink as={Link} route="host.dashboard" params={{ hostCollectiveSlug: collective.slug }}>
                 <FormattedMessage id="host.dashboard" defaultMessage="Dashboard" />
@@ -364,15 +360,7 @@ const CollectiveNavbar = ({
           )}
         </Container>
         <div>
-          <CollectiveCallsToAction
-            display={['none', 'flex']}
-            collective={collective}
-            hasSubmitExpense={hasSubmitExpense}
-            hasContact={hasContact}
-            hasApply={hasApply}
-            hasDashboard={hasDashboard}
-            hasManageSubscriptions={hasManageSubscriptions}
-          />
+          <CollectiveCallsToAction display={['none', 'flex']} collective={collective} callsToAction={callsToAction} />
         </div>
       </Container>
     </MainContainer>
@@ -390,11 +378,13 @@ CollectiveNavbar.propTypes = {
     host: PropTypes.object,
   }).isRequired,
   /** Defines the calls to action displayed next to the NavBar items. Match PropTypes of `CollectiveCallsToAction` */
-  hasContact: PropTypes.bool,
-  hasSubmitExpense: PropTypes.bool,
-  hasApply: PropTypes.bool,
-  hasDashboard: PropTypes.bool,
-  hasManageSubscriptions: PropTypes.bool,
+  callsToAction: PropTypes.shape({
+    hasContact: PropTypes.bool,
+    hasSubmitExpense: PropTypes.bool,
+    hasApply: PropTypes.bool,
+    hasDashboard: PropTypes.bool,
+    hasManageSubscriptions: PropTypes.bool,
+  }),
   /** Used to check what sections can be used */
   isAdmin: PropTypes.bool,
   /** Wether we want to display the "/edit" button */
@@ -424,7 +414,7 @@ CollectiveNavbar.propTypes = {
 CollectiveNavbar.defaultProps = {
   hideInfos: false,
   isAnimated: false,
-  hasContact: true,
+  callsToAction: { hasContact: true },
   // eslint-disable-next-line react/prop-types
   LinkComponent: function DefaultNavbarLink({ section, label, collectivePath, className }) {
     return (

--- a/components/collective-page/Hero.js
+++ b/components/collective-page/Hero.js
@@ -67,16 +67,7 @@ const StyledShortDescription = styled.h2`
 /**
  * Collective's page Hero/Banner/Cover component.
  */
-const Hero = ({
-  collective,
-  host,
-  isAdmin,
-  onCollectiveClick,
-  hasContact,
-  hasDashboard,
-  hasManageSubscriptions,
-  intl,
-}) => {
+const Hero = ({ collective, host, isAdmin, onCollectiveClick, callsToAction, intl }) => {
   const isCollective = collective.type === CollectiveType.COLLECTIVE;
 
   return (
@@ -202,9 +193,7 @@ const Hero = ({
           display={['flex', 'none']}
           mt={3}
           collective={collective}
-          hasContact={hasContact}
-          hasDashboard={hasDashboard}
-          hasManageSubscriptions={hasManageSubscriptions}
+          callsToAction={callsToAction}
         />
       </ContainerSectionContent>
     </Container>
@@ -242,14 +231,8 @@ Hero.propTypes = {
   /** When users click on avatar or collective name */
   onCollectiveClick: PropTypes.func.isRequired,
 
-  /** Show contact button */
-  hasContact: PropTypes.bool,
-
-  /** Show dashboard button */
-  hasDashboard: PropTypes.bool,
-
-  /** Show manage subscriptions button */
-  hasManageSubscriptions: PropTypes.bool,
+  /** Defines which buttons get displayed. See `CollectiveCallsToAction` */
+  callsToAction: PropTypes.object,
 
   /** Define if we need to display special actions like the "Edit collective" button */
   isAdmin: PropTypes.bool,

--- a/components/collective-page/index.js
+++ b/components/collective-page/index.js
@@ -129,6 +129,17 @@ class CollectivePage extends Component {
     }
   };
 
+  getCallsToAction = memoizeOne((type, isHost, isAdmin) => {
+    const isCollective = type === CollectiveType.COLLECTIVE;
+    return {
+      hasContact: isCollective,
+      hasSubmitExpense: isCollective,
+      hasApply: isHost,
+      hasDashboard: isHost && isAdmin,
+      hasManageSubscriptions: !isHost && isAdmin && !isCollective,
+    };
+  });
+
   onCollectiveClick = () => {
     window.scrollTo(0, 0);
   };
@@ -187,9 +198,7 @@ class CollectivePage extends Component {
     const { collective, host, isAdmin, onPrimaryColorChange } = this.props;
     const { isFixed, selectedSection, hasColorPicker } = this.state;
     const sections = this.getSections(this.props);
-    const hasContact = collective.type === CollectiveType.COLLECTIVE || collective.isHost;
-    const hasDashboard = collective.isHost && isAdmin;
-    const hasManageSubscriptions = !collective.isHost && isAdmin && collective.type !== CollectiveType.COLLECTIVE;
+    const callsToAction = this.getCallsToAction(collective.type, collective.isHost, isAdmin);
 
     return (
       <Container
@@ -202,9 +211,7 @@ class CollectivePage extends Component {
           host={host}
           isAdmin={isAdmin}
           onCollectiveClick={this.onCollectiveClick}
-          hasContact={hasContact}
-          hasDashboard={hasDashboard}
-          hasManageSubscriptions={hasManageSubscriptions}
+          callsToAction={callsToAction}
         />
         <Container mt={[0, -30]} position="sticky" top={0} zIndex={999} ref={this.navbarRef}>
           <CollectiveNavbar
@@ -213,10 +220,7 @@ class CollectivePage extends Component {
             isAdmin={isAdmin}
             selected={selectedSection || sections[0]}
             onCollectiveClick={this.onCollectiveClick}
-            hasContact={hasContact}
-            hasApply={collective.isHost}
-            hasDashboard={hasDashboard}
-            hasManageSubscriptions={hasManageSubscriptions}
+            callsToAction={callsToAction}
             hideInfos={!isFixed}
             isAnimated={true}
             onSectionClick={this.onSectionClick}


### PR DESCRIPTION
Component usage has been simplified to only pass a `callsToAction` object instead of passing the individuals props.

![image](https://user-images.githubusercontent.com/1556356/63791267-68140600-c8fb-11e9-9536-9fec6e388da1.png)
