### PR TITLE
fix(NCP/Contributions): Don't use yearlyBudget

### DIFF
--- a/components/StyledMembershipCard.js
+++ b/components/StyledMembershipCard.js
@@ -15,7 +15,6 @@ import { P, Span } from './Text';
 import Avatar from './Avatar';
 import I18nCollectiveTags from './I18nCollectiveTags';
 import StyledTag from './StyledTag';
-import FormattedMoneyAmount from './FormattedMoneyAmount';
 
 const getBackground = collective => {
   const backgroundImage = collective.backgroundImageUrl || get(collective, 'parentCollective.backgroundImageUrl');
@@ -83,18 +82,15 @@ const StyledMembershipCard = ({ membership, intl, ...props }) => {
               </P>
             ) : (
               <P mt={3} fontSize="Caption">
-                {collective.stats.yearlyBudget > 0 && (
+                {collective.stats.backers.all > 0 && (
                   <FormattedMessage
-                    id="StyledMembershipCard.YearlyBudget"
-                    defaultMessage="{amount} yearly budget"
+                    id="StyledMembershipCard.backers.all"
+                    defaultMessage="{count, plural, one {{prettyCount} contributor} other {{prettyCount} contributors}}"
                     values={{
-                      amount: (
-                        <Span fontWeight="bold">
-                          <FormattedMoneyAmount
-                            amount={collective.stats.yearlyBudget}
-                            currency={collective.currency || 'USD'}
-                            amountStyles={{ fontSize: 'LeadParagraph' }}
-                          />
+                      count: collective.stats.backers.all,
+                      prettyCount: (
+                        <Span fontWeight="bold" fontSize="LeadParagraph">
+                          {collective.stats.backers.all}
                         </Span>
                       ),
                     }}
@@ -132,7 +128,6 @@ StyledMembershipCard.propTypes = {
         backgroundImageUrl: PropTypes.string,
       }),
       stats: PropTypes.shape({
-        yearlyBudget: PropTypes.numer,
         backers: PropTypes.shape({
           all: PropTypes.number,
         }),

--- a/components/collective-page/sections/Contributions.js
+++ b/components/collective-page/sections/Contributions.js
@@ -89,7 +89,6 @@ const ParentedCollectivesQuery = gql`
         }
         stats {
           id
-          yearlyBudget
           backers {
             id
             all
@@ -108,7 +107,9 @@ class SectionContributions extends React.PureComponent {
       name: PropTypes.string.isRequired,
       type: PropTypes.string.isRequired,
       stats: PropTypes.shape({
-        yearlyBudget: PropTypes.number,
+        backers: PropTypes.shape({
+          all: PropTypes.number,
+        }),
       }).isRequired,
     }).isRequired,
 
@@ -189,14 +190,14 @@ class SectionContributions extends React.PureComponent {
   });
 
   sortMemberships = memoizeOne(memberships => {
-    // Sort memberships: hosted are always first, then we sort by yearly budget then by total amount donated
+    // Sort memberships: hosted are always first, then we sort by number of backers then by total amount donated
     return [...memberships].sort((m1, m2) => {
       if (m1.role === roles.HOST && m2.role !== roles.HOST) {
         return -1;
       } else if (m1.role !== roles.HOST && m2.role === roles.HOST) {
         return 1;
       } else if (m1.role === roles.HOST) {
-        return m1.collective.stats.yearlyBudget > m2.collective.stats.yearlyBudget ? -1 : 1;
+        return m1.collective.stats.backers.all > m2.collective.stats.backers.all ? -1 : 1;
       } else {
         return m1.stats.totalDonations > m2.stats.totalDonations ? -1 : 1;
       }
@@ -303,11 +304,11 @@ class SectionContributions extends React.PureComponent {
 
 const withData = graphql(
   gql`
-    query SectionCollective($id: Int!) {
+    query SectionContributions($id: Int!) {
       Collective(id: $id) {
         id
         settings
-        memberOf(onlyActiveCollectives: true) {
+        memberOf(onlyActiveCollectives: true, limit: 1500) {
           id
           role
           since
@@ -336,7 +337,6 @@ const withData = graphql(
             }
             stats {
               id
-              yearlyBudget
               backers {
                 id
                 all

--- a/lang/de.json
+++ b/lang/de.json
@@ -955,7 +955,7 @@
   "signin.noAccount": "Don't have an account?",
   "signin.unknownEmail": "There is no user with this email address.",
   "signin.usingEmail": "Sign in using your email address:",
-  "StyledMembershipCard.YearlyBudget": "{amount} yearly budget",
+  "StyledMembershipCard.backers.all": "{count, plural, one {{prettyCount} contributor} other {{prettyCount} contributors}}",
   "subscription.amountToDate": "contributed to date",
   "subscription.cancel.btn": "yes",
   "subscription.cancel.no.btn": "no",

--- a/lang/en.json
+++ b/lang/en.json
@@ -955,7 +955,7 @@
   "signin.noAccount": "Don't have an account?",
   "signin.unknownEmail": "There is no user with this email address.",
   "signin.usingEmail": "Sign in using your email address:",
-  "StyledMembershipCard.YearlyBudget": "{amount} yearly budget",
+  "StyledMembershipCard.backers.all": "{count, plural, one {{prettyCount} contributor} other {{prettyCount} contributors}}",
   "subscription.amountToDate": "contributed to date",
   "subscription.cancel.btn": "yes",
   "subscription.cancel.no.btn": "no",

--- a/lang/es.json
+++ b/lang/es.json
@@ -955,7 +955,7 @@
   "signin.noAccount": "Don't have an account?",
   "signin.unknownEmail": "No hay ningún usuario con esta dirección de correo electrónico.",
   "signin.usingEmail": "Inicia sesión con tu dirección de correo electrónico:",
-  "StyledMembershipCard.YearlyBudget": "{amount} yearly budget",
+  "StyledMembershipCard.backers.all": "{count, plural, one {{prettyCount} contributor} other {{prettyCount} contributors}}",
   "subscription.amountToDate": "contribuido hasta la fecha",
   "subscription.cancel.btn": "sí",
   "subscription.cancel.no.btn": "no",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -955,7 +955,7 @@
   "signin.noAccount": "Pas encore de compte ?",
   "signin.unknownEmail": "Il n'y a aucun utilisateur avec cette adresse e-mail.",
   "signin.usingEmail": "Connectez-vous avec votre adresse email :",
-  "StyledMembershipCard.YearlyBudget": "Budget annuel : {amount}",
+  "StyledMembershipCard.backers.all": "{count, plural, one {{prettyCount} contributor} other {{prettyCount} contributors}}",
   "subscription.amountToDate": "ont contribué jusqu'à présent",
   "subscription.cancel.btn": "oui",
   "subscription.cancel.no.btn": "non",

--- a/lang/it.json
+++ b/lang/it.json
@@ -955,7 +955,7 @@
   "signin.noAccount": "Don't have an account?",
   "signin.unknownEmail": "There is no user with this email address.",
   "signin.usingEmail": "Sign in using your email address:",
-  "StyledMembershipCard.YearlyBudget": "{amount} yearly budget",
+  "StyledMembershipCard.backers.all": "{count, plural, one {{prettyCount} contributor} other {{prettyCount} contributors}}",
   "subscription.amountToDate": "contributed to date",
   "subscription.cancel.btn": "yes",
   "subscription.cancel.no.btn": "no",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -955,7 +955,7 @@
   "signin.noAccount": "アカウントを持っていませんか?",
   "signin.unknownEmail": "このメールアドレスを使っているユーザーはいません。",
   "signin.usingEmail": "あなたは次のメールアドレスを使ってログインしています:",
-  "StyledMembershipCard.YearlyBudget": "{amount} yearly budget",
+  "StyledMembershipCard.backers.all": "{count, plural, one {{prettyCount} contributor} other {{prettyCount} contributors}}",
   "subscription.amountToDate": "contributed to date",
   "subscription.cancel.btn": "はい",
   "subscription.cancel.no.btn": "いいえ",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -955,7 +955,7 @@
   "signin.noAccount": "Don't have an account?",
   "signin.unknownEmail": "There is no user with this email address.",
   "signin.usingEmail": "Sign in using your email address:",
-  "StyledMembershipCard.YearlyBudget": "{amount} yearly budget",
+  "StyledMembershipCard.backers.all": "{count, plural, one {{prettyCount} contributor} other {{prettyCount} contributors}}",
   "subscription.amountToDate": "contributed to date",
   "subscription.cancel.btn": "yes",
   "subscription.cancel.no.btn": "no",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -955,7 +955,7 @@
   "signin.noAccount": "Don't have an account?",
   "signin.unknownEmail": "There is no user with this email address.",
   "signin.usingEmail": "Sign in using your email address:",
-  "StyledMembershipCard.YearlyBudget": "{amount} yearly budget",
+  "StyledMembershipCard.backers.all": "{count, plural, one {{prettyCount} contributor} other {{prettyCount} contributors}}",
   "subscription.amountToDate": "contributed to date",
   "subscription.cancel.btn": "yes",
   "subscription.cancel.no.btn": "no",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -955,7 +955,7 @@
   "signin.noAccount": "Don't have an account?",
   "signin.unknownEmail": "There is no user with this email address.",
   "signin.usingEmail": "Sign in using your email address:",
-  "StyledMembershipCard.YearlyBudget": "{amount} yearly budget",
+  "StyledMembershipCard.backers.all": "{count, plural, one {{prettyCount} contributor} other {{prettyCount} contributors}}",
   "subscription.amountToDate": "contributed to date",
   "subscription.cancel.btn": "yes",
   "subscription.cancel.no.btn": "no",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -955,7 +955,7 @@
   "signin.noAccount": "Don't have an account?",
   "signin.unknownEmail": "Нет пользователя с такой почтой.",
   "signin.usingEmail": "Авторизоваться по электронной почте:",
-  "StyledMembershipCard.YearlyBudget": "{amount} yearly budget",
+  "StyledMembershipCard.backers.all": "{count, plural, one {{prettyCount} contributor} other {{prettyCount} contributors}}",
   "subscription.amountToDate": "contributed to date",
   "subscription.cancel.btn": "да",
   "subscription.cancel.no.btn": "нет",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -955,7 +955,7 @@
   "signin.noAccount": "Don't have an account?",
   "signin.unknownEmail": "There is no user with this email address.",
   "signin.usingEmail": "Sign in using your email address:",
-  "StyledMembershipCard.YearlyBudget": "{amount} yearly budget",
+  "StyledMembershipCard.backers.all": "{count, plural, one {{prettyCount} contributor} other {{prettyCount} contributors}}",
   "subscription.amountToDate": "contributed to date",
   "subscription.cancel.btn": "yes",
   "subscription.cancel.no.btn": "no",


### PR DESCRIPTION
`yearlyBudget` has no loader, as a consequence querying it for all memberships had a massive cost, it was actually crashing staging.

This temporary fix replaces that with the number of contributors.

![image](https://user-images.githubusercontent.com/1556356/65278341-383bd500-db2c-11e9-986a-d5ae6697e434.png)
