### PR TITLE
CommentForm: Handle errors and surface message

### DIFF
--- a/components/CommentForm.js
+++ b/components/CommentForm.js
@@ -6,6 +6,7 @@ import InputField from './InputField';
 import SmallButton from './SmallButton';
 import Avatar from './Avatar';
 import Link from './Link';
+import MessageBox from './MessageBox';
 
 /**
  * Component to render for for **new** comments. Comment Edit form is created
@@ -37,15 +38,19 @@ class CommentForm extends React.Component {
       },
     });
 
-    this.state = { comment: {} };
+    this.state = { comment: {}, error: null };
   }
 
   async onSubmit() {
-    const res = await this.props.onSubmit(pick(this.state.comment, ['html']));
-    const comment = res.data && res.data.createComment;
-    if (comment) {
-      const newEmptyComment = { id: comment.id++ };
-      this.setState({ comment: newEmptyComment });
+    this.setState({ error: null });
+    try {
+      const comment = await this.props.onSubmit(pick(this.state.comment, ['html']));
+      if (comment) {
+        const newEmptyComment = { id: comment.id++ };
+        this.setState({ comment: newEmptyComment });
+      }
+    } catch (e) {
+      this.setState({ error: e });
     }
   }
 
@@ -136,6 +141,11 @@ class CommentForm extends React.Component {
                   className="small"
                 />
               </div>
+              {this.state.error && (
+                <MessageBox type="error" withIcon mb={2}>
+                  {this.state.error.toString()}
+                </MessageBox>
+              )}
               <div className="actions">
                 <SmallButton className="primary save" onClick={this.onSubmit}>
                   <FormattedMessage id="comment.btn" defaultMessage="Comment" />

--- a/components/CommentsWithData.js
+++ b/components/CommentsWithData.js
@@ -39,14 +39,9 @@ class CommentsWithData extends React.Component {
       FromCollectiveId: LoggedInUser.collective.id,
       ExpenseId: expense.id,
     };
-    console.log('>>> createComment', CommentInputType);
-    let res;
-    try {
-      res = await this.props.createComment(CommentInputType);
-    } catch (e) {
-      console.error('>>> error while trying to create the comment', CommentInputType, e);
-    }
-    return res;
+
+    const res = await this.props.createComment(CommentInputType);
+    return res.data.createComment;
   }
 
   renderUserAction(LoggedInUser, expense, notice) {


### PR DESCRIPTION
Resolve https://sentry.io/organizations/open-collective/issues/1252503001/?project=1736806&query=is%3Aunresolved+has%3Auser.email&statsPeriod=14d

Before this PR a failure on the the API when posting a comment would crash the page because `onSubmit` returned a null comment. This PR adds handling for the error and surfaces the message.

![2019-10-02_17:01:34](https://user-images.githubusercontent.com/1556356/66055982-b8076d80-e536-11e9-8174-a3b7b0d6ff9a.png)
