### PR TITLE
NCP/Hero: Background z-index must be -1 per default

### DIFF
--- a/components/collective-page/hero/HeroBackground.js
+++ b/components/collective-page/hero/HeroBackground.js
@@ -46,7 +46,7 @@ const StyledBackground = styled.div`
   height: 100%;
   width: 100%;
   max-width: 1368px; // Should match SVG's viewbox
-  z-index: 0;
+  z-index: ${props => (props.isEditing ? 0 : -1)};
 
   @supports (mask-size: cover) {
     background: ${props => generateBackground(props.theme)};


### PR DESCRIPTION
Before this fix there was a bug were you could not click on host anymore and neither on hero's buttons on mobile devices.