### PR TITLE
fix(2524) : Event: content is overlapping footer

### DIFF
--- a/components/Responses.js
+++ b/components/Responses.js
@@ -17,6 +17,7 @@ class Responses extends React.Component {
           {`
             .Responses {
               width: 100%;
+              display: inline-block;
             }
             .innerResponses {
               margin: 3rem auto;


### PR DESCRIPTION
@Betree  The height of Response was causing the issue https://github.com/opencollective/opencollective/issues/2524 , I have added dynamic height to resolve it, please take a look if this is the correct way of handling the issue 
 
![Screenshot from 2019-10-16 22-17-42](https://user-images.githubusercontent.com/21286134/66941433-79a89d00-f064-11e9-841b-69deb08f81b0.png)
