### PR TITLE
Prevent zombie card from being used

### DIFF
--- a/components/StyledRadioList.js
+++ b/components/StyledRadioList.js
@@ -44,7 +44,7 @@ const StyledRadioList = ({ children, id, name, onChange, options, keyGetter, dis
                 id={id && key + id}
                 value={key}
                 defaultChecked={props.defaultValue !== undefined && defaultValueStr === key}
-                disabled={disabled}
+                disabled={value.disabled || disabled} // disable a specific option or entire options
               />
             ),
           })}

--- a/components/StyledRadioList.js
+++ b/components/StyledRadioList.js
@@ -44,7 +44,7 @@ const StyledRadioList = ({ children, id, name, onChange, options, keyGetter, dis
                 id={id && key + id}
                 value={key}
                 defaultChecked={props.defaultValue !== undefined && defaultValueStr === key}
-                disabled={value.disabled || disabled} // disable a specific option or entire options
+                disabled={disabled || (value && value.disabled)} // disable a specific option or entire options
               />
             ),
           })}

--- a/components/contribution-flow/StepPayment.js
+++ b/components/contribution-flow/StepPayment.js
@@ -297,6 +297,7 @@ class StepPayment extends React.Component {
               borderBottom={index !== paymentMethodsOptions.length - 1 ? '1px solid' : 'none'}
               bg="white.full"
               borderColor="black.200"
+              css={disabled ? 'filter: grayscale(1);' : undefined}
               cursor={this.getCursor(disabled || this.props.disabled, checked)}
             >
               <Flex alignItems="center">

--- a/components/contribution-flow/StepPayment.js
+++ b/components/contribution-flow/StepPayment.js
@@ -66,18 +66,7 @@ const getPaymentMethodMetadata = pm => {
       />
     );
   } else if (pm.type === 'virtualcard') {
-    if (pm.expiryDate && pm.balance > minBalance) {
-      return (
-        <FormattedMessage
-          id="ContributePayment.balanceAndExpiry"
-          defaultMessage="{balance} left, expires on {expiryDate}"
-          values={{
-            expiryDate: <FormattedDate value={pm.expiryDate} day="numeric" month="long" year="numeric" />,
-            balance: formatCurrency(pm.balance, pm.currency),
-          }}
-        />
-      );
-    } else if (pm.balance < minBalance) {
+    if (pm.balance < minBalance) {
       return (
         <FormattedMessage
           id="ContributePayment.unusableBalance"
@@ -85,6 +74,17 @@ const getPaymentMethodMetadata = pm => {
           values={{
             balance: formatCurrency(pm.balance, pm.currency),
             minBalance: formatCurrency(minBalance, pm.currency),
+          }}
+        />
+      );
+    } else if (pm.expiryDate) {
+      return (
+        <FormattedMessage
+          id="ContributePayment.balanceAndExpiry"
+          defaultMessage="{balance} left, expires on {expiryDate}"
+          values={{
+            expiryDate: <FormattedDate value={pm.expiryDate} day="numeric" month="long" year="numeric" />,
+            balance: formatCurrency(pm.balance, pm.currency),
           }}
         />
       );

--- a/components/contribution-flow/StepPayment.js
+++ b/components/contribution-flow/StepPayment.js
@@ -36,6 +36,8 @@ const PaymentEntryContainer = styled(Container)`
   }
 `;
 
+const minBalance = 50; // Minimum usable balance for virtual card
+
 const getPaymentMethodIcon = (pm, collective) => {
   if (pm.type === 'creditcard') {
     return <CreditCard />;
@@ -64,7 +66,7 @@ const getPaymentMethodMetadata = pm => {
       />
     );
   } else if (pm.type === 'virtualcard') {
-    if (pm.expiryDate) {
+    if (pm.expiryDate && pm.balance > minBalance) {
       return (
         <FormattedMessage
           id="ContributePayment.balanceAndExpiry"
@@ -72,6 +74,17 @@ const getPaymentMethodMetadata = pm => {
           values={{
             expiryDate: <FormattedDate value={pm.expiryDate} day="numeric" month="long" year="numeric" />,
             balance: formatCurrency(pm.balance, pm.currency),
+          }}
+        />
+      );
+    } else if (pm.balance < minBalance) {
+      return (
+        <FormattedMessage
+          id="ContributePayment.unusableBalance"
+          defaultMessage="{balance} left, balance less than {minBalance} cannot be used."
+          values={{
+            balance: formatCurrency(pm.balance, pm.currency),
+            minBalance: formatCurrency(minBalance, pm.currency),
           }}
         />
       );
@@ -169,7 +182,6 @@ class StepPayment extends React.Component {
 
   generatePaymentsOptions() {
     const { collective, defaultValue, withPaypal, manual } = this.props;
-
     // Add collective payment methods
     const paymentMethodsOptions = (collective.paymentMethods || []).map(pm => ({
       key: `pm-${pm.id}`,
@@ -177,6 +189,7 @@ class StepPayment extends React.Component {
       subtitle: getPaymentMethodMetadata(pm),
       icon: getPaymentMethodIcon(pm, collective),
       paymentMethod: pm,
+      disabled: pm.balance < minBalance,
     }));
 
     // Add other PMs types (new credit card, bank transfer...etc) if collective is not a `COLLECTIVE`
@@ -277,14 +290,14 @@ class StepPayment extends React.Component {
           defaultValue={selectedOption.key}
           disabled={this.props.disabled}
         >
-          {({ radio, checked, index, value: { key, title, subtitle, icon, data } }) => (
+          {({ radio, checked, index, value: { key, title, subtitle, icon, data, disabled } }) => (
             <PaymentEntryContainer
               px={[3, 24]}
               py={3}
               borderBottom={index !== paymentMethodsOptions.length - 1 ? '1px solid' : 'none'}
               bg="white.full"
               borderColor="black.200"
-              cursor={this.getCursor(this.props.disabled, checked)}
+              cursor={this.getCursor(disabled || this.props.disabled, checked)}
             >
               <Flex alignItems="center">
                 <Box as="span" mr={[2, 21]} flexWrap="wrap">

--- a/lang/de.json
+++ b/lang/de.json
@@ -353,6 +353,7 @@
   "ContributePayment.balanceAndExpiry": "{balance} left, expires on {expiryDate}",
   "ContributePayment.balanceLeft": "{balance} left",
   "ContributePayment.expiresOn": "Expires on {expiryDate}",
+  "ContributePayment.unusableBalance": "{balance} left, balance less than {minBalance} cannot be used.",
   "contributeSuccess.discover": "Discover other related collectives to support:",
   "ContributeTier.StartsAt": "Starts at",
   "contribution": "{n, plural, one {contribution} other {contributions}}",

--- a/lang/en.json
+++ b/lang/en.json
@@ -353,6 +353,7 @@
   "ContributePayment.balanceAndExpiry": "{balance} left, expires on {expiryDate}",
   "ContributePayment.balanceLeft": "{balance} left",
   "ContributePayment.expiresOn": "Expires on {expiryDate}",
+  "ContributePayment.unusableBalance": "{balance} left, balance less than {minBalance} cannot be used.",
   "contributeSuccess.discover": "Discover other related collectives to support:",
   "ContributeTier.StartsAt": "Starts at",
   "contribution": "{n, plural, one {contribution} other {contributions}}",

--- a/lang/es.json
+++ b/lang/es.json
@@ -353,6 +353,7 @@
   "ContributePayment.balanceAndExpiry": "{balance} restante, expira en {expiryDate}",
   "ContributePayment.balanceLeft": "{balance} restante",
   "ContributePayment.expiresOn": "Expira el {expiryDate}",
+  "ContributePayment.unusableBalance": "{balance} left, balance less than {minBalance} cannot be used.",
   "contributeSuccess.discover": "Descubre otros colectivos relacionados a los que apoyar:",
   "ContributeTier.StartsAt": "Starts at",
   "contribution": "{n, plural, one {contribution} other {contributions}}",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -353,6 +353,7 @@
   "ContributePayment.balanceAndExpiry": "{balance} restant, expire le {expiryDate}",
   "ContributePayment.balanceLeft": "{balance} restants",
   "ContributePayment.expiresOn": "Expire le {expiryDate}",
+  "ContributePayment.unusableBalance": "{balance} left, balance less than {minBalance} cannot be used.",
   "contributeSuccess.discover": "Découvrez d'autres collectifs similaires à soutenir :",
   "ContributeTier.StartsAt": "À partir de",
   "contribution": "{n, plural, one {contribution} other {contributions}}",

--- a/lang/it.json
+++ b/lang/it.json
@@ -353,6 +353,7 @@
   "ContributePayment.balanceAndExpiry": "{balance} left, expires on {expiryDate}",
   "ContributePayment.balanceLeft": "{balance} left",
   "ContributePayment.expiresOn": "Expires on {expiryDate}",
+  "ContributePayment.unusableBalance": "{balance} left, balance less than {minBalance} cannot be used.",
   "contributeSuccess.discover": "Discover other related collectives to support:",
   "ContributeTier.StartsAt": "Starts at",
   "contribution": "{n, plural, one {contribution} other {contributions}}",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -353,6 +353,7 @@
   "ContributePayment.balanceAndExpiry": "残り {balance} の有効期限が {expiryDate} に切れます",
   "ContributePayment.balanceLeft": "残り {balance}",
   "ContributePayment.expiresOn": "{expiryDate} に期限切れ",
+  "ContributePayment.unusableBalance": "{balance} left, balance less than {minBalance} cannot be used.",
   "contributeSuccess.discover": "サポートするほかのコレクティブを見つける:",
   "ContributeTier.StartsAt": "Starts at",
   "contribution": "{n, plural, one {件のコントリビュート} other {件のコントリビュート}}",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -353,6 +353,7 @@
   "ContributePayment.balanceAndExpiry": "{balance} left, expires on {expiryDate}",
   "ContributePayment.balanceLeft": "{balance} left",
   "ContributePayment.expiresOn": "Expires on {expiryDate}",
+  "ContributePayment.unusableBalance": "{balance} left, balance less than {minBalance} cannot be used.",
   "contributeSuccess.discover": "Discover other related collectives to support:",
   "ContributeTier.StartsAt": "Starts at",
   "contribution": "{n, plural, one {contribution} other {contributions}}",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -353,6 +353,7 @@
   "ContributePayment.balanceAndExpiry": "{balance} left, expires on {expiryDate}",
   "ContributePayment.balanceLeft": "{balance} left",
   "ContributePayment.expiresOn": "Expires on {expiryDate}",
+  "ContributePayment.unusableBalance": "{balance} left, balance less than {minBalance} cannot be used.",
   "contributeSuccess.discover": "Discover other related collectives to support:",
   "ContributeTier.StartsAt": "Starts at",
   "contribution": "{n, plural, one {contribution} other {contributions}}",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -353,6 +353,7 @@
   "ContributePayment.balanceAndExpiry": "{balance} sobrando, vence em {expiryDate}",
   "ContributePayment.balanceLeft": "{balance} sobrando",
   "ContributePayment.expiresOn": "Vence em {expiryDate}",
+  "ContributePayment.unusableBalance": "{balance} left, balance less than {minBalance} cannot be used.",
   "contributeSuccess.discover": "Descubra outros coletivos parecidos para ajudar:",
   "ContributeTier.StartsAt": "Começa em",
   "contribution": "{n, plural, one {contribuição} other {contribuições}}",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -353,6 +353,7 @@
   "ContributePayment.balanceAndExpiry": "{balance} осталось, истекает {expiryDate}",
   "ContributePayment.balanceLeft": "{balance} осталось",
   "ContributePayment.expiresOn": "Истекает {expiryDate}",
+  "ContributePayment.unusableBalance": "{balance} left, balance less than {minBalance} cannot be used.",
   "contributeSuccess.discover": "Discover other related collectives to support:",
   "ContributeTier.StartsAt": "Starts at",
   "contribution": "{n, plural, one {contribution} other {contributions}}",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -353,6 +353,7 @@
   "ContributePayment.balanceAndExpiry": "{balance} left, expires on {expiryDate}",
   "ContributePayment.balanceLeft": "{balance} left",
   "ContributePayment.expiresOn": "Expires on {expiryDate}",
+  "ContributePayment.unusableBalance": "{balance} left, balance less than {minBalance} cannot be used.",
   "contributeSuccess.discover": "Discover other related collectives to support:",
   "ContributeTier.StartsAt": "Starts at",
   "contribution": "{n, plural, one {contribution} other {contributions}}",


### PR DESCRIPTION
Follows up https://github.com/opencollective/opencollective/issues/1524

- Add small enhancement to disable specific option (before you can only disable the entire options)
- Add option subtitle for zombie card.

<img width="512" alt="Screenshot 2019-10-04 at 10 19 37 AM" src="https://user-images.githubusercontent.com/15707013/66196480-84d8f180-e690-11e9-9dab-f7a540547403.png">

