### PR TITLE
fix(NCP): sorting of contribution cards

### DIFF
--- a/components/collective-page/sections/Contributions.js
+++ b/components/collective-page/sections/Contributions.js
@@ -218,8 +218,10 @@ class SectionContributions extends React.PureComponent {
         return -1;
       } else if (m1.role !== roles.HOST && m2.role === roles.HOST) {
         return 1;
-      } else if (m1.role === roles.HOST) {
+      } else if (m1.role === roles.HOST && m1.collective.stats.backers.all !== m2.collective.stats.backers.all) {
         return m1.collective.stats.backers.all > m2.collective.stats.backers.all ? -1 : 1;
+      } else if (m1.stats.totalDonations === m2.stats.totalDonations) {
+        return 0;
       } else {
         return m1.stats.totalDonations > m2.stats.totalDonations ? -1 : 1;
       }


### PR DESCRIPTION
Fixes https://github.com/opencollective/opencollective/issues/2497

This fix makes the sorting function of the contribution cards consistent, so that two elements that are equal are not sorted (i.e. `sort(a, a) === 0`), as different environments (server vs client in this case) can use different sorting methods and call the callback with arguments in a different order.

Not the most exciting screen capture, but here you can see that it does not switch the order from the initial server side render anymore 🙂
![Oct-09-2019 12-19-44](https://user-images.githubusercontent.com/1552194/66473242-23998f80-ea8f-11e9-81ce-1aa59155b939.gif)
