### PR TITLE
fix: Don't zoom when focusing on input

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -74,7 +74,7 @@ class Header extends React.Component {
     return (
       <header>
         <Head>
-          <meta name="viewport" content="width=device-width, initial-scale=1" />
+          <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
           <meta property="og:logo" content="/static/images/opencollectiveicon240x240" size="240x240" />
           <meta property="og:logo" content="/static/images/opencollectiveicon48x48" size="48x48" />
           <meta property="og:logo" content="/static/images/opencollectivelogo480x80" size="480x80" />


### PR DESCRIPTION
For disable focusing on iOS, we should have font-size more than 16px. So I replaced `Paragraph` with `LeadParagraph` on input. But I cannot test with Safari on iPhone so could someone test this?

Fixes https://github.com/opencollective/opencollective/issues/1649