### PR TITLE
ContributionFlow: Set canonical URLs

### DIFF
--- a/pages/createOrder.js
+++ b/pages/createOrder.js
@@ -4,6 +4,7 @@ import { injectIntl, defineMessages, FormattedMessage } from 'react-intl';
 import { graphql } from 'react-apollo';
 import gql from 'graphql-tag';
 import { Flex } from '@rebass/grid';
+import { get } from 'lodash';
 
 import { compose, parseToBoolean } from '../lib/utils';
 import { CollectiveType } from '../lib/constants/collectives';
@@ -81,6 +82,16 @@ class CreateOrderPage extends React.Component {
     skipStepDetails: PropTypes.bool,
   };
 
+  getCanonicalURL(collective, tier) {
+    if (!tier) {
+      return `/${collective.slug}/donate`;
+    } else if (collective.type === CollectiveType.EVENT) {
+      return `/${get(collective.parentCollective, 'slug', collective.slug)}/events/${collective.slug}/order/${tier.id}`;
+    } else {
+      return `/${collective.slug}/contribute/${tier.slug}-${tier.id}/checkout`;
+    }
+  }
+
   getPageMetadata() {
     const { intl, data } = this.props;
 
@@ -90,6 +101,7 @@ class CreateOrderPage extends React.Component {
 
     const collective = data.Collective;
     return {
+      canonicalURL: this.getCanonicalURL(collective, data.Tier),
       description: collective.description,
       twitterHandle: collective.twitterHandle,
       image: collective.image || collective.backgroundImage,


### PR DESCRIPTION
See https://github.com/opencollective/opencollective/issues/2364
The goal is to update the routes indexed by Google for the contribution flow. We may want to play with Google search console to check the results and force the change.

## Without tier (donate)

![2019-09-24_18:31:34](https://user-images.githubusercontent.com/1556356/65531328-e9aa8400-def9-11e9-97be-e45a139c44e4.png)

## With a tier

![2019-09-24_18:32:01](https://user-images.githubusercontent.com/1556356/65531326-e9aa8400-def9-11e9-80bc-914a42b1d5af.png)

## Event ticket

![2019-09-24_18:32:51](https://user-images.githubusercontent.com/1556356/65531325-e9aa8400-def9-11e9-90c6-32d1f9814352.png)

