### PR TITLE
Fix Jest warnings for missing theme provider

### DIFF
--- a/components/__tests__/OrderForm.test.js
+++ b/components/__tests__/OrderForm.test.js
@@ -1,12 +1,12 @@
-import { ApolloProvider } from 'react-apollo';
 import React from 'react';
-import OrderForm from '../OrderForm';
+import { mount } from 'enzyme';
 import sinon from 'sinon';
+
+import { withRequiredProviders } from '../../test/providers';
+
+import OrderForm from '../OrderForm';
 import * as stripe from '../../lib/stripe';
 import * as api from '../../lib/api';
-import { IntlProvider } from 'react-intl';
-
-import { mount } from 'enzyme';
 
 const getStripeToken = sinon.stub(stripe, 'getStripeToken').callsFake(() => {
   return {
@@ -59,15 +59,9 @@ describe('OrderForm component', () => {
 
   const mountComponent = (props, queryStub) =>
     mount(
-      <ApolloProvider
-        client={{
-          query: queryStub || Promise.resolve,
-        }}
-      >
-        <IntlProvider locale="en">
-          <OrderForm {...props} />
-        </IntlProvider>
-      </ApolloProvider>,
+      withRequiredProviders(<OrderForm {...props} />, {
+        ApolloProvider: { client: { query: queryStub || Promise.resolve } },
+      }),
     );
 
   let component;

--- a/components/__tests__/SubscriptionCard.test.js
+++ b/components/__tests__/SubscriptionCard.test.js
@@ -1,23 +1,12 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { IntlProvider } from 'react-intl';
-import { ApolloProvider } from 'react-apollo';
 
 import SubscriptionCard from '../SubscriptionCard';
 
-import initClient from '../../lib/initClient';
-
-const apolloClient = initClient();
+import { withRequiredProviders } from '../../test/providers';
 
 describe('SubscriptionCard.test.js', () => {
-  const mountComponent = props =>
-    mount(
-      <IntlProvider locale="en">
-        <ApolloProvider client={apolloClient}>
-          <SubscriptionCard {...props} />
-        </ApolloProvider>
-      </IntlProvider>,
-    );
+  const mountComponent = props => mount(withRequiredProviders(<SubscriptionCard {...props} />));
 
   const defaultValues = {
     slug: 'userSlug',

--- a/components/__tests__/Tier.test.js
+++ b/components/__tests__/Tier.test.js
@@ -1,18 +1,13 @@
 import { mount } from 'enzyme';
 import React from 'react';
 import Tier from '../Tier';
-import { IntlProvider } from 'react-intl';
 import { capitalize } from '../../lib/utils';
+import { withRequiredProviders } from '../../test/providers';
 
 const DEBUG = process.env.DEBUG || false;
 
 describe('Tier component', () => {
-  const mountComponent = props =>
-    mount(
-      <IntlProvider locale="en">
-        <Tier {...props} />
-      </IntlProvider>,
-    );
+  const mountComponent = props => mount(withRequiredProviders(<Tier {...props} />));
 
   describe('Donate Tier', () => {
     it('Change the preset and interval', done => {

--- a/components/expenses/__tests__/Expenses.test.js
+++ b/components/expenses/__tests__/Expenses.test.js
@@ -1,13 +1,8 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { IntlProvider } from 'react-intl';
-import { ApolloProvider } from 'react-apollo';
 
 import Expenses from '../Expenses';
-
-import initClient from '../../../lib/initClient';
-
-const apolloClient = initClient();
+import { withRequiredProviders } from '../../../test/providers';
 
 describe('Expenses component', () => {
   const host = {
@@ -63,17 +58,15 @@ describe('Expenses component', () => {
   };
 
   const component = mount(
-    <IntlProvider locale="en">
-      <ApolloProvider client={apolloClient}>
-        <Expenses
-          expenses={expenses}
-          host={host}
-          editable={true}
-          LoggedInUser={loggedInUser}
-          payExpense={() => setTimeout(() => Promise.resolve(), 2000)}
-        />
-      </ApolloProvider>
-    </IntlProvider>,
+    withRequiredProviders(
+      <Expenses
+        expenses={expenses}
+        host={host}
+        editable={true}
+        LoggedInUser={loggedInUser}
+        payExpense={() => setTimeout(() => Promise.resolve(), 2000)}
+      />,
+    ),
   );
 
   describe('Paying expenses', () => {

--- a/test/providers.js
+++ b/test/providers.js
@@ -1,0 +1,35 @@
+import 'intl';
+import 'intl/locale-data/jsonp/en.js';
+import 'intl-pluralrules';
+import '@formatjs/intl-relativetimeformat/polyfill';
+import '@formatjs/intl-relativetimeformat/dist/locale-data/en';
+import '@formatjs/intl-relativetimeformat/dist/locale-data/fr';
+import React from 'react';
+import { get } from 'lodash';
+import { IntlProvider } from 'react-intl';
+import { ThemeProvider } from 'styled-components';
+import { ApolloProvider } from 'react-apollo';
+import theme from '../lib/theme';
+import * as Intl from '../server/intl';
+import initClient from '../lib/initClient';
+
+const apolloClient = initClient();
+
+/**
+ * A helper to wrap component under all required OC's providers
+ *
+ * @param {ReactNode} component - the component to render
+ * @param {Object} providerParams - parameters to give to the providers:
+ *    - IntlProvider: { locale }
+ *    - ThemeProvider: { theme }
+ */
+export const withRequiredProviders = (component, providersParams = {}) => {
+  const locale = get(providersParams, 'IntlProvider.locale', 'en');
+  return (
+    <IntlProvider locale={locale} messages={locale === 'en' ? undefined : Intl.getMessages(locale)}>
+      <ApolloProvider client={get(providersParams, 'ApolloProvider.client', apolloClient)}>
+        <ThemeProvider theme={get(providersParams, 'ThemeProvider.theme', theme)}>{component}</ThemeProvider>
+      </ApolloProvider>
+    </IntlProvider>
+  );
+};

--- a/test/snapshot-helpers.js
+++ b/test/snapshot-helpers.js
@@ -1,16 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { IntlProvider } from 'react-intl';
-import { ThemeProvider } from 'styled-components';
-import { get } from 'lodash';
-import 'intl';
-import 'intl/locale-data/jsonp/en.js';
-import 'intl-pluralrules';
-import '@formatjs/intl-relativetimeformat/polyfill';
-import '@formatjs/intl-relativetimeformat/dist/locale-data/en';
-import '@formatjs/intl-relativetimeformat/dist/locale-data/fr';
-import theme from '../lib/theme';
-import * as Intl from '../server/intl';
+import { withRequiredProviders } from './providers';
 
 /**
  * A helper to:
@@ -24,19 +15,8 @@ import * as Intl from '../server/intl';
  *    - ThemeProvider: { theme }
  */
 export const snapshot = (component, providersParams = {}) => {
-  let messages;
-  const locale = get(providersParams, 'IntlProvider.locale', 'en');
-  if (locale !== 'en') {
-    messages = Intl.getMessages(locale);
-  }
-
-  const tree = renderer
-    .create(
-      <IntlProvider locale={locale} messages={messages}>
-        <ThemeProvider theme={get(providersParams, 'ThemeProvider.theme', theme)}>{component}</ThemeProvider>
-      </IntlProvider>,
-    )
-    .toJSON();
+  const componentWithProviders = withRequiredProviders(component, providersParams);
+  const tree = renderer.create(componentWithProviders).toJSON();
   return expect(tree).toMatchSnapshot();
 };
 


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2443

Extracted the helper to bind required providers used in snapshots to its own file so it can be used when mounting components in other tests.