### PR TITLE
HostDashboard: Don't use the new collective Navbar

### DIFF
--- a/pages/host.dashboard.js
+++ b/pages/host.dashboard.js
@@ -111,6 +111,7 @@ class HostDashboardPage extends React.Component {
             collective={host}
             href={`/${host.slug}/dashboard`}
             className="small"
+            forceLegacy
             title={
               <FormattedMessage
                 id="host.dashboard.title"


### PR DESCRIPTION
New NavBar doesn't looks nice on this page (there's a gap between the two bars) and seems inappropriate.

**Before**
![image](https://user-images.githubusercontent.com/1556356/64236831-81204680-cefb-11e9-978e-098496175e8e.png)


**After**
![image](https://user-images.githubusercontent.com/1556356/64236729-4d452100-cefb-11e9-9a40-298b7a4b7c4a.png)
