### PR TITLE
Don't crash if localStorage is null

### DIFF
--- a/components/EditConnectedAccount.js
+++ b/components/EditConnectedAccount.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import { HelpBlock, Button } from 'react-bootstrap';
 import { defineMessages, injectIntl } from 'react-intl';
+
+import { getFromLocalStorage, LOCAL_STORAGE_KEYS } from '../lib/local-storage';
 import { connectAccount } from '../lib/api';
 import EditTwitterAccount from './EditTwitterAccount';
 
@@ -76,7 +77,7 @@ class EditConnectedAccount extends React.Component {
       return window.location.replace(
         `/api/connected-accounts/${service}/oauthUrl?CollectiveId=${collective.id}&redirect=${encodeURIComponent(
           redirect,
-        )}&access_token=${localStorage.accessToken}`,
+        )}&access_token=${getFromLocalStorage(LOCAL_STORAGE_KEYS.ACCESS_TOKEN)}`,
       );
     }
 

--- a/components/OrderForm.js
+++ b/components/OrderForm.js
@@ -18,6 +18,7 @@ import { getStripeToken } from '../lib/stripe';
 import { getRecaptcha, getRecaptchaSiteKey } from '../lib/recaptcha';
 import { checkUserExistence, signin } from '../lib/api';
 import { paymentMethodLabelWithIcon } from '../lib/payment_method_label';
+import { removeFromLocalStorage, LOCAL_STORAGE_KEYS } from '../lib/local-storage';
 
 class OrderForm extends React.Component {
   static propTypes = {
@@ -409,8 +410,8 @@ class OrderForm extends React.Component {
   };
 
   logout = () => {
-    window.localStorage.removeItem('accessToken');
-    window.localStorage.removeItem('LoggedInUser');
+    removeFromLocalStorage(LOCAL_STORAGE_KEYS.ACCESS_TOKEN);
+    removeFromLocalStorage(LOCAL_STORAGE_KEYS.LOGGED_IN_USER);
     window.location.replace(window.location.href);
   };
 

--- a/components/TopBarProfileMenu.js
+++ b/components/TopBarProfileMenu.js
@@ -1,13 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ChevronDown } from 'styled-icons/boxicons-regular/ChevronDown';
-import { Link } from '../server/pages';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
-import { withUser } from './UserProvider';
-import { formatCurrency, capitalize } from '../lib/utils';
 import { Badge } from 'react-bootstrap';
 import { get, uniqBy } from 'lodash';
 import { Box, Flex } from '@rebass/grid';
+import { ChevronDown } from 'styled-icons/boxicons-regular/ChevronDown';
+
+import { Link } from '../server/pages';
+import { formatCurrency, capitalize } from '../lib/utils';
+import { getFromLocalStorage, LOCAL_STORAGE_KEYS } from '../lib/local-storage';
+import { withUser } from './UserProvider';
 import Avatar from './Avatar';
 import Hide from './Hide';
 import { P } from './Text';
@@ -49,10 +51,8 @@ class TopBarProfileMenu extends React.Component {
 
   componentDidMount() {
     document.addEventListener('click', this.onClickOutside);
-    if (typeof window !== 'undefined') {
-      if (!window.localStorage.accessToken) {
-        this.setState({ loading: false });
-      }
+    if (!getFromLocalStorage(LOCAL_STORAGE_KEYS.ACCESS_TOKEN)) {
+      this.setState({ loading: false });
     }
   }
 

--- a/components/UserProvider.js
+++ b/components/UserProvider.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import { isEqual } from 'lodash';
 import PropTypes from 'prop-types';
-
 import { withApollo } from 'react-apollo';
-import UserClass from '../lib/LoggedInUser';
+
 import { Router } from '../server/pages';
+import UserClass from '../lib/LoggedInUser';
 import withLoggedInUser from '../lib/withLoggedInUser';
+import { removeFromLocalStorage, LOCAL_STORAGE_KEYS } from '../lib/local-storage';
 
 export const UserContext = React.createContext({
   loadingLoggedInUser: true,
@@ -64,8 +65,8 @@ class UserProvider extends React.Component {
   };
 
   logout = async () => {
-    window.localStorage.removeItem('accessToken');
-    window.localStorage.removeItem('LoggedInUser');
+    removeFromLocalStorage(LOCAL_STORAGE_KEYS.ACCESS_TOKEN);
+    removeFromLocalStorage(LOCAL_STORAGE_KEYS.LOGGED_IN_USER);
     this.props.client.resetStore();
     this.setState({ LoggedInUser: null, errorLoggedInUser: null });
   };

--- a/components/expenses/ExpenseDetails.js
+++ b/components/expenses/ExpenseDetails.js
@@ -5,6 +5,7 @@ import { defineMessages, FormattedNumber, FormattedMessage, injectIntl } from 'r
 import { graphql } from 'react-apollo';
 import { get } from 'lodash';
 
+import { getFromLocalStorage, LOCAL_STORAGE_KEYS } from '../../lib/local-storage';
 import { capitalize, getCurrencySymbol, imagePreview } from '../../lib/utils';
 import InputField from '../../components/InputField';
 import categories from '../../lib/constants/categories';
@@ -376,8 +377,7 @@ const getExpenseQuery = gql`
 `;
 
 export const addGetExpense = component => {
-  const accessToken =
-    typeof window !== 'undefined' && window.localStorage && window.localStorage.getItem('accessToken');
+  const accessToken = getFromLocalStorage(LOCAL_STORAGE_KEYS.ACCESS_TOKEN);
 
   // if we don't have an accessToken, there is no need to get the details of a expense
   // as we won't have access to any more information than the allExpenses query

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { isValidEmail, getWebsiteUrl } from './utils';
+import { getFromLocalStorage, LOCAL_STORAGE_KEYS } from './local-storage';
 
 // Webpack error: Cannot find module 'webpack/lib/RequestShortener'
 // import queryString from 'query-string';
@@ -29,8 +30,10 @@ export function checkResponseStatus(response) {
 }
 
 function addAuthTokenToHeader(obj = {}) {
-  const accessToken = localStorage.getItem('accessToken');
-  if (!accessToken) return obj;
+  const accessToken = getFromLocalStorage(LOCAL_STORAGE_KEYS.ACCESS_TOKEN);
+  if (!accessToken) {
+    return obj;
+  }
   return {
     Authorization: `Bearer ${accessToken}`,
     ...obj,

--- a/lib/initClient.js
+++ b/lib/initClient.js
@@ -10,6 +10,7 @@ import { setContext } from 'apollo-link-context';
 import { InMemoryCache, IntrospectionFragmentMatcher } from 'apollo-cache-inmemory';
 
 import { getGraphqlUrl } from './utils';
+import { getFromLocalStorage, LOCAL_STORAGE_KEYS } from './local-storage';
 
 let apolloClient = null;
 
@@ -29,7 +30,7 @@ const fragmentMatcher = new IntrospectionFragmentMatcher({
 
 function createClient(initialState) {
   const authLink = setContext((_, { headers }) => {
-    const token = process.browser && window.localStorage.getItem('accessToken');
+    const token = getFromLocalStorage(LOCAL_STORAGE_KEYS.ACCESS_TOKEN);
     return {
       headers: {
         ...headers,

--- a/lib/local-storage.js
+++ b/lib/local-storage.js
@@ -1,0 +1,52 @@
+/**
+ * A map of keys used for local storage.
+ */
+export const LOCAL_STORAGE_KEYS = {
+  ACCESS_TOKEN: 'accessToken',
+  LOGGED_IN_USER: 'LoggedInUser',
+};
+
+/**
+ * Helper to check if localStorage is supported in current context
+ */
+export const hasLocalStorage = () => {
+  return Boolean(typeof window !== 'undefined' && window.localStorage);
+};
+
+/**
+ * A helper to get a value from localStorage that returns null instead of crashing
+ * if localStorage doesn't exist. This is useful for:
+ *  - SSR, because localStorage doesn't exist in this context
+ *  - Because robots/crawlers (like Google) don't have it and we don't want to crash when they visit us
+ */
+export const getFromLocalStorage = key => {
+  if (hasLocalStorage()) {
+    return window.localStorage.getItem(key);
+  } else {
+    return null;
+  }
+};
+
+/**
+ * A helper to set a value in localStorage that doesn't crash if localStorage doesn't exist.
+ * This is useful for:
+ *  - SSR, because localStorage doesn't exist in this context
+ *  - Because robots/crawlers (like Google) don't have it and we don't want to crash when they visit us
+ */
+export const setLocalStorage = (key, value) => {
+  if (hasLocalStorage()) {
+    return window.localStorage.setItem(key, value);
+  }
+};
+
+/**
+ * A helper to remove an entry in localStorage that doesn't crash if localStorage doesn't exist.
+ * This is useful for:
+ *  - SSR, because localStorage doesn't exist in this context
+ *  - Because robots/crawlers (like Google) don't have it and we don't want to crash when they visit us
+ */
+export const removeFromLocalStorage = key => {
+  if (hasLocalStorage()) {
+    return window.localStorage.removeItem(key);
+  }
+};

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,13 +1,15 @@
+import { getFromLocalStorage, removeFromLocalStorage, setLocalStorage } from './local-storage';
+
 function set(key, value, ttl = 1000 * 60 * 60) {
   if (!value) {
-    return localStorage.removeItem(key);
+    return removeFromLocalStorage(key);
   }
   const expire = new Date(Date.now() + ttl).getTime();
-  localStorage.setItem(key, JSON.stringify({ timestamp: new Date().getTime(), expire, value }));
+  setLocalStorage(key, JSON.stringify({ timestamp: new Date().getTime(), expire, value }));
 }
 
 function get(key) {
-  const entry = localStorage.getItem(key);
+  const entry = getFromLocalStorage(key);
   if (!entry) return;
   try {
     const obj = JSON.parse(entry);

--- a/lib/withLoggedInUser.js
+++ b/lib/withLoggedInUser.js
@@ -5,10 +5,11 @@ import jwt from 'jsonwebtoken';
 import * as Sentry from '@sentry/browser';
 import { pick } from 'lodash';
 
-import * as api from '../lib/api';
-import storage from '../lib/storage';
-import LoggedInUser from '../lib/LoggedInUser';
-import { getLoggedInUserQuery } from '../lib/graphql/queries';
+import * as api from './api';
+import storage from './storage';
+import LoggedInUser from './LoggedInUser';
+import { getLoggedInUserQuery } from './graphql/queries';
+import { getFromLocalStorage, LOCAL_STORAGE_KEYS, setLocalStorage } from './local-storage';
 
 const maybeRefreshAccessToken = async currentToken => {
   const decodeResult = jwt.decode(currentToken);
@@ -26,7 +27,7 @@ const maybeRefreshAccessToken = async currentToken => {
     if (error) {
       return null;
     } else if (token) {
-      window.localStorage.setItem('accessToken', token);
+      setLocalStorage(LOCAL_STORAGE_KEYS.ACCESS_TOKEN, token);
       return token;
     }
   }
@@ -89,12 +90,12 @@ export default WrappedComponent => {
         const newToken = await maybeRefreshAccessToken(token);
         if (!newToken) {
           throw Error('Invalid token');
-        } else if (window.localStorage.getItem('accessToken') !== newToken) {
-          window.localStorage.setItem('accessToken', newToken);
+        } else if (getFromLocalStorage(LOCAL_STORAGE_KEYS.ACCESS_TOKEN) !== newToken) {
+          setLocalStorage(LOCAL_STORAGE_KEYS.ACCESS_TOKEN, newToken);
         }
       } else {
         // If no localStorage token, reset LoggedInUser
-        const localStorageToken = window.localStorage.getItem('accessToken');
+        const localStorageToken = getFromLocalStorage(LOCAL_STORAGE_KEYS.ACCESS_TOKEN);
         if (!localStorageToken) {
           if (storage.get('LoggedInUser')) {
             storage.set('LoggedInUser', null);

--- a/pages/claimCollective.js
+++ b/pages/claimCollective.js
@@ -9,6 +9,7 @@ import { Github } from 'styled-icons/fa-brands/Github';
 import { URLSearchParams } from 'universal-url';
 
 import { compose, getBaseApiUrl, getWebsiteUrl } from '../lib/utils';
+import { getFromLocalStorage, LOCAL_STORAGE_KEYS } from '../lib/local-storage';
 
 import { Router, Link } from '../server/pages';
 
@@ -133,11 +134,11 @@ class ClaimCollectivePage extends React.Component {
 
   getGithubConnectUrl() {
     const { slug } = this.props;
-
     const urlParams = new URLSearchParams({ redirect: `${getWebsiteUrl()}/${slug}/claim` });
+    const accessToken = getFromLocalStorage(LOCAL_STORAGE_KEYS.ACCESS_TOKEN);
 
-    if (typeof window !== 'undefined' && window.localStorage.accessToken) {
-      urlParams.set('access_token', window.localStorage.accessToken);
+    if (accessToken) {
+      urlParams.set('access_token', accessToken);
     }
 
     return `/api/connected-accounts/github?${urlParams.toString()}`;

--- a/pages/openSourceApply.js
+++ b/pages/openSourceApply.js
@@ -21,6 +21,7 @@ import { Router } from '../server/pages';
 
 import { getGithubRepos } from '../lib/api';
 import { getWebsiteUrl } from '../lib/utils';
+import { LOCAL_STORAGE_KEYS, getFromLocalStorage } from '../lib/local-storage';
 
 class OpenSourceApplyPage extends Component {
   static async getInitialProps({ query }) {
@@ -150,9 +151,10 @@ class OpenSourceApplyPage extends Component {
 
   getGithubConnectUrl() {
     const urlParams = new URLSearchParams({ redirect: `${getWebsiteUrl()}/opensource/apply` });
+    const accessToken = getFromLocalStorage(LOCAL_STORAGE_KEYS.ACCESS_TOKEN);
 
-    if (typeof window !== 'undefined' && window.localStorage.accessToken) {
-      urlParams.set('access_token', window.localStorage.accessToken);
+    if (accessToken) {
+      urlParams.set('access_token', accessToken);
     }
 
     return `/api/connected-accounts/github?${urlParams.toString()}`;


### PR DESCRIPTION
This created more than 10K entries in [Sentry](https://sentry.io/organizations/open-collective/issues/1238965650/). It should not have impact on users because they *normally* have a `localStorage`, except maybe some of them who disable this with privacy extensions?. 

Anyway, this will basically ignore the calls to `localStorage` when it's undefined, which should solve the error.