### PR TITLE
Events: Never use the new navbar

### DIFF
--- a/components/CollectiveCover.js
+++ b/components/CollectiveCover.js
@@ -12,7 +12,7 @@ import { prettyUrl, imagePreview } from '../lib/utils';
 import Currency from './Currency';
 import Avatar from './Avatar';
 import Logo from './Logo';
-import { defaultBackgroundImage } from '../lib/constants/collectives';
+import { defaultBackgroundImage, CollectiveType } from '../lib/constants/collectives';
 import Link from './Link';
 import GoalsCover from './GoalsCover';
 import MenuBar from './MenuBar';
@@ -174,8 +174,9 @@ ${description}`;
     const canEdit = LoggedInUser && LoggedInUser.canEditCollective(collective);
     const ncpIsDefault = process.env.NCP_IS_DEFAULT === 'true';
     const useNewCollectiveNavbar = ncpIsDefault || get(collective, 'settings.collectivePage.useV2');
+    const isEvent = type === CollectiveType.EVENT;
 
-    if (useNewCollectiveNavbar) {
+    if (!isEvent && useNewCollectiveNavbar) {
       return (
         <Container borderTop="1px solid #E6E8EB" mb={4}>
           <CollectiveNavbar collective={collective} isAdmin={canEdit} showEdit {...this.props.callsToAction} />


### PR DESCRIPTION
Events are not yet ready for the design of the new NavBar because the cover for it includes the start/end date, the location...etc

This PR ensures that we won't show the new navbar for events.

![image](https://user-images.githubusercontent.com/1556356/63839670-fc27b100-c97f-11e9-9c05-f79a5f135626.png)
