### PR TITLE
ops(styleguide): Move to Netlify

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
     "prettier:write": "npm run prettier -- --write",
     "start": "node dist/server",
     "styleguide:build": "styleguidist build",
-    "styleguide:deploy": "NODE_ENV=production npm run styleguide:build && npx now styleguide && npx now alias -A styleguide/now.json",
     "styleguide:dev": "styleguidist server",
     "test": "npm run test:jest",
     "test:clean": "shx rm -rf test/cypress/screenshots test/cypress/videos",

--- a/styleguide/now.json
+++ b/styleguide/now.json
@@ -1,6 +1,0 @@
-{
-  "name": "opencollective-styleguide",
-  "alias": ["opencollective-styleguide", "styleguide.opencollective.com"],
-  "version": 1,
-  "files": ["index.html", "build", "static"]
-}


### PR DESCRIPTION
Because we already use Netlify for `styleguidist` deploy previews, we also have an auto-deploy for the latest version of our styleguide that is always up to date with master on https://oc-styleguide.netlify.com/. The one we have with Now on https://styleguide.opencollective.com is never up to date, we always forget to deploy it. 

If we decide to go with this PR, we'll have to:
- Redirect the subdomain to Netlify
- Remove the project from Now

Because Netlify is free, there will not be any associated cost.

---

@znarf I'll wait for your feedback before taking any further action 