### PR TITLE
fix(NCP/Profiles): Don't crash if role is missing

### DIFF
--- a/components/StyledMembershipCard.js
+++ b/components/StyledMembershipCard.js
@@ -53,16 +53,18 @@ const StyledMembershipCard = ({ membership, intl, ...props }) => {
         </Container>
         <Container p={3}>
           <Box mb={2}>
-            <P fontSize="Caption" mb={3}>
-              <FormattedMessage
-                id="Membership.ContributorSince"
-                defaultMessage="{contributorType} since"
-                values={{ contributorType: formatMemberRole(intl, role) }}
-              />
-              <Span display="block" fontSize="LeadParagraph" fontWeight="bold">
-                <FormattedDate value={since} month="long" year="numeric" />
-              </Span>
-            </P>
+            {role && (
+              <P fontSize="Caption" mb={3}>
+                <FormattedMessage
+                  id="Membership.ContributorSince"
+                  defaultMessage="{contributorType} since"
+                  values={{ contributorType: formatMemberRole(intl, role) }}
+                />
+                <Span display="block" fontSize="LeadParagraph" fontWeight="bold">
+                  <FormattedDate value={since} month="long" year="numeric" />
+                </Span>
+              </P>
+            )}
             {role === roles.BACKER ? (
               <P mt={3}>
                 <FormattedMessage id="membership.totalDonations.title" defaultMessage="amount contributed">

--- a/lib/i18n-member-role.js
+++ b/lib/i18n-member-role.js
@@ -43,7 +43,8 @@ const RolesTranslations = defineMessages({
  * @param {string} `role` - see `roles`
  */
 const formatMemberRole = (intl, role) => {
-  return intl.formatMessage(RolesTranslations[role]);
+  const i18nMsg = RolesTranslations[role];
+  return i18nMsg ? intl.formatMessage(i18nMsg) : role;
 };
 
 export default formatMemberRole;


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/2426

Also made `formatMemberRole` function safer by ensuring message exists.

