### PR TITLE
Widgets: Add example badge for all financial contributors

### DIFF
--- a/components/ExportImages.js
+++ b/components/ExportImages.js
@@ -29,7 +29,7 @@ class ExportImages extends React.Component {
         name: tier.name,
         images: [
           {
-            name: 'badge',
+            name: 'Tier badge',
             url: `https://opencollective.com/${collective.slug}/tiers/${tier.slug}/badge.svg?label=${tier.name}&color=brightgreen`,
             code: `<img src="https://opencollective.com/${collective.slug}/tiers/${tier.slug}/badge.svg?label=${tier.name}&color=brightgreen" />`,
             options: [
@@ -47,7 +47,7 @@ class ExportImages extends React.Component {
             ],
           },
           {
-            name: 'financial contributors',
+            name: 'Financial contributors widget',
             url: `https://opencollective.com/${collective.slug}/tiers/${tier.slug}.svg?avatarHeight=36`,
             code: `<object type="image/svg+xml" data="https://opencollective.com/${collective.slug}/tiers/${tier.slug}.svg?avatarHeight=36&width=600"></object>`,
             options: [
@@ -125,7 +125,12 @@ class ExportImages extends React.Component {
         <h1>
           <FormattedMessage id="export.images.title" defaultMessage="Export images" />
         </h1>
-        <p>You can export images showing the financial contributors to each tier.</p>
+        <p>
+          <FormattedMessage
+            id="ExportImages.Title"
+            defaultMessage="You can export images showing the financial contributors to each tier."
+          />
+        </p>
         <div>
           <InputField
             name="tiers"
@@ -173,6 +178,20 @@ class ExportImages extends React.Component {
             ))}
           </div>
         )}
+        <hr />
+        <label>
+          <FormattedMessage id="ExportImages.AllFinancial" defaultMessage="All financial contributors badge" />
+        </label>
+        <div className="url">
+          <a
+            href={`https://opencollective.com/${collective.slug}/tiers/badge.svg`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {`https://opencollective.com/${collective.slug}/tiers/badge.svg`}
+          </a>
+        </div>
+        <img src={`https://opencollective.com/${collective.slug}/tiers/badge.svg`} />
       </div>
     );
   }

--- a/lang/de.json
+++ b/lang/de.json
@@ -623,6 +623,8 @@
   "ExportContributors.OnlyIndividuals": "Only individuals: {link}",
   "ExportContributors.OnlyOrganizations": "Only organizations: {link}",
   "ExportContributors.Title": "Export {format}",
+  "ExportImages.AllFinancial": "All financial contributors badge",
+  "ExportImages.Title": "You can export images showing the financial contributors to each tier.",
   "Filter.ByName": "Filter by name",
   "Fiscalhost": "Fiscal Host",
   "Fiscalhost.definition": "A fiscal host is a legal entity holding the money and responsible for the admin/taxes forms for the collective.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -623,6 +623,8 @@
   "ExportContributors.OnlyIndividuals": "Only individuals: {link}",
   "ExportContributors.OnlyOrganizations": "Only organizations: {link}",
   "ExportContributors.Title": "Export {format}",
+  "ExportImages.AllFinancial": "All financial contributors badge",
+  "ExportImages.Title": "You can export images showing the financial contributors to each tier.",
   "Filter.ByName": "Filter by name",
   "Fiscalhost": "Fiscal Host",
   "Fiscalhost.definition": "A fiscal host is a legal entity holding the money and responsible for the admin/taxes forms for the collective.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -623,6 +623,8 @@
   "ExportContributors.OnlyIndividuals": "Only individuals: {link}",
   "ExportContributors.OnlyOrganizations": "Only organizations: {link}",
   "ExportContributors.Title": "Export {format}",
+  "ExportImages.AllFinancial": "All financial contributors badge",
+  "ExportImages.Title": "You can export images showing the financial contributors to each tier.",
   "Filter.ByName": "Filter by name",
   "Fiscalhost": "Fiscal Host",
   "Fiscalhost.definition": "A fiscal host is a legal entity holding the money and responsible for the admin/taxes forms for the collective.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -623,6 +623,8 @@
   "ExportContributors.OnlyIndividuals": "Seulement les personnes : {link}",
   "ExportContributors.OnlyOrganizations": "Seulement les organisations : {link}",
   "ExportContributors.Title": "Exporter au format {format}",
+  "ExportImages.AllFinancial": "All financial contributors badge",
+  "ExportImages.Title": "You can export images showing the financial contributors to each tier.",
   "Filter.ByName": "Filtrer par nom",
   "Fiscalhost": "Hôte fiscal",
   "Fiscalhost.definition": "Un hôte fiscal est une entité légale qui stocke l'argent et a la responsabilité de l'administration et des taxes pour le collectif.",

--- a/lang/it.json
+++ b/lang/it.json
@@ -623,6 +623,8 @@
   "ExportContributors.OnlyIndividuals": "Only individuals: {link}",
   "ExportContributors.OnlyOrganizations": "Only organizations: {link}",
   "ExportContributors.Title": "Export {format}",
+  "ExportImages.AllFinancial": "All financial contributors badge",
+  "ExportImages.Title": "You can export images showing the financial contributors to each tier.",
   "Filter.ByName": "Filter by name",
   "Fiscalhost": "Fiscal Host",
   "Fiscalhost.definition": "A fiscal host is a legal entity holding the money and responsible for the admin/taxes forms for the collective.",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -623,6 +623,8 @@
   "ExportContributors.OnlyIndividuals": "Only individuals: {link}",
   "ExportContributors.OnlyOrganizations": "Only organizations: {link}",
   "ExportContributors.Title": "Export {format}",
+  "ExportImages.AllFinancial": "All financial contributors badge",
+  "ExportImages.Title": "You can export images showing the financial contributors to each tier.",
   "Filter.ByName": "Filter by name",
   "Fiscalhost": "Fiscal Host",
   "Fiscalhost.definition": "A fiscal host is a legal entity holding the money and responsible for the admin/taxes forms for the collective.",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -623,6 +623,8 @@
   "ExportContributors.OnlyIndividuals": "Only individuals: {link}",
   "ExportContributors.OnlyOrganizations": "Only organizations: {link}",
   "ExportContributors.Title": "Export {format}",
+  "ExportImages.AllFinancial": "All financial contributors badge",
+  "ExportImages.Title": "You can export images showing the financial contributors to each tier.",
   "Filter.ByName": "Filter by name",
   "Fiscalhost": "Fiscal Host",
   "Fiscalhost.definition": "A fiscal host is a legal entity holding the money and responsible for the admin/taxes forms for the collective.",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -623,6 +623,8 @@
   "ExportContributors.OnlyIndividuals": "Only individuals: {link}",
   "ExportContributors.OnlyOrganizations": "Only organizations: {link}",
   "ExportContributors.Title": "Export {format}",
+  "ExportImages.AllFinancial": "All financial contributors badge",
+  "ExportImages.Title": "You can export images showing the financial contributors to each tier.",
   "Filter.ByName": "Filter by name",
   "Fiscalhost": "Fiscal Host",
   "Fiscalhost.definition": "A fiscal host is a legal entity holding the money and responsible for the admin/taxes forms for the collective.",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -623,6 +623,8 @@
   "ExportContributors.OnlyIndividuals": "Apenas indivíduos: {link}",
   "ExportContributors.OnlyOrganizations": "Apenas organizações: {link}",
   "ExportContributors.Title": "Exportar para {format}",
+  "ExportImages.AllFinancial": "All financial contributors badge",
+  "ExportImages.Title": "You can export images showing the financial contributors to each tier.",
   "Filter.ByName": "Filtrar por nome",
   "Fiscalhost": "Administrador Fiscal",
   "Fiscalhost.definition": "Um administrador fiscal é uma entidade legal que detém o dinheiro e é responsável pelos formulários de administração/impostos do coletivo.",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -623,6 +623,8 @@
   "ExportContributors.OnlyIndividuals": "Only individuals: {link}",
   "ExportContributors.OnlyOrganizations": "Only organizations: {link}",
   "ExportContributors.Title": "Export {format}",
+  "ExportImages.AllFinancial": "All financial contributors badge",
+  "ExportImages.Title": "You can export images showing the financial contributors to each tier.",
   "Filter.ByName": "Filter by name",
   "Fiscalhost": "Фискальный представитель",
   "Fiscalhost.definition": "A fiscal host is a legal entity holding the money and responsible for the admin/taxes forms for the collective.",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -623,6 +623,8 @@
   "ExportContributors.OnlyIndividuals": "Only individuals: {link}",
   "ExportContributors.OnlyOrganizations": "Only organizations: {link}",
   "ExportContributors.Title": "Export {format}",
+  "ExportImages.AllFinancial": "All financial contributors badge",
+  "ExportImages.Title": "You can export images showing the financial contributors to each tier.",
   "Filter.ByName": "Filter by name",
   "Fiscalhost": "Fiscal Host",
   "Fiscalhost.definition": "A fiscal host is a legal entity holding the money and responsible for the admin/taxes forms for the collective.",


### PR DESCRIPTION
Following https://opencollective.freshdesk.com/a/tickets/826

The ability to show a badge with all financial contributors (regardless of the tier) was undocumented.

This is this badge:
![badge.svg](https://opencollective.com/carbon-app/tiers/badge.svg)

> https://opencollective.com/carbon-app/tiers/badge.svg

---

![image](https://user-images.githubusercontent.com/1556356/64710644-9deaea00-d4b8-11e9-8f6c-dce6b6702cbb.png)
