### PR TITLE
NCP/Updates: Make refetch func optional

### DIFF
--- a/components/collective-page/sections/Updates.js
+++ b/components/collective-page/sections/Updates.js
@@ -72,7 +72,7 @@ class SectionUpdates extends React.PureComponent {
 
     /** Transactions */
     data: PropTypes.shape({
-      refetch: PropTypes.func.isRequired,
+      refetch: PropTypes.func,
       Collective: PropTypes.shape({
         updates: PropTypes.arrayOf(
           PropTypes.shape({
@@ -98,8 +98,9 @@ class SectionUpdates extends React.PureComponent {
 
   componentDidUpdate(oldProps) {
     // If user log in/out we need to refresh data as it depends on the current user
-    if (oldProps.isLoggedIn !== this.props.isLoggedIn) {
-      this.props.data.refetch();
+    const refetch = get(this.props.data, 'refetch');
+    if (oldProps.isLoggedIn !== this.props.isLoggedIn && refetch) {
+      refetch();
     }
   }
 


### PR DESCRIPTION
This generated a warning on SSR, seems like apollo doesn't provide the function during SSR (or maybe when `loading=true`?)