### PR TITLE
Fix ContributionFlow steps for memberships tiers

### DIFF
--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -543,7 +543,8 @@ class CreateOrderPage extends React.Component {
     const tier = this.props.tier;
     const forceInterval = Boolean(tier) || Boolean(this.props.fixedInterval);
     const forceAmount = !get(tier, 'presets') && !isNil(get(tier, 'amount') || this.props.fixedAmount);
-    return forceInterval && forceAmount;
+    const isFlexible = tier && tier.amountType === AmountTypes.FLEXIBLE;
+    return !isFlexible && forceInterval && forceAmount;
   }
 
   /** Returns true if taxes may apply with this tier/host */


### PR DESCRIPTION
Resolve https://opencollective.freshdesk.com/a/tickets/1801
See erroneous tier: https://opencollective.com/expand/contribute/backer-9467/checkout