### PR TITLE
Enhancement: Host admin can un-pay an expense

### DIFF
--- a/components/expenses/Expense.js
+++ b/components/expenses/Expense.js
@@ -17,6 +17,7 @@ import ExpenseNeedsTaxFormBadge from './ExpenseNeedsTaxFormBadge';
 import ApproveExpenseBtn from './ApproveExpenseBtn';
 import RejectExpenseBtn from './RejectExpenseBtn';
 import PayExpenseBtn from './PayExpenseBtn';
+import MarkExpenseAsUnpaidBtn from './MarkExpenseAsUnpaidBtn';
 import EditPayExpenseFeesForm from './EditPayExpenseFeesForm';
 
 class Expense extends React.Component {
@@ -155,6 +156,11 @@ class Expense extends React.Component {
     mode = mode || view;
 
     const canPay = LoggedInUser && LoggedInUser.canPayExpense(expense) && expense.status === 'APPROVED';
+    const canReverseOtherPayment =
+      LoggedInUser &&
+      LoggedInUser.canPayExpense(expense) &&
+      expense.status === 'PAID' &&
+      expense.payoutMethod === 'other';
 
     const canReject =
       LoggedInUser &&
@@ -385,7 +391,7 @@ class Expense extends React.Component {
                   </div>
                 </div>
               )}
-              {mode !== 'edit' && (canPay || canApprove || canReject) && (
+              {mode !== 'edit' && (canPay || canApprove || canReject || canReverseOtherPayment) && (
                 <div className="manageExpense">
                   {canPay && expense.payoutMethod === 'other' && (
                     <EditPayExpenseFeesForm
@@ -408,6 +414,7 @@ class Expense extends React.Component {
                     )}
                     {canApprove && <ApproveExpenseBtn id={expense.id} />}
                     {canReject && <RejectExpenseBtn id={expense.id} />}
+                    {canReverseOtherPayment && <MarkExpenseAsUnpaidBtn id={expense.id} />}
                   </div>
                 </div>
               )}

--- a/components/expenses/Expense.js
+++ b/components/expenses/Expense.js
@@ -156,7 +156,7 @@ class Expense extends React.Component {
     mode = mode || view;
 
     const canPay = LoggedInUser && LoggedInUser.canPayExpense(expense) && expense.status === 'APPROVED';
-    const canReverseOtherPayment =
+    const canMarkExpenseAsUnpaid =
       LoggedInUser &&
       LoggedInUser.canPayExpense(expense) &&
       expense.status === 'PAID' &&
@@ -391,7 +391,7 @@ class Expense extends React.Component {
                   </div>
                 </div>
               )}
-              {mode !== 'edit' && (canPay || canApprove || canReject || canReverseOtherPayment) && (
+              {mode !== 'edit' && (canPay || canApprove || canReject || canMarkExpenseAsUnpaid) && (
                 <div className="manageExpense">
                   {canPay && expense.payoutMethod === 'other' && (
                     <EditPayExpenseFeesForm
@@ -414,7 +414,7 @@ class Expense extends React.Component {
                     )}
                     {canApprove && <ApproveExpenseBtn id={expense.id} />}
                     {canReject && <RejectExpenseBtn id={expense.id} />}
-                    {canReverseOtherPayment && <MarkExpenseAsUnpaidBtn id={expense.id} />}
+                    {canMarkExpenseAsUnpaid && <MarkExpenseAsUnpaidBtn id={expense.id} />}
                   </div>
                 </div>
               )}

--- a/components/expenses/MarkExpenseAsUnpaidBtn.js
+++ b/components/expenses/MarkExpenseAsUnpaidBtn.js
@@ -49,7 +49,7 @@ const MarkExpenseAsUnpaidBtn = ({ id, markExpenseAsUnpaid }) => {
           mt={2}
           buttonStyle="secondary"
         >
-          <FormattedMessage id="expense.markAsUnpaid.btn" defaultMessage="mark as unpaid" />
+          <FormattedMessage id="expense.markAsUnpaid.btn" defaultMessage="Mark as unpaid" />
         </StyledButton>
       )}
     </Fragment>

--- a/components/expenses/MarkExpenseAsUnpaidBtn.js
+++ b/components/expenses/MarkExpenseAsUnpaidBtn.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import gql from 'graphql-tag';
+import { graphql } from 'react-apollo';
+import { FormattedMessage } from 'react-intl';
+
+import StyledButton from '../StyledButton';
+
+const MarkExpenseAsUnpaidBtn = ({ id, markExpenseAsUnpaid }) => {
+  async function handleOnClick() {
+    try {
+      await markExpenseAsUnpaid(id);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  return (
+    <StyledButton onClick={() => handleOnClick()} mt={2} buttonStyle="secondary">
+      <FormattedMessage id="expense.markAsUnpaid.btn" defaultMessage="mark as unpaid" />
+    </StyledButton>
+  );
+};
+
+MarkExpenseAsUnpaidBtn.propTypes = {
+  id: PropTypes.number.isRequired,
+  markExpenseAsUnpaid: PropTypes.func.isRequired,
+};
+
+const markExpenseAsUnpaidQuery = gql`
+  mutation markExpenseAsUnpaid($id: Int!) {
+    markExpenseAsUnpaid(id: $id) {
+      id
+      status
+    }
+  }
+`;
+
+const addMutation = graphql(markExpenseAsUnpaidQuery, {
+  props: ({ mutate }) => ({
+    markExpenseAsUnpaid: async id => {
+      return await mutate({ variables: { id } });
+    },
+  }),
+});
+
+export default addMutation(MarkExpenseAsUnpaidBtn);

--- a/lang/de.json
+++ b/lang/de.json
@@ -549,7 +549,7 @@
   "expense.expensePolicy.add": "add an expense policy",
   "expense.hostFeeInCollectiveCurrency": "host fee",
   "expense.incurredAt": "Date",
-  "expense.markAsUnpaid.btn": "mark as unpaid",
+  "expense.markAsUnpaid.btn": "Mark as unpaid",
   "expense.markAsUnpaid.continue.btn": "Continue",
   "expense.new.submit": "Submit Expense",
   "expense.paid": "paid",

--- a/lang/de.json
+++ b/lang/de.json
@@ -550,6 +550,7 @@
   "expense.hostFeeInCollectiveCurrency": "host fee",
   "expense.incurredAt": "Date",
   "expense.markAsUnpaid.btn": "mark as unpaid",
+  "expense.markAsUnpaid.continue.btn": "Continue",
   "expense.new.submit": "Submit Expense",
   "expense.paid": "paid",
   "expense.pay.btn": "pay with {paymentMethod}",

--- a/lang/de.json
+++ b/lang/de.json
@@ -549,6 +549,7 @@
   "expense.expensePolicy.add": "add an expense policy",
   "expense.hostFeeInCollectiveCurrency": "host fee",
   "expense.incurredAt": "Date",
+  "expense.markAsUnpaid.btn": "mark as unpaid",
   "expense.new.submit": "Submit Expense",
   "expense.paid": "paid",
   "expense.pay.btn": "pay with {paymentMethod}",

--- a/lang/en.json
+++ b/lang/en.json
@@ -549,7 +549,7 @@
   "expense.expensePolicy.add": "add an expense policy",
   "expense.hostFeeInCollectiveCurrency": "host fee",
   "expense.incurredAt": "Date",
-  "expense.markAsUnpaid.btn": "mark as unpaid",
+  "expense.markAsUnpaid.btn": "Mark as unpaid",
   "expense.markAsUnpaid.continue.btn": "Continue",
   "expense.new.submit": "Submit Expense",
   "expense.paid": "paid",

--- a/lang/en.json
+++ b/lang/en.json
@@ -550,6 +550,7 @@
   "expense.hostFeeInCollectiveCurrency": "host fee",
   "expense.incurredAt": "Date",
   "expense.markAsUnpaid.btn": "mark as unpaid",
+  "expense.markAsUnpaid.continue.btn": "Continue",
   "expense.new.submit": "Submit Expense",
   "expense.paid": "paid",
   "expense.pay.btn": "pay with {paymentMethod}",

--- a/lang/en.json
+++ b/lang/en.json
@@ -549,6 +549,7 @@
   "expense.expensePolicy.add": "add an expense policy",
   "expense.hostFeeInCollectiveCurrency": "host fee",
   "expense.incurredAt": "Date",
+  "expense.markAsUnpaid.btn": "mark as unpaid",
   "expense.new.submit": "Submit Expense",
   "expense.paid": "paid",
   "expense.pay.btn": "pay with {paymentMethod}",

--- a/lang/es.json
+++ b/lang/es.json
@@ -549,6 +549,7 @@
   "expense.expensePolicy.add": "add an expense policy",
   "expense.hostFeeInCollectiveCurrency": "comisión del host",
   "expense.incurredAt": "Fecha",
+  "expense.markAsUnpaid.btn": "mark as unpaid",
   "expense.new.submit": "Enviar gasto",
   "expense.paid": "pagado",
   "expense.pay.btn": "pague con {paymentMethod}",

--- a/lang/es.json
+++ b/lang/es.json
@@ -550,6 +550,7 @@
   "expense.hostFeeInCollectiveCurrency": "comisión del host",
   "expense.incurredAt": "Fecha",
   "expense.markAsUnpaid.btn": "mark as unpaid",
+  "expense.markAsUnpaid.continue.btn": "Continue",
   "expense.new.submit": "Enviar gasto",
   "expense.paid": "pagado",
   "expense.pay.btn": "pague con {paymentMethod}",

--- a/lang/es.json
+++ b/lang/es.json
@@ -549,7 +549,7 @@
   "expense.expensePolicy.add": "add an expense policy",
   "expense.hostFeeInCollectiveCurrency": "comisión del host",
   "expense.incurredAt": "Fecha",
-  "expense.markAsUnpaid.btn": "mark as unpaid",
+  "expense.markAsUnpaid.btn": "Mark as unpaid",
   "expense.markAsUnpaid.continue.btn": "Continue",
   "expense.new.submit": "Enviar gasto",
   "expense.paid": "pagado",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -549,7 +549,7 @@
   "expense.expensePolicy.add": "Ajouter des règles de dépense",
   "expense.hostFeeInCollectiveCurrency": "commission de l'hôte",
   "expense.incurredAt": "Date",
-  "expense.markAsUnpaid.btn": "mark as unpaid",
+  "expense.markAsUnpaid.btn": "Mark as unpaid",
   "expense.markAsUnpaid.continue.btn": "Continue",
   "expense.new.submit": "Ajouter une dépense",
   "expense.paid": "payé",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -549,6 +549,7 @@
   "expense.expensePolicy.add": "Ajouter des règles de dépense",
   "expense.hostFeeInCollectiveCurrency": "commission de l'hôte",
   "expense.incurredAt": "Date",
+  "expense.markAsUnpaid.btn": "mark as unpaid",
   "expense.new.submit": "Ajouter une dépense",
   "expense.paid": "payé",
   "expense.pay.btn": "payer avec {paymentMethod}",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -550,6 +550,7 @@
   "expense.hostFeeInCollectiveCurrency": "commission de l'hôte",
   "expense.incurredAt": "Date",
   "expense.markAsUnpaid.btn": "mark as unpaid",
+  "expense.markAsUnpaid.continue.btn": "Continue",
   "expense.new.submit": "Ajouter une dépense",
   "expense.paid": "payé",
   "expense.pay.btn": "payer avec {paymentMethod}",

--- a/lang/it.json
+++ b/lang/it.json
@@ -549,7 +549,7 @@
   "expense.expensePolicy.add": "add an expense policy",
   "expense.hostFeeInCollectiveCurrency": "host fee",
   "expense.incurredAt": "Date",
-  "expense.markAsUnpaid.btn": "mark as unpaid",
+  "expense.markAsUnpaid.btn": "Mark as unpaid",
   "expense.markAsUnpaid.continue.btn": "Continue",
   "expense.new.submit": "Submit Expense",
   "expense.paid": "paid",

--- a/lang/it.json
+++ b/lang/it.json
@@ -550,6 +550,7 @@
   "expense.hostFeeInCollectiveCurrency": "host fee",
   "expense.incurredAt": "Date",
   "expense.markAsUnpaid.btn": "mark as unpaid",
+  "expense.markAsUnpaid.continue.btn": "Continue",
   "expense.new.submit": "Submit Expense",
   "expense.paid": "paid",
   "expense.pay.btn": "pay with {paymentMethod}",

--- a/lang/it.json
+++ b/lang/it.json
@@ -549,6 +549,7 @@
   "expense.expensePolicy.add": "add an expense policy",
   "expense.hostFeeInCollectiveCurrency": "host fee",
   "expense.incurredAt": "Date",
+  "expense.markAsUnpaid.btn": "mark as unpaid",
   "expense.new.submit": "Submit Expense",
   "expense.paid": "paid",
   "expense.pay.btn": "pay with {paymentMethod}",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -549,7 +549,7 @@
   "expense.expensePolicy.add": "請求ポリシーを追加",
   "expense.hostFeeInCollectiveCurrency": "ホストの手数料",
   "expense.incurredAt": "日付",
-  "expense.markAsUnpaid.btn": "mark as unpaid",
+  "expense.markAsUnpaid.btn": "Mark as unpaid",
   "expense.markAsUnpaid.continue.btn": "Continue",
   "expense.new.submit": "経費申請する",
   "expense.paid": "支払い済み",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -550,6 +550,7 @@
   "expense.hostFeeInCollectiveCurrency": "ホストの手数料",
   "expense.incurredAt": "日付",
   "expense.markAsUnpaid.btn": "mark as unpaid",
+  "expense.markAsUnpaid.continue.btn": "Continue",
   "expense.new.submit": "経費申請する",
   "expense.paid": "支払い済み",
   "expense.pay.btn": "{paymentMethod} で支払う",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -549,6 +549,7 @@
   "expense.expensePolicy.add": "請求ポリシーを追加",
   "expense.hostFeeInCollectiveCurrency": "ホストの手数料",
   "expense.incurredAt": "日付",
+  "expense.markAsUnpaid.btn": "mark as unpaid",
   "expense.new.submit": "経費申請する",
   "expense.paid": "支払い済み",
   "expense.pay.btn": "{paymentMethod} で支払う",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -549,7 +549,7 @@
   "expense.expensePolicy.add": "add an expense policy",
   "expense.hostFeeInCollectiveCurrency": "host fee",
   "expense.incurredAt": "Date",
-  "expense.markAsUnpaid.btn": "mark as unpaid",
+  "expense.markAsUnpaid.btn": "Mark as unpaid",
   "expense.markAsUnpaid.continue.btn": "Continue",
   "expense.new.submit": "Submit Expense",
   "expense.paid": "paid",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -550,6 +550,7 @@
   "expense.hostFeeInCollectiveCurrency": "host fee",
   "expense.incurredAt": "Date",
   "expense.markAsUnpaid.btn": "mark as unpaid",
+  "expense.markAsUnpaid.continue.btn": "Continue",
   "expense.new.submit": "Submit Expense",
   "expense.paid": "paid",
   "expense.pay.btn": "pay with {paymentMethod}",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -549,6 +549,7 @@
   "expense.expensePolicy.add": "add an expense policy",
   "expense.hostFeeInCollectiveCurrency": "host fee",
   "expense.incurredAt": "Date",
+  "expense.markAsUnpaid.btn": "mark as unpaid",
   "expense.new.submit": "Submit Expense",
   "expense.paid": "paid",
   "expense.pay.btn": "pay with {paymentMethod}",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -549,7 +549,7 @@
   "expense.expensePolicy.add": "add an expense policy",
   "expense.hostFeeInCollectiveCurrency": "host fee",
   "expense.incurredAt": "Date",
-  "expense.markAsUnpaid.btn": "mark as unpaid",
+  "expense.markAsUnpaid.btn": "Mark as unpaid",
   "expense.markAsUnpaid.continue.btn": "Continue",
   "expense.new.submit": "Submit Expense",
   "expense.paid": "paid",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -550,6 +550,7 @@
   "expense.hostFeeInCollectiveCurrency": "host fee",
   "expense.incurredAt": "Date",
   "expense.markAsUnpaid.btn": "mark as unpaid",
+  "expense.markAsUnpaid.continue.btn": "Continue",
   "expense.new.submit": "Submit Expense",
   "expense.paid": "paid",
   "expense.pay.btn": "pay with {paymentMethod}",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -549,6 +549,7 @@
   "expense.expensePolicy.add": "add an expense policy",
   "expense.hostFeeInCollectiveCurrency": "host fee",
   "expense.incurredAt": "Date",
+  "expense.markAsUnpaid.btn": "mark as unpaid",
   "expense.new.submit": "Submit Expense",
   "expense.paid": "paid",
   "expense.pay.btn": "pay with {paymentMethod}",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -549,6 +549,7 @@
   "expense.expensePolicy.add": "add an expense policy",
   "expense.hostFeeInCollectiveCurrency": "comissão do organizador",
   "expense.incurredAt": "Data",
+  "expense.markAsUnpaid.btn": "mark as unpaid",
   "expense.new.submit": "Enviar despesa",
   "expense.paid": "pago",
   "expense.pay.btn": "pagar com {paymentMethod}",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -549,7 +549,7 @@
   "expense.expensePolicy.add": "add an expense policy",
   "expense.hostFeeInCollectiveCurrency": "comissão do organizador",
   "expense.incurredAt": "Data",
-  "expense.markAsUnpaid.btn": "mark as unpaid",
+  "expense.markAsUnpaid.btn": "Mark as unpaid",
   "expense.markAsUnpaid.continue.btn": "Continue",
   "expense.new.submit": "Enviar despesa",
   "expense.paid": "pago",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -550,6 +550,7 @@
   "expense.hostFeeInCollectiveCurrency": "comissão do organizador",
   "expense.incurredAt": "Data",
   "expense.markAsUnpaid.btn": "mark as unpaid",
+  "expense.markAsUnpaid.continue.btn": "Continue",
   "expense.new.submit": "Enviar despesa",
   "expense.paid": "pago",
   "expense.pay.btn": "pagar com {paymentMethod}",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -550,6 +550,7 @@
   "expense.hostFeeInCollectiveCurrency": "комиссия представителя",
   "expense.incurredAt": "Дата",
   "expense.markAsUnpaid.btn": "mark as unpaid",
+  "expense.markAsUnpaid.continue.btn": "Continue",
   "expense.new.submit": "Учесть расходы",
   "expense.paid": "оплачено",
   "expense.pay.btn": "оплатить при помощи {paymentMethod}",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -549,6 +549,7 @@
   "expense.expensePolicy.add": "добавить политику расходов",
   "expense.hostFeeInCollectiveCurrency": "комиссия представителя",
   "expense.incurredAt": "Дата",
+  "expense.markAsUnpaid.btn": "mark as unpaid",
   "expense.new.submit": "Учесть расходы",
   "expense.paid": "оплачено",
   "expense.pay.btn": "оплатить при помощи {paymentMethod}",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -549,7 +549,7 @@
   "expense.expensePolicy.add": "добавить политику расходов",
   "expense.hostFeeInCollectiveCurrency": "комиссия представителя",
   "expense.incurredAt": "Дата",
-  "expense.markAsUnpaid.btn": "mark as unpaid",
+  "expense.markAsUnpaid.btn": "Mark as unpaid",
   "expense.markAsUnpaid.continue.btn": "Continue",
   "expense.new.submit": "Учесть расходы",
   "expense.paid": "оплачено",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -549,7 +549,7 @@
   "expense.expensePolicy.add": "add an expense policy",
   "expense.hostFeeInCollectiveCurrency": "host fee",
   "expense.incurredAt": "Date",
-  "expense.markAsUnpaid.btn": "mark as unpaid",
+  "expense.markAsUnpaid.btn": "Mark as unpaid",
   "expense.markAsUnpaid.continue.btn": "Continue",
   "expense.new.submit": "Submit Expense",
   "expense.paid": "paid",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -550,6 +550,7 @@
   "expense.hostFeeInCollectiveCurrency": "host fee",
   "expense.incurredAt": "Date",
   "expense.markAsUnpaid.btn": "mark as unpaid",
+  "expense.markAsUnpaid.continue.btn": "Continue",
   "expense.new.submit": "Submit Expense",
   "expense.paid": "paid",
   "expense.pay.btn": "pay with {paymentMethod}",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -549,6 +549,7 @@
   "expense.expensePolicy.add": "add an expense policy",
   "expense.hostFeeInCollectiveCurrency": "host fee",
   "expense.incurredAt": "Date",
+  "expense.markAsUnpaid.btn": "mark as unpaid",
   "expense.new.submit": "Submit Expense",
   "expense.paid": "paid",
   "expense.pay.btn": "pay with {paymentMethod}",

--- a/lib/graphql/schema.graphql
+++ b/lib/graphql/schema.graphql
@@ -1512,6 +1512,7 @@ type Mutation {
   createExpense(expense: ExpenseInputType!): ExpenseType
   editExpense(expense: ExpenseInputType!): ExpenseType
   deleteExpense(id: Int!): ExpenseType
+  markExpenseAsUnpaid(id: Int!): ExpenseType
 
   """
   Update a single tier

--- a/lib/graphql/schema.graphql
+++ b/lib/graphql/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:3060/graphql
-# timestamp: Thu Oct 03 2019 11:57:30 GMT+0200 (GMT+02:00)
+# timestamp: Sun Oct 06 2019 22:51:40 GMT+0100 (West Africa Standard Time)
 
 """
 Application model
@@ -1512,7 +1512,7 @@ type Mutation {
   createExpense(expense: ExpenseInputType!): ExpenseType
   editExpense(expense: ExpenseInputType!): ExpenseType
   deleteExpense(id: Int!): ExpenseType
-  markExpenseAsUnpaid(id: Int!): ExpenseType
+  markExpenseAsUnpaid(id: Int!, processorFeeRefunded: Boolean!): ExpenseType
 
   """
   Update a single tier


### PR DESCRIPTION
This PR follows up https://github.com/opencollective/opencollective/issues/2324, the goal is to give host admin ability to mark paid expense with other payout method as unpaid.

API - https://github.com/opencollective/opencollective-api/pull/2652

#### Screenshot
<img width="554" alt="Screenshot 2019-10-02 at 6 23 45 PM" src="https://user-images.githubusercontent.com/15707013/66066637-cc9d3300-e541-11e9-8da6-62b8b990e5e2.png">
