### PR TITLE
chore(e2e): Adapt tests for new collective page as default

### DIFF
--- a/test/cypress/integration/01-collective.test.js
+++ b/test/cypress/integration/01-collective.test.js
@@ -1,6 +1,6 @@
 describe('collective page', () => {
   before(() => {
-    cy.visit('/apex');
+    cy.visit('/apex/legacy');
   });
 
   it('loads the collective page', () => {

--- a/test/cypress/integration/04-organization.test.js
+++ b/test/cypress/integration/04-organization.test.js
@@ -1,6 +1,6 @@
 describe('organization profile page', () => {
   it('shows the collectives backed by the organization', () => {
-    cy.visit('/pubnub');
+    cy.visit('/pubnub/legacy');
     cy.get('#backer');
     cy.get('.CollectiveCard')
       .first()

--- a/test/cypress/integration/05-user.test.js
+++ b/test/cypress/integration/05-user.test.js
@@ -1,6 +1,6 @@
 describe('user profile page', () => {
   it('shows the collectives backed by the user', () => {
-    cy.visit('/xdamman');
+    cy.visit('/xdamman/legacy');
     cy.get('#backer');
     cy.get('#admin.organization [data-cy=subtitle]').contains("I'm an admin of these 2 Organizations");
     cy.get('#admin.organization .CollectiveCard').should('have.length', 2);

--- a/test/cypress/integration/25-host.apply.test.js
+++ b/test/cypress/integration/25-host.apply.test.js
@@ -1,6 +1,6 @@
 describe('apply to host', () => {
   it('as a new collective', () => {
-    cy.visit('/brusselstogetherasbl');
+    cy.visit('/brusselstogetherasbl/legacy');
     cy.get('#hosting h1').contains('We are fiscally hosting 2 Collectives');
     cy.contains('.CollectiveCover [data-cy="host-apply-btn"]', 'Apply').click();
     cy.get('#email').type('testuser@opencollective.com');

--- a/test/cypress/integration/30-archiveCollective.test.js
+++ b/test/cypress/integration/30-archiveCollective.test.js
@@ -4,7 +4,7 @@ describe('Archive Collective', () => {
       // Create a new organization
       cy.createCollective({ type: 'ORGANIZATION' }).then(collective => {
         const collectiveSlug = collective.slug;
-        cy.visit(`/${collectiveSlug}`);
+        cy.visit(`/${collectiveSlug}/legacy`);
         cy.wait(1000);
         cy.get('[data-cy=editBtn]').click();
         cy.wait(300);

--- a/test/cypress/integration/31-unarchiveCollective.test.js
+++ b/test/cypress/integration/31-unarchiveCollective.test.js
@@ -4,7 +4,7 @@ describe('Unarchive collective', () => {
       // Create a new organization
       cy.createCollective({ type: 'ORGANIZATION' }).then(collective => {
         const collectiveSlug = collective.slug;
-        cy.visit(`/${collectiveSlug}`);
+        cy.visit(`/${collectiveSlug}/legacy`);
         cy.wait(1000);
         cy.get('[data-cy=editBtn]').click();
         cy.contains('a', 'Advanced').click();


### PR DESCRIPTION
This PR intends to lazily adapt the test for when the new collective page is activated per default (`NCP_IS_DEFAULT=true`) by using `/legacy`.

**TODO before merging**
- [x] Remove the flag in `run_e2e_tests.sh`
    _Because it will be merged in https://github.com/opencollective/opencollective-frontend/pull/2643, that's where we'll set it_

**TODO after merging**
- [ ] Create an issue to migrate the tests to `/v2`