### PR TITLE
Add button to open inbox on SignIn page

### DIFF
--- a/components/OpenEmailProviderButton.js
+++ b/components/OpenEmailProviderButton.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import StyledButton from './StyledButton';
+import { FormattedMessage } from 'react-intl';
+
+function OpenEmailProviderButton({ email }) {
+  const gmailregex = /@gmail\.com$/.test(email);
+  const hotmailregex = /@outlook\.com$/.test(email);
+  const gmaillink =
+    'https://mail.google.com/mail/u/2/#advanced-search/subject=Open+Collective%3A+Login&amp;subset=all&amp;within=1d';
+  const hotmaillink = 'https://outlook.live.com/mail/inbox';
+  const btntext = gmailregex ? 'Gmail' : hotmailregex ? 'HotMail' : 'Inbox';
+  const link = gmailregex ? gmaillink : hotmailregex ? hotmaillink : '';
+  const emailProvider = gmailregex || hotmailregex ? true : false;
+
+  return emailProvider ? (
+    <div>
+      <a data-cy="open-inbox-link" href={link}>
+        <StyledButton buttonStyle="primary" minWidth={200} mx={2} my={3}>
+          <FormattedMessage id="openinbox" defaultMessage={`Open {buttontext}`} values={{ buttontext: btntext }} />
+        </StyledButton>
+      </a>
+    </div>
+  ) : null;
+}
+
+OpenEmailProviderButton.propTypes = {
+  email: PropTypes.string,
+};
+export default OpenEmailProviderButton;

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -819,6 +819,7 @@
   "no": "No",
   "notFound": "Not found",
   "notFound.search": "Search for {term}",
+  "openinbox": "Open {buttontext}",
   "openSourceApply.description.p1": "You're creating software. You don't want to worry about creating a legal entity or seperate bank account, paying taxes, or providing invoices to sponsors. Let us take care of all that, so you can stay focused on your project.",
   "openSourceApply.description.p2": "We have created the {osclink}, a non-profit umbrella organization, to serve the open source community. To join, you need at least 100 stars on Github (or other equivilant evidence of your project's validity), and to respect our {communityguidelineslink}.",
   "openSourceApply.description.p3": "Fees: 10% of funds raised. Half goes to Open Collective Inc to continue improving the software platform, and half to the Open Source Collective to cover its legal and financial services.",

--- a/lang/de.json
+++ b/lang/de.json
@@ -819,6 +819,7 @@
   "no": "No",
   "notFound": "Not found",
   "notFound.search": "Search for {term}",
+  "openinbox": "Open {buttontext}",
   "openSourceApply.description.p1": "You're creating software. You don't want to worry about creating a legal entity or seperate bank account, paying taxes, or providing invoices to sponsors. Let us take care of all that, so you can stay focused on your project.",
   "openSourceApply.description.p2": "We have created the {osclink}, a non-profit umbrella organization, to serve the open source community. To join, you need at least 100 stars on Github (or other equivilant evidence of your project's validity), and to respect our {communityguidelineslink}.",
   "openSourceApply.description.p3": "Fees: 10% of funds raised. Half goes to Open Collective Inc to continue improving the software platform, and half to the Open Source Collective to cover its legal and financial services.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -819,6 +819,7 @@
   "no": "No",
   "notFound": "Not found",
   "notFound.search": "Search for {term}",
+  "openinbox": "Open {buttontext}",
   "openSourceApply.description.p1": "You're creating software. You don't want to worry about creating a legal entity or seperate bank account, paying taxes, or providing invoices to sponsors. Let us take care of all that, so you can stay focused on your project.",
   "openSourceApply.description.p2": "We have created the {osclink}, a non-profit umbrella organization, to serve the open source community. To join, you need at least 100 stars on Github (or other equivilant evidence of your project's validity), and to respect our {communityguidelineslink}.",
   "openSourceApply.description.p3": "Fees: 10% of funds raised. Half goes to Open Collective Inc to continue improving the software platform, and half to the Open Source Collective to cover its legal and financial services.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -819,6 +819,7 @@
   "no": "No",
   "notFound": "not found",
   "notFound.search": "Search for {term}",
+  "openinbox": "Open {buttontext}",
   "openSourceApply.description.p1": "You're creating software. You don't want to worry about creating a legal entity or seperate bank account, paying taxes, or providing invoices to sponsors. Let us take care of all that, so you can stay focused on your project.",
   "openSourceApply.description.p2": "We have created the {osclink}, a non-profit umbrella organization, to serve the open source community. To join, you need at least 100 stars on Github (or other equivilant evidence of your project's validity), and to respect our {communityguidelineslink}.",
   "openSourceApply.description.p3": "Fees: 10% of funds raised. Half goes to Open Collective Inc to continue improving the software platform, and half to the Open Source Collective to cover its legal and financial services.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -819,6 +819,7 @@
   "no": "Non",
   "notFound": "Pas trouvé",
   "notFound.search": "Rechercher {term}",
+  "openinbox": "Open {buttontext}",
   "openSourceApply.description.p1": "Vous créez un logiciel. Vous ne voulez pas vous soucier de créer une entité juridique ou un compte bancaire distinct, de payer des impôts ou de fournir des factures aux sponsors. Laissez-nous nous occuper de tout ça, pour que vous puissiez rester concentré sur votre projet.",
   "openSourceApply.description.p2": "We have created the {osclink}, a non-profit umbrella organization, to serve the open source community. To join, you need at least 100 stars on Github (or other equivilant evidence of your project's validity), and to respect our {communityguidelineslink}.",
   "openSourceApply.description.p3": "Fees: 10% of funds raised. Half goes to Open Collective Inc to continue improving the software platform, and half to the Open Source Collective to cover its legal and financial services.",

--- a/lang/it.json
+++ b/lang/it.json
@@ -819,6 +819,7 @@
   "no": "No",
   "notFound": "Non trovato",
   "notFound.search": "Search for {term}",
+  "openinbox": "Open {buttontext}",
   "openSourceApply.description.p1": "You're creating software. You don't want to worry about creating a legal entity or seperate bank account, paying taxes, or providing invoices to sponsors. Let us take care of all that, so you can stay focused on your project.",
   "openSourceApply.description.p2": "We have created the {osclink}, a non-profit umbrella organization, to serve the open source community. To join, you need at least 100 stars on Github (or other equivilant evidence of your project's validity), and to respect our {communityguidelineslink}.",
   "openSourceApply.description.p3": "Fees: 10% of funds raised. Half goes to Open Collective Inc to continue improving the software platform, and half to the Open Source Collective to cover its legal and financial services.",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -819,6 +819,7 @@
   "no": "No",
   "notFound": "ページが見付かりません",
   "notFound.search": "Search for {term}",
+  "openinbox": "Open {buttontext}",
   "openSourceApply.description.p1": "You're creating software. You don't want to worry about creating a legal entity or seperate bank account, paying taxes, or providing invoices to sponsors. Let us take care of all that, so you can stay focused on your project.",
   "openSourceApply.description.p2": "We have created the {osclink}, a non-profit umbrella organization, to serve the open source community. To join, you need at least 100 stars on Github (or other equivilant evidence of your project's validity), and to respect our {communityguidelineslink}.",
   "openSourceApply.description.p3": "Fees: 10% of funds raised. Half goes to Open Collective Inc to continue improving the software platform, and half to the Open Source Collective to cover its legal and financial services.",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -819,6 +819,7 @@
   "no": "No",
   "notFound": "Not found",
   "notFound.search": "Search for {term}",
+  "openinbox": "Open {buttontext}",
   "openSourceApply.description.p1": "You're creating software. You don't want to worry about creating a legal entity or seperate bank account, paying taxes, or providing invoices to sponsors. Let us take care of all that, so you can stay focused on your project.",
   "openSourceApply.description.p2": "We have created the {osclink}, a non-profit umbrella organization, to serve the open source community. To join, you need at least 100 stars on Github (or other equivilant evidence of your project's validity), and to respect our {communityguidelineslink}.",
   "openSourceApply.description.p3": "Fees: 10% of funds raised. Half goes to Open Collective Inc to continue improving the software platform, and half to the Open Source Collective to cover its legal and financial services.",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -819,6 +819,7 @@
   "no": "No",
   "notFound": "Not found",
   "notFound.search": "Search for {term}",
+  "openinbox": "Open {buttontext}",
   "openSourceApply.description.p1": "You're creating software. You don't want to worry about creating a legal entity or seperate bank account, paying taxes, or providing invoices to sponsors. Let us take care of all that, so you can stay focused on your project.",
   "openSourceApply.description.p2": "We have created the {osclink}, a non-profit umbrella organization, to serve the open source community. To join, you need at least 100 stars on Github (or other equivilant evidence of your project's validity), and to respect our {communityguidelineslink}.",
   "openSourceApply.description.p3": "Fees: 10% of funds raised. Half goes to Open Collective Inc to continue improving the software platform, and half to the Open Source Collective to cover its legal and financial services.",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -819,6 +819,7 @@
   "no": "Não",
   "notFound": "Não encontrado",
   "notFound.search": "Procure por {term}",
+  "openinbox": "Open {buttontext}",
   "openSourceApply.description.p1": "Você está criando software. Você não deseja se preocupar em criar uma entidade legal ou uma conta bancária separada, pagar impostos ou fornecer faturas aos patrocinadores. Vamos cuidar de tudo isso, para que você possa se concentrar no seu projeto.",
   "openSourceApply.description.p2": "Criamos a {osclink}, uma organização guarda-chuva sem fins lucrativos, para servir a comunidade de código aberto. Para participar, você precisa de pelo menos 100 estrelas no Github (ou outra evidência equivalente da validade do seu projeto) e respeitar nosso {communityguidelineslink}.",
   "openSourceApply.description.p3": "Tarifa: 10% dos fundos captados. Metade vai para o Open Collective Inc para continuar melhorando a plataforma de software e metade para o Open Source Collective para cobrir seus serviços jurídicos e financeiros.",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -819,6 +819,7 @@
   "no": "No",
   "notFound": "Не найдено",
   "notFound.search": "Search for {term}",
+  "openinbox": "Open {buttontext}",
   "openSourceApply.description.p1": "You're creating software. You don't want to worry about creating a legal entity or seperate bank account, paying taxes, or providing invoices to sponsors. Let us take care of all that, so you can stay focused on your project.",
   "openSourceApply.description.p2": "We have created the {osclink}, a non-profit umbrella organization, to serve the open source community. To join, you need at least 100 stars on Github (or other equivilant evidence of your project's validity), and to respect our {communityguidelineslink}.",
   "openSourceApply.description.p3": "Fees: 10% of funds raised. Half goes to Open Collective Inc to continue improving the software platform, and half to the Open Source Collective to cover its legal and financial services.",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -819,6 +819,7 @@
   "no": "No",
   "notFound": "Not found",
   "notFound.search": "Search for {term}",
+  "openinbox": "Open {buttontext}",
   "openSourceApply.description.p1": "You're creating software. You don't want to worry about creating a legal entity or seperate bank account, paying taxes, or providing invoices to sponsors. Let us take care of all that, so you can stay focused on your project.",
   "openSourceApply.description.p2": "We have created the {osclink}, a non-profit umbrella organization, to serve the open source community. To join, you need at least 100 stars on Github (or other equivilant evidence of your project's validity), and to respect our {communityguidelineslink}.",
   "openSourceApply.description.p3": "Fees: 10% of funds raised. Half goes to Open Collective Inc to continue improving the software platform, and half to the Open Source Collective to cover its legal and financial services.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10129,13 +10129,13 @@
       "dependencies": {
         "colors": {
           "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "resolved": "http://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
           "dev": true
         },
         "commander": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
           "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
           "dev": true
         }
@@ -11066,7 +11066,7 @@
         },
         "node-fetch": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
           "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
           "dev": true
         }
@@ -20754,7 +20754,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
@@ -22279,7 +22279,7 @@
         },
         "globby": {
           "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
           "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
           "dev": true,
           "requires": {
@@ -26142,7 +26142,7 @@
       "dependencies": {
         "ast-types": {
           "version": "0.7.8",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
+          "resolved": "http://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
           "integrity": "sha1-kC0uDWDQcb3NRtwRXhgJ7RHBOKk=",
           "dev": true
         },

--- a/pages/signinLinkSent.js
+++ b/pages/signinLinkSent.js
@@ -8,6 +8,7 @@ import Container from '../components/Container';
 import Page from '../components/Page';
 import { H3, P } from '../components/Text';
 import { PaperPlane } from 'styled-icons/boxicons-regular/PaperPlane';
+import OpenEmailProviderButton from '../components/OpenEmailProviderButton';
 
 const Icon = styled(PaperPlane)`
   color: ${themeGet('colors.primary.300')};
@@ -47,6 +48,9 @@ class SignInLinkSent extends Component {
 
           <P color="black.700" mt={3}>
             You&apos;ll be automatically redirected to the page before signing in. You can close this tab.
+          </P>
+          <P>
+            <OpenEmailProviderButton email={email} />
           </P>
         </Container>
       </Page>

--- a/test/cypress/integration/07-signin.test.js
+++ b/test/cypress/integration/07-signin.test.js
@@ -1,4 +1,4 @@
-import { randomEmail } from '../support/faker';
+import { randomEmail, randomGmailEmail, randomHotMail } from '../support/faker';
 import generateToken from '../support/token';
 
 describe('signin', () => {
@@ -110,6 +110,34 @@ describe('signin', () => {
     cy.get('button[type=submit]').click();
     cy.contains('Your magic link is on its way!');
     cy.contains(`We've sent it to ${email}.`);
+  });
+
+  it('can signup a user with gmail and show Open Gmail button ', () => {
+    // Submit the form using the email providers--gmail)
+    const gmail_email = randomGmailEmail(false);
+    cy.visit('/signin');
+    cy.contains('a', 'Join Free').click();
+    cy.get('input[name=email]').type(`{selectall}${gmail_email}`);
+    cy.get('button[type=submit]').click();
+    cy.contains('Your magic link is on its way!');
+    cy.contains(`We've sent it to ${gmail_email}.`);
+    cy.getByDataCy('open-inbox-link').should(
+      'have.prop',
+      'href',
+      'https://mail.google.com/mail/u/2/#advanced-search/subject=Open+Collective%3A+Login&amp;subset=all&amp;within=1d',
+    );
+  });
+
+  it('can signup a user with Hotmail and show Open Hotmail button', () => {
+    // Submit the form using the email providers--hotmail
+    const hotmail = randomHotMail(false);
+    cy.visit('/signin');
+    cy.contains('a', 'Join Free').click();
+    cy.get('input[name=email]').type(`{selectall}${hotmail}`);
+    cy.get('button[type=submit]').click();
+    cy.contains('Your magic link is on its way!');
+    cy.contains(`We've sent it to ${hotmail}.`);
+    cy.getByDataCy('open-inbox-link').should('have.prop', 'href', 'https://outlook.live.com/mail/inbox');
   });
 
   it('can signup as organization', () => {

--- a/test/cypress/support/faker.js
+++ b/test/cypress/support/faker.js
@@ -13,6 +13,16 @@ export const randomEmail = (directSignIn = true) => {
   return directSignIn ? `oc-test-${randomID}@opencollective.com` : `oc-noDirectSignIn-${randomID}@opencollective.com`;
 };
 
+export const randomGmailEmail = () => {
+  const randomID = uuidv4().split('-')[0];
+  return `test-${randomID}@gmail.com`;
+};
+
+export const randomHotMail = () => {
+  const randomID = uuidv4().split('-')[0];
+  return `test-${randomID}@outlook.com`;
+};
+
 export const randomSlug = () => {
   return uuidv4().split('-')[0];
 };


### PR DESCRIPTION
Resolve: [opencollective/opencollective#1915](https://github.com/opencollective/opencollective/issues/1915)

This PR adds  a button to open inbox for 2 email  providers(Gmail and hotmail)

with Gmail:
<img width="1440" alt="Screen Shot 2019-10-11 at 12 45 07 PM" src="https://user-images.githubusercontent.com/29824008/66642321-2f1ebf00-ec25-11e9-97be-db32e4bc1a33.png">
With Hotmail:
<img width="1440" alt="Screen Shot 2019-10-11 at 12 43 51 PM" src="https://user-images.githubusercontent.com/29824008/66642372-4cec2400-ec25-11e9-810a-d1ccf44e7918.png">

for any other email:
<img width="1440" alt="Screen Shot 2019-10-11 at 12 45 52 PM" src="https://user-images.githubusercontent.com/29824008/66642406-5bd2d680-ec25-11e9-82ae-39cd03c6de49.png">


