### PR TITLE
feat(expense): Allow expense creator to edit approved expense

### DIFF
--- a/lib/LoggedInUser.js
+++ b/lib/LoggedInUser.js
@@ -93,13 +93,17 @@ LoggedInUser.prototype.canApproveExpense = function(expense) {
 
 /**
  * CanEditExpense if not paid yet and LoggedInUser is:
- * - author of the expense and expense.status === 'PENDING'
+ * - author of the expense and expense.status === 'PENDING' or 'APPROVED'
  * - can approve expense (admin or host of expense.collective or expense.collective.host)
  */
 LoggedInUser.prototype.canEditExpense = function(expense) {
   if (!expense) return false;
   if (expense.status === 'PAID') return false;
-  if (expense.status === 'PENDING' && expense.fromCollective && expense.fromCollective.id === this.collective.id)
+  if (
+    (expense.status === 'PENDING' || expense.status === 'APPROVED') &&
+    expense.fromCollective &&
+    expense.fromCollective.id === this.collective.id
+  )
     return true;
   return this.canApproveExpense(expense);
 };


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/1384.

Adding the ability for an expense creator to edit their own expenses with `APPROVED` status (after which it will go back to `PENDING` from already existing functionality).

The API already allowed this mutation (only blocking edits where the status is `PAID`):
https://github.com/opencollective/opencollective-api/blob/9f07f63ca346c300247e7b580c4c443bc6fb75cd/server/graphql/v1/mutations/expenses.js#L42-L51

Screen capture:
![Oct-12-2019 17-21-19](https://user-images.githubusercontent.com/1552194/66703611-c4e54780-ed14-11e9-8786-727659f1a1ad.gif)


