### PR TITLE
Rollback styled-icons to 8.3.0

### DIFF
--- a/components/expenses/DownloadInvoicesPopOver.js
+++ b/components/expenses/DownloadInvoicesPopOver.js
@@ -7,7 +7,7 @@ import { FormattedMessage } from 'react-intl';
 import { graphql } from 'react-apollo';
 import { Popover, OverlayTrigger } from 'react-bootstrap';
 import { uniq, omit, groupBy } from 'lodash';
-import { FileDownload } from 'styled-icons/fa-solid/FileDownload';
+import { FileDownload } from 'styled-icons/material/FileDownload';
 
 import { formatCurrency, getCollectiveImage } from '../../lib/utils';
 

--- a/components/expenses/TransactionsExportPopoverAndButton.js
+++ b/components/expenses/TransactionsExportPopoverAndButton.js
@@ -4,7 +4,7 @@ import moment from 'moment';
 import { withApollo } from 'react-apollo';
 import { FormattedMessage } from 'react-intl';
 import { Button, Popover, OverlayTrigger } from 'react-bootstrap';
-import { FileDownload } from 'styled-icons/fa-solid/FileDownload';
+import { FileDownload } from 'styled-icons/material/FileDownload';
 
 import { getTransactionsQuery } from '../../lib/graphql/queries';
 import { exportFile } from '../../lib/export_file';

--- a/components/tier-page/ShareButtons.js
+++ b/components/tier-page/ShareButtons.js
@@ -9,7 +9,7 @@ import { Mail } from 'styled-icons/feather/Mail';
 import { Twitter } from 'styled-icons/feather/Twitter';
 import { Facebook } from 'styled-icons/feather/Facebook';
 import { Linkedin } from 'styled-icons/feather/Linkedin';
-import { Clipboard } from 'styled-icons/feather/Clipboard';
+import { ContentCopy } from 'styled-icons/material/ContentCopy';
 
 // Open Collective Frontend imports
 import { facebooKShareURL, tweetURL, linkedInShareURL, mailToURL } from '../../lib/url_helpers';
@@ -57,7 +57,7 @@ const ShareButtons = ({ pageUrl, intl, collective: { name, twitterHandle } }) =>
         </StyledRoundButton>
       </ExternalLinkNewTab>
       <StyledRoundButton size={40} onClick={() => copy(pageUrl)}>
-        <Clipboard size={15} />
+        <ContentCopy size={14} />
       </StyledRoundButton>
     </Flex>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -9318,13 +9318,13 @@
       "dependencies": {
         "colors": {
           "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "resolved": "http://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
           "dev": true
         },
         "commander": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
           "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
           "dev": true
         }
@@ -10244,7 +10244,7 @@
         },
         "node-fetch": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
           "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
           "dev": true
         }
@@ -19865,7 +19865,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
@@ -20901,7 +20901,7 @@
         },
         "globby": {
           "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
           "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
           "dev": true,
           "requires": {
@@ -24025,9 +24025,9 @@
       }
     },
     "styled-icons": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/styled-icons/-/styled-icons-8.4.1.tgz",
-      "integrity": "sha512-gF99n5GAgMu9VDqjLjL9uWV/T33br+VringNKPbgnQAHuks377auxAgV9TAZoU+FiEIfv/mT6hNZ7oErPX1U6Q==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/styled-icons/-/styled-icons-8.3.0.tgz",
+      "integrity": "sha512-6qCrJzaaDQjdIOsXeMA6Wc8oA0vu2dzMfgTo0TxolCJJwUE0vQoJGnfU0NdJkic+MaHPKa2j5F7Gqm+baW6wkw==",
       "requires": {
         "@emotion/is-prop-valid": "^0.8.2",
         "tslib": "^1.9.3"
@@ -24705,7 +24705,7 @@
       "dependencies": {
         "ast-types": {
           "version": "0.7.8",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
+          "resolved": "http://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
           "integrity": "sha1-kC0uDWDQcb3NRtwRXhgJ7RHBOKk=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "showdown": "1.9.0",
     "slugify": "1.3.4",
     "styled-components": "5.0.0-beta.8",
-    "styled-icons": "8.4.1",
+    "styled-icons": "8.3.0",
     "styled-jsx": "3.2.2",
     "styled-system": "5.1.1",
     "title-case": "2.1.1",


### PR DESCRIPTION
Rollback https://github.com/opencollective/opencollective-frontend/pull/2478
Rollback https://github.com/opencollective/opencollective-frontend/pull/2457
Root cause https://github.com/jacobwgillespie/styled-icons/issues/945

I missed it when testing because it only affects icons imported from `Feather` library.