### PR TITLE
remove emailWaitingForValidation property from the query(LoggedInUser)

### DIFF
--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -89,7 +89,6 @@ export const getLoggedInUserQuery = gql`
       firstName
       lastName
       email
-      emailWaitingForValidation
       paypalEmail
       image
       CollectiveId


### PR DESCRIPTION
Solves **2** of TODOs at https://github.com/opencollective/opencollective/issues/2126

Unnecessary call for this property at `LoggedInUser` as `emailWaitingForValidation` is just used at `EditUserEmailForm` and is anyway queried there - https://github.com/opencollective/opencollective-frontend/blob/enhancement%2Fseggregate-emailWaitingForValidation-loggedinuser/components/EditUserEmailForm.js#L168