### PR TITLE
Delete Events

### DIFF
--- a/components/Button.js
+++ b/components/Button.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import colors from '../lib/constants/colors';
+import defaultColors from '../lib/theme/colors';
 import { Router } from '../server/pages';
 import HashLink from 'react-scrollchor';
 
@@ -123,6 +124,19 @@ class Button extends React.Component {
             .blue:active {
               background-color: ${colors.blueActive};
               border-color: ${colors.blueActive};
+            }
+            .red {
+              color: white;
+              border-color: ${colors.white};
+              background-color: ${defaultColors.red[500]};
+            }
+            .red:hover {
+              background-color: ${defaultColors.red[400]};
+              border-color: ${defaultColors.red[400]};
+            }
+            .red:active {
+              background-color: ${defaultColors.red[600]};
+              border-color: ${defaultColors.red[600]};
             }
             .gray {
               color: ${colors.darkgray};

--- a/components/EditEvent.js
+++ b/components/EditEvent.js
@@ -43,7 +43,6 @@ class EditEvent extends React.Component {
       console.error('>>> editEvent error: ', JSON.stringify(err));
       const errorMsg = err.graphQLErrors && err.graphQLErrors[0] ? err.graphQLErrors[0].message : err.message;
       this.setState({ status: 'idle', result: { error: errorMsg } });
-      throw new Error(errorMsg);
     }
   }
 
@@ -60,7 +59,6 @@ class EditEvent extends React.Component {
       console.error('>>> deleteEvent error: ', JSON.stringify(err));
       const errorMsg = err.graphQLErrors && err.graphQLErrors[0] ? err.graphQLErrors[0].message : err.message;
       this.setState({ result: { error: errorMsg } });
-      throw new Error(errorMsg);
     }
   }
 

--- a/components/EditEvent.js
+++ b/components/EditEvent.js
@@ -15,6 +15,7 @@ class EditEvent extends React.Component {
     event: PropTypes.object,
     editCollective: PropTypes.func,
     LoggedInUser: PropTypes.object,
+    deleteCollective: PropTypes.func,
   };
 
   constructor(props) {

--- a/components/EditEventForm.js
+++ b/components/EditEventForm.js
@@ -282,9 +282,8 @@ class EditEventForm extends React.Component {
                 <ModalBody>
                   <P>
                     <FormattedMessage
-                      id="collective.delete.modal.body"
-                      values={{ type: event.type.toLowerCase() }}
-                      defaultMessage={'Are you sure you want to delete this {type}?'}
+                      id="collective.event.modal.body"
+                      defaultMessage="Are you sure you want to delete this event?"
                     />
                   </P>
                 </ModalBody>

--- a/components/EditEventForm.js
+++ b/components/EditEventForm.js
@@ -1,11 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { defineMessages, injectIntl } from 'react-intl';
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 
 import Button from './Button';
 import InputField from './InputField';
 import EditTiers from './EditTiers';
 import TimezonePicker from './TimezonePicker';
+import Container from './Container';
+import { P } from './Text';
+import Modal, { ModalBody, ModalHeader, ModalFooter } from './StyledModal';
 
 class EditEventForm extends React.Component {
   static propTypes = {
@@ -23,10 +26,11 @@ class EditEventForm extends React.Component {
     this.handleChange = this.handleChange.bind(this);
     this.handleTiersChange = this.handleTiersChange.bind(this);
     this.handleTimezoneChange = this.handleTimezoneChange.bind(this);
+    this.handleModal = this.handleModal.bind(this);
 
     const event = { ...(props.event || {}) };
     event.slug = event.slug ? event.slug.replace(/.*\//, '') : '';
-    this.state = { event, tiers: event.tiers || [{}], disabled: false };
+    this.state = { event, tiers: event.tiers || [{}], disabled: false, showDeleteModal: false };
 
     this.messages = defineMessages({
       'slug.label': { id: 'event.slug.label', defaultMessage: 'url' },
@@ -101,6 +105,12 @@ class EditEventForm extends React.Component {
 
   handleTiersChange(tiers) {
     this.setState(tiers);
+  }
+
+  handleModal() {
+    this.setState(state => ({
+      showDeleteModal: !state.showDeleteModal,
+    }));
   }
 
   async handleSubmit() {
@@ -258,7 +268,49 @@ class EditEventForm extends React.Component {
             onClick={this.handleSubmit}
             disabled={this.state.disabled ? true : loading}
           />
-          {!isNew && <Button className="blue" label={deleteBtnLabel} onClick={onDelete} />}
+          {!isNew && (
+            <>
+              <Button className="blue" label={deleteBtnLabel} onClick={this.handleModal} />
+              <Modal width="570px" show={this.state.showDeleteModal} onClose={this.handleModal}>
+                <ModalHeader>
+                  <FormattedMessage
+                    id="collective.delete.modal.header"
+                    values={{ name: event.name }}
+                    defaultMessage={'Delete {name}'}
+                  />
+                </ModalHeader>
+                <ModalBody>
+                  <P>
+                    <FormattedMessage
+                      id="collective.delete.modal.body"
+                      values={{ type: event.type.toLowerCase() }}
+                      defaultMessage={'Are you sure you want to delete this {type}?'}
+                    />
+                  </P>
+                </ModalBody>
+                <ModalFooter>
+                  <Container display="flex" justifyContent="flex-end">
+                    <div>
+                      <Button
+                        className="blue"
+                        label={<FormattedMessage id="collective.delete.cancel.btn" defaultMessage={'Cancel'} />}
+                        onClick={this.handleModal}
+                      />
+                      {'  '}
+                      <Button
+                        className="blue"
+                        label={<FormattedMessage id="collective.delete.confirm.btn" defaultMessage={'Delete'} />}
+                        onClick={() => {
+                          this.handleModal();
+                          onDelete();
+                        }}
+                      />
+                    </div>
+                  </Container>
+                </ModalFooter>
+              </Modal>
+            </>
+          )}
         </div>
       </div>
     );

--- a/components/EditEventForm.js
+++ b/components/EditEventForm.js
@@ -264,7 +264,7 @@ class EditEventForm extends React.Component {
         <div className="actions">
           {!isNew && (
             <>
-              <Button className="blue" label={deleteBtnLabel} onClick={this.handleModal} />
+              <Button className="red" label={deleteBtnLabel} onClick={this.handleModal} />
               <Modal width="570px" show={this.state.showDeleteModal} onClose={this.handleModal}>
                 <ModalHeader>
                   <FormattedMessage

--- a/components/EditEventForm.js
+++ b/components/EditEventForm.js
@@ -13,6 +13,8 @@ class EditEventForm extends React.Component {
     loading: PropTypes.bool,
     onSubmit: PropTypes.func,
     intl: PropTypes.object.isRequired,
+    deleteLoading: PropTypes.bool,
+    onDelete: PropTypes.func,
   };
 
   constructor(props) {
@@ -108,12 +110,13 @@ class EditEventForm extends React.Component {
   }
 
   render() {
-    const { event, loading, intl } = this.props;
+    const { event, loading, intl, deleteLoading, onDelete } = this.props;
 
     if (!event.parentCollective) return <div />;
 
     const isNew = !(event && event.id);
     const submitBtnLabel = loading ? 'loading' : isNew ? 'Create Event' : 'Save';
+    const deleteBtnLabel = deleteLoading ? 'loading...' : 'Delete Event';
     const defaultStartsAt = new Date();
     defaultStartsAt.setHours(19);
     defaultStartsAt.setMinutes(0);
@@ -255,6 +258,7 @@ class EditEventForm extends React.Component {
             onClick={this.handleSubmit}
             disabled={this.state.disabled ? true : loading}
           />
+          {!isNew && <Button className="blue" label={deleteBtnLabel} onClick={onDelete} />}
         </div>
       </div>
     );

--- a/components/EditEventForm.js
+++ b/components/EditEventForm.js
@@ -262,12 +262,6 @@ class EditEventForm extends React.Component {
           />
         </div>
         <div className="actions">
-          <Button
-            className="blue"
-            label={submitBtnLabel}
-            onClick={this.handleSubmit}
-            disabled={this.state.disabled ? true : loading}
-          />
           {!isNew && (
             <>
               <Button className="blue" label={deleteBtnLabel} onClick={this.handleModal} />
@@ -310,6 +304,12 @@ class EditEventForm extends React.Component {
               </Modal>
             </>
           )}
+          <Button
+            className="blue"
+            label={submitBtnLabel}
+            onClick={this.handleSubmit}
+            disabled={this.state.disabled ? true : loading}
+          />
         </div>
       </div>
     );

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -157,6 +157,7 @@
   "collective.empty.confirm.btn": "Confirm",
   "collective.emptyBalance.body": "Are you sure you want to {action} to {collective}?",
   "collective.emptyBalance.header": "{action} Balance",
+  "collective.event.modal.body": "Are you sure you want to delete this event?",
   "collective.expensePolicy.description": "It can be daunting to file an expense if you're not sure what's allowed. Provide a clear policy to guide expense submitters.",
   "collective.expensePolicy.label": "Collective expense policy",
   "collective.expensePolicy.placeholder": "For example: what type of expenses will be approved, any limitations on amounts, what documentation is required, and who to contact with questions.",

--- a/lang/de.json
+++ b/lang/de.json
@@ -157,6 +157,7 @@
   "collective.empty.confirm.btn": "Confirm",
   "collective.emptyBalance.body": "Are you sure you want to {action} to {collective}?",
   "collective.emptyBalance.header": "{action} Balance",
+  "collective.event.modal.body": "Are you sure you want to delete this event?",
   "collective.expensePolicy.description": "It can be daunting to file an expense if you're not sure what's allowed. Provide a clear policy to guide expense submitters.",
   "collective.expensePolicy.label": "Collective expense policy",
   "collective.expensePolicy.placeholder": "For example: what type of expenses will be approved, any limitations on amounts, what documentation is required, and who to contact with questions.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -157,6 +157,7 @@
   "collective.empty.confirm.btn": "Confirm",
   "collective.emptyBalance.body": "Are you sure you want to {action} to {collective}?",
   "collective.emptyBalance.header": "{action} Balance",
+  "collective.event.modal.body": "Are you sure you want to delete this event?",
   "collective.expensePolicy.description": "It can be daunting to file an expense if you're not sure what's allowed. Provide a clear policy to guide expense submitters.",
   "collective.expensePolicy.label": "Collective expense policy",
   "collective.expensePolicy.placeholder": "For example: what type of expenses will be approved, any limitations on amounts, what documentation is required, and who to contact with questions.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -157,6 +157,7 @@
   "collective.empty.confirm.btn": "Confirm",
   "collective.emptyBalance.body": "Are you sure you want to {action} to {collective}?",
   "collective.emptyBalance.header": "{action} Balance",
+  "collective.event.modal.body": "Are you sure you want to delete this event?",
   "collective.expensePolicy.description": "It can be daunting to file an expense if you're not sure what's allowed. Provide a clear policy to guide expense submitters.",
   "collective.expensePolicy.label": "Collective expense policy",
   "collective.expensePolicy.placeholder": "For example: what type of expenses will be approved, any limitations on amounts, what documentation is required, and who to contact with questions.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -157,6 +157,7 @@
   "collective.empty.confirm.btn": "Confirmer",
   "collective.emptyBalance.body": "Êtes-vous sûr de vouloir {action} ce {collective} ?",
   "collective.emptyBalance.header": "{action} Balance",
+  "collective.event.modal.body": "Are you sure you want to delete this event?",
   "collective.expensePolicy.description": "Ajouter une dépense peut être intimidant si vous ne savez pas ce qui est attendu. Ajoutez des consignes claires pour guider les personnes qui ajoutent ces dépenses.",
   "collective.expensePolicy.label": "Politique de remboursement du collectif",
   "collective.expensePolicy.placeholder": "Par exemple : quel type de dépenses seront acceptées, les limites sur le montant, les documents requis et qui contacter s'il y a des questions.",

--- a/lang/it.json
+++ b/lang/it.json
@@ -157,6 +157,7 @@
   "collective.empty.confirm.btn": "Conferma",
   "collective.emptyBalance.body": "Are you sure you want to {action} to {collective}?",
   "collective.emptyBalance.header": "{action} Balance",
+  "collective.event.modal.body": "Are you sure you want to delete this event?",
   "collective.expensePolicy.description": "It can be daunting to file an expense if you're not sure what's allowed. Provide a clear policy to guide expense submitters.",
   "collective.expensePolicy.label": "Collective expense policy",
   "collective.expensePolicy.placeholder": "For example: what type of expenses will be approved, any limitations on amounts, what documentation is required, and who to contact with questions.",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -157,6 +157,7 @@
   "collective.empty.confirm.btn": "確認",
   "collective.emptyBalance.body": "本当に {action} から {collective} にしますか？",
   "collective.emptyBalance.header": "{action} Balance",
+  "collective.event.modal.body": "Are you sure you want to delete this event?",
   "collective.expensePolicy.description": "It can be daunting to file an expense if you're not sure what's allowed. Provide a clear policy to guide expense submitters.",
   "collective.expensePolicy.label": "Collective expense policy",
   "collective.expensePolicy.placeholder": "For example: what type of expenses will be approved, any limitations on amounts, what documentation is required, and who to contact with questions.",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -157,6 +157,7 @@
   "collective.empty.confirm.btn": "Confirm",
   "collective.emptyBalance.body": "Are you sure you want to {action} to {collective}?",
   "collective.emptyBalance.header": "{action} Balance",
+  "collective.event.modal.body": "Are you sure you want to delete this event?",
   "collective.expensePolicy.description": "It can be daunting to file an expense if you're not sure what's allowed. Provide a clear policy to guide expense submitters.",
   "collective.expensePolicy.label": "Collective expense policy",
   "collective.expensePolicy.placeholder": "For example: what type of expenses will be approved, any limitations on amounts, what documentation is required, and who to contact with questions.",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -157,6 +157,7 @@
   "collective.empty.confirm.btn": "Bevestig",
   "collective.emptyBalance.body": "Ben je zeker dat je {collective} wilt {action}?",
   "collective.emptyBalance.header": "{action} Balans",
+  "collective.event.modal.body": "Are you sure you want to delete this event?",
   "collective.expensePolicy.description": "Het kan intimiderend zijn om een onkostennota in te dienen als je niet zeker bent wat is toegestaan. Voorzie duidelijke richtlijnen om indieners van onkosten te helpen.",
   "collective.expensePolicy.label": "Richtlijnen voor onkosten",
   "collective.expensePolicy.placeholder": "Bijvoorbeeld: wat voor soort onkosten zullen goedgekeurd worden, is er een maximumbedrag, welke documentatie is vereist en wie moet gecontacteerd worden bij vragen.",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -157,6 +157,7 @@
   "collective.empty.confirm.btn": "Confirmar",
   "collective.emptyBalance.body": "Você tem certeza de que deseja {action} para {collective}?",
   "collective.emptyBalance.header": "{action} Balanço",
+  "collective.event.modal.body": "Are you sure you want to delete this event?",
   "collective.expensePolicy.description": "Pode ser assustador registrar uma despesa se você não tiver certeza do que é permitido. Forneça uma política clara para orientar os remetentes de despesas.",
   "collective.expensePolicy.label": "Política de despesas do Coletivo",
   "collective.expensePolicy.placeholder": "Por exemplo: que tipo de despesa será aprovada, quaisquer limitações de valores, que documentação é necessária e com quem entrar em contato em caso de perguntas.",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -157,6 +157,7 @@
   "collective.empty.confirm.btn": "Подтвердить",
   "collective.emptyBalance.body": "Are you sure you want to {action} to {collective}?",
   "collective.emptyBalance.header": "{action} Баланс",
+  "collective.event.modal.body": "Are you sure you want to delete this event?",
   "collective.expensePolicy.description": "It can be daunting to file an expense if you're not sure what's allowed. Provide a clear policy to guide expense submitters.",
   "collective.expensePolicy.label": "Политика расходов коллектива",
   "collective.expensePolicy.placeholder": "For example: what type of expenses will be approved, any limitations on amounts, what documentation is required, and who to contact with questions.",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -157,6 +157,7 @@
   "collective.empty.confirm.btn": "Confirm",
   "collective.emptyBalance.body": "Are you sure you want to {action} to {collective}?",
   "collective.emptyBalance.header": "{action} Balance",
+  "collective.event.modal.body": "Are you sure you want to delete this event?",
   "collective.expensePolicy.description": "It can be daunting to file an expense if you're not sure what's allowed. Provide a clear policy to guide expense submitters.",
   "collective.expensePolicy.label": "Collective expense policy",
   "collective.expensePolicy.placeholder": "For example: what type of expenses will be approved, any limitations on amounts, what documentation is required, and who to contact with questions.",

--- a/test/cypress/integration/23-event.create.test.js
+++ b/test/cypress/integration/23-event.create.test.js
@@ -48,7 +48,9 @@ describe('event.create.test.js', () => {
       .blur();
     cy.wait(300);
     cy.screenshot(`s${i++}`);
-    cy.get('.actions button').click();
+    cy.get('.actions button')
+      .eq(0)
+      .click();
     cy.wait(500);
     cy.screenshot(`s${i++}`);
     cy.get('#location .address').contains('Lesbroussart');
@@ -63,7 +65,9 @@ describe('event.create.test.js', () => {
     cy.get('.inputs .inputField.name input', { timeout: 10000 }).type(`{selectall}${updatedTitle}`);
     cy.get('.EditTiers .tier:nth-child(2) .removeTier').click();
     cy.wait(300);
-    cy.get('.actions button').click();
+    cy.get('.actions button')
+      .eq(0)
+      .click();
     cy.wait(500);
     cy.reload(true);
     cy.wait(500);

--- a/test/cypress/integration/23-event.create.test.js
+++ b/test/cypress/integration/23-event.create.test.js
@@ -49,7 +49,7 @@ describe('event.create.test.js', () => {
     cy.wait(300);
     cy.screenshot(`s${i++}`);
     cy.get('.actions button')
-      .eq(0)
+      .eq(1)
       .click();
     cy.wait(500);
     cy.screenshot(`s${i++}`);
@@ -66,7 +66,7 @@ describe('event.create.test.js', () => {
     cy.get('.EditTiers .tier:nth-child(2) .removeTier').click();
     cy.wait(300);
     cy.get('.actions button')
-      .eq(0)
+      .eq(1)
       .click();
     cy.wait(500);
     cy.reload(true);


### PR DESCRIPTION
Solves - https://github.com/opencollective/opencollective/issues/2496 raised by @piamancini 
### Description
Add a `Delete` button at `Edit Event` page to delete the particular event.

### How?
- `Delete` button on click calls the `deleteCollective` Mutation with the event id

### What is Included
- Delete Button
- Delete Event Method
- Redirect to the Parent Collective Page
- Show Success and Errors


### How to test
- Go to - `url/{collective-slug}/events/new`
- Create a new `event` 🎈 
- Go to that event page
- And then go to the `Edit Event` Page
- Saw a `Delete` button at the bottom of the page?
- Click that button
- Your event will get deleted and you shall be directed to the `url/{collective-slug}` page
