### PR TITLE
chore: don't crash when localStorage throws exceptions

### DIFF
--- a/lib/local-storage.js
+++ b/lib/local-storage.js
@@ -7,47 +7,49 @@ export const LOCAL_STORAGE_KEYS = {
   HOST_DASHBOARD_FILTER_PREFERENCES: 'hostDashBoardFilterPreferences',
 };
 
-/**
- * Helper to check if localStorage is supported in current context
- */
-export const hasLocalStorage = () => {
-  return Boolean(typeof window !== 'undefined' && window.localStorage);
-};
+// The below helpers use a try-catch to gracefully fallback in these scenarios:
+// - SSR (server-side rendering), where the emulated context might not have localStorage.
+// - Some robots and crawlers (like Google), although these usually either don't execute JS,
+//   or do so in a modern engine with supported (but ignored) localStorage.
+// - Private browsing mode. Here, localStorage methods may throw exceptions.
+// - Regular browsing mode, if the user configured the browser to require permission before
+//   storing data. If the current site isn't yet whitelisted and JS attempts to access
+//   window.localStorage, an exception is thrown. Even `if (window.localStorage)` crashes.
+// - Regular browsing mode, where localStorage is full. In those cases, localStorage.setItem()
+//   will throw an exception.
 
 /**
- * A helper to get a value from localStorage that returns null instead of crashing
- * if localStorage doesn't exist. This is useful for:
- *  - SSR, because localStorage doesn't exist in this context
- *  - Because robots/crawlers (like Google) don't have it and we don't want to crash when they visit us
+ * A helper to get a value from localStorage.
+ * Returns the value, or null if no value exists or if storage is unavailable.
  */
 export const getFromLocalStorage = key => {
-  if (hasLocalStorage()) {
+  try {
     return window.localStorage.getItem(key);
-  } else {
+  } catch (e) {
     return null;
   }
 };
 
 /**
- * A helper to set a value in localStorage that doesn't crash if localStorage doesn't exist.
- * This is useful for:
- *  - SSR, because localStorage doesn't exist in this context
- *  - Because robots/crawlers (like Google) don't have it and we don't want to crash when they visit us
+ * A helper to set a value in localStorage.
+ * Ignores errors about full, disallowed or unsupported storage.
  */
 export const setLocalStorage = (key, value) => {
-  if (hasLocalStorage()) {
-    return window.localStorage.setItem(key, value);
+  try {
+    window.localStorage.setItem(key, value);
+  } catch (e) {
+    // Ignore errors
   }
 };
 
 /**
- * A helper to remove an entry in localStorage that doesn't crash if localStorage doesn't exist.
- * This is useful for:
- *  - SSR, because localStorage doesn't exist in this context
- *  - Because robots/crawlers (like Google) don't have it and we don't want to crash when they visit us
+ * A helper to remove an entry in localStorage.
+ * Ignores errors about full, disallowed or unsupported storage.
  */
 export const removeFromLocalStorage = key => {
-  if (hasLocalStorage()) {
-    return window.localStorage.removeItem(key);
+  try {
+    window.localStorage.removeItem(key);
+  } catch (e) {
+    // Ignore errors
   }
 };


### PR DESCRIPTION
Follows-up commit 43664fd1 and pull https://github.com/opencollective/opencollective-frontend/pull/2642.

Resolves two problems:

* The frontend still crashed on all page loads for some users because the
  hasLocalStorage() function did not consider the window.localStorage property
  access itself causing an exception.

* The frontend still crashed on iOS when local storage is full,
  or in Mobile Safari "Private" mode where setItem() will throw,
  for cases where the frontend would try to store data.

Implemented by replacing the if-check with a try-catch. I also
removed the "return" statements from setItem() and removeItem()
so that the wrapper method has stable behaviour both when it exists
and when it doesn't exist, regardless of what the native method
might do in the future. Right now, though, it also returns
undefined always.

Fixes https://github.com/opencollective/opencollective/issues/2542.