### PR TITLE
fix(payexpensefeesform): fix form field spacing in expense fee form

### DIFF
--- a/components/expenses/EditPayExpenseFeesForm.js
+++ b/components/expenses/EditPayExpenseFeesForm.js
@@ -52,7 +52,7 @@ class EditPayExpenseFees extends React.Component {
               font-size: 1.2rem;
             }
             .col {
-              width: 13rem;
+              width: 14rem;
               margin-right: 2rem;
             }
             label {

--- a/components/expenses/PayExpenseBtn.js
+++ b/components/expenses/PayExpenseBtn.js
@@ -91,7 +91,7 @@ class PayExpenseBtn extends React.Component {
         <style jsx>
           {`
             .PayExpenseBtn {
-              align-items: flex-end;
+              align-items: center;
               display: flex;
               flex-wrap: wrap;
             }


### PR DESCRIPTION
fixed spacing in the fields of the expense fee form

![image](https://user-images.githubusercontent.com/21009455/66132466-bd39ea80-e612-11e9-961c-41df8521c01b.png)

@piamancini this is how this looks, pretty straightforward, lmk if we'd like more space. :)

@znarf @Betree did a trivial fix, would love to know if we're going for a diff solution. Thanks!

PS: Also centered the error message with the button since it looks better now, lmk if we'd like to revert that.

Fix: https://github.com/opencollective/opencollective/issues/1828