### PR TITLE
StyledButton: remove focus box-shadow effect

### DIFF
--- a/components/StyledButton.js
+++ b/components/StyledButton.js
@@ -25,10 +25,6 @@ const StyledButtonContent = styled.button`
     cursor: not-allowed;
   }
 
-  &:focus {
-    box-shadow: 0px 0px 0px 2px #83EBB4;
-  }
-
   ${buttonStyle}
   ${buttonSize}
 


### PR DESCRIPTION
This was implemented on https://github.com/opencollective/opencollective-frontend/pull/2399 to match the latest design but it doesn't play nice with custom theming and with some flex displays. Will need deeper dive before re-implementing.