### PR TITLE
NCP: Improve NavBar section scroll detection formula

### DIFF
--- a/components/collective-page/index.js
+++ b/components/collective-page/index.js
@@ -87,14 +87,14 @@ class CollectivePage extends Component {
       isFixed = false;
     }
 
-    // Get the currently selected section
-    const distanceThreshold = 500;
-    const currentViewBottom = window.scrollY + window.innerHeight - distanceThreshold;
+    // Get the currently section that is at the top of the screen.
+    const distanceThreshold = 200;
+    const breakpoint = window.scrollY + distanceThreshold;
     const sections = this.getSections(this.props);
     for (let i = sections.length - 1; i >= 0; i--) {
       const sectionName = sections[i];
       const sectionRef = this.sectionsRefs[sectionName];
-      if (sectionRef && currentViewBottom > sectionRef.offsetTop) {
+      if (sectionRef && breakpoint >= sectionRef.offsetTop) {
         selectedSection = sectionName;
         break;
       }


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2482

With this PR the selected section will always be the one at the top of the screen. We allow a 200px offset above the section.

![Peek 11-10-2019 16-42](https://user-images.githubusercontent.com/1556356/66670100-3d86ce00-ec59-11e9-948b-374dc22ba7c0.gif)
