### PR TITLE
Host dashboard: Add "Record as paid" button for PayPal

### DIFF
--- a/components/expenses/ApproveExpenseBtn.js
+++ b/components/expenses/ApproveExpenseBtn.js
@@ -4,7 +4,7 @@ import gql from 'graphql-tag';
 import { graphql } from 'react-apollo';
 import { FormattedMessage } from 'react-intl';
 
-import SmallButton from '../SmallButton';
+import StyledButton from '../StyledButton';
 
 class ApproveExpenseBtn extends React.Component {
   static propTypes = {
@@ -27,9 +27,9 @@ class ApproveExpenseBtn extends React.Component {
   render() {
     return (
       <div className="ApproveExpenseBtn" data-cy="approve-expense-btn">
-        <SmallButton className="approve" bsStyle="success" onClick={this.onClick}>
+        <StyledButton className="approve" mr={2} buttonStyle="primary" onClick={this.onClick}>
           <FormattedMessage id="expense.approve.btn" defaultMessage="Approve" />
-        </SmallButton>
+        </StyledButton>
       </div>
     );
   }

--- a/components/expenses/EditPayExpenseFeesForm.js
+++ b/components/expenses/EditPayExpenseFeesForm.js
@@ -12,6 +12,7 @@ class EditPayExpenseFees extends React.Component {
     onChange: PropTypes.func.isRequired,
     disabled: PropTypes.bool,
     canEditPlatformFee: PropTypes.bool,
+    payoutMethod: PropTypes.string,
   };
 
   constructor(props) {
@@ -29,7 +30,7 @@ class EditPayExpenseFees extends React.Component {
   }
 
   render() {
-    const { currency, canEditPlatformFee } = this.props;
+    const { currency, canEditPlatformFee, payoutMethod } = this.props;
 
     return (
       <div className="EditPayExpenseFees">
@@ -81,20 +82,21 @@ class EditPayExpenseFees extends React.Component {
         </style>
 
         <div className="columns fees">
-          <div className="hostFeeInCollectiveCurrency col">
-            <label htmlFor="hostFeeInCollectiveCurrency">
-              <FormattedMessage id="expense.hostFeeInCollectiveCurrency" defaultMessage="host fee" />
-            </label>
-            <InputField
-              defaultValue={0}
-              id="hostFeeInCollectiveCurrency"
-              name="hostFeeInCollectiveCurrency"
-              onChange={hostFeeInCollectiveCurrency => this.handleChange({ hostFeeInCollectiveCurrency })}
-              pre={getCurrencySymbol(currency)}
-              type="currency"
-            />
-          </div>
-
+          {payoutMethod === 'other' && (
+            <div className="hostFeeInCollectiveCurrency col">
+              <label htmlFor="hostFeeInCollectiveCurrency">
+                <FormattedMessage id="expense.hostFeeInCollectiveCurrency" defaultMessage="host fee" />
+              </label>
+              <InputField
+                defaultValue={0}
+                id="hostFeeInCollectiveCurrency"
+                name="hostFeeInCollectiveCurrency"
+                onChange={hostFeeInCollectiveCurrency => this.handleChange({ hostFeeInCollectiveCurrency })}
+                pre={getCurrencySymbol(currency)}
+                type="currency"
+              />
+            </div>
+          )}
           <div className="paymentProcessorFeeInCollectiveCurrency col">
             <label htmlFor="paymentProcessorFeeInCollectiveCurrency">
               <FormattedMessage
@@ -114,7 +116,7 @@ class EditPayExpenseFees extends React.Component {
             />
           </div>
 
-          {canEditPlatformFee && (
+          {canEditPlatformFee && payoutMethod === 'other' && (
             <div className="platformFeeInCollectiveCurrency col">
               <label htmlFor="platformFeeInCollectiveCurrency">
                 <FormattedMessage id="expense.platformFeeInCollectiveCurrency" defaultMessage="platform fee" />

--- a/components/expenses/Expense.js
+++ b/components/expenses/Expense.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
+import styled from 'styled-components';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import { graphql } from 'react-apollo';
+import { Flex } from '@rebass/grid';
 
 import { capitalize, formatCurrency, compose } from '../../lib/utils';
 import colors from '../../lib/constants/colors';
@@ -22,6 +24,11 @@ import MarkExpenseAsUnpaidBtn from './MarkExpenseAsUnpaidBtn';
 import EditPayExpenseFeesForm from './EditPayExpenseFeesForm';
 import ConfirmationModal from '../ConfirmationModal';
 import StyledButton from '../StyledButton';
+import Container from '../Container';
+
+const ExpenseActionsWrapper = styled(Container)`
+  display: flex;
+`;
 
 class Expense extends React.Component {
   static propTypes = {
@@ -438,7 +445,7 @@ class Expense extends React.Component {
                 <Span color="red.500">{intl.formatMessage(this.messages['expenseTypeMissing'])}</Span>
               )}
               {mode !== 'edit' && (canPay || canApprove || canReject || canMarkExpenseAsUnpaid) && (
-                <div className="manageExpense">
+                <Flex flexDirection="column">
                   {canPay && (
                     <EditPayExpenseFeesForm
                       canEditPlatformFee={LoggedInUser.isRoot()}
@@ -447,7 +454,7 @@ class Expense extends React.Component {
                       payoutMethod={expense.payoutMethod}
                     />
                   )}
-                  <div className="expenseActions" data-cy="expense-actions">
+                  <ExpenseActionsWrapper className="expenseActions" data-cy="expense-actions">
                     {canPay && (
                       <PayExpenseBtn
                         expense={expense}
@@ -472,8 +479,8 @@ class Expense extends React.Component {
                     {canMarkExpenseAsUnpaid && <MarkExpenseAsUnpaidBtn refetch={this.props.refetch} id={expense.id} />}
                     {canApprove && <ApproveExpenseBtn refetch={this.props.refetch} id={expense.id} />}
                     {canReject && <RejectExpenseBtn refetch={this.props.refetch} id={expense.id} />}
-                  </div>
-                </div>
+                  </ExpenseActionsWrapper>
+                </Flex>
               )}
             </div>
           )}

--- a/components/expenses/Expense.js
+++ b/components/expenses/Expense.js
@@ -439,11 +439,12 @@ class Expense extends React.Component {
               )}
               {mode !== 'edit' && (canPay || canApprove || canReject || canMarkExpenseAsUnpaid) && (
                 <div className="manageExpense">
-                  {canPay && expense.payoutMethod === 'other' && (
+                  {canPay && (
                     <EditPayExpenseFeesForm
                       canEditPlatformFee={LoggedInUser.isRoot()}
                       currency={collective.currency}
                       onChange={fees => this.handleChange({ fees })}
+                      payoutMethod={expense.payoutMethod}
                     />
                   )}
                   <div className="expenseActions" data-cy="expense-actions">

--- a/components/expenses/Expense.js
+++ b/components/expenses/Expense.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
-import styled from 'styled-components';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import { graphql } from 'react-apollo';
 import { Flex } from '@rebass/grid';
@@ -24,11 +23,6 @@ import MarkExpenseAsUnpaidBtn from './MarkExpenseAsUnpaidBtn';
 import EditPayExpenseFeesForm from './EditPayExpenseFeesForm';
 import ConfirmationModal from '../ConfirmationModal';
 import StyledButton from '../StyledButton';
-import Container from '../Container';
-
-const ExpenseActionsWrapper = styled(Container)`
-  display: flex;
-`;
 
 class Expense extends React.Component {
   static propTypes = {
@@ -454,7 +448,7 @@ class Expense extends React.Component {
                       payoutMethod={expense.payoutMethod}
                     />
                   )}
-                  <ExpenseActionsWrapper className="expenseActions" data-cy="expense-actions">
+                  <Flex data-cy="expense-actions">
                     {canPay && (
                       <PayExpenseBtn
                         expense={expense}
@@ -479,7 +473,7 @@ class Expense extends React.Component {
                     {canMarkExpenseAsUnpaid && <MarkExpenseAsUnpaidBtn refetch={this.props.refetch} id={expense.id} />}
                     {canApprove && <ApproveExpenseBtn refetch={this.props.refetch} id={expense.id} />}
                     {canReject && <RejectExpenseBtn refetch={this.props.refetch} id={expense.id} />}
-                  </ExpenseActionsWrapper>
+                  </Flex>
                 </Flex>
               )}
             </div>

--- a/components/expenses/PayExpenseBtn.js
+++ b/components/expenses/PayExpenseBtn.js
@@ -31,7 +31,7 @@ class PayExpenseBtn extends React.Component {
       loading: false,
       paymentProcessorFeeInCollectiveCurrency: 0,
     };
-    this.onClick = this.onClick.bind(this);
+
     this.messages = defineMessages({
       'paypal.missing': {
         id: 'expense.payoutMethod.paypal.missing',
@@ -40,7 +40,7 @@ class PayExpenseBtn extends React.Component {
     });
   }
 
-  async onClick() {
+  async handleOnClickPay(forceManual = false) {
     const { expense, lock, unlock } = this.props;
     if (this.props.disabled) {
       return;
@@ -53,6 +53,7 @@ class PayExpenseBtn extends React.Component {
         this.props.paymentProcessorFeeInCollectiveCurrency,
         this.props.hostFeeInCollectiveCurrency,
         this.props.platformFeeInCollectiveCurrency,
+        forceManual,
       );
       this.setState({ loading: false });
       await this.props.refetch();
@@ -134,7 +135,7 @@ class PayExpenseBtn extends React.Component {
         <StyledButton
           className="pay"
           buttonStyle="success"
-          onClick={this.onClick}
+          onClick={() => this.handleOnClickPay(true)}
           disabled={this.props.disabled || disabled}
           title={title}
         >
@@ -144,7 +145,7 @@ class PayExpenseBtn extends React.Component {
             <StyledButton
             className="pay"
             buttonStyle="success"
-            onClick={this.onClick}
+            onClick={() => this.handleOnClickPay()}
             disabled={this.props.disabled || disabled}
             title={title}
           >
@@ -167,12 +168,14 @@ const payExpenseQuery = gql`
     $paymentProcessorFeeInCollectiveCurrency: Int
     $hostFeeInCollectiveCurrency: Int
     $platformFeeInCollectiveCurrency: Int
+    $forcedManual: Boolean
   ) {
     payExpense(
       id: $id
       paymentProcessorFeeInCollectiveCurrency: $paymentProcessorFeeInCollectiveCurrency
       hostFeeInCollectiveCurrency: $hostFeeInCollectiveCurrency
       platformFeeInCollectiveCurrency: $platformFeeInCollectiveCurrency
+      forceManual: $forceManual
     ) {
       id
       status
@@ -201,6 +204,7 @@ const addMutation = graphql(payExpenseQuery, {
       paymentProcessorFeeInCollectiveCurrency,
       hostFeeInCollectiveCurrency,
       platformFeeInCollectiveCurrency,
+      manuallyPayPaypalMethod,
     ) => {
       return await mutate({
         variables: {
@@ -208,6 +212,7 @@ const addMutation = graphql(payExpenseQuery, {
           paymentProcessorFeeInCollectiveCurrency,
           hostFeeInCollectiveCurrency,
           platformFeeInCollectiveCurrency,
+          manuallyPayPaypalMethod,
         },
       });
     },

--- a/components/expenses/PayExpenseBtn.js
+++ b/components/expenses/PayExpenseBtn.js
@@ -126,6 +126,9 @@ class PayExpenseBtn extends React.Component {
             .processorFee .inputField {
               margin-top: 0.5rem;
             }
+            .recordAsPaid {
+              margin-right: 5px;
+            }
           `}
         </style>
         <StyledButton

--- a/components/expenses/PayExpenseBtn.js
+++ b/components/expenses/PayExpenseBtn.js
@@ -96,6 +96,7 @@ class PayExpenseBtn extends React.Component {
               align-items: center;
               display: flex;
               flex-wrap: wrap;
+              justify-content: space-between;
             }
             .error {
               display: flex;
@@ -134,17 +135,23 @@ class PayExpenseBtn extends React.Component {
           disabled={this.props.disabled || disabled}
           title={title}
         >
-          {selectedPayoutMethod === 'other' && (
-            <FormattedMessage id="expense.pay.manual.btn" defaultMessage="Record as paid" />
-          )}
-          {selectedPayoutMethod !== 'other' && (
+          <FormattedMessage id="expense.pay.manual.btn" defaultMessage="Record as paid" />
+        </StyledButton>
+        {selectedPayoutMethod !== 'other' && (
+            <StyledButton
+            className="pay"
+            buttonStyle="success"
+            onClick={this.onClick}
+            disabled={this.props.disabled || disabled}
+            title={title}
+          >
             <FormattedMessage
               id="expense.pay.btn"
               defaultMessage="Pay with {paymentMethod}"
               values={{ paymentMethod: expense.payoutMethod }}
             />
-          )}
-        </StyledButton>
+          </StyledButton>
+        )}
         <div className="error">{error}</div>
       </div>
     );

--- a/components/expenses/PayExpenseBtn.js
+++ b/components/expenses/PayExpenseBtn.js
@@ -47,6 +47,7 @@ class PayExpenseBtn extends React.Component {
     }
     lock();
     this.setState({ loading: true });
+
     try {
       await this.props.payExpense(
         expense.id,
@@ -135,14 +136,15 @@ class PayExpenseBtn extends React.Component {
         <StyledButton
           className="pay"
           buttonStyle="success"
-          onClick={() => this.handleOnClickPay(true)}
+          onClick={() => this.handleOnClickPay(expense.payoutMethod === 'paypal')}
           disabled={this.props.disabled || disabled}
           title={title}
+          mr={2}
         >
           <FormattedMessage id="expense.pay.manual.btn" defaultMessage="Record as paid" />
         </StyledButton>
         {selectedPayoutMethod !== 'other' && (
-            <StyledButton
+          <StyledButton
             className="pay"
             buttonStyle="success"
             onClick={() => this.handleOnClickPay()}
@@ -168,7 +170,7 @@ const payExpenseQuery = gql`
     $paymentProcessorFeeInCollectiveCurrency: Int
     $hostFeeInCollectiveCurrency: Int
     $platformFeeInCollectiveCurrency: Int
-    $forcedManual: Boolean
+    $forceManual: Boolean
   ) {
     payExpense(
       id: $id
@@ -204,7 +206,7 @@ const addMutation = graphql(payExpenseQuery, {
       paymentProcessorFeeInCollectiveCurrency,
       hostFeeInCollectiveCurrency,
       platformFeeInCollectiveCurrency,
-      manuallyPayPaypalMethod,
+      forceManual,
     ) => {
       return await mutate({
         variables: {
@@ -212,7 +214,7 @@ const addMutation = graphql(payExpenseQuery, {
           paymentProcessorFeeInCollectiveCurrency,
           hostFeeInCollectiveCurrency,
           platformFeeInCollectiveCurrency,
-          manuallyPayPaypalMethod,
+          forceManual,
         },
       });
     },

--- a/components/expenses/__tests__/Expenses.test.js
+++ b/components/expenses/__tests__/Expenses.test.js
@@ -47,6 +47,7 @@ describe('Expenses component', () => {
   ];
 
   const loggedInUser = {
+    isRoot: () => true,
     canPayExpense: () => true,
     canApproveExpense: () => true,
     canEditCollective: () => true,
@@ -72,7 +73,7 @@ describe('Expenses component', () => {
   describe('Paying expenses', () => {
     it('disables all buttons while one expense is being paid', done => {
       // make sure there are two pay buttons on the page
-      expect(component.find('.PayExpenseBtn button').length).toEqual(2);
+      expect(component.find('.PayExpenseBtn button').length).toEqual(4);
 
       // make sure none are disabled
       expect(component.find('.PayExpenseBtn button[disabled]').lenght).toEqual(undefined);
@@ -84,7 +85,7 @@ describe('Expenses component', () => {
         .simulate('click');
 
       // expect two disabled buttons again
-      expect(component.find('.PayExpenseBtn button[disabled]').length).toEqual(2);
+      expect(component.find('.PayExpenseBtn button[disabled]').length).toEqual(4);
 
       // after timeout, make sure there is only button and it's not disabled.
       setTimeout(() => {

--- a/lib/graphql/schema.graphql
+++ b/lib/graphql/schema.graphql
@@ -1575,6 +1575,7 @@ type Mutation {
     paymentProcessorFeeInCollectiveCurrency: Int
     hostFeeInCollectiveCurrency: Int
     platformFeeInCollectiveCurrency: Int
+    manuallyPayPaypalMethod: Boolean
   ): ExpenseType
   markOrderAsPaid(id: Int!): OrderType
   markPendingOrderAsExpired(id: Int!): OrderType

--- a/lib/graphql/schema.graphql
+++ b/lib/graphql/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:3060/graphql
-# timestamp: Mon Dec 02 2019 11:01:12 GMT+0100 (GMT+01:00)
+# timestamp: Wed Dec 04 2019 10:36:41 GMT+0100 (West Africa Standard Time)
 
 """
 Application model
@@ -1575,7 +1575,11 @@ type Mutation {
     paymentProcessorFeeInCollectiveCurrency: Int
     hostFeeInCollectiveCurrency: Int
     platformFeeInCollectiveCurrency: Int
-    manuallyPayPaypalMethod: Boolean
+
+    """
+    Force expense with paypal method to be paid manually
+    """
+    forceManual: Boolean
   ): ExpenseType
   markOrderAsPaid(id: Int!): OrderType
   markPendingOrderAsExpired(id: Int!): OrderType


### PR DESCRIPTION
This PR follows up https://github.com/opencollective/opencollective/issues/1976

The goal is to add "Record as paid" button for expense with paypal payment method.

<img width="581" alt="Screenshot 2019-10-07 at 4 05 20 PM" src="https://user-images.githubusercontent.com/15707013/66329667-cbe01480-e926-11e9-8fbc-d3c65875b693.png">

#### TODO

- [ ] Modify [`payExpense`](https://github.com/opencollective/opencollective-api/blob/master/server/graphql/v1/mutations/expenses.js#L340) mutation to allow recording of expense with paypal method


