### PR TITLE
NCP/About: Change wording for users/orgs empty description

### DIFF
--- a/components/collective-page/SectionAbout.js
+++ b/components/collective-page/SectionAbout.js
@@ -29,12 +29,13 @@ const Markdown = dynamic(() => import('react-markdown'));
  */
 const SectionAbout = ({ collective, canEdit, editMutation }) => {
   const isEmptyDescription = isEmptyValue(collective.longDescription);
+  const isCollective = collective.type === CollectiveType.COLLECTIVE;
   canEdit = collective.isArchived ? false : canEdit;
 
   return (
     <Flex flexDirection="column" alignItems="center" px={2} pb={6} pt={[3, 5]}>
       <H3 fontSize="H2" lineHeight="H2" fontWeight="normal" textAlign="center" mb={5}>
-        {collective.type === CollectiveType.COLLECTIVE ? (
+        {isCollective ? (
           <FormattedMessage id="SectionAbout.Title" defaultMessage="Why we do what we do" />
         ) : (
           <FormattedMessage
@@ -70,14 +71,16 @@ const SectionAbout = ({ collective, canEdit, editMutation }) => {
                 <Flex justifyContent="center">
                   {canEdit ? (
                     <Flex flexDirection="column" alignItems="center">
-                      <MessageBox type="info" withIcon fontStyle="italic" fontSize="Paragraph" mb={4}>
-                        <FormattedMessage
-                          id="SectionAbout.Why"
-                          defaultMessage="Your collective is unique and wants to achieve great things. Here is the place to explain it!"
-                        />
-                      </MessageBox>
+                      {isCollective && (
+                        <MessageBox type="info" withIcon fontStyle="italic" fontSize="Paragraph" mb={4}>
+                          <FormattedMessage
+                            id="SectionAbout.Why"
+                            defaultMessage="Your collective is unique and wants to achieve great things. Here is the place to explain it!"
+                          />
+                        </MessageBox>
+                      )}
                       <StyledButton buttonSize="large" onClick={enableEditor}>
-                        <FormattedMessage id="CollectivePage.AddLongDescription" defaultMessage="Add your mission" />
+                        <FormattedMessage id="CollectivePage.AddLongDescription" defaultMessage="Add a description" />
                       </StyledButton>
                     </Flex>
                   ) : (

--- a/lang/de.json
+++ b/lang/de.json
@@ -216,7 +216,7 @@
   "collective.user.orderProcessing.message": "Deine Spende für {collective} ist in Bearbeitung. Wir werden sie deinem Profil hinzufügen und dir eine Bestätigungsmail senden sobald die Zahlung bestätigt ist.",
   "collective.website.description": "Gib die URL deiner Webseite oder Facebook Seite ein",
   "collective.website.label": "Webseite",
-  "CollectivePage.AddLongDescription": "Add your mission",
+  "CollectivePage.AddLongDescription": "Add a description",
   "CollectivePage.AllOfUs": "{collectiveName} is all of us",
   "CollectivePage.Contribute": "Spende",
   "CollectivePage.Contribute.Custom": "Donation",

--- a/lang/en.json
+++ b/lang/en.json
@@ -216,7 +216,7 @@
   "collective.user.orderProcessing.message": "We are currently processing your donation to {collective}. We will add it to your profile and we will send you a confirmation email once the payment is confirmed.",
   "collective.website.description": "Enter the URL of your website or Facebook Page",
   "collective.website.label": "Website",
-  "CollectivePage.AddLongDescription": "Add your mission",
+  "CollectivePage.AddLongDescription": "Add a description",
   "CollectivePage.AllOfUs": "{collectiveName} is all of us",
   "CollectivePage.Contribute": "Contribute",
   "CollectivePage.Contribute.Custom": "Donation",

--- a/lang/es.json
+++ b/lang/es.json
@@ -216,7 +216,7 @@
   "collective.user.orderProcessing.message": "Actualmente estamos procesando su donación a {collective}. Lo agregaremos a su perfil y le enviaremos un correo electrónico de confirmación una vez que se confirme el pago.",
   "collective.website.description": "Escribe la dirección web de tu página web o página de Facebook",
   "collective.website.label": "Página web",
-  "CollectivePage.AddLongDescription": "Añade tu misión",
+  "CollectivePage.AddLongDescription": "Add a description",
   "CollectivePage.AllOfUs": "{collectiveName} somos todos nosotros",
   "CollectivePage.Contribute": "Contribuir",
   "CollectivePage.Contribute.Custom": "Donation",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -216,7 +216,7 @@
   "collective.user.orderProcessing.message": "Votre don à {collective} est en train d'être traité. Nous l'ajouterons à votre profil et un email de confirmation vous sera envoyé une fois que le paiement sera confirmé.",
   "collective.website.description": "Entrez l'adresse URL de votre site Web ou de votre page Facebook",
   "collective.website.label": "Site Internet",
-  "CollectivePage.AddLongDescription": "Ajoutez votre mission",
+  "CollectivePage.AddLongDescription": "Add a description",
   "CollectivePage.AllOfUs": "{collectiveName}, c'est nous tous",
   "CollectivePage.Contribute": "Contribuer",
   "CollectivePage.Contribute.Custom": "Donation",

--- a/lang/it.json
+++ b/lang/it.json
@@ -216,7 +216,7 @@
   "collective.user.orderProcessing.message": "We are currently processing your donation to {collective}. We will add it to your profile and we will send you a confirmation email once the payment is confirmed.",
   "collective.website.description": "Enter the URL of your website or Facebook Page",
   "collective.website.label": "Website",
-  "CollectivePage.AddLongDescription": "Add your mission",
+  "CollectivePage.AddLongDescription": "Add a description",
   "CollectivePage.AllOfUs": "{collectiveName} is all of us",
   "CollectivePage.Contribute": "Contribute",
   "CollectivePage.Contribute.Custom": "Donation",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -216,7 +216,7 @@
   "collective.user.orderProcessing.message": "We are currently processing your donation to {collective}. We will add it to your profile and we will send you a confirmation email once the payment is confirmed.",
   "collective.website.description": "あなたのウェブサイトまたは Facebook ページの URL を入力してください",
   "collective.website.label": "ウェブサイト",
-  "CollectivePage.AddLongDescription": "Add your mission",
+  "CollectivePage.AddLongDescription": "Add a description",
   "CollectivePage.AllOfUs": "{collectiveName} is all of us",
   "CollectivePage.Contribute": "Contribute",
   "CollectivePage.Contribute.Custom": "Donation",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -216,7 +216,7 @@
   "collective.user.orderProcessing.message": "We are currently processing your donation to {collective}. We will add it to your profile and we will send you a confirmation email once the payment is confirmed.",
   "collective.website.description": "Enter the URL of your website or Facebook Page",
   "collective.website.label": "Website",
-  "CollectivePage.AddLongDescription": "Add your mission",
+  "CollectivePage.AddLongDescription": "Add a description",
   "CollectivePage.AllOfUs": "{collectiveName} is all of us",
   "CollectivePage.Contribute": "Contribute",
   "CollectivePage.Contribute.Custom": "Donation",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -216,7 +216,7 @@
   "collective.user.orderProcessing.message": "We zijn momenteel je donatie aan {collective} aan het verwerken. We zullen het toevoegen aan je profiel en je een email sturen zodra de betaling bevestigd is.",
   "collective.website.description": "Geef de URL in van je website of Facebook pagina",
   "collective.website.label": "Website",
-  "CollectivePage.AddLongDescription": "Voeg je missie toe",
+  "CollectivePage.AddLongDescription": "Add a description",
   "CollectivePage.AllOfUs": "wij zijn {collectiveName}",
   "CollectivePage.Contribute": "Draag bij",
   "CollectivePage.Contribute.Custom": "Donation",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -216,7 +216,7 @@
   "collective.user.orderProcessing.message": "We are currently processing your donation to {collective}. We will add it to your profile and we will send you a confirmation email once the payment is confirmed.",
   "collective.website.description": "Enter the URL of your website or Facebook Page",
   "collective.website.label": "Website",
-  "CollectivePage.AddLongDescription": "Add your mission",
+  "CollectivePage.AddLongDescription": "Add a description",
   "CollectivePage.AllOfUs": "{collectiveName} is all of us",
   "CollectivePage.Contribute": "Contribute",
   "CollectivePage.Contribute.Custom": "Donation",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -216,7 +216,7 @@
   "collective.user.orderProcessing.message": "В данный момент мы проверяем ваше пожертвование в {collective}. Мы добавим эту информацию в ваш профиль, и пришлём вам подтверждающее письмо, как только платёж будет подтверждён.",
   "collective.website.description": "Enter the URL of your website or Facebook Page",
   "collective.website.label": "Сайт",
-  "CollectivePage.AddLongDescription": "Add your mission",
+  "CollectivePage.AddLongDescription": "Add a description",
   "CollectivePage.AllOfUs": "{collectiveName} is all of us",
   "CollectivePage.Contribute": "Contribute",
   "CollectivePage.Contribute.Custom": "Donation",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -216,7 +216,7 @@
   "collective.user.orderProcessing.message": "我们目前正在处理您的捐款到 {collective}。我们将把它添加到您的个人资料, 一旦付款确认, 我们将向您发送一封确认电子邮件。",
   "collective.website.description": "输入您的网站或 Facebook 主页的 URL",
   "collective.website.label": "网站",
-  "CollectivePage.AddLongDescription": "添加你的任务",
+  "CollectivePage.AddLongDescription": "Add a description",
   "CollectivePage.AllOfUs": "{collectiveName} is all of us",
   "CollectivePage.Contribute": "贡献",
   "CollectivePage.Contribute.Custom": "Donation",

--- a/test/cypress/integration/04-collective_v2.test.js
+++ b/test/cypress/integration/04-collective_v2.test.js
@@ -49,7 +49,7 @@ describe('New collective page', () => {
     it('Can add description to about section', () => {
       const richDescription = 'Hello{selectall}{ctrl}B{rightarrow}{ctrl}B world!';
       cy.get('#section-about').scrollIntoView();
-      cy.contains('#section-about button', 'Add your mission').click();
+      cy.contains('#section-about button', 'Add a description').click();
       cy.get('#section-about [data-cy="HTMLEditor"] .ql-editor').type(richDescription);
       cy.get('[data-cy="InlineEditField-Btn-Save"]').click();
       cy.get('[data-cy="longDescription"]').should('have.html', '<p><strong>Hello</strong> world!</p>');


### PR DESCRIPTION
User/orgs admins will now see this instead:

![image](https://user-images.githubusercontent.com/1556356/63932025-ae31ac80-ca56-11e9-8334-50bbee6e772b.png)
