### PR TITLE
build: remove console.log from the code

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -29,6 +29,12 @@
     "production": {
       "plugins": [
         [
+          "transform-remove-console",
+          {
+            "exclude": "error"
+          },
+        ],
+        [
           "transform-react-remove-prop-types",
           {
             "removeImport": true

--- a/.babelrc
+++ b/.babelrc
@@ -31,7 +31,7 @@
         [
           "transform-remove-console",
           {
-            "exclude": "error"
+            "exclude": ["error"]
           },
         ],
         [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,6 @@
   "env": { "jest": true },
   "plugins": ["graphql", "react-hooks"],
   "rules": {
-    "no-console": "warn",
     "require-atomic-updates": "warn",
     "graphql/template-strings": ["error", { "env": "apollo" }],
     "graphql/named-operations": ["error"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -4950,6 +4950,12 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
     },
+    "babel-plugin-transform-remove-console": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
+      "integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=",
+      "dev": true
+    },
     "babel-preset-jest": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
@@ -6400,7 +6406,7 @@
         },
         "is-obj": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
           "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
         },
         "json-schema-traverse": {
@@ -11279,7 +11285,7 @@
     },
     "immutable": {
       "version": "3.7.6",
-      "resolved": "http://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
       "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
     },
     "import-cwd": {
@@ -11836,7 +11842,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-observable": {

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "babel-plugin-react-remove-properties": "0.3.0",
     "babel-plugin-styled-components": "1.10.6",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
+    "babel-plugin-transform-remove-console": "^6.9.4",
     "commitizen": "^4.0.3",
     "cross-env": "^6.0.0",
     "cypress": "^3.4.1",


### PR DESCRIPTION
Removes the console from the code via the
babel plugin. Additionally the eslint rule
for no console was removed.

Fixes issue [1669](https://github.com/opencollective/opencollective/issues/1669)