### PR TITLE
fix - HTML Editor full height to container

### DIFF
--- a/components/HTMLEditor.js
+++ b/components/HTMLEditor.js
@@ -166,6 +166,10 @@ class HTMLEditor extends React.Component {
               border: 1px solid #dcdee0;
               border-radius: 4px;
             }
+            .HTMLEditor :global(.ql-editor) {
+              min-height: 20rem;
+              max-height: 35rem;
+            }
             .HTMLEditor :global(.ql-toolbar) {
               border: 1px solid #dcdee0;
               border-radius: 4px;

--- a/components/HTMLEditor.js
+++ b/components/HTMLEditor.js
@@ -165,6 +165,7 @@ class HTMLEditor extends React.Component {
               overflow-y: auto;
               border: 1px solid #dcdee0;
               border-radius: 4px;
+              overflow: hidden;
             }
             .HTMLEditor :global(.ql-editor) {
               min-height: 20rem;


### PR DESCRIPTION
Fixes - https://github.com/opencollective/opencollective/issues/2457

On the rich text editor field, click now works on the whole container/height of the box

/cc @Betree 