### PR TITLE
EditTiers: Never strip data when editing tiers

### DIFF
--- a/components/EditCollective.js
+++ b/components/EditCollective.js
@@ -54,12 +54,7 @@ class EditCollective extends React.Component {
     window.OC.editCollective = this.editCollective.bind(this);
   }
 
-  async validate(CollectiveInputType) {
-    const tiers = this.cleanTiers(CollectiveInputType.tiers);
-    if (tiers) {
-      CollectiveInputType.tiers = tiers;
-    }
-
+  validate(CollectiveInputType) {
     if (typeof CollectiveInputType.tags === 'string') {
       CollectiveInputType.tags = CollectiveInputType.tags.split(',').map(t => t.trim());
     }
@@ -85,36 +80,8 @@ class EditCollective extends React.Component {
     return CollectiveInputType;
   }
 
-  cleanTiers(tiers) {
-    if (!tiers) return null;
-    return tiers.map(tier => {
-      let resetAttributes = [];
-      switch (tier.type) {
-        case 'TICKET':
-        case 'PRODUCT':
-          resetAttributes = ['interval', 'presets'];
-          break;
-        case 'MEMBERSHIP':
-        case 'SERVICE':
-          resetAttributes = ['presets', 'maxQuantity'];
-          break;
-        case 'DONATION':
-          resetAttributes = ['maxQuantity'];
-          break;
-      }
-      const cleanTier = { ...tier };
-      resetAttributes.map(attr => {
-        cleanTier[attr] = null;
-      });
-      if (tier.amountType === 'FIXED') {
-        cleanTier.presets = null;
-      }
-      return cleanTier;
-    });
-  }
-
   async editCollective(CollectiveInputType) {
-    CollectiveInputType = await this.validate(CollectiveInputType);
+    CollectiveInputType = this.validate(CollectiveInputType);
     if (!CollectiveInputType) {
       return false;
     }


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2470

We were stripping data in multiple cases (see the diff) for tiers. Because the UI was not always reflecting these changes (for example when changing tier type to `MEMBERSHIP`), we ended up with strange behaviors where the data was stripped without informing users (we have at least two tickets from people being confused by this behavior).

I've made the choice to never strip the data from tiers. My opinion is that there's no reason for us to strip it: if the `FIXED` amount type doesn't allow presets, then just don't use them. We don't need to remove the actual data.

If re-implemented, it should take place in the edit tiers form, not at the top level `editCollective`.