### PR TITLE
NCP/TopContributors: Make container wider

### DIFF
--- a/components/collective-page/TopContributors.js
+++ b/components/collective-page/TopContributors.js
@@ -182,7 +182,7 @@ const TopContributors = ({ organizations, individuals, currency }) => {
 
   return (
     <TopContributorsContainer>
-      <Container maxWidth={1050} m="0 auto" px={[15, 30]}>
+      <Container maxWidth={1090} m="0 auto" px={[15, 30]}>
         <H4 fontWeight="normal" color="black.700" mb={3}>
           <FormattedMessage id="SectionContribute.TopContributors" defaultMessage="Top financial contributors" />
         </H4>


### PR DESCRIPTION
This small tweak of 40px will help to better display contributors.

**Before**

![Screenshot_2019-08-29 Solidus - Open Collective(1)](https://user-images.githubusercontent.com/1556356/63933032-bb4f9b00-ca58-11e9-966d-fb240c1cc4f7.png)


**After**

![Screenshot_2019-08-29 Solidus - Open Collective](https://user-images.githubusercontent.com/1556356/63932983-9f4bf980-ca58-11e9-82ab-447cb2b5a959.png)
