### PR TITLE
Update name and formula of getidx() to change contributor grid

### DIFF
--- a/components/ContributorsGrid.js
+++ b/components/ContributorsGrid.js
@@ -74,8 +74,8 @@ const ContributorCardContainer = styled.div`
 `;
 
 /** Get an index in a single dimension array from a matrix coordinate */
-const getIdx = (colIndex, rowIndex, nbCols) => {
-  return rowIndex * nbCols + colIndex;
+const getContributorIdx = (colIndex, rowIndex, nbRows) => {
+  return rowIndex + nbRows * colIndex;
 };
 
 /** Get the items repartition, aka the number of columns and rows. */
@@ -121,12 +121,12 @@ const ContributorsGrid = ({ contributors, width, maxNbRowsForViewports, viewport
       outerElementType={getGridContainer(paddingLeft, hasScroll)}
       innerElementType={GridInnerContainer}
       itemKey={({ columnIndex, rowIndex }) => {
-        const idx = getIdx(columnIndex, rowIndex, nbCols);
+        const idx = getContributorIdx(columnIndex, rowIndex, nbRows);
         return idx < contributors.length ? contributors[idx].id : `empty-${idx}`;
       }}
     >
       {({ columnIndex, rowIndex, style }) => {
-        const idx = getIdx(columnIndex, rowIndex, nbCols);
+        const idx = getContributorIdx(columnIndex, rowIndex, nbRows);
         const contributor = contributors[idx];
 
         return !contributor ? null : (

--- a/components/ContributorsGrid.js
+++ b/components/ContributorsGrid.js
@@ -74,8 +74,8 @@ const ContributorCardContainer = styled.div`
 `;
 
 /** Get an index in a single dimension array from a matrix coordinate */
-const getContributorIdx = (colIndex, rowIndex, nbRows) => {
-  return rowIndex + nbRows * colIndex;
+const getContributorIdx = (colIndex, rowIndex, nbRows, nbCols, hasScroll) => {
+  return hasScroll ? rowIndex + nbRows * colIndex : rowIndex * nbCols + colIndex;
 };
 
 /** Get the items repartition, aka the number of columns and rows. */
@@ -121,12 +121,12 @@ const ContributorsGrid = ({ contributors, width, maxNbRowsForViewports, viewport
       outerElementType={getGridContainer(paddingLeft, hasScroll)}
       innerElementType={GridInnerContainer}
       itemKey={({ columnIndex, rowIndex }) => {
-        const idx = getContributorIdx(columnIndex, rowIndex, nbRows);
+        const idx = getContributorIdx(columnIndex, rowIndex, nbRows, nbCols, hasScroll);
         return idx < contributors.length ? contributors[idx].id : `empty-${idx}`;
       }}
     >
       {({ columnIndex, rowIndex, style }) => {
-        const idx = getContributorIdx(columnIndex, rowIndex, nbRows);
+        const idx = getContributorIdx(columnIndex, rowIndex, nbRows, nbCols, hasScroll);
         const contributor = contributors[idx];
 
         return !contributor ? null : (


### PR DESCRIPTION
Handling opencollective/opencollective#2459


![Screenshot from 2019-10-04 14-51-05](https://user-images.githubusercontent.com/21286134/66196893-f2981400-e6b6-11e9-8d1a-2c5b13874e3b.png)



- [x] Rename the function to getContributorIdx
- [x] Update the formula
- [x] Ensure it works with a variety of collectives, you can use
         (small) https://staging.opencollective.com/styled-icons
         (medium) https://staging.opencollective.com/vis
        (big) https://staging.opencollective.com/webpack
