### PR TITLE
EditCollective: Show images section for events

### DIFF
--- a/components/EditCollectiveForm.js
+++ b/components/EditCollectiveForm.js
@@ -88,7 +88,7 @@ class EditCollectiveForm extends React.Component {
     const isNewCollectivePage = parseToBoolean(process.env.NCP_IS_DEFAULT);
     this.showEditTiers = ['COLLECTIVE', 'EVENT'].includes(collective.type);
     this.showExpenses = collective.type === 'COLLECTIVE' || collective.isHost;
-    this.showEditImages = !isNewCollectivePage;
+    this.showEditImages = !isNewCollectivePage || collective.type === CollectiveType.EVENT;
     this.showEditGoals = collective.type === CollectiveType.COLLECTIVE;
     this.showHost = collective.type === 'COLLECTIVE';
     this.defaultTierType = collective.type === 'EVENT' ? 'TICKET' : 'TIER';


### PR DESCRIPTION
Was removed in https://github.com/opencollective/opencollective-frontend/pull/2648

We still want to show the `images` section for events cause there's no way for them to change their images otherwise.