### PR TITLE
Event: Check collective timezone prop

### DIFF
--- a/components/CollectiveCover.js
+++ b/components/CollectiveCover.js
@@ -235,13 +235,15 @@ ${description}`;
   }
 
   checkTimeDiff() {
-    const eventTimezone = moment()
-      .tz(this.props.collective.timezone)
-      .format('Z');
-    const browserTimezone = moment()
-      .tz(momentTimezone.tz.guess())
-      .format('Z');
-    return eventTimezone !== browserTimezone;
+    if (this.props.collective.timezone) {
+      const eventTimezone = moment()
+        .tz(this.props.collective.timezone)
+        .format('Z');
+      const browserTimezone = moment()
+        .tz(momentTimezone.tz.guess())
+        .format('Z');
+      return eventTimezone !== browserTimezone;
+    }
   }
 
   render() {


### PR DESCRIPTION
This PR fix https://github.com/opencollective/opencollective/issues/2520

Ensure `this.prop.collective.timezone` is present before attempting to check time difference. 