### PR TITLE
ExternalLink: Don't add unnecessary prop to <a/>

### DIFF
--- a/components/ExternalLink.js
+++ b/components/ExternalLink.js
@@ -5,8 +5,8 @@ import PropTypes from 'prop-types';
  * A simple `<a>` link with `target="_blank"` and `rel="noopener noreferrer"` set when
  * `openInNewTab` is true so we don't forget to add them.
  */
-const ExternalLink = props => {
-  if (props.openInNewTab) {
+const ExternalLink = ({ openInNewTab, ...props }) => {
+  if (openInNewTab) {
     return <a {...props} target="_blank" rel="noopener noreferrer" />;
   }
   return <a {...props} />;


### PR DESCRIPTION
I missed it in my initial review, we added an unnecessary prop to the link which resulted in the following warning:

```
Warning: React does not recognize the `openInNewTab` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `openinnewtab` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in a (created by ExternalLink)
    in ExternalLink (created by ReactTooltip)
    in FormattedMessage (created by ReactTooltip)
    in div (created by ReactTooltip)
    in ReactTooltip (created by StyledTooltip)
    in StyledTooltip (created by Tooltip)
    in Tooltip (created by Footer)
    in div (created by Text__P)
    in Text__P (created by Footer)
    in div (created by Container)
    in Container (created by Footer)
    in div (created by Container)
    in Container (created by Footer)
    in div (created by Footer___StyledFlex)
    in Footer___StyledFlex (created by Footer)
    in div (created by Container)
    in Container (created by Footer)
    in Footer (created by ErrorPage)
    in div (created by ErrorPage)
    in ErrorPage (created by CreateOrganizationPage)
    in CreateOrganizationPage (created by Context.Consumer)
    in WithUser (created by OpenCollectiveFrontendApp)
    in UserProvider (created by withLoggedInUser(undefined))
    in withLoggedInUser(undefined) (created by Context.Consumer)
    in ApolloConsumer (created by withApollo(withLoggedInUser(undefined)))
    in withApollo(withLoggedInUser(undefined)) (created by OpenCollectiveFrontendApp)
    in IntlProvider (created by OpenCollectiveFrontendApp)
    in Provider (created by StripeProvider)
    in StripeProvider (created by OpenCollectiveFrontendApp)
    in ThemeProvider (created by OpenCollectiveFrontendApp)
    in ApolloProvider (created by OpenCollectiveFrontendApp)
    in OpenCollectiveFrontendApp (created by WithData(OpenCollectiveFrontendApp))
    in WithData(OpenCollectiveFrontendApp)
    in Suspense (created by AppContainer)
    in Container (created by AppContainer)
    in AppContainer
```
cc/ @EvanBurchard 