### PR TITLE
Improve usability of tag entry field

### DIFF
--- a/components/EditCollectiveForm.js
+++ b/components/EditCollectiveForm.js
@@ -122,7 +122,7 @@ class EditCollectiveForm extends React.Component {
       },
       'tags.description': {
         id: 'collective.tags.edit.description',
-        defaultMessage: 'Make your Collective more discoverable (comma separated)',
+        defaultMessage: 'Make your Collective more discoverable',
       },
       'company.label': {
         id: 'collective.company.label',

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -197,7 +197,7 @@
   "collective.stats.totalAmountRaised.label": "Total amount raised",
   "collective.stats.totalAmountSpent.label": "Total amount contributed",
   "collective.tags.description": "Tags helps people discover your collective",
-  "collective.tags.edit.description": "Make your Collective more discoverable (comma separated)",
+  "collective.tags.edit.description": "Make your Collective more discoverable",
   "collective.tags.label": "Tags",
   "collective.tiers.donate": "Or make a custom financial contribution",
   "collective.tos.description": "Link to the terms by which this host will collect money on behalf of their collectives",

--- a/lang/de.json
+++ b/lang/de.json
@@ -197,7 +197,7 @@
   "collective.stats.totalAmountRaised.label": "Gesamter gesammelter Betrag",
   "collective.stats.totalAmountSpent.label": "Gesamter gespendeter Betrag",
   "collective.tags.description": "Tags helfen anderen dein Collective zu finden",
-  "collective.tags.edit.description": "Make your Collective more discoverable (comma separated)",
+  "collective.tags.edit.description": "Make your Collective more discoverable",
   "collective.tags.label": "Tags",
   "collective.tiers.donate": "Or make a custom financial contribution",
   "collective.tos.description": "Link to the terms by which this host will collect money on behalf of their collectives",

--- a/lang/en.json
+++ b/lang/en.json
@@ -197,7 +197,7 @@
   "collective.stats.totalAmountRaised.label": "Total amount raised",
   "collective.stats.totalAmountSpent.label": "Total amount contributed",
   "collective.tags.description": "Tags helps people discover your collective",
-  "collective.tags.edit.description": "Make your Collective more discoverable (comma separated)",
+  "collective.tags.edit.description": "Make your Collective more discoverable",
   "collective.tags.label": "Tags",
   "collective.tiers.donate": "Or make a custom financial contribution",
   "collective.tos.description": "Link to the terms by which this host will collect money on behalf of their collectives",

--- a/lang/es.json
+++ b/lang/es.json
@@ -197,7 +197,7 @@
   "collective.stats.totalAmountRaised.label": "Monto total donado",
   "collective.stats.totalAmountSpent.label": "Total amount contributed",
   "collective.tags.description": "Las etiquetas ayudan a la gente a encontrar tu colecta",
-  "collective.tags.edit.description": "Make your Collective more discoverable (comma separated)",
+  "collective.tags.edit.description": "Make your Collective more discoverable",
   "collective.tags.label": "Tags",
   "collective.tiers.donate": "Or make a custom financial contribution",
   "collective.tos.description": "Enlace a los términos y condiciones por los cuales este anfitrión realiza la colecta de dinero en nombre de sus colectas",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -197,7 +197,7 @@
   "collective.stats.totalAmountRaised.label": "Montant total levé",
   "collective.stats.totalAmountSpent.label": "Montant total contribué",
   "collective.tags.description": "Les tags aident la communauté à découvrir votre collectif",
-  "collective.tags.edit.description": "Rendre votre collectif plus facilement trouvable (séparez les termes par des virgules)",
+  "collective.tags.edit.description": "Rendre votre collectif plus facilement trouvable",
   "collective.tags.label": "Tags",
   "collective.tiers.donate": "Ou faire une contribution personnalisée",
   "collective.tos.description": "Lien vers les conditions d'utilisation que les collectifs qui souhaitent être hébergés doivent accepter",

--- a/lang/it.json
+++ b/lang/it.json
@@ -197,7 +197,7 @@
   "collective.stats.totalAmountRaised.label": "Importo totale raccolto",
   "collective.stats.totalAmountSpent.label": "Total amount contributed",
   "collective.tags.description": "I tag aiutano le persone a scoprire il tuo collettivo",
-  "collective.tags.edit.description": "Rendi il tuo Collettivo più visibile (separato da una virgola)",
+  "collective.tags.edit.description": "Rendi il tuo Collettivo più visibile",
   "collective.tags.label": "Tags",
   "collective.tiers.donate": "Or make a custom financial contribution",
   "collective.tos.description": "Link ai termini in base ai quali questo organizzatore raccoglierà denaro per conto dei loro collettivi",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -197,7 +197,7 @@
   "collective.stats.totalAmountRaised.label": "調達総額",
   "collective.stats.totalAmountSpent.label": "Total amount contributed",
   "collective.tags.description": "タグはあなたのコレクティブをほかの人が探すのを助けます",
-  "collective.tags.edit.description": "Make your Collective more discoverable (comma separated)",
+  "collective.tags.edit.description": "Make your Collective more discoverable",
   "collective.tags.label": "タグ",
   "collective.tiers.donate": "Or make a custom financial contribution",
   "collective.tos.description": "Link to the terms by which this host will collect money on behalf of their collectives",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -197,7 +197,7 @@
   "collective.stats.totalAmountRaised.label": "Total amount raised",
   "collective.stats.totalAmountSpent.label": "Total amount contributed",
   "collective.tags.description": "Tags helps people discover your collective",
-  "collective.tags.edit.description": "Make your Collective more discoverable (comma separated)",
+  "collective.tags.edit.description": "Make your Collective more discoverable",
   "collective.tags.label": "Tags",
   "collective.tiers.donate": "Or make a custom financial contribution",
   "collective.tos.description": "Link to the terms by which this host will collect money on behalf of their collectives",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -197,7 +197,7 @@
   "collective.stats.totalAmountRaised.label": "Totaal aantal opgehaald",
   "collective.stats.totalAmountSpent.label": "Totale hoeveelheid bijgedragen",
   "collective.tags.description": "Labels helpen mensen je collectief te ontdekken",
-  "collective.tags.edit.description": "Make je collectief gemakkelijker te ontdekken (comma gescheiden)",
+  "collective.tags.edit.description": "Make je collectief gemakkelijker te ontdekken",
   "collective.tags.label": "Labels",
   "collective.tiers.donate": "Of maak een aangepaste financiële bijdrage",
   "collective.tos.description": "Verwijs naar de voorwaarden waarbij deze beheerder geld zal verzamelen in naam van hun collectieven",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -197,7 +197,7 @@
   "collective.stats.totalAmountRaised.label": "Quantia arrecadada total",
   "collective.stats.totalAmountSpent.label": "Quantia contribuída total",
   "collective.tags.description": "Tags ajudam pessoas a descobrir seu coletivo",
-  "collective.tags.edit.description": "Faça seu coletivo aparecer mais (separado por vírgula)",
+  "collective.tags.edit.description": "Faça seu coletivo aparecer mais",
   "collective.tags.label": "Tags",
   "collective.tiers.donate": "Ou faça uma contribuição financeira personalizada",
   "collective.tos.description": "Link para os termos pelos quais este organizador vai coletar dinheiro em nome dos seus coletivos",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -197,7 +197,7 @@
   "collective.stats.totalAmountRaised.label": "Всего получено",
   "collective.stats.totalAmountSpent.label": "Всего пожертвовано",
   "collective.tags.description": "Tags helps people discover your collective",
-  "collective.tags.edit.description": "Make your Collective more discoverable (comma separated)",
+  "collective.tags.edit.description": "Make your Collective more discoverable",
   "collective.tags.label": "Теги",
   "collective.tiers.donate": "Or make a custom financial contribution",
   "collective.tos.description": "Link to the terms by which this host will collect money on behalf of their collectives",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -197,7 +197,7 @@
   "collective.stats.totalAmountRaised.label": "总共被筹募的数目",
   "collective.stats.totalAmountSpent.label": "Total amount contributed",
   "collective.tags.description": "Tags helps people discover your collective",
-  "collective.tags.edit.description": "Make your Collective more discoverable (comma separated)",
+  "collective.tags.edit.description": "Make your Collective more discoverable",
   "collective.tags.label": "标签",
   "collective.tiers.donate": "Or make a custom financial contribution",
   "collective.tos.description": "Link to the terms by which this host will collect money on behalf of their collectives",

--- a/static/styles/react-tags.css
+++ b/static/styles/react-tags.css
@@ -10,7 +10,7 @@ div.ReactTags__tags {
 
 /* Styles for the input */
 div.ReactTags__tagInput {
-  width: 200px;
+  width: 15em;
   border-radius: 2px;
   display: inline-block;
 }


### PR DESCRIPTION
The tag entry field makes conflicting statements, it suggests that tags are entered using the Enter key and then in the text below, using commas. See screenshot below. It would be ideal if the instruction were just in the placeholder. Having the choice of using commas or the Enter key is nice, but probably not essential to most people. This PR suggests removing the comma instruction in the placeholder, and widening the text field so that the instruction fits.

![Screenshot from 2019-10-18 21-40-21](https://user-images.githubusercontent.com/31819/67123438-9b368f80-f1f0-11e9-9378-7f582cdd8fff.png)
_Image of current tag entry field_

Nota Bene:
- I have not tested this locally. For example, it would be good to check if other languages also fit the placeholder, and test the deployment process used for translations.
- When creating my organization, I used commas. But then I got one long tag ("switzerland,schweiz,suisse,svizzera") instead of having them separate. I'll try to reproduce this and raise a separate issue.