### PR TITLE
Budget: fix download invoice button

### DIFF
--- a/components/BudgetItemsList.js
+++ b/components/BudgetItemsList.js
@@ -296,7 +296,8 @@ const BudgetItem = ({ item, isInverted, isCompact, canDownloadInvoice, intl }) =
   const { isCredit, amount, collective, paymentMethod, transaction, isExpense } = getItemInfo(item, isInverted);
   const ItemContainer = isCredit ? CreditItem : DebitItem;
   const hasRefund = Boolean(transaction && transaction.refundTransaction);
-  const hasInvoiceBtn = canDownloadInvoice && !isExpense && !hasRefund && (!isCredit || !isInverted);
+  const hasAccessToInvoice = canDownloadInvoice && transaction && transaction.uuid;
+  const hasInvoiceBtn = hasAccessToInvoice && !isExpense && !hasRefund && (!isCredit || !isInverted);
 
   return (
     <React.Fragment>
@@ -581,4 +582,4 @@ BudgetItemsList.defaultProps = {
   canDownloadInvoice: false,
 };
 
-export default injectIntl(BudgetItemsList);
+export default injectIntl(React.memo(BudgetItemsList));

--- a/components/collective-page/sections/Transactions.js
+++ b/components/collective-page/sections/Transactions.js
@@ -56,6 +56,7 @@ class SectionTransactions extends React.Component {
     /** @ignore from withData */
     data: PropTypes.shape({
       loading: PropTypes.bool,
+      refetch: PropTypes.func,
       /** Expenses paid + refunds */
       contributions: PropTypes.arrayOf(
         PropTypes.shape({
@@ -109,6 +110,14 @@ class SectionTransactions extends React.Component {
   };
 
   state = { filter: FILTERS.ALL };
+
+  componentDidUpdate(oldProps) {
+    // If user just logged in, refetch the data so we can get the transactions `uuid` that
+    // will make it possible for him to download the expenses.
+    if (!oldProps.idAdmin && this.props.isAdmin) {
+      this.props.data.refetch();
+    }
+  }
 
   getBudgetItems = memoizeOne((contributions, expenses, filter) => {
     if (filter === FILTERS.EXPENSES) {


### PR DESCRIPTION
I missed this bug in local because of hot reload: we need to refresh transactions once users are logged in so that we have access to the `uuid` that is required to download the previous invoices.