### PR TITLE
styles: remove global overflow-x

### DIFF
--- a/components/Body.js
+++ b/components/Body.js
@@ -26,7 +26,6 @@ export default class Body extends React.Component {
               font-weight: 300;
               font-size: 1.6rem;
               line-height: 1.5;
-              overflow-x: hidden;
               margin: 0;
               padding: 0;
             }

--- a/pages/tier.js
+++ b/pages/tier.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { graphql } from 'react-apollo';
 import gql from 'graphql-tag';
 import { get } from 'lodash';
-import { createGlobalStyle } from 'styled-components';
 
 import { withUser } from '../components/UserProvider';
 import ErrorPage from '../components/ErrorPage';
@@ -11,14 +10,6 @@ import Page from '../components/Page';
 import Loading from '../components/Loading';
 import CollectiveThemeProvider from '../components/CollectiveThemeProvider';
 import TierPageContent from '../components/tier-page';
-
-/** Overrides global styles for this page */
-const GlobalStyles = createGlobalStyle`
-  main {
-    /** The "overflow: hidden" set in Body prevents from using position sticky */
-    overflow-x: inherit !important;
-  }
-`;
 
 /**
  * The main page to display collectives. Wrap route parameters and GraphQL query
@@ -75,18 +66,15 @@ class TierPage extends React.Component {
         {data.loading || !data.Tier || !data.Tier.collective ? (
           <Loading />
         ) : (
-          <React.Fragment>
-            <GlobalStyles />
-            <CollectiveThemeProvider collective={data.Tier.collective}>
-              <TierPageContent
-                LoggedInUser={LoggedInUser}
-                collective={data.Tier.collective}
-                tier={data.Tier}
-                contributors={data.Tier.contributors}
-                contributorsStats={data.Tier.stats.contributors}
-              />
-            </CollectiveThemeProvider>
-          </React.Fragment>
+          <CollectiveThemeProvider collective={data.Tier.collective}>
+            <TierPageContent
+              LoggedInUser={LoggedInUser}
+              collective={data.Tier.collective}
+              tier={data.Tier}
+              contributors={data.Tier.contributors}
+              contributorsStats={data.Tier.stats.contributors}
+            />
+          </CollectiveThemeProvider>
         )}
       </Page>
     );


### PR DESCRIPTION
The global `overflow-x: hidden;` that we set on `main` prevents us from using `sticky` position and has some incidence on other styles. It was implemented in https://github.com/opencollective/opencollective-frontend/commit/3e63f4172b70f7f9db4f7d3fbe050893e297b2f2 -- probably to fix the overly large page issues but this is not the way to fix it. At least it should be implemented specifically for each pages, not site-wise.

I tried to test important pages to ensure nothing was broken.

**Tested paths**
- Homepage
- Sign in
- Old collective page
- New collective page
- Contribution flow
- Expenses
- Transactions
- Settings