### PR TITLE
Change .content max-width to match ncp/navbar

### DIFF
--- a/components/Body.js
+++ b/components/Body.js
@@ -50,8 +50,8 @@ export default class Body extends React.Component {
             }
 
             .content {
-              max-width: 111rem;
-              padding: 2rem 1.5rem;
+              max-width: 1260px;
+              padding: 2rem 30px;
               margin: 0 auto;
               line-height: 1.5;
               overflow: hidden;

--- a/components/CollectiveNavbar.js
+++ b/components/CollectiveNavbar.js
@@ -102,7 +102,7 @@ const MenuLinkContainer = styled.div`
 `;
 
 const InfosContainer = styled(Container)`
-  padding: 14px 24px;
+  padding: 14px 30px;
   display: flex;
   justify-content: space-between;
   align-items: center;


### PR DESCRIPTION
Though the use of `.content` is deprecated and should not be encouraged, this will at least force the existing content to match the sections width defined in the new navbar.

**Before**
![image](https://user-images.githubusercontent.com/1556356/65764588-4d18f980-e126-11e9-8bb4-46bb9f2ab76c.png)


**After**
![image](https://user-images.githubusercontent.com/1556356/65764769-ae40cd00-e126-11e9-85d7-dbf305bfb767.png)
