### PR TITLE
GithubFlow: Don't filter repositories on the frontend

### DIFF
--- a/pages/openSourceApply.js
+++ b/pages/openSourceApply.js
@@ -22,8 +22,6 @@ import { Router } from '../server/pages';
 import { getGithubRepos } from '../lib/api';
 import { getWebsiteUrl } from '../lib/utils';
 
-const MIN_REPO_STARS = 100;
-
 class OpenSourceApplyPage extends Component {
   static async getInitialProps({ query }) {
     return {
@@ -61,9 +59,7 @@ class OpenSourceApplyPage extends Component {
     this.setState({ loadingRepos: true });
 
     try {
-      const repositories = await getGithubRepos(token).then(repositories =>
-        repositories.filter(repo => repo.stargazers_count >= MIN_REPO_STARS),
-      );
+      const repositories = await getGithubRepos(token);
       if (repositories.length !== 0) {
         this.setState({ repositories, loadingRepos: false, result: {} });
       } else {
@@ -112,7 +108,6 @@ class OpenSourceApplyPage extends Component {
         creatingCollective: false,
         result: { type: 'error', mesg: errorMsg },
       });
-      // throw new Error(errorMsg);
     }
   }
 


### PR DESCRIPTION
Related to opencollective/opencollective#2333

This will ensure we show all the repos returned by the API in the Github flow. Together with https://github.com/opencollective/opencollective-api/pull/2481, this will show all users repositories in dev / staging.

Filtering is already done in https://github.com/opencollective/opencollective-api/blob/21dc0392dda4173b45db34f0560302b9a013c4ac/server/controllers/connectedAccounts.js#L173