### PR TITLE
[enhancement]: Edit button overlapping text in About section #2523

### DIFF
--- a/components/InlineEditField.js
+++ b/components/InlineEditField.js
@@ -68,10 +68,13 @@ class InlineEditField extends Component {
      * Highly recommended if field is nullable.
      */
     placeholder: PropTypes.node,
+    /** Editing the top value. */
+    topEdit: PropTypes.number,
   };
 
   static defaultProps = {
     showEditIcon: true,
+    topEdit: -5,
   };
 
   state = { isEditing: false, draft: '' };
@@ -109,16 +112,25 @@ class InlineEditField extends Component {
   }
   z;
   render() {
-    const { field, values, mutation, canEdit, formatBeforeSubmit, showEditIcon, placeholder, children } = this.props;
+    const {
+      field,
+      values,
+      mutation,
+      canEdit,
+      formatBeforeSubmit,
+      showEditIcon,
+      placeholder,
+      children,
+      topEdit,
+    } = this.props;
     const { isEditing, draft } = this.state;
     const value = get(values, field);
     const touched = draft !== value;
-
     if (!isEditing) {
       return (
         <Container position="relative">
           {canEdit && showEditIcon && (
-            <Container position="absolute" top={-5} right={-5} zIndex={2}>
+            <Container position="absolute" top={topEdit} right={-5} zIndex={2}>
               <EditIcon size={24} onClick={this.enableEditor} data-cy={`InlineEditField-Trigger-${field}`} />
             </Container>
           )}

--- a/components/collective-page/sections/About.js
+++ b/components/collective-page/sections/About.js
@@ -53,6 +53,7 @@ const SectionAbout = ({ collective, canEdit, intl }) => {
           values={collective}
           field="longDescription"
           canEdit={canEdit}
+          topEdit={-20}
           showEditIcon={!isEmptyDescription}
           formatBeforeSubmit={v => (isEmptyValue(v) ? null : v)}
         >


### PR DESCRIPTION
Handling:  #[opencollective/opencollective#2523](https://github.com/opencollective/opencollective/issues/2523)
Edit button overlapping in About section is fixed.

- Added a new prop `topEdit` in `InlineEditField.js`

- Set the `topEdit` value to -20 to avoid overlapping in `About.js`