### PR TITLE
EditGoals: Hide if new collective page is enabled

### DIFF
--- a/components/EditCollectiveForm.js
+++ b/components/EditCollectiveForm.js
@@ -10,6 +10,7 @@ import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import { isMemberOfTheEuropeanUnion } from '@opencollective/taxes';
 
 import { defaultBackgroundImage, CollectiveType } from '../lib/constants/collectives';
+import { parseToBoolean } from '../lib/utils';
 import { VAT_OPTIONS } from '../lib/constants/vat';
 import { Router } from '../server/pages';
 
@@ -87,7 +88,7 @@ class EditCollectiveForm extends React.Component {
 
     this.showEditTiers = ['COLLECTIVE', 'EVENT'].includes(collective.type);
     this.showExpenses = collective.type === 'COLLECTIVE' || collective.isHost;
-    this.showEditGoals = collective.type === 'COLLECTIVE';
+    this.showEditGoals = collective.type === 'COLLECTIVE' && !parseToBoolean(process.env.NCP_IS_DEFAULT);
     this.showHost = collective.type === 'COLLECTIVE';
     this.defaultTierType = collective.type === 'EVENT' ? 'TICKET' : 'TIER';
     this.showEditMembers = ['COLLECTIVE', 'ORGANIZATION'].includes(collective.type);


### PR DESCRIPTION
As we're getting rid of collective goals in NCP (see https://github.com/opencollective/opencollective/issues/2288) there's no reason to show them anymore in the collective edit section.