### PR TITLE
style(UnapproveExpenseBtn): Remove secondary button type

### DIFF
--- a/components/expenses/UnapproveExpenseBtn.js
+++ b/components/expenses/UnapproveExpenseBtn.js
@@ -16,7 +16,7 @@ const UnapproveExpenseBtn = ({ id, unapproveExpense }) => {
   };
 
   return (
-    <StyledButton mr={2} buttonStyle="secondary" onClick={() => handleOnClick()}>
+    <StyledButton mr={2} onClick={() => handleOnClick()}>
       <FormattedMessage id="expense.unapprove.btn" defaultMessage="Unapprove" />
     </StyledButton>
   );


### PR DESCRIPTION
`secondary` button style is there for important calls to actions. Un-approving expenses is not an action that we want to put up-front, it's an advanced feature that serves in rare cases