### PR TITLE
NCP: Hide 'Edit > Images' if NCP is the default

### DIFF
--- a/components/EditCollectiveForm.js
+++ b/components/EditCollectiveForm.js
@@ -86,9 +86,11 @@ class EditCollectiveForm extends React.Component {
       goals: collective.settings.goals || [{}],
     };
 
+    const isNewCollectivePage = parseToBoolean(process.env.NCP_IS_DEFAULT);
     this.showEditTiers = ['COLLECTIVE', 'EVENT'].includes(collective.type);
     this.showExpenses = collective.type === 'COLLECTIVE' || collective.isHost;
-    this.showEditGoals = collective.type === 'COLLECTIVE' && !parseToBoolean(process.env.NCP_IS_DEFAULT);
+    this.showEditImages = !isNewCollectivePage;
+    this.showEditGoals = collective.type === 'COLLECTIVE' && !isNewCollectivePage;
     this.showHost = collective.type === 'COLLECTIVE';
     this.defaultTierType = collective.type === 'EVENT' ? 'TICKET' : 'TIER';
     this.showEditMembers = ['COLLECTIVE', 'ORGANIZATION'].includes(collective.type);
@@ -653,14 +655,16 @@ class EditCollectiveForm extends React.Component {
             >
               <FormattedMessage id="editCollective.menu.info" defaultMessage="Info" />
             </MenuItem>
-            <MenuItem
-              selected={this.state.section === 'images'}
-              route="editCollective"
-              params={{ slug: collective.slug, section: 'images' }}
-              className="MenuItem images"
-            >
-              <FormattedMessage id="editCollective.menu." defaultMessage="Images" />
-            </MenuItem>
+            {this.showEditImages && (
+              <MenuItem
+                selected={this.state.section === 'images'}
+                route="editCollective"
+                params={{ slug: collective.slug, section: 'images' }}
+                className="MenuItem images"
+              >
+                <FormattedMessage id="editCollective.menu." defaultMessage="Images" />
+              </MenuItem>
+            )}
             {this.showEditMembers && (
               <MenuItem
                 selected={this.state.section === 'members'}


### PR DESCRIPTION
With the NCP in place we have a new way to upload collective images. We don't want users to use the old paths because they can't see the images in context nor resize/crop from there.

In a similar fashion to https://github.com/opencollective/opencollective-frontend/pull/2584, this PR hides the edit section if NCP is the default.

![image](https://user-images.githubusercontent.com/1556356/65516742-dd1a3180-dee1-11e9-8536-5f4219b2d7eb.png)
