### PR TITLE
Add link to individual expense page from all transactions view

### DIFF
--- a/components/expenses/Transaction.js
+++ b/components/expenses/Transaction.js
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 import { Flex } from '@rebass/grid';
 import { FormattedMessage } from 'react-intl';
 
+import Link from '../Link';
+import { capitalize } from '../../lib/utils';
+
 import Avatar from '../Avatar';
 import Container from '../Container';
 import LinkCollective from '../LinkCollective';
@@ -21,7 +24,6 @@ class Transaction extends React.Component {
     createdAt: PropTypes.string.isRequired,
     description: PropTypes.string,
     currency: PropTypes.string.isRequired,
-    attachment: PropTypes.string,
     uuid: PropTypes.string,
     netAmountInCollectiveCurrency: PropTypes.number,
     platformFeeInHostCurrency: PropTypes.number,
@@ -35,6 +37,11 @@ class Transaction extends React.Component {
     host: PropTypes.shape({
       hostFeePercent: PropTypes.number,
       slug: PropTypes.string.isRequired,
+    }),
+    expense: PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      attachment: PropTypes.string,
+      category: PropTypes.string,
     }),
     fromCollective: PropTypes.shape({
       id: PropTypes.number,
@@ -117,6 +124,7 @@ class Transaction extends React.Component {
       type,
       paymentProcessorFeeInHostCurrency,
       dateDisplayType,
+      expense,
     } = this.props;
 
     if (!fromCollective) {
@@ -143,9 +151,17 @@ class Transaction extends React.Component {
         <Container ml={3} width={1}>
           <Flex justifyContent="space-between" alignItems="baseline">
             <div>
-              <P fontSize="1.4rem" color="#313233" display="inline">
-                {description}
-              </P>
+              {(expense && (
+                <Link route={`/${collective.slug}/expenses/${expense.id}`}>
+                  <P fontSize="1.4rem" color="#313233" display="inline">
+                    {description}
+                  </P>
+                </Link>
+              )) || (
+                <P fontSize="1.4rem" color="#313233" display="inline">
+                  {description}
+                </P>
+              )}
               <Span fontSize="1.6rem">{type === 'CREDIT' && ' 🎉'}</Span>
             </div>
             <AmountCurrency amount={amountToDisplay} currency={currency} precision={precision} />
@@ -154,6 +170,21 @@ class Transaction extends React.Component {
             {this.renderPaymentOrigin()}
             {' | '}
             <Moment relative={dateDisplayType === 'interval'} value={createdAt} />
+            {expense && (
+              <Fragment>
+                {' | '}
+                <Link
+                  route="expenses"
+                  params={{
+                    collectiveSlug: collective.slug,
+                    filter: 'categories',
+                    value: expense.category,
+                  }}
+                >
+                  {capitalize(expense.category)}
+                </Link>
+              </Fragment>
+            )}
             {paymentProcessorFeeInHostCurrency !== undefined && (
               <Fragment>
                 {' | '}

--- a/components/expenses/TransactionDetails.js
+++ b/components/expenses/TransactionDetails.js
@@ -20,8 +20,6 @@ class TransactionDetails extends React.Component {
     }),
     id: PropTypes.number.isRequired,
     amount: PropTypes.number.isRequired,
-    /** If the transaction has an attachement attached, it will replace the invoice link */
-    attachment: PropTypes.string,
     canDownloadInvoice: PropTypes.bool,
     canRefund: PropTypes.bool,
     className: PropTypes.string,
@@ -35,6 +33,12 @@ class TransactionDetails extends React.Component {
     hostCurrencyFxRate: PropTypes.number,
     paymentMethod: PropTypes.shape({
       service: PropTypes.string.isRequired,
+    }),
+    expense: PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      /** If the transaction has an attachement attached, it will replace the invoice link */
+      attachment: PropTypes.string,
+      category: PropTypes.string,
     }),
     host: PropTypes.shape({
       slug: PropTypes.string.isRequired,
@@ -169,7 +173,7 @@ class TransactionDetails extends React.Component {
       paymentMethod,
       isRefund,
       uuid,
-      attachment,
+      expense,
     } = this.props;
 
     const amountDetailsStr = this.formatAmountDetails();
@@ -262,8 +266,8 @@ class TransactionDetails extends React.Component {
               <FormattedMessage id="transaction.invoice" defaultMessage="invoice" />
             </label>
             <div>
-              {attachment ? (
-                <ExternalLinkNewTab href={attachment}>
+              {expense && expense.attachment ? (
+                <ExternalLinkNewTab href={expense.attachment}>
                   <FormattedMessage id="actions.download" defaultMessage="Download" />
                 </ExternalLinkNewTab>
               ) : (

--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -54,8 +54,11 @@ export const transactionFields = `
     type
   }
   ... on Expense {
-    category
-    attachment
+    expense {
+      id
+      category
+      attachment
+    }
   }
   ... on Order {
     createdAt


### PR DESCRIPTION
This pr adds the link to expense Transactions

![Screenshot from 2019-09-17 16-30-18](https://user-images.githubusercontent.com/18349358/65050932-7ee0d200-d968-11e9-9b48-d82015ea6d50.png)

This pr to close this issue : https://github.com/opencollective/opencollective/issues/1590