### PR TITLE
ui(components) Add mobile layout for StepProgress; Add styleguide exa…

### DIFF
--- a/styleguide/examples/StepsProgress.md
+++ b/styleguide/examples/StepsProgress.md
@@ -17,6 +17,20 @@ initialState = { focus: null };
 </div>;
 ```
 
+```js
+initialState = { focus: null };
+<div style={{ resize: 'horizontal', padding: '15px', overflow: 'auto', width: '80%', maxWidth: '95%' }}>
+  <StepsProgress
+    forceMobile
+    steps={[{ name: 'BUY POTATOES' }, { name: 'COOK POTATOES' }, { name: 'EAT POTATOES' }]}
+    focus={state.focus}
+    onStepSelect={focus => setState({ focus })}
+  >
+    {({ step }) => <div style={{ textAlign: 'center' }}>{step.name}</div>}
+  </StepsProgress>
+</div>;
+```
+
 ### With disabled steps
 
 ```js
@@ -52,4 +66,44 @@ initialState = { focus: null };
   onStepSelect={focus => setState({ focus })}
   allCompleted
 />;
+```
+
+```js
+initialState = { focus: null };
+<StepsProgress
+  forceMobile
+  steps={[{ name: 'BUY POTATOES' }, { name: 'COOK POTATOES' }, { name: 'EAT POTATOES' }]}
+  onStepSelect={focus => setState({ focus })}
+  allCompleted
+/>;
+```
+
+### Mobile, second step and third step of 4
+
+```js
+initialState = { focus: { name: 'COOK POTATOES' } };
+<div style={{ resize: 'horizontal', padding: '15px', overflow: 'auto', width: '80%', maxWidth: '95%' }}>
+  <StepsProgress
+    forceMobile
+    steps={[{ name: 'BUY POTATOES' }, { name: 'COOK POTATOES' }, { name: 'EAT POTATOES' }, { name: 'DO DISHES' }]}
+    focus={state.focus}
+    onStepSelect={focus => setState({ focus })}
+  >
+    {({ step }) => <div style={{ textAlign: 'center' }}>{step.name}</div>}
+  </StepsProgress>
+</div>;
+```
+
+```js
+initialState = { focus: { name: 'EAT POTATOES' } };
+<div style={{ resize: 'horizontal', padding: '15px', overflow: 'auto', width: '80%', maxWidth: '95%' }}>
+  <StepsProgress
+    forceMobile
+    steps={[{ name: 'BUY POTATOES' }, { name: 'COOK POTATOES' }, { name: 'EAT POTATOES' }, { name: 'DO DISHES' }]}
+    focus={state.focus}
+    onStepSelect={focus => setState({ focus })}
+  >
+    {({ step }) => <div style={{ textAlign: 'center' }}>{step.name}</div>}
+  </StepsProgress>
+</div>;
 ```


### PR DESCRIPTION
…mples

- Add mobile layout and necessary styles, variables, elements to render a circle progress bar that can adapt to variable number of steps
- Add values as props to the progress pie so that it can be moved out to a separate file for the ease of maintainability in the future
- Add `forceMobile` option for styleguide development
- Closes https://github.com/opencollective/opencollective/issues/1727

I want to get early feedback and clarify the list of TODO items, so that i can work against a fixed list of todos to complete the task
TODO:
- Because this component will be rendered server-side (SSR), we must render both mobile and desktop views and use CSS for conditional rendering. A nice optimization can be made client-side thanks to the withViewport helper to avoid rendering the view that will not be displayed when viewport is not UNKNOWN
-  Finish styles as per design