### PR TITLE
Host dashboard: Keep filter preferences when refilling paypal balance

### DIFF
--- a/components/ConnectPaypal.js
+++ b/components/ConnectPaypal.js
@@ -12,6 +12,7 @@ class ConnectPaypal extends React.Component {
   static propTypes = {
     collective: PropTypes.object.isRequired,
     onChange: PropTypes.func,
+    onClickRefillBalance: PropTypes.func,
   };
 
   constructor(props) {
@@ -30,6 +31,7 @@ class ConnectPaypal extends React.Component {
     this.setState({ connectingPaypal: true });
     try {
       const json = await connectAccount(this.props.collective.id, 'paypal');
+      this.props.onClickRefillBalance(); // save the current filter preferences before redirect
       window.location.replace(json.redirectUrl);
     } catch (e) {
       this.setState({ connectingPaypal: false });

--- a/components/host-dashboard/CollectivePickerWithData.js
+++ b/components/host-dashboard/CollectivePickerWithData.js
@@ -14,7 +14,9 @@ class CollectivePickerWithData extends React.Component {
   static propTypes = {
     host: PropTypes.object.isRequired,
     onChange: PropTypes.func,
+    saveFilterPreferences: PropTypes.func,
     LoggedInUser: PropTypes.object,
+    selectedCollectiveId: PropTypes.number,
     addFundsToCollective: PropTypes.func.isRequired,
     intl: PropTypes.object.isRequired,
   };
@@ -25,6 +27,7 @@ class CollectivePickerWithData extends React.Component {
       connectingPaypal: false,
       loading: false,
       showAddFunds: false,
+      CollectiveId: props.selectedCollectiveId,
     };
     this.addFunds = this.addFunds.bind(this);
     this.toggleAddFunds = this.toggleAddFunds.bind(this);
@@ -202,7 +205,7 @@ class CollectivePickerWithData extends React.Component {
   }
 
   render() {
-    const { host } = this.props;
+    const { host, saveFilterPreferences } = this.props;
 
     this.hostCollective = host;
     if (!this.hostCollective) {
@@ -332,7 +335,9 @@ class CollectivePickerWithData extends React.Component {
             )}
           </div>
           <div className="right" style={{ maxWidth: 450 }}>
-            {this.canEdit() && <ConnectPaypal collective={this.hostCollective} />}
+            {this.canEdit() && (
+              <ConnectPaypal onClickRefillBalance={saveFilterPreferences} collective={this.hostCollective} />
+            )}
           </div>
         </div>
         <div>

--- a/components/host-dashboard/Dashboard.js
+++ b/components/host-dashboard/Dashboard.js
@@ -13,6 +13,12 @@ import MessageBox from '../MessageBox';
 import Loading from '../Loading';
 import CollectivePicker from './CollectivePickerWithData';
 import { withUser } from '../UserProvider';
+import {
+  getFromLocalStorage,
+  setLocalStorage,
+  LOCAL_STORAGE_KEYS,
+  removeFromLocalStorage,
+} from '../../lib/local-storage';
 
 class HostDashboard extends React.Component {
   static propTypes = {
@@ -27,8 +33,33 @@ class HostDashboard extends React.Component {
     this.state = { selectedCollective: null, expensesFilters: null };
   }
 
+  componentDidMount() {
+    this.restoreFilterPreferences();
+  }
+
   pickCollective(selectedCollective) {
     this.setState({ selectedCollective });
+  }
+
+  saveFilterPreferences() {
+    const { selectedCollective, expensesFilters } = this.state;
+    setLocalStorage(
+      LOCAL_STORAGE_KEYS.HOST_DASHBOARD_FILTER_PREFERENCES,
+      JSON.stringify({
+        selectedCollective,
+        expensesFilters,
+      }),
+    );
+  }
+
+  restoreFilterPreferences() {
+    let filterPreferences = getFromLocalStorage(LOCAL_STORAGE_KEYS.HOST_DASHBOARD_FILTER_PREFERENCES);
+    if (filterPreferences) {
+      filterPreferences = JSON.parse(filterPreferences);
+      this.setState({ ...filterPreferences }, () => {
+        removeFromLocalStorage(LOCAL_STORAGE_KEYS.HOST_DASHBOARD_FILTER_PREFERENCES);
+      });
+    }
   }
 
   render() {
@@ -108,6 +139,8 @@ class HostDashboard extends React.Component {
             host={host}
             LoggedInUser={LoggedInUser}
             onChange={selectedCollective => this.pickCollective(selectedCollective)}
+            selectedCollectiveId={selectedCollective.id}
+            saveFilterPreferences={() => this.saveFilterPreferences()}
           />
         )}
         <div className="content">

--- a/lib/local-storage.js
+++ b/lib/local-storage.js
@@ -4,6 +4,7 @@
 export const LOCAL_STORAGE_KEYS = {
   ACCESS_TOKEN: 'accessToken',
   LOGGED_IN_USER: 'LoggedInUser',
+  HOST_DASHBOARD_FILTER_PREFERENCES: 'hostDashBoardFilterPreferences',
 };
 
 /**


### PR DESCRIPTION
Follows up https://github.com/opencollective/opencollective/issues/2018

This PR uses `localstorage` to temporarily save host admin current filter preferences (expenses and collective filters) before redirecting to Paypal to Refill balance. The preferences are then restored and removed from localstorage as soon as the admin is redirected back to the dashboard.