### PR TITLE
feat: Enable deletion of rejected expenses #2337

### DIFF
--- a/components/SmallButton.js
+++ b/components/SmallButton.js
@@ -65,12 +65,14 @@ class SmallButton extends React.Component {
               border-color: #3399ff;
               color: white;
             }
-            .SmallButton.reject button {
+            .SmallButton.reject button,
+            .SmallButton.delete button {
               background: white;
               border: solid 2px #e63956;
               color: #e63956;
             }
-            .SmallButton.reject button:hover {
+            .SmallButton.reject button:hover,
+            .SmallButton.delete button:hover {
               background: #e63956;
               border: solid 2px #e63956;
               color: white;

--- a/components/expenses/DeleteExpenseBtn.js
+++ b/components/expenses/DeleteExpenseBtn.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import gql from 'graphql-tag';
+import { graphql } from 'react-apollo';
+import { FormattedMessage } from 'react-intl';
+
+import SmallButton from '../SmallButton';
+
+class DeleteExpenseBtn extends React.Component {
+  static propTypes = {
+    id: PropTypes.number.isRequired,
+    deleteExpense: PropTypes.func.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.onClick = this.onClick.bind(this);
+  }
+
+  async onClick() {
+    const { id } = this.props;
+    const res = window.confirm('Do you want to delete this rejected expense?');
+    if (res == true) {
+      await this.props.deleteExpense(id);
+    }
+  }
+
+  render() {
+    return (
+      <div className="DeleteExpenseBtn">
+        <SmallButton className="delete" bsStyle="danger" onClick={this.onClick}>
+          <FormattedMessage id="expense.delete.btn" defaultMessage="delete" />
+        </SmallButton>
+      </div>
+    );
+  }
+}
+
+const deleteExpenseQuery = gql`
+  mutation deleteExpense($id: Int!) {
+    deleteExpense(id: $id) {
+      id
+      status
+    }
+  }
+`;
+
+const addMutation = graphql(deleteExpenseQuery, {
+  props: ({ mutate }) => ({
+    deleteExpense: async id => {
+      return await mutate({ variables: { id } });
+    },
+  }),
+});
+
+export default addMutation(DeleteExpenseBtn);

--- a/components/expenses/Expense.js
+++ b/components/expenses/Expense.js
@@ -16,6 +16,7 @@ import ExpenseDetails from './ExpenseDetails';
 import ExpenseNeedsTaxFormBadge from './ExpenseNeedsTaxFormBadge';
 import ApproveExpenseBtn from './ApproveExpenseBtn';
 import RejectExpenseBtn from './RejectExpenseBtn';
+import DeleteExpenseBtn from './DeleteExpenseBtn';
 import PayExpenseBtn from './PayExpenseBtn';
 import EditPayExpenseFeesForm from './EditPayExpenseFeesForm';
 
@@ -170,6 +171,7 @@ class Expense extends React.Component {
       (expense.status === 'PENDING' ||
         (expense.status === 'REJECTED' && Date.now() - new Date(expense.updatedAt).getTime() < 60 * 1000 * 15)); // we can approve an expense for up to 10mn after rejecting it
 
+    const canDelete = LoggedInUser && LoggedInUser.canApproveExpense(expense) && expense.status === 'REJECTED';
     return (
       <div className={`expense ${status} ${this.state.mode}View`}>
         <style jsx>
@@ -385,7 +387,7 @@ class Expense extends React.Component {
                   </div>
                 </div>
               )}
-              {mode !== 'edit' && (canPay || canApprove || canReject) && (
+              {mode !== 'edit' && (canPay || canApprove || canReject || canDelete) && (
                 <div className="manageExpense">
                   {canPay && expense.payoutMethod === 'other' && (
                     <EditPayExpenseFeesForm
@@ -408,6 +410,7 @@ class Expense extends React.Component {
                     )}
                     {canApprove && <ApproveExpenseBtn id={expense.id} />}
                     {canReject && <RejectExpenseBtn id={expense.id} />}
+                    {canDelete && <DeleteExpenseBtn id={expense.id} />}
                   </div>
                 </div>
               )}

--- a/lang/de.json
+++ b/lang/de.json
@@ -545,6 +545,7 @@
   "expense.closeDetails": "Close Details",
   "expense.created": "Your expense has been submitted with success. It is now pending approval from one of the core contributors of the collective. You will be notified by email once it has been approved. Then, the host ({host}) will proceed to reimburse your expense.",
   "expense.created.noHost": "Your expense has been submitted with success. It is now pending approval from one of the core contributors of the collective. You will be notified by email once it has been approved.",
+  "expense.delete.btn": "delete",
   "expense.description": "description",
   "expense.disclaimer": "You must upload a valid receipt or invoice clearly showing the total amount, date, legal address, and what the payment is for.",
   "expense.edit": "edit",

--- a/lang/en.json
+++ b/lang/en.json
@@ -545,6 +545,7 @@
   "expense.closeDetails": "Close Details",
   "expense.created": "Your expense has been submitted with success. It is now pending approval from one of the core contributors of the collective. You will be notified by email once it has been approved. Then, the host ({host}) will proceed to reimburse your expense.",
   "expense.created.noHost": "Your expense has been submitted with success. It is now pending approval from one of the core contributors of the collective. You will be notified by email once it has been approved.",
+  "expense.delete.btn": "delete",
   "expense.description": "description",
   "expense.disclaimer": "You must upload a valid receipt or invoice clearly showing the total amount, date, legal address, and what the payment is for.",
   "expense.edit": "edit",

--- a/lang/es.json
+++ b/lang/es.json
@@ -545,6 +545,7 @@
   "expense.closeDetails": "Cerrar Detalles",
   "expense.created": "Your expense has been submitted with success. It is now pending approval from one of the core contributors of the collective. You will be notified by email once it has been approved. Then, the host {host} will proceed to reimburse your expense.",
   "expense.created.noHost": "Su gasto ha sido enviado con éxito. Ahora está pendiente la aprobación de uno de los contribuyentes principales del colectivo. Se le notificará por correo electrónico una vez que haya sido aprobado.",
+  "expense.delete.btn": "delete",
   "expense.description": "descripción",
   "expense.disclaimer": "You must upload a valid receipt or invoice clearly showing the total amount, date, legal address, and what the payment is for.",
   "expense.edit": "editar",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -545,6 +545,7 @@
   "expense.closeDetails": "Fermer les détails",
   "expense.created": "Votre dépense a bien été soumise avec succès. Elle est maintenant en attente d'approbation par les administrateurs du collectif. Vous serez notifié dès qu'elle aura été approuvée. Ensuite, l'hôte du collectif ({host}) procédera au remboursement.",
   "expense.created.noHost": "Votre dépense a bien été soumise avec succès. Elle est maintenant en attente d'approbation par les administrateurs du collectif. Vous serez notifié dès qu'elle aura été approuvée.",
+  "expense.delete.btn": "delete",
   "expense.description": "description",
   "expense.disclaimer": "Vous devez téléverser un reçu ou une facture valide affichant de manière claire le montant total, la date, l'adresse légale et l'objet du paiement.",
   "expense.edit": "éditer",

--- a/lang/it.json
+++ b/lang/it.json
@@ -545,6 +545,7 @@
   "expense.closeDetails": "Close Details",
   "expense.created": "Your expense has been submitted with success. It is now pending approval from one of the core contributors of the collective. You will be notified by email once it has been approved. Then, the host ({host}) will proceed to reimburse your expense.",
   "expense.created.noHost": "Your expense has been submitted with success. It is now pending approval from one of the core contributors of the collective. You will be notified by email once it has been approved.",
+  "expense.delete.btn": "delete",
   "expense.description": "description",
   "expense.disclaimer": "You must upload a valid receipt or invoice clearly showing the total amount, date, legal address, and what the payment is for.",
   "expense.edit": "edit",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -545,6 +545,7 @@
   "expense.closeDetails": "詳細を閉じる",
   "expense.created": "あなたの経費申請は成功しました。現在コレクティブのコアコントリビューターからの承認を待っています。承認されるとメールで通知されます。それからホスト ({host}) があなたの経費を払い戻します。",
   "expense.created.noHost": "Your expense has been submitted with success. It is now pending approval from one of the core contributors of the collective. You will be notified by email once it has been approved.",
+  "expense.delete.btn": "delete",
   "expense.description": "説明",
   "expense.disclaimer": "You must upload a valid receipt or invoice clearly showing the total amount, date, legal address, and what the payment is for.",
   "expense.edit": "編集",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -545,6 +545,7 @@
   "expense.closeDetails": "Close Details",
   "expense.created": "Your expense has been submitted with success. It is now pending approval from one of the core contributors of the collective. You will be notified by email once it has been approved. Then, the host ({host}) will proceed to reimburse your expense.",
   "expense.created.noHost": "Your expense has been submitted with success. It is now pending approval from one of the core contributors of the collective. You will be notified by email once it has been approved.",
+  "expense.delete.btn": "delete",
   "expense.description": "description",
   "expense.disclaimer": "You must upload a valid receipt or invoice clearly showing the total amount, date, legal address, and what the payment is for.",
   "expense.edit": "edit",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -545,6 +545,7 @@
   "expense.closeDetails": "Close Details",
   "expense.created": "Your expense has been submitted with success. It is now pending approval from one of the core contributors of the collective. You will be notified by email once it has been approved. Then, the host ({host}) will proceed to reimburse your expense.",
   "expense.created.noHost": "Your expense has been submitted with success. It is now pending approval from one of the core contributors of the collective. You will be notified by email once it has been approved.",
+  "expense.delete.btn": "delete",
   "expense.description": "description",
   "expense.disclaimer": "You must upload a valid receipt or invoice clearly showing the total amount, date, legal address, and what the payment is for.",
   "expense.edit": "edit",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -545,6 +545,7 @@
   "expense.closeDetails": "Close Details",
   "expense.created": "Your expense has been submitted with success. It is now pending approval from one of the core contributors of the collective. You will be notified by email once it has been approved. Then, the host ({host}) will proceed to reimburse your expense.",
   "expense.created.noHost": "Your expense has been submitted with success. It is now pending approval from one of the core contributors of the collective. You will be notified by email once it has been approved.",
+  "expense.delete.btn": "delete",
   "expense.description": "description",
   "expense.disclaimer": "You must upload a valid receipt or invoice clearly showing the total amount, date, legal address, and what the payment is for.",
   "expense.edit": "edit",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -545,6 +545,7 @@
   "expense.closeDetails": "Скрыть детали",
   "expense.created": "Your expense has been submitted with success. It is now pending approval from one of the core contributors of the collective. You will be notified by email once it has been approved. Then, the host ({host}) will proceed to reimburse your expense.",
   "expense.created.noHost": "Your expense has been submitted with success. It is now pending approval from one of the core contributors of the collective. You will be notified by email once it has been approved.",
+  "expense.delete.btn": "delete",
   "expense.description": "описание",
   "expense.disclaimer": "You must upload a valid receipt or invoice clearly showing the total amount, date, legal address, and what the payment is for.",
   "expense.edit": "редактировать",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -545,6 +545,7 @@
   "expense.closeDetails": "关闭详情",
   "expense.created": "Your expense has been submitted with success. It is now pending approval from one of the core contributors of the collective. You will be notified by email once it has been approved. Then, the host ({host}) will proceed to reimburse your expense.",
   "expense.created.noHost": "Your expense has been submitted with success. It is now pending approval from one of the core contributors of the collective. You will be notified by email once it has been approved.",
+  "expense.delete.btn": "delete",
   "expense.description": "描述",
   "expense.disclaimer": "You must upload a valid receipt or invoice clearly showing the total amount, date, legal address, and what the payment is for.",
   "expense.edit": "编辑",


### PR DESCRIPTION
This PR aims at resolving [2337 Enable deletion of rejected expenses](https://github.com/opencollective/opencollective/issues/2337) 

The solution goes thus:
- on clicking the reject button, the expense status becomes 'REJECTED' and the 'DELETE' button appears
- on clicking the DELETE button, a `window.confirm` dialog prompts for confirmation
- on clicking YES, a query with the expenseId is sent to the backend to delete the expense

![issue_2337](https://user-images.githubusercontent.com/37955249/66191140-7bc13380-e642-11e9-95ce-9414280c197a.gif)
