### PR TITLE
Set new nextChargeDate for subscription made after middle of the month

### DIFF
--- a/components/faqs/ContributeDetailsFAQ.js
+++ b/components/faqs/ContributeDetailsFAQ.js
@@ -43,7 +43,7 @@ const ContributeDetailsFAQ = ({ tax, isIncognito, hasInterval, ...props }) =>
           <Content>
             <FormattedMessage
               id="ContributeDetails.faq.frequency.content"
-              defaultMessage="You will be charged today, and then on the 1st of each month (for monthly contributions) or the 1st of the same month next year (for yearly contributions). Warning: you may be charged twice in a short time frame if you are setting up a monthly contribution close to the end of the month."
+              defaultMessage="You will be charged today, and then on the 1st of each month (for monthly contributions) or the 1st of the same month next year (for yearly contributions). Note: To prevent you from being charged twice in a short time frame, if you contribute after the 15th of a given month, the next charge will not be the 1st of next month but the month after."
             />
           </Content>
         </Entry>

--- a/lang/de.json
+++ b/lang/de.json
@@ -338,7 +338,7 @@
   "ContributeCard.ReadMore": "Mehr lesen",
   "ContributeCard.SeeCollective": "View collective",
   "ContributedAmount": "Contributed {amount}",
-  "ContributeDetails.faq.frequency.content": "You will be charged today, and then on the 1st of each month (for monthly contributions) or the 1st of the same month next year (for yearly contributions). Warning: you may be charged twice in a short time frame if you are setting up a monthly contribution close to the end of the month.",
+  "ContributeDetails.faq.frequency.content": "You will be charged today, and then on the 1st of each month (for monthly contributions) or the 1st of the same month next year (for yearly contributions). Note: To prevent you from being charged twice in a short time frame, if you contribute after the 15th of a given month, the next charge will not be the 1st of next month but the month after.",
   "ContributeDetails.faq.frequency.title": "When will I be billed next time?",
   "ContributeDetails.faq.isIncognito.content": "If you chose to contribute as \"incognito\", your financial contribution will show up publicly as an incognito donation and it won't link to your public profile. However, in the effort of being transparent and compliant with KYC regulations (Know Your Customer), the fiscal host and the administrators of the collective can export a list of all the financial contributors with their personal information.",
   "ContributeDetails.faq.isIncognito.title": "What is an incognito contribution?",

--- a/lang/en.json
+++ b/lang/en.json
@@ -338,7 +338,7 @@
   "ContributeCard.ReadMore": "Read more",
   "ContributeCard.SeeCollective": "View collective",
   "ContributedAmount": "Contributed {amount}",
-  "ContributeDetails.faq.frequency.content": "You will be charged today, and then on the 1st of each month (for monthly contributions) or the 1st of the same month next year (for yearly contributions). Warning: you may be charged twice in a short time frame if you are setting up a monthly contribution close to the end of the month.",
+  "ContributeDetails.faq.frequency.content": "You will be charged today, and then on the 1st of each month (for monthly contributions) or the 1st of the same month next year (for yearly contributions). Note: To prevent you from being charged twice in a short time frame, if you contribute after the 15th of a given month, the next charge will not be the 1st of next month but the month after.",
   "ContributeDetails.faq.frequency.title": "When will I be billed next time?",
   "ContributeDetails.faq.isIncognito.content": "If you chose to contribute as \"incognito\", your financial contribution will show up publicly as an incognito donation and it won't link to your public profile. However, in the effort of being transparent and compliant with KYC regulations (Know Your Customer), the fiscal host and the administrators of the collective can export a list of all the financial contributors with their personal information.",
   "ContributeDetails.faq.isIncognito.title": "What is an incognito contribution?",

--- a/lang/es.json
+++ b/lang/es.json
@@ -338,7 +338,7 @@
   "ContributeCard.ReadMore": "Leer más",
   "ContributeCard.SeeCollective": "View collective",
   "ContributedAmount": "Contributed {amount}",
-  "ContributeDetails.faq.frequency.content": "You will be charged today, and then on the 1st of each month (for monthly contributions) or the 1st of the same month next year (for yearly contributions). Warning: you may be charged twice in a short time frame if you are setting up a monthly contribution close to the end of the month.",
+  "ContributeDetails.faq.frequency.content": "You will be charged today, and then on the 1st of each month (for monthly contributions) or the 1st of the same month next year (for yearly contributions). Note: To prevent you from being charged twice in a short time frame, if you contribute after the 15th of a given month, the next charge will not be the 1st of next month but the month after.",
   "ContributeDetails.faq.frequency.title": "When will I be billed next time?",
   "ContributeDetails.faq.isIncognito.content": "If you chose to contribute as \"incognito\", your financial contribution will show up publicly as an incognito donation and it won't link to your public profile. However, in the effort of being transparent and compliant with KYC regulations (Know Your Customer), the fiscal host and the administrators of the collective can export a list of all the financial contributors with their personal information.",
   "ContributeDetails.faq.isIncognito.title": "What is an incognito contribution?",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -338,7 +338,7 @@
   "ContributeCard.ReadMore": "Voir plus",
   "ContributeCard.SeeCollective": "Voir le Collectif",
   "ContributedAmount": "A contribué à hauteur de {amount}",
-  "ContributeDetails.faq.frequency.content": "Vous serez débité aujourd’hui, puis le 1er de chaque mois (pour les contributions mensuelles) ou le 1er du même mois chaque année (pour les abonnements annuels). Avertissement : vous serez débité deux fois dans une courte période si vous démarrez une contribution mensuelle à la fin du mois.",
+  "ContributeDetails.faq.frequency.content": "You will be charged today, and then on the 1st of each month (for monthly contributions) or the 1st of the same month next year (for yearly contributions). Note: To prevent you from being charged twice in a short time frame, if you contribute after the 15th of a given month, the next charge will not be the 1st of next month but the month after.",
   "ContributeDetails.faq.frequency.title": "Quand serais-je facturé la prochaine fois ?",
   "ContributeDetails.faq.isIncognito.content": "Si vous choisissez de contribuer en \"incognito\", votre contribution financière apparaîtra publiquement comme un don privé qui ne sera pas lié à votre profil public. Afin d'être en conformité avec les réglementations KYC regulations (Know Your Customer), l'hôte fiscal et les administrateurs du collectifs peuvent toutefois exporter une liste de toutes les contributions financières avec vos information personnelles.",
   "ContributeDetails.faq.isIncognito.title": "Qu'est ce qu'une contribution incognito ?",

--- a/lang/it.json
+++ b/lang/it.json
@@ -338,7 +338,7 @@
   "ContributeCard.ReadMore": "Read more",
   "ContributeCard.SeeCollective": "View collective",
   "ContributedAmount": "Contributed {amount}",
-  "ContributeDetails.faq.frequency.content": "You will be charged today, and then on the 1st of each month (for monthly contributions) or the 1st of the same month next year (for yearly contributions). Warning: you may be charged twice in a short time frame if you are setting up a monthly contribution close to the end of the month.",
+  "ContributeDetails.faq.frequency.content": "You will be charged today, and then on the 1st of each month (for monthly contributions) or the 1st of the same month next year (for yearly contributions). Note: To prevent you from being charged twice in a short time frame, if you contribute after the 15th of a given month, the next charge will not be the 1st of next month but the month after.",
   "ContributeDetails.faq.frequency.title": "When will I be billed next time?",
   "ContributeDetails.faq.isIncognito.content": "If you chose to contribute as \"incognito\", your financial contribution will show up publicly as an incognito donation and it won't link to your public profile. However, in the effort of being transparent and compliant with KYC regulations (Know Your Customer), the fiscal host and the administrators of the collective can export a list of all the financial contributors with their personal information.",
   "ContributeDetails.faq.isIncognito.title": "What is an incognito contribution?",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -338,7 +338,7 @@
   "ContributeCard.ReadMore": "もっと見る",
   "ContributeCard.SeeCollective": "コレクティブを見る",
   "ContributedAmount": "Contributed {amount}",
-  "ContributeDetails.faq.frequency.content": "You will be charged today, and then on the 1st of each month (for monthly contributions) or the 1st of the same month next year (for yearly contributions). Warning: you may be charged twice in a short time frame if you are setting up a monthly contribution close to the end of the month.",
+  "ContributeDetails.faq.frequency.content": "You will be charged today, and then on the 1st of each month (for monthly contributions) or the 1st of the same month next year (for yearly contributions). Note: To prevent you from being charged twice in a short time frame, if you contribute after the 15th of a given month, the next charge will not be the 1st of next month but the month after.",
   "ContributeDetails.faq.frequency.title": "When will I be billed next time?",
   "ContributeDetails.faq.isIncognito.content": "If you chose to contribute as \"incognito\", your financial contribution will show up publicly as an incognito donation and it won't link to your public profile. However, in the effort of being transparent and compliant with KYC regulations (Know Your Customer), the fiscal host and the administrators of the collective can export a list of all the financial contributors with their personal information.",
   "ContributeDetails.faq.isIncognito.title": "What is an incognito contribution?",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -338,7 +338,7 @@
   "ContributeCard.ReadMore": "Read more",
   "ContributeCard.SeeCollective": "View collective",
   "ContributedAmount": "Contributed {amount}",
-  "ContributeDetails.faq.frequency.content": "You will be charged today, and then on the 1st of each month (for monthly contributions) or the 1st of the same month next year (for yearly contributions). Warning: you may be charged twice in a short time frame if you are setting up a monthly contribution close to the end of the month.",
+  "ContributeDetails.faq.frequency.content": "You will be charged today, and then on the 1st of each month (for monthly contributions) or the 1st of the same month next year (for yearly contributions). Note: To prevent you from being charged twice in a short time frame, if you contribute after the 15th of a given month, the next charge will not be the 1st of next month but the month after.",
   "ContributeDetails.faq.frequency.title": "When will I be billed next time?",
   "ContributeDetails.faq.isIncognito.content": "If you chose to contribute as \"incognito\", your financial contribution will show up publicly as an incognito donation and it won't link to your public profile. However, in the effort of being transparent and compliant with KYC regulations (Know Your Customer), the fiscal host and the administrators of the collective can export a list of all the financial contributors with their personal information.",
   "ContributeDetails.faq.isIncognito.title": "What is an incognito contribution?",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -338,7 +338,7 @@
   "ContributeCard.ReadMore": "Lees meer",
   "ContributeCard.SeeCollective": "View collective",
   "ContributedAmount": "Bijgedragen {amount}",
-  "ContributeDetails.faq.frequency.content": "Je zal vandaag vandaag kosten aangerekend krijgen en dan op de 1ste van elke maand (voor maandelijkse bijdragen) of de 1ste van dezelfde maand van volgend jaar (voor jaarlijkse bijdragen). Let op: je kan twee keer kosten aangerekend krijgen in een korte tijd als je een maandelijkse bijdrage opstelt dicht bij het einde van de maand.",
+  "ContributeDetails.faq.frequency.content": "You will be charged today, and then on the 1st of each month (for monthly contributions) or the 1st of the same month next year (for yearly contributions). Note: To prevent you from being charged twice in a short time frame, if you contribute after the 15th of a given month, the next charge will not be the 1st of next month but the month after.",
   "ContributeDetails.faq.frequency.title": "Wanneer ontvang ik de volgende rekening?",
   "ContributeDetails.faq.isIncognito.content": "Als je kiest om \"incognito\" bij te dragen, je financiële bijdrage zal publiekelijk verschijnen als een incognito donatie en het zal niet verwijzen naar je publiek profiel. Niettemin, in de poging om transparant en conform met de KYC regelgeving (Know Your Customer), de fiscaal beheerder en de administrators van het collectief kunnen een lijst oproepen van alle financiële bijdragers met hun persoonlijke informatie.",
   "ContributeDetails.faq.isIncognito.title": "Wat is een incognito bijdrage?",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -338,7 +338,7 @@
   "ContributeCard.ReadMore": "Leia mais",
   "ContributeCard.SeeCollective": "Ver coletivo",
   "ContributedAmount": "{amount} contribuído",
-  "ContributeDetails.faq.frequency.content": "You will be charged today, and then on the 1st of each month (for monthly contributions) or the 1st of the same month next year (for yearly contributions). Warning: you may be charged twice in a short time frame if you are setting up a monthly contribution close to the end of the month.",
+  "ContributeDetails.faq.frequency.content": "You will be charged today, and then on the 1st of each month (for monthly contributions) or the 1st of the same month next year (for yearly contributions). Note: To prevent you from being charged twice in a short time frame, if you contribute after the 15th of a given month, the next charge will not be the 1st of next month but the month after.",
   "ContributeDetails.faq.frequency.title": "When will I be billed next time?",
   "ContributeDetails.faq.isIncognito.content": "If you chose to contribute as \"incognito\", your financial contribution will show up publicly as an incognito donation and it won't link to your public profile. However, in the effort of being transparent and compliant with KYC regulations (Know Your Customer), the fiscal host and the administrators of the collective can export a list of all the financial contributors with their personal information.",
   "ContributeDetails.faq.isIncognito.title": "What is an incognito contribution?",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -338,7 +338,7 @@
   "ContributeCard.ReadMore": "Узнать больше",
   "ContributeCard.SeeCollective": "View collective",
   "ContributedAmount": "Contributed {amount}",
-  "ContributeDetails.faq.frequency.content": "You will be charged today, and then on the 1st of each month (for monthly contributions) or the 1st of the same month next year (for yearly contributions). Warning: you may be charged twice in a short time frame if you are setting up a monthly contribution close to the end of the month.",
+  "ContributeDetails.faq.frequency.content": "You will be charged today, and then on the 1st of each month (for monthly contributions) or the 1st of the same month next year (for yearly contributions). Note: To prevent you from being charged twice in a short time frame, if you contribute after the 15th of a given month, the next charge will not be the 1st of next month but the month after.",
   "ContributeDetails.faq.frequency.title": "Когда с меня спишут средства в следующий раз?",
   "ContributeDetails.faq.isIncognito.content": "If you chose to contribute as \"incognito\", your financial contribution will show up publicly as an incognito donation and it won't link to your public profile. However, in the effort of being transparent and compliant with KYC regulations (Know Your Customer), the fiscal host and the administrators of the collective can export a list of all the financial contributors with their personal information.",
   "ContributeDetails.faq.isIncognito.title": "What is an incognito contribution?",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -338,7 +338,7 @@
   "ContributeCard.ReadMore": "阅读详情",
   "ContributeCard.SeeCollective": "View collective",
   "ContributedAmount": "Contributed {amount}",
-  "ContributeDetails.faq.frequency.content": "You will be charged today, and then on the 1st of each month (for monthly contributions) or the 1st of the same month next year (for yearly contributions). Warning: you may be charged twice in a short time frame if you are setting up a monthly contribution close to the end of the month.",
+  "ContributeDetails.faq.frequency.content": "You will be charged today, and then on the 1st of each month (for monthly contributions) or the 1st of the same month next year (for yearly contributions). Note: To prevent you from being charged twice in a short time frame, if you contribute after the 15th of a given month, the next charge will not be the 1st of next month but the month after.",
   "ContributeDetails.faq.frequency.title": "When will I be billed next time?",
   "ContributeDetails.faq.isIncognito.content": "If you chose to contribute as \"incognito\", your financial contribution will show up publicly as an incognito donation and it won't link to your public profile. However, in the effort of being transparent and compliant with KYC regulations (Know Your Customer), the fiscal host and the administrators of the collective can export a list of all the financial contributors with their personal information.",
   "ContributeDetails.faq.isIncognito.title": "What is an incognito contribution?",

--- a/lib/date-utils.js
+++ b/lib/date-utils.js
@@ -9,7 +9,7 @@ import INTERVALS from './constants/intervals';
  */
 export const getNextChargeDate = (firstChargeDate, interval) => {
   if (interval === INTERVALS.month) {
-    if (firstChargeDate.getDate() >= 15) {
+    if (firstChargeDate.getDate() > 15) {
       return new Date(firstChargeDate.getFullYear(), firstChargeDate.getMonth() + 2);
     }
     return new Date(firstChargeDate.getFullYear(), firstChargeDate.getMonth() + 1);

--- a/lib/date-utils.js
+++ b/lib/date-utils.js
@@ -9,6 +9,9 @@ import INTERVALS from './constants/intervals';
  */
 export const getNextChargeDate = (firstChargeDate, interval) => {
   if (interval === INTERVALS.month) {
+    if (firstChargeDate.getDate() >= 15) {
+      return new Date(firstChargeDate.getFullYear(), firstChargeDate.getMonth() + 2);
+    }
     return new Date(firstChargeDate.getFullYear(), firstChargeDate.getMonth() + 1);
   } else if (interval === INTERVALS.year) {
     return new Date(firstChargeDate.getFullYear() + 1, firstChargeDate.getMonth());

--- a/test/cypress/integration/12-contributionFlow.donate.test.js
+++ b/test/cypress/integration/12-contributionFlow.donate.test.js
@@ -38,7 +38,8 @@ describe('Contribution Flow: Donate', () => {
       cy.contains('[data-cy="select-option"]', 'Monthly').click();
       cy.tick(1000); // Update details is debounced, we need to tick the clock to trigger update
       cy.contains('.step-details', '$1,337.00 per month');
-      cy.contains('Next charge: Jun 1, 2042');
+      // next charge in 2 months time, first day, because it was made on or after 15th.
+      cy.contains('Next charge: Jul 1, 2042');
 
       // Change frequency - yearly
       cy.get('#interval').click();

--- a/test/cypress/integration/13-contributionFlow.contribute.test.js
+++ b/test/cypress/integration/13-contributionFlow.contribute.test.js
@@ -51,7 +51,7 @@ describe('Contribution Flow: Order', () => {
 
   it('Can order as new user', () => {
     // Mock clock so we can check next contribution date in a consistent way
-    cy.clock(Date.parse('2042/05/25'));
+    cy.clock(Date.parse('2042/05/03'));
 
     const userParams = { firstName: 'Order', lastName: 'Tester' };
     const visitParams = { onBeforeLoad: mockRecaptcha };
@@ -98,7 +98,7 @@ describe('Contribution Flow: Order', () => {
   });
 
   it('Can order with an existing orgnanization', () => {
-    cy.clock(Date.parse('2042/05/25'));
+    cy.clock(Date.parse('2042/05/03'));
     let collectiveSlug = null;
     const visitParams = { onBeforeLoad: mockRecaptcha };
 


### PR DESCRIPTION
This PR follows up https://github.com/opencollective/opencollective-api/pull/2637 to fix [#1215](https://github.com/opencollective/opencollective/issues/1215). 

This only affect subscription made on or after 15th of each months. 

<img width="1102" alt="Screenshot 2019-09-30 at 10 16 44 PM" src="https://user-images.githubusercontent.com/15707013/65944770-5eb21800-e42a-11e9-8336-7036bb4f870e.png">
