### PR TITLE
Fix StyledCheckbox width

### DIFF
--- a/components/ApplyToHostBtnLoggedIn.js
+++ b/components/ApplyToHostBtnLoggedIn.js
@@ -31,11 +31,6 @@ const TOS = styled(P)`
   margin-bottom: 16px;
 `;
 
-const TOSLinkWrapper = styled.div`
-  text-align: left;
-  margin-left: 20px;
-`;
-
 class ApplyToHostBtnLoggedIn extends React.Component {
   static propTypes = {
     LoggedInUser: PropTypes.object.isRequired,
@@ -141,17 +136,21 @@ class ApplyToHostBtnLoggedIn extends React.Component {
                 onChange={({ checked }) => this.setState({ checkTOS: checked })}
                 checked={this.state.checkTOS}
                 size={16}
+                label={
+                  <Container ml={2}>
+                    <FormattedMessage
+                      id="ApplyToHostBtnLoggedIn.TOS"
+                      defaultMessage="I agree with the <tos-link>terms of fiscal sponsorship of the host</tos-link> ({hostName}) that will collect money on behalf of our collective."
+                      values={{
+                        'tos-link': msg => (
+                          <ExternalLinkNewTab href={get(host, 'settings.tos')}>{msg}</ExternalLinkNewTab>
+                        ),
+                        hostName: host.name,
+                      }}
+                    />
+                  </Container>
+                }
               />
-              <TOSLinkWrapper>
-                <FormattedMessage
-                  id="ApplyToHostBtnLoggedIn.TOS"
-                  defaultMessage="I agree with the <tos-link>terms of fiscal sponsorship of the host</tos-link> ({hostName}) that will collect money on behalf of our collective."
-                  values={{
-                    'tos-link': msg => <ExternalLinkNewTab href={get(host, 'settings.tos')}>{msg}</ExternalLinkNewTab>,
-                    hostName: host.name,
-                  }}
-                />
-              </TOSLinkWrapper>
             </CheckboxWrapper>
           </ModalBody>
           <ModalFooter>

--- a/components/StyledCheckbox.js
+++ b/components/StyledCheckbox.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { typography, size } from 'styled-system';
 import themeGet from '@styled-system/theme-get';
-import { Flex } from '@rebass/grid';
 
 const IconCheckmark = () => {
   return (
@@ -34,10 +33,11 @@ const CustomCheckbox = styled.span`
   }
 `;
 
-const CheckboxContainer = styled(Flex)`
+const CheckboxContainer = styled.div`
+  display: flex;
   align-items: center;
   width: 100%;
-  ${size}
+  line-height: 1.4em;
   ${typography}
 
   /* Hide the default checkbox */


### PR DESCRIPTION
This was certainly broken in https://github.com/opencollective/opencollective-frontend/pull/2471

**Before**
![image](https://user-images.githubusercontent.com/1556356/65027908-71f9b980-d93b-11e9-9d6c-4b0acb832037.png)

**After**
![image](https://user-images.githubusercontent.com/1556356/65027790-3fe85780-d93b-11e9-9beb-af9d87e6aff3.png)

I've also updated the modal, as a consequence the label is now clickable:

![Peek 17-09-2019 11-18](https://user-images.githubusercontent.com/1556356/65029285-c3a34380-d93d-11e9-984c-49281d5d3edb.gif)
