### PR TITLE
NCP/Contributions: Better spacing for membership cards

### DIFF
--- a/components/collective-page/sections/Contributions.js
+++ b/components/collective-page/sections/Contributions.js
@@ -15,13 +15,14 @@ import LoadingPlaceholder from '../../LoadingPlaceholder';
 import StyledMembershipCard from '../../StyledMembershipCard';
 import StyledButton from '../../StyledButton';
 import StyledFilters from '../../StyledFilters';
+import Container from '../../Container';
+import { fadeIn } from '../../StyledKeyframes';
 
 // Local imports
 import SectionTitle from '../SectionTitle';
 import ContainerSectionContent from '../ContainerSectionContent';
 import EmptyCollectivesSectionImageSVG from '../images/EmptyCollectivesSectionImage.svg';
 import { Dimensions } from '../_constants';
-import { fadeIn } from '../../StyledKeyframes';
 
 const FILTERS = { ALL: 'ALL', HOST: 'HOST', CORE: 'CORE', FINANCIAL: 'FINANCIAL', EVENTS: 'EVENTS' };
 const FILTERS_LIST = Object.values(FILTERS);
@@ -71,12 +72,17 @@ const MembershipCardContainer = styled.div`
   margin-bottom: 40px;
   margin-right: 4px;
 
-  @media screen and (min-width: 52em) {
-    margin-right: 34px;
+  @media screen and (min-width: 40em) {
+    margin-right: 5%;
   }
 
-  @media screen and (min-width: 40em) {
-    margin-right: 32px;
+  @media screen and (min-width: 64em) {
+    margin-right: 2%;
+  }
+
+  @media screen and (min-width: 1250px) {
+    margin-right: 57px;
+    margin-bottom: 50px;
   }
 `;
 
@@ -271,7 +277,7 @@ class SectionContributions extends React.PureComponent {
                 />
               </Box>
             )}
-            <ContainerSectionContent>
+            <Container maxWidth={Dimensions.MAX_SECTION_WIDTH} pl={Dimensions.PADDING_X} m="0 auto">
               <Flex flexWrap="wrap" justifyContent={['space-evenly', 'left']}>
                 {sortedMemberships.slice(0, nbMemberships).map(membership => (
                   <MembershipCardContainer key={membership.id}>
@@ -279,14 +285,14 @@ class SectionContributions extends React.PureComponent {
                   </MembershipCardContainer>
                 ))}
               </Flex>
-              {nbMemberships < sortedMemberships.length && (
-                <Flex mt={3} justifyContent="center">
-                  <StyledButton textTransform="capitalize" minWidth={170} onClick={this.showMoreMemberships}>
-                    <FormattedMessage id="loadMore" defaultMessage="load more" /> ↓
-                  </StyledButton>
-                </Flex>
-              )}
-            </ContainerSectionContent>
+            </Container>
+            {nbMemberships < sortedMemberships.length && (
+              <Flex mt={3} justifyContent="center">
+                <StyledButton textTransform="capitalize" minWidth={170} onClick={this.showMoreMemberships}>
+                  <FormattedMessage id="loadMore" defaultMessage="load more" /> ↓
+                </StyledButton>
+              </Flex>
+            )}
           </React.Fragment>
         )}
         {isOrganization && superCollectiveTags.length > 0 && (
@@ -297,22 +303,26 @@ class SectionContributions extends React.PureComponent {
                 return null;
               }
               return (
-                <ContainerSectionContent>
-                  <SectionTitle textAlign="left" mb={4}>
-                    <FormattedMessage
-                      id="CP.Contributions.PartOfOrg"
-                      defaultMessage="{n, plural, one {This Collective is} other {These Collectives are}} part of our Organization"
-                      values={{ n: collectives.length }}
-                    />
-                  </SectionTitle>
-                  <Flex flexWrap="wrap" justifyContent={['space-evenly', 'left']}>
-                    {collectives.map(collective => (
-                      <MembershipCardContainer key={collective.id}>
-                        <StyledMembershipCard membership={{ collective }} />
-                      </MembershipCardContainer>
-                    ))}
-                  </Flex>
-                </ContainerSectionContent>
+                <React.Fragment>
+                  <ContainerSectionContent>
+                    <SectionTitle textAlign="left" mb={4}>
+                      <FormattedMessage
+                        id="CP.Contributions.PartOfOrg"
+                        defaultMessage="{n, plural, one {This Collective is} other {These Collectives are}} part of our Organization"
+                        values={{ n: collectives.length }}
+                      />
+                    </SectionTitle>
+                  </ContainerSectionContent>
+                  <Container maxWidth={Dimensions.MAX_SECTION_WIDTH} pl={Dimensions.PADDING_X} m="0 auto">
+                    <Flex flexWrap="wrap" justifyContent={['space-evenly', 'left']}>
+                      {collectives.map(collective => (
+                        <MembershipCardContainer key={collective.id}>
+                          <StyledMembershipCard membership={{ collective }} />
+                        </MembershipCardContainer>
+                      ))}
+                    </Flex>
+                  </Container>
+                </React.Fragment>
               );
             }}
           </Query>


### PR DESCRIPTION
By removing the padding right we're able to use (almost) the full available width. Also improved responsiveness.

**Before**
![image](https://user-images.githubusercontent.com/1556356/65764244-71c0a180-e125-11e9-8b7b-d4b233cb6e9e.png)


**After**
![image](https://user-images.githubusercontent.com/1556356/65764183-5190e280-e125-11e9-88ce-7a8b07861b5d.png)
