### PR TITLE
fix(locales): change nativeName of Dutch

### DIFF
--- a/lib/constants/locales.js
+++ b/lib/constants/locales.js
@@ -10,7 +10,7 @@ export default {
   en: { name: 'English' },
   fr: { name: 'French', nativeName: 'Français', completion: '80%' },
   es: { name: 'Spanish', nativeName: 'Español', completion: '32%' },
-  nl: { name: 'Dutch', nativeName: 'Niederländisch', completion: '29%' },
+  nl: { name: 'Dutch', nativeName: 'Nederlands', completion: '29%' },
   ja: { name: 'Japanese', nativeName: '日本語', completion: '25%' },
   ru: { name: 'Russian', nativeName: 'Русский', completion: '23%' },
 };


### PR DESCRIPTION
This changes the `nativeName` property from "Niederländisch" (which is the German word for "Dutch") to "Nederlands" (which is the Dutch word for "Dutch").

See issue: https://github.com/opencollective/opencollective/issues/2407