### PR TITLE
Disable save button for events if name is empty

### DIFF
--- a/components/EditEventForm.js
+++ b/components/EditEventForm.js
@@ -22,7 +22,7 @@ class EditEventForm extends React.Component {
 
     const event = { ...(props.event || {}) };
     event.slug = event.slug ? event.slug.replace(/.*\//, '') : '';
-    this.state = { event, tiers: event.tiers || [{}] };
+    this.state = { event, tiers: event.tiers || [{}], disabled: false };
 
     this.messages = defineMessages({
       'slug.label': { id: 'event.slug.label', defaultMessage: 'url' },
@@ -79,6 +79,11 @@ class EditEventForm extends React.Component {
         value = newEndDate.toString();
         event['endsAt'] = value;
       }
+    }
+    if (!value) {
+      this.setState({ disabled: true });
+    } else {
+      this.setState({ disabled: false });
     }
 
     this.setState({ event: Object.assign({}, this.state.event, event) });
@@ -231,7 +236,12 @@ class EditEventForm extends React.Component {
           />
         </div>
         <div className="actions">
-          <Button className="blue" label={submitBtnLabel} onClick={this.handleSubmit} disabled={loading} />
+          <Button
+            className="blue"
+            label={submitBtnLabel}
+            onClick={this.handleSubmit}
+            disabled={this.state.disabled ? true : loading}
+          />
         </div>
       </div>
     );

--- a/components/EditEventForm.js
+++ b/components/EditEventForm.js
@@ -80,10 +80,12 @@ class EditEventForm extends React.Component {
         event['endsAt'] = value;
       }
     }
-    if (!value) {
-      this.setState({ disabled: true });
-    } else {
-      this.setState({ disabled: false });
+    if (fieldname === 'name') {
+      if (!event['name']) {
+        this.setState({ disabled: true });
+      } else {
+        this.setState({ disabled: false });
+      }
     }
 
     this.setState({ event: Object.assign({}, this.state.event, event) });

--- a/components/EditEventForm.js
+++ b/components/EditEventForm.js
@@ -81,7 +81,7 @@ class EditEventForm extends React.Component {
       }
     }
     if (fieldname === 'name') {
-      if (!event['name']) {
+      if (!event['name'].trim()) {
         this.setState({ disabled: true });
       } else {
         this.setState({ disabled: false });


### PR DESCRIPTION
Fix `Event with blank name should not be allowed #2179`

 - I checked if the name or any other input field is empty
 - If the above is true, I disable the button

---

*Edit from @Betree: https://github.com/opencollective/opencollective/issues/2179*