### PR TITLE
(fix/2487): Show Collective's host on expense page

### DIFF
--- a/components/CollectiveNavbar.js
+++ b/components/CollectiveNavbar.js
@@ -8,6 +8,8 @@ import { Flex } from '@rebass/grid';
 
 import { Cog } from 'styled-icons/typicons/Cog';
 import { ChevronDown } from 'styled-icons/boxicons-regular/ChevronDown';
+import DefinedTerm, { Terms } from './DefinedTerm';
+import { Span } from './Text';
 
 import { CollectiveType } from '../lib/constants/collectives';
 import Container from './Container';
@@ -303,6 +305,20 @@ const CollectiveNavbar = ({
           )}
         </Flex>
         <ExpandMenuIcon onClick={() => setExpended(!isExpended)} />
+        <Container>
+          <FormattedMessage
+            id="Collective.Hero.Host"
+            defaultMessage="{FiscalHost}: {hostName}"
+            values={{
+              FiscalHost: <DefinedTerm term={Terms.FISCAL_HOST} />,
+              hostName: (
+                <LinkCollective collective={collective.host}>
+                  <Span color="black.600">{collective.host.name}</Span>
+                </LinkCollective>
+              ),
+            }}
+          />
+        </Container>
       </InfosContainer>
 
       {/** Navbar items and buttons */}


### PR DESCRIPTION
handling : https://github.com/opencollective/opencollective/issues/2487

I have added the Host at the top right so that the height is not increased and the host could be seen along with the collective name 

Screen shot for a particular expense

![Screenshot from 2019-10-21 15-41-34](https://user-images.githubusercontent.com/21286134/67197496-89383500-f41a-11e9-93fe-7c125849f133.png)

Screen shot for all the expenses 

![Screenshot from 2019-10-21 15-41-53](https://user-images.githubusercontent.com/21286134/67197518-96edba80-f41a-11e9-8eef-d98d83034454.png)
