### PR TITLE
EditCollective: Remove longDescription from fields

### DIFF
--- a/components/EditCollectiveForm.js
+++ b/components/EditCollectiveForm.js
@@ -139,10 +139,6 @@ class EditCollectiveForm extends React.Component {
         id: 'collective.description.label',
         defaultMessage: 'Short description',
       },
-      'longDescription.label': {
-        id: 'collective.longDescription.label',
-        defaultMessage: 'Long description',
-      },
       'expensePolicy.label': {
         id: 'collective.expensePolicy.label',
         defaultMessage: 'Collective expense policy',
@@ -479,12 +475,6 @@ class EditCollectiveForm extends React.Component {
           },
         },
         {
-          name: 'longDescription',
-          type: 'textarea',
-          placeholder: '',
-          description: 'Protip: you can use markdown',
-        },
-        {
           name: 'tags',
           maxLength: 128,
           type: 'tags',
@@ -588,10 +578,6 @@ class EditCollectiveForm extends React.Component {
             :global(textarea) {
               width: 300px;
               font-size: 1.5rem;
-            }
-
-            .EditCollectiveForm :global(textarea[name='longDescription']) {
-              height: 30rem;
             }
 
             .EditCollectiveForm :global(textarea[name='expensePolicy']) {

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -164,7 +164,6 @@
   "collective.isArchived.description": "This collective has been archived and can no longer be used for any activities.",
   "collective.isArchived.edit.description": "This {type} has been archived and can no longer be used for any activities.",
   "collective.location.label": "City",
-  "collective.longDescription.label": "Long description",
   "collective.markdown.description": "Use markdown editor",
   "collective.markdown.label": "Default editor",
   "collective.meetup.label": "Meetup URL",

--- a/lang/de.json
+++ b/lang/de.json
@@ -164,7 +164,6 @@
   "collective.isArchived.description": "This collective has been archived and can no longer be used for any activities.",
   "collective.isArchived.edit.description": "This {type} has been archived and can no longer be used for any activities.",
   "collective.location.label": "Stadt",
-  "collective.longDescription.label": "Long description",
   "collective.markdown.description": "Use markdown editor",
   "collective.markdown.label": "Default editor",
   "collective.meetup.label": "Meetup URL",

--- a/lang/en.json
+++ b/lang/en.json
@@ -164,7 +164,6 @@
   "collective.isArchived.description": "This collective has been archived and can no longer be used for any activities.",
   "collective.isArchived.edit.description": "This {type} has been archived and can no longer be used for any activities.",
   "collective.location.label": "City",
-  "collective.longDescription.label": "Long description",
   "collective.markdown.description": "Use markdown editor",
   "collective.markdown.label": "Default editor",
   "collective.meetup.label": "Meetup URL",

--- a/lang/es.json
+++ b/lang/es.json
@@ -164,7 +164,6 @@
   "collective.isArchived.description": "Este colectivo ha sido archivado y no podrá seguir siendo usado para ninguna actividad.",
   "collective.isArchived.edit.description": "Este {type} ha sido archivado y no podrá seguir siendo usado para ninguna actividad.",
   "collective.location.label": "Ciudad",
-  "collective.longDescription.label": "Descripción larga",
   "collective.markdown.description": "Utilizar el editor de markdown",
   "collective.markdown.label": "Editor por defecto",
   "collective.meetup.label": "URL de reunión",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -164,7 +164,6 @@
   "collective.isArchived.description": "Ce collectif a été archivé et ne peut plus être utilisé.",
   "collective.isArchived.edit.description": "Ce {type} a été archivé et ne peut plus être utilisé.",
   "collective.location.label": "Lieux",
-  "collective.longDescription.label": "Longue description",
   "collective.markdown.description": "Utiliser markdown comme éditeur",
   "collective.markdown.label": "Éditeur de texte par défaut",
   "collective.meetup.label": "URL du Meetup",

--- a/lang/it.json
+++ b/lang/it.json
@@ -164,7 +164,6 @@
   "collective.isArchived.description": "This collective has been archived and can no longer be used for any activities.",
   "collective.isArchived.edit.description": "This {type} has been archived and can no longer be used for any activities.",
   "collective.location.label": "Città",
-  "collective.longDescription.label": "Descrizione lunga",
   "collective.markdown.description": "Usa markdown editor",
   "collective.markdown.label": "Editor predefinito",
   "collective.meetup.label": "Meetup URL",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -164,7 +164,6 @@
   "collective.isArchived.description": "This collective has been archived and can no longer be used for any activities.",
   "collective.isArchived.edit.description": "This {type} has been archived and can no longer be used for any activities.",
   "collective.location.label": "都市",
-  "collective.longDescription.label": "詳細",
   "collective.markdown.description": "Markdown エディターを使う",
   "collective.markdown.label": "デフォルトエディター",
   "collective.meetup.label": "ミートアップ URL",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -164,7 +164,6 @@
   "collective.isArchived.description": "This collective has been archived and can no longer be used for any activities.",
   "collective.isArchived.edit.description": "This {type} has been archived and can no longer be used for any activities.",
   "collective.location.label": "City",
-  "collective.longDescription.label": "Long description",
   "collective.markdown.description": "Use markdown editor",
   "collective.markdown.label": "Default editor",
   "collective.meetup.label": "Meetup URL",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -164,7 +164,6 @@
   "collective.isArchived.description": "Dit collectief is gearchiveerd en kan niet meer gebruikt worden voor enige activiteiten.",
   "collective.isArchived.edit.description": "Deze {type} is gearchiveerd en kan niet meer gebruikt worden voor enige activiteiten.",
   "collective.location.label": "Stad",
-  "collective.longDescription.label": "Lange beschrijving",
   "collective.markdown.description": "Gebruik prijsverlagingsbewerker",
   "collective.markdown.label": "Standaard editor",
   "collective.meetup.label": "Bijeenkomst URL",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -164,7 +164,6 @@
   "collective.isArchived.description": "Este coletivo foi arquivado e não pode ser mais usado para nenhuma atividade.",
   "collective.isArchived.edit.description": "Este {type} foi arquivado e não pode ser mais usado para nenhuma atividade.",
   "collective.location.label": "Cidade",
-  "collective.longDescription.label": "Descrição longa",
   "collective.markdown.description": "Use editor markdown",
   "collective.markdown.label": "Editor padrão",
   "collective.meetup.label": "URL do Meetup",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -164,7 +164,6 @@
   "collective.isArchived.description": "Этот коллектив добавили в архив, и он не может быть использован.",
   "collective.isArchived.edit.description": "Этот {type} был добавлен в архив и больше не может быть использован.",
   "collective.location.label": "Город",
-  "collective.longDescription.label": "Длинное описание",
   "collective.markdown.description": "Использовать редактор markdown",
   "collective.markdown.label": "Редактор по умолчанию",
   "collective.meetup.label": "URL митапа",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -164,7 +164,6 @@
   "collective.isArchived.description": "此集体已存档, 不能再用于任何活动。",
   "collective.isArchived.edit.description": "此 {type} 已存档, 不能再用于任何活动。",
   "collective.location.label": "城市",
-  "collective.longDescription.label": "长描述",
   "collective.markdown.description": "使用 markdown 编辑器",
   "collective.markdown.label": "默认编辑器",
   "collective.meetup.label": "Meetup 链接",


### PR DESCRIPTION
I missed it when we released, we're still showing the long description among other fields in info. This is not good because the description is now html content so it's not the right editor for it.

I didn't remove the fields from the query because create/edit event still use this.

![2019-10-09_15:17:31](https://user-images.githubusercontent.com/1556356/66484891-218ffa80-eaa8-11e9-84e6-5d8bff03d092.png)
