### PR TITLE
ContributionFlow: Improve spacing for custom fields

### DIFF
--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -267,7 +267,13 @@ const StepDetails = ({
         customFields.map(customField => {
           const value = customData && customData[customField.name] ? customData[customField.name] : '';
           return (
-            <StyledInputField mt={2} key={customField.name} htmlFor={customField.name} label={customField.label}>
+            <StyledInputField
+              mt={3}
+              key={customField.name}
+              htmlFor={customField.name}
+              label={customField.label}
+              width="100%"
+            >
               {fieldProps => (
                 <StyledInput
                   type={customField.type}


### PR DESCRIPTION
Depending on input type, some of them were not using the full width.

# Use full width

## Before

![image](https://user-images.githubusercontent.com/1556356/67040338-90fa8f80-f123-11e9-8495-67f08e928926.png)

## After
![image](https://user-images.githubusercontent.com/1556356/67040399-b9828980-f123-11e9-87d0-d3136ab1f08b.png)

## No change for BackYourStack

![image](https://user-images.githubusercontent.com/1556356/67040471-d4ed9480-f123-11e9-9ca8-4cc00928b615.png)

# Use bigger Y margin

Use the same margin that between amount and interval (16px)

## Before

![image](https://user-images.githubusercontent.com/1556356/67040830-95737800-f124-11e9-9f95-d1bf18c2e7bd.png)


## After

![image](https://user-images.githubusercontent.com/1556356/67040765-6d841480-f124-11e9-9d5b-31d62fdf6abf.png)
