### PR TITLE
sets max length for inputs in create collective form

### DIFF
--- a/components/CreateCollectiveForm.js
+++ b/components/CreateCollectiveForm.js
@@ -393,6 +393,7 @@ class CreateCollectiveForm extends React.Component {
                           pre={field.pre}
                           context={this.state.collective}
                           onChange={value => this.handleChange(field.name, value)}
+                          maxLength={field.maxLength}
                         />
                       ),
                   )}


### PR DESCRIPTION
Fixes - https://github.com/opencollective/opencollective/issues/1342

Solution - adds the `maxlength` prop to the inputs