### PR TITLE
Contributors: Fetch in separate query and limit number

### DIFF
--- a/components/ContributorCard.js
+++ b/components/ContributorCard.js
@@ -122,7 +122,6 @@ ContributorCard.propTypes = {
     isAdmin: PropTypes.bool.isRequired,
     isBacker: PropTypes.bool.isRequired,
     isCore: PropTypes.bool.isRequired,
-    isFundraiser: PropTypes.bool.isRequired,
   }).isRequired,
   /** The currency used to show the contributions */
   currency: PropTypes.string,

--- a/components/ContributorsFilter.js
+++ b/components/ContributorsFilter.js
@@ -10,7 +10,7 @@ export const CONTRIBUTOR_FILTERS = {
   FINANCIAL: 'FINANCIAL',
 };
 
-const FILTERS_LIST = Object.values(CONTRIBUTOR_FILTERS);
+export const FILTERS_LIST = Object.values(CONTRIBUTOR_FILTERS);
 
 const Translations = defineMessages({
   [CONTRIBUTOR_FILTERS.ALL]: {

--- a/components/ContributorsGrid.js
+++ b/components/ContributorsGrid.js
@@ -152,16 +152,6 @@ ContributorsGrid.propTypes = {
   contributors: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,
-      name: PropTypes.string.isRequired,
-      image: PropTypes.string.isRequired,
-      roles: PropTypes.arrayOf(PropTypes.string.isRequired),
-      isCore: PropTypes.bool.isRequired,
-      isBacker: PropTypes.bool.isRequired,
-      isFundraiser: PropTypes.bool.isRequired,
-      totalAmountDonated: PropTypes.number,
-      publicMessage: PropTypes.string,
-      collectiveSlug: PropTypes.string,
-      type: PropTypes.string,
     }),
   ),
 

--- a/components/collective-page/graphql/fragments.js
+++ b/components/collective-page/graphql/fragments.js
@@ -82,7 +82,6 @@ export const ContributorsFieldsFragment = gql`
     isAdmin
     isCore
     isBacker
-    isFundraiser
     since
     image
     description

--- a/components/collective-page/graphql/fragments.js
+++ b/components/collective-page/graphql/fragments.js
@@ -70,3 +70,26 @@ export const UpdatesFieldsFragment = gql`
     }
   }
 `;
+
+/**
+ * Fields fetched for contributors
+ */
+export const ContributorsFieldsFragment = gql`
+  fragment ContributorsFieldsFragment on Contributor {
+    id
+    name
+    roles
+    isAdmin
+    isCore
+    isBacker
+    isFundraiser
+    since
+    image
+    description
+    collectiveSlug
+    totalAmountDonated
+    type
+    publicMessage
+    isIncognito
+  }
+`;

--- a/components/collective-page/index.js
+++ b/components/collective-page/index.js
@@ -30,7 +30,8 @@ class CollectivePage extends Component {
   static propTypes = {
     collective: PropTypes.object.isRequired,
     host: PropTypes.object,
-    contributors: PropTypes.arrayOf(PropTypes.object),
+    financialContributors: PropTypes.arrayOf(PropTypes.object),
+    coreContributors: PropTypes.arrayOf(PropTypes.object),
     topOrganizations: PropTypes.arrayOf(PropTypes.object),
     topIndividuals: PropTypes.arrayOf(PropTypes.object),
     tiers: PropTypes.arrayOf(PropTypes.object),
@@ -150,12 +151,19 @@ class CollectivePage extends Component {
             collective={this.props.collective}
             tiers={this.props.tiers}
             events={this.props.events}
-            contributors={this.props.contributors}
+            contributors={this.props.financialContributors}
             contributorsStats={this.props.stats.backers}
           />
         );
       case Sections.CONTRIBUTORS:
-        return <SectionContributors collective={this.props.collective} contributors={this.props.contributors} />;
+        return (
+          <SectionContributors
+            collective={this.props.collective}
+            financialContributors={this.props.financialContributors}
+            coreContributors={this.props.coreContributors}
+            stats={this.props.stats}
+          />
+        );
       case Sections.UPDATES:
         return (
           <SectionUpdates

--- a/lib/graphql/schema.graphql
+++ b/lib/graphql/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:3060/graphql
-# timestamp: Wed Sep 04 2019 09:58:05 GMT+0200 (GMT+02:00)
+# timestamp: Wed Sep 18 2019 11:08:33 GMT+0200 (GMT+02:00)
 
 """
 Application model
@@ -170,7 +170,7 @@ type Collective implements CollectiveInterface {
   """
   All the persons and entities that contribute to this organization
   """
-  contributors(limit: Int = 1000): [Contributor]
+  contributors(limit: Int = 1000, roles: [ContributorRole]): [Contributor]
   collectives(
     orderBy: CollectiveOrderField = name
     orderDirection: OrderDirection = ASC
@@ -405,7 +405,7 @@ interface CollectiveInterface {
   """
   All the persons and entities that contribute to this organization
   """
-  contributors(limit: Int = 1000): [Contributor]
+  contributors(limit: Int = 1000, roles: [ContributorRole]): [Contributor]
 
   """
   List of all collectives hosted by this collective
@@ -751,6 +751,11 @@ type Contributor {
   isFundraiser: Boolean!
 
   """
+  A list of tier ids that this contributors is a member of. A null value indicates that a membership without tier.
+  """
+  tiersIds: [Int]!
+
+  """
   Member join date
   """
   since: IsoDateString!
@@ -976,7 +981,7 @@ type Event implements CollectiveInterface {
   """
   All the persons and entities that contribute to this organization
   """
-  contributors(limit: Int = 1000): [Contributor]
+  contributors(limit: Int = 1000, roles: [ContributorRole]): [Contributor]
   collectives(
     orderBy: CollectiveOrderField = name
     orderDirection: OrderDirection = ASC
@@ -2072,7 +2077,7 @@ type Organization implements CollectiveInterface {
   """
   All the persons and entities that contribute to this organization
   """
-  contributors(limit: Int = 1000): [Contributor]
+  contributors(limit: Int = 1000, roles: [ContributorRole]): [Contributor]
   collectives(
     orderBy: CollectiveOrderField = name
     orderDirection: OrderDirection = ASC
@@ -3002,7 +3007,7 @@ type User implements CollectiveInterface {
   """
   All the persons and entities that contribute to this organization
   """
-  contributors(limit: Int = 1000): [Contributor]
+  contributors(limit: Int = 1000, roles: [ContributorRole]): [Contributor]
   collectives(
     orderBy: CollectiveOrderField = name
     orderDirection: OrderDirection = ASC

--- a/pages/new-collective-page.js
+++ b/pages/new-collective-page.js
@@ -45,7 +45,8 @@ class NewCollectivePage extends React.Component {
         parentCollective: PropTypes.shape({ image: PropTypes.string }),
         host: PropTypes.object,
         stats: PropTypes.object,
-        contributors: PropTypes.arrayOf(PropTypes.object),
+        coreContributors: PropTypes.arrayOf(PropTypes.object),
+        financialContributors: PropTypes.arrayOf(PropTypes.object),
         tiers: PropTypes.arrayOf(PropTypes.object),
         events: PropTypes.arrayOf(PropTypes.object),
         transactions: PropTypes.arrayOf(PropTypes.object),
@@ -99,7 +100,8 @@ class NewCollectivePage extends React.Component {
             <CollectivePage
               collective={collective}
               host={collective.host}
-              contributors={collective.contributors}
+              coreContributors={collective.coreContributors}
+              financialContributors={collective.financialContributors}
               tiers={collective.tiers}
               events={collective.events}
               transactions={collective.transactions}
@@ -167,22 +169,11 @@ const getCollective = graphql(gql`
         slug
         type
       }
-      contributors {
-        id
-        name
-        roles
-        isAdmin
-        isCore
-        isBacker
-        isFundraiser
-        since
-        image
-        description
-        collectiveSlug
-        totalAmountDonated
-        type
-        publicMessage
-        isIncognito
+      coreContributors: contributors(roles: [ADMIN, MEMBER]) {
+        ...ContributorsFieldsFragment
+      }
+      financialContributors: contributors(roles: [BACKER]) {
+        ...ContributorsFieldsFragment
       }
       tiers {
         id
@@ -247,6 +238,7 @@ const getCollective = graphql(gql`
 
   ${fragments.TransactionsAndExpensesFragment}
   ${fragments.UpdatesFieldsFragment}
+  ${fragments.ContributorsFieldsFragment}
 `);
 
 export default withUser(getCollective(NewCollectivePage));

--- a/pages/new-collective-page.js
+++ b/pages/new-collective-page.js
@@ -172,7 +172,7 @@ const getCollective = graphql(gql`
       coreContributors: contributors(roles: [ADMIN, MEMBER]) {
         ...ContributorsFieldsFragment
       }
-      financialContributors: contributors(roles: [BACKER]) {
+      financialContributors: contributors(roles: [BACKER], limit: 150) {
         ...ContributorsFieldsFragment
       }
       tiers {


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-api/pull/2569

This will solve the issue of missing core contributors. It will also five more flexibility to later fetch financial contributors dynamically.

I've also reduced the number of contributors fetched to 150 to optimize the page. I'll open another issue to add dynamic loading so we can still show all contributors in the future.

We may want to reproduce these changes for the tier page in the future.