### PR TITLE
Currency: Fix abbreviated amount with intl

### DIFF
--- a/components/Currency.js
+++ b/components/Currency.js
@@ -1,34 +1,30 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedNumber } from 'react-intl';
-
-import { abbreviateNumber } from '../lib/utils';
+import { getCurrencySymbol, abbreviateNumber, formatCurrency } from '../lib/utils';
 
 import { Span } from './Text';
 
-const Currency = ({ abbreviate, currency, precision, value, ...styles }) => (
-  <FormattedNumber
-    value={value / 100}
-    currency={currency}
-    style="currency"
-    currencyDisplay="symbol"
-    minimumFractionDigits={precision}
-    maximumFractionDigits={precision}
-  >
-    {formattedNumber =>
-      abbreviate ? (
-        <Span {...styles} whiteSpace="nowrap">
-          {formattedNumber.slice(0, 1)}
-          {value > 0 && abbreviateNumber(value / 100, precision)}
-        </Span>
-      ) : (
-        <Span {...styles} whiteSpace="nowrap">
-          {formattedNumber}
-        </Span>
-      )
-    }
-  </FormattedNumber>
-);
+/**
+ * Shows a money amount with the currency.
+ *
+ * ⚠️ Abbreviated mode is only for English at the moment. Abbreviated amount will not be internationalized.
+ */
+const Currency = ({ abbreviate, currency, precision, value, ...styles }) => {
+  if (abbreviate) {
+    return (
+      <Span {...styles} whiteSpace="nowrap">
+        {getCurrencySymbol(currency)}
+        {abbreviateNumber(value / 100, precision)}
+      </Span>
+    );
+  } else {
+    return (
+      <Span {...styles} whiteSpace="nowrap">
+        {formatCurrency(value, currency, { precision })}
+      </Span>
+    );
+  }
+};
 
 Currency.propTypes = {
   /** The amount to display, in cents */

--- a/components/__tests__/Currency.test.js
+++ b/components/__tests__/Currency.test.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { snapshot } from '../../test/snapshot-helpers';
+import Currency from '../Currency';
+
+describe('Currency', () => {
+  it('renders default options', () => {
+    snapshot(<Currency value={4200} currency="USD" />);
+    snapshot(<Currency value={1900000} currency="USD" />, { IntlProvider: { locale: 'fr' } });
+  });
+
+  it('abbreviated version', () => {
+    snapshot(<Currency abbreviate value={4200} currency="USD" />);
+    snapshot(<Currency abbreviate value={1900000} currency="USD" />, { IntlProvider: { locale: 'fr' } });
+  });
+});

--- a/components/__tests__/__snapshots__/Currency.test.js.snap
+++ b/components/__tests__/__snapshots__/Currency.test.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Currency abbreviated version 1`] = `
+<span
+  className="Text__P-sc-3suny7-0-span dleGAN"
+  fontSize="inherit"
+  letterSpacing="-0.4px"
+>
+  $
+  42
+</span>
+`;
+
+exports[`Currency abbreviated version 2`] = `
+<span
+  className="Text__P-sc-3suny7-0-span dleGAN"
+  fontSize="inherit"
+  letterSpacing="-0.4px"
+>
+  $
+  19k
+</span>
+`;
+
+exports[`Currency renders default options 1`] = `
+<span
+  className="Text__P-sc-3suny7-0-span dleGAN"
+  fontSize="inherit"
+  letterSpacing="-0.4px"
+>
+  $42
+</span>
+`;
+
+exports[`Currency renders default options 2`] = `
+<span
+  className="Text__P-sc-3suny7-0-span dleGAN"
+  fontSize="inherit"
+  letterSpacing="-0.4px"
+>
+  $19,000
+</span>
+`;

--- a/test/snapshot-helpers.js
+++ b/test/snapshot-helpers.js
@@ -1,16 +1,50 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { IntlProvider } from 'react-intl';
+import { ThemeProvider } from 'styled-components';
+import { get } from 'lodash';
+import 'intl';
+import 'intl/locale-data/jsonp/en.js';
+import 'intl-pluralrules';
+import '@formatjs/intl-relativetimeformat/polyfill';
+import '@formatjs/intl-relativetimeformat/dist/locale-data/en';
+import '@formatjs/intl-relativetimeformat/dist/locale-data/fr';
+import theme from '../lib/theme';
+import * as Intl from '../server/intl';
 
-export const snapshot = component => {
-  const tree = renderer.create(component).toJSON();
+/**
+ * A helper to:
+ *  1. Wrap component under all required OC's providers
+ *  2. Render the tree
+ *  3. Compare with snapshot
+ *
+ * @param {ReactNode} component - the component to render
+ * @param {Object} providerParams - parameters to give to the providers:
+ *    - IntlProvider: { locale }
+ *    - ThemeProvider: { theme }
+ */
+export const snapshot = (component, providersParams = {}) => {
+  let messages;
+  const locale = get(providersParams, 'IntlProvider.locale', 'en');
+  if (locale !== 'en') {
+    messages = Intl.getMessages(locale);
+  }
+
+  const tree = renderer
+    .create(
+      <IntlProvider locale={locale} messages={messages}>
+        <ThemeProvider theme={get(providersParams, 'ThemeProvider.theme', theme)}>{component}</ThemeProvider>
+      </IntlProvider>,
+    )
+    .toJSON();
   return expect(tree).toMatchSnapshot();
 };
 
 /**
+ * @deprecated Use `snapshot`
  * Same as `snapshot` but wraps component in a IntlProvider
  */
-export const snapshotI18n = component => {
-  const tree = renderer.create(<IntlProvider locale="en">{component}</IntlProvider>).toJSON();
+export const snapshotI18n = (component, locale = 'en') => {
+  const tree = renderer.create(<IntlProvider locale={locale}>{component}</IntlProvider>).toJSON();
   return expect(tree).toMatchSnapshot();
 };


### PR DESCRIPTION
When producing abbreviated amounts, we were assuming that the first letter is the currency. This is true for US (ex: `$42000`) but not with others (ex: `42000€`). As a result we were duplicating the first number, abbreviated amounts for French or Spanish looked like `442k` instead of `42000€`.

Because `Intl` doesn't support abbreviation yet (though there is a proposal for it https://github.com/tc39/proposal-unified-intl-numberformat), the proposed fix will not localize abbreviated amounts.

