### PR TITLE
Show contact button in fiscal host collective page

### DIFF
--- a/components/collective-page/index.js
+++ b/components/collective-page/index.js
@@ -122,7 +122,7 @@ class CollectivePage extends Component {
   getCallsToAction = memoizeOne((type, isHost, isAdmin, isRoot) => {
     const isCollective = type === CollectiveType.COLLECTIVE;
     return {
-      hasContact: isCollective || isHost,
+      hasContact: isCollective || (isHost && !isAdmin),
       hasSubmitExpense: isCollective,
       hasApply: isHost,
       hasDashboard: isHost && isAdmin,

--- a/components/collective-page/index.js
+++ b/components/collective-page/index.js
@@ -122,7 +122,7 @@ class CollectivePage extends Component {
   getCallsToAction = memoizeOne((type, isHost, isAdmin, isRoot) => {
     const isCollective = type === CollectiveType.COLLECTIVE;
     return {
-      hasContact: isCollective,
+      hasContact: isCollective || isHost,
       hasSubmitExpense: isCollective,
       hasApply: isHost,
       hasDashboard: isHost && isAdmin,


### PR DESCRIPTION
Follows up https://github.com/opencollective/opencollective/issues/2080

Basically enable the contact button to be shown in fiscal host collective page, this was only showing for non host collective page before.

<img width="1440" alt="Screenshot 2019-10-04 at 12 07 46 PM" src="https://user-images.githubusercontent.com/15707013/66203185-9b3a7980-e69f-11e9-9ffa-1acc683035af.png">
