### PR TITLE
Fix CollectiveColorPicker crash with invalid values

### DIFF
--- a/components/CollectiveThemeProvider.js
+++ b/components/CollectiveThemeProvider.js
@@ -4,6 +4,8 @@ import { get, throttle } from 'lodash';
 import memoizeOne from 'memoize-one';
 import { darken, lighten } from 'polished';
 import { ThemeProvider } from 'styled-components';
+import { isHexColor } from 'validator';
+
 import defaultTheme, { generateTheme } from '../lib/theme';
 
 /**
@@ -26,6 +28,9 @@ export default class CollectiveThemeProvider extends React.PureComponent {
 
   getTheme = memoizeOne(primaryColor => {
     if (!primaryColor) {
+      return defaultTheme;
+    } else if (!isHexColor(primaryColor)) {
+      console.warn(`Invalid custom color: ${primaryColor}`);
       return defaultTheme;
     } else {
       return generateTheme({

--- a/components/StyledInputGroup.js
+++ b/components/StyledInputGroup.js
@@ -131,8 +131,18 @@ const StyledInputGroup = ({
           py="0"
           error={error}
           {...inputProps}
-          onFocus={() => setFocus(true)}
-          onBlur={() => setFocus(false)}
+          onFocus={e => {
+            setFocus(true);
+            if (inputProps && inputProps.onFocus) {
+              inputProps.onFocus(e);
+            }
+          }}
+          onBlur={e => {
+            setFocus(false);
+            if (inputProps && inputProps.onBlur) {
+              inputProps.onBlur(e);
+            }
+          }}
         />
         {append && (
           <Container bg={getBgColor({ error, focused, success })} borderRadius="4px 0 0 4px" p={2}>

--- a/lang/de.json
+++ b/lang/de.json
@@ -219,6 +219,7 @@
   "collective.website.description": "Gib die URL deiner Webseite oder Facebook Seite ein",
   "collective.website.label": "Webseite",
   "CollectiveColorPicker.Custom": "Use custom color",
+  "CollectiveColorPicker.Error": "Please use an hexadecimal value (eg. #3E8DCE)",
   "CollectiveColorPicker.Preset": "Preset colors",
   "CollectiveColorPicker.Title": "Select page color",
   "CollectivePage.AddLongDescription": "Add a description",

--- a/lang/en.json
+++ b/lang/en.json
@@ -219,6 +219,7 @@
   "collective.website.description": "Enter the URL of your website or Facebook Page",
   "collective.website.label": "Website",
   "CollectiveColorPicker.Custom": "Use custom color",
+  "CollectiveColorPicker.Error": "Please use an hexadecimal value (eg. #3E8DCE)",
   "CollectiveColorPicker.Preset": "Preset colors",
   "CollectiveColorPicker.Title": "Select page color",
   "CollectivePage.AddLongDescription": "Add a description",

--- a/lang/es.json
+++ b/lang/es.json
@@ -219,6 +219,7 @@
   "collective.website.description": "Escribe la dirección web de tu página web o página de Facebook",
   "collective.website.label": "Página web",
   "CollectiveColorPicker.Custom": "Use custom color",
+  "CollectiveColorPicker.Error": "Please use an hexadecimal value (eg. #3E8DCE)",
   "CollectiveColorPicker.Preset": "Preset colors",
   "CollectiveColorPicker.Title": "Select page color",
   "CollectivePage.AddLongDescription": "Add a description",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -219,6 +219,7 @@
   "collective.website.description": "Entrez l'adresse URL de votre site Web ou de votre page Facebook",
   "collective.website.label": "Site Internet",
   "CollectiveColorPicker.Custom": "Use custom color",
+  "CollectiveColorPicker.Error": "Please use an hexadecimal value (eg. #3E8DCE)",
   "CollectiveColorPicker.Preset": "Preset colors",
   "CollectiveColorPicker.Title": "Select page color",
   "CollectivePage.AddLongDescription": "Ajouter une description",

--- a/lang/it.json
+++ b/lang/it.json
@@ -219,6 +219,7 @@
   "collective.website.description": "Enter the URL of your website or Facebook Page",
   "collective.website.label": "Website",
   "CollectiveColorPicker.Custom": "Use custom color",
+  "CollectiveColorPicker.Error": "Please use an hexadecimal value (eg. #3E8DCE)",
   "CollectiveColorPicker.Preset": "Preset colors",
   "CollectiveColorPicker.Title": "Select page color",
   "CollectivePage.AddLongDescription": "Add a description",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -219,6 +219,7 @@
   "collective.website.description": "あなたのウェブサイトまたは Facebook ページの URL を入力してください",
   "collective.website.label": "ウェブサイト",
   "CollectiveColorPicker.Custom": "Use custom color",
+  "CollectiveColorPicker.Error": "Please use an hexadecimal value (eg. #3E8DCE)",
   "CollectiveColorPicker.Preset": "Preset colors",
   "CollectiveColorPicker.Title": "Select page color",
   "CollectivePage.AddLongDescription": "Add a description",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -219,6 +219,7 @@
   "collective.website.description": "Enter the URL of your website or Facebook Page",
   "collective.website.label": "Website",
   "CollectiveColorPicker.Custom": "Use custom color",
+  "CollectiveColorPicker.Error": "Please use an hexadecimal value (eg. #3E8DCE)",
   "CollectiveColorPicker.Preset": "Preset colors",
   "CollectiveColorPicker.Title": "Select page color",
   "CollectivePage.AddLongDescription": "Add a description",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -219,6 +219,7 @@
   "collective.website.description": "Geef de URL in van je website of Facebook pagina",
   "collective.website.label": "Website",
   "CollectiveColorPicker.Custom": "Use custom color",
+  "CollectiveColorPicker.Error": "Please use an hexadecimal value (eg. #3E8DCE)",
   "CollectiveColorPicker.Preset": "Preset colors",
   "CollectiveColorPicker.Title": "Select page color",
   "CollectivePage.AddLongDescription": "Add a description",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -219,6 +219,7 @@
   "collective.website.description": "Enter the URL of your website or Facebook Page",
   "collective.website.label": "Website",
   "CollectiveColorPicker.Custom": "Use custom color",
+  "CollectiveColorPicker.Error": "Please use an hexadecimal value (eg. #3E8DCE)",
   "CollectiveColorPicker.Preset": "Preset colors",
   "CollectiveColorPicker.Title": "Select page color",
   "CollectivePage.AddLongDescription": "Add a description",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -219,6 +219,7 @@
   "collective.website.description": "Enter the URL of your website or Facebook Page",
   "collective.website.label": "Сайт",
   "CollectiveColorPicker.Custom": "Use custom color",
+  "CollectiveColorPicker.Error": "Please use an hexadecimal value (eg. #3E8DCE)",
   "CollectiveColorPicker.Preset": "Preset colors",
   "CollectiveColorPicker.Title": "Select page color",
   "CollectivePage.AddLongDescription": "Add a description",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -219,6 +219,7 @@
   "collective.website.description": "输入您的网站或 Facebook 主页的 URL",
   "collective.website.label": "网站",
   "CollectiveColorPicker.Custom": "Use custom color",
+  "CollectiveColorPicker.Error": "Please use an hexadecimal value (eg. #3E8DCE)",
   "CollectiveColorPicker.Preset": "Preset colors",
   "CollectiveColorPicker.Title": "Select page color",
   "CollectivePage.AddLongDescription": "Add a description",


### PR DESCRIPTION
- Display an error message if string is not a valid hex color
- Don't use `primaryColor` in `CollectiveThemeProvider` if the color is not a valid hex color (avoid crashing if the setting is incorrect).

![Peek 17-09-2019 13-00](https://user-images.githubusercontent.com/1556356/65036210-34049180-d94b-11e9-9d62-0ca3cb880759.gif)
