### PR TITLE
NCP/Contribute: Use full width for cards if necessary

### DIFF
--- a/components/HorizontalScroller.js
+++ b/components/HorizontalScroller.js
@@ -62,14 +62,10 @@ class HorizontalScroller extends React.PureComponent {
      *    is not scrollable, nothing will be rendered.
      */
     children: PropTypes.func.isRequired,
-    /** [0-1] Percentage of the view width scrolled when we click on prev/next chevrons */
-    scrollPercentage: PropTypes.number.isRequired,
+    /** Callback to get the scrolled distance when we click on prev/next chevrons */
+    getScrollDistance: PropTypes.func,
     /** @ignore from withViewport */
     width: PropTypes.number,
-  };
-
-  static defaultProps = {
-    scrollPercentage: 0.75,
   };
 
   constructor(props) {
@@ -109,12 +105,23 @@ class HorizontalScroller extends React.PureComponent {
   // > - If specified as a value less than 0 (greater than 0 for right-to-left elements), scrollLeft is set to 0.
   // > - If specified as a value greater than the maximum that the content can be scrolled, scrollLeft is set to the maximum.
   onPrevClick = () => {
-    this.ref.current.scrollLeft -= this.props.scrollPercentage * this.ref.current.offsetWidth;
+    this.ref.current.scrollLeft -= this.getScrollDistance();
   };
 
   onNextClick = () => {
-    this.ref.current.scrollLeft += this.props.scrollPercentage * this.ref.current.offsetWidth;
+    this.ref.current.scrollLeft += this.getScrollDistance();
   };
+
+  getScrollDistance() {
+    const offsetWidth = this.ref.current.offsetWidth;
+    if (this.props.getScrollDistance) {
+      return this.props.getScrollDistance(offsetWidth);
+    } else {
+      // Default behavior: scroll by 75% of the full width
+      const scrollPercentage = 0.75;
+      return scrollPercentage * offsetWidth;
+    }
+  }
 
   render() {
     const { canGoPrev, canGoNext } = this.state;

--- a/components/collective-page/ContributeCardsContainer.js
+++ b/components/collective-page/ContributeCardsContainer.js
@@ -23,8 +23,20 @@ const ContributeCardsContainer = styled.div`
   }
 
   /** Respect left margin / center cards on widescreens */
-  @media (min-width: ${Dimensions.MAX_SECTION_WIDTH}px) {
-    padding-left: calc((100% - ${Dimensions.MAX_SECTION_WIDTH + 10}px) / 2);
+
+  @supports (width: fit-content) {
+    @media (min-width: ${Dimensions.MAX_SECTION_WIDTH}px) {
+      margin: 0 auto;
+      min-width: ${Dimensions.MAX_SECTION_WIDTH}px;
+      width: fit-content;
+      max-width: 100%;
+    }
+  }
+
+  @supports not (width: fit-content) {
+    @media (min-width: ${Dimensions.MAX_SECTION_WIDTH}px) {
+      padding-left: calc((100% - ${Dimensions.MAX_SECTION_WIDTH + 10}px) / 2);
+    }
   }
 `;
 

--- a/components/collective-page/sections/Contribute.js
+++ b/components/collective-page/sections/Contribute.js
@@ -18,8 +18,9 @@ import ContainerSectionContent from '../ContainerSectionContent';
 import TopContributors from '../TopContributors';
 import SectionTitle from '../SectionTitle';
 import CreateNew from '../../contribute-cards/CreateNew';
+import { CONTRIBUTE_CARD_WIDTH } from '../../contribute-cards/Contribute';
 
-const CONTRIBUTE_CARD_PADDING_X = [3, 21];
+const CONTRIBUTE_CARD_PADDING_X = [15, 18];
 
 /**
  * The contribute section, implemented as a pure component to avoid unnecessary
@@ -95,6 +96,17 @@ class SectionContribute extends React.PureComponent {
     return contributors.find(c => c.isBacker);
   });
 
+  getContributeCardsScrollDistance(width) {
+    const oneCardScrollDistance = CONTRIBUTE_CARD_WIDTH + CONTRIBUTE_CARD_PADDING_X[0] * 2;
+    if (width <= oneCardScrollDistance * 2) {
+      return oneCardScrollDistance;
+    } else if (width <= oneCardScrollDistance * 4) {
+      return oneCardScrollDistance * 2;
+    } else {
+      return oneCardScrollDistance * 3;
+    }
+  }
+
   render() {
     const { collective, tiers, events, contributors, contributorsStats, isAdmin } = this.props;
     const [topOrganizations, topIndividuals] = this.getTopContributors(contributors);
@@ -111,7 +123,7 @@ class SectionContribute extends React.PureComponent {
         </ContainerSectionContent>
 
         <Box mb={4}>
-          <HorizontalScroller>
+          <HorizontalScroller getScrollDistance={this.getContributeCardsScrollDistance}>
             {(ref, Chevrons) => (
               <div>
                 <ContainerSectionContent>
@@ -152,7 +164,7 @@ class SectionContribute extends React.PureComponent {
           </HorizontalScroller>
         </Box>
         {(isAdmin || events.length > 0) && (
-          <HorizontalScroller>
+          <HorizontalScroller getScrollDistance={this.getContributeCardsScrollDistance}>
             {(ref, Chevrons) => (
               <div>
                 <ContainerSectionContent>


### PR DESCRIPTION
**2 tiers** => no change

![image](https://user-images.githubusercontent.com/1556356/65245974-eb390e00-daed-11e9-952e-9942f4faf0f2.png)

**3 tiers** => no change
![image](https://user-images.githubusercontent.com/1556356/65246268-79ad8f80-daee-11e9-9caa-398b234414cd.png)

**4 tiers** => center
![image](https://user-images.githubusercontent.com/1556356/65246146-44a13d00-daee-11e9-8024-053033df3ea3.png)

**5 tiers** => we use the full width - no need to scroll anymore on a 1920x1080!

![image](https://user-images.githubusercontent.com/1556356/65245912-ca70b880-daed-11e9-9532-b40e6d5b5983.png)


**Full preview with `drupal-recording-initiative`**

![Screenshot_2019-09-19 Drupal Recording Initiative - Open Collective](https://user-images.githubusercontent.com/1556356/65246387-bf6a5800-daee-11e9-9975-ec879d470b6b.png)
