### PR TITLE
ErrorPage: Fix regex check for homepage

### DIFF
--- a/pages/_error.js
+++ b/pages/_error.js
@@ -25,7 +25,8 @@ class NextJSErrorPage extends React.Component {
     if (statusCode === 404 && url) {
       const slugRegex = /^\/([^/?]+)/;
       const parsedUrl = slugRegex.exec(url);
-      return <ErrorPage log={false} error={generateError.notFound(parsedUrl[1])} />;
+      const pageSlug = parsedUrl && parsedUrl[1];
+      return <ErrorPage log={false} error={generateError.notFound(pageSlug)} />;
     } else {
       return <ErrorPage />;
     }


### PR DESCRIPTION
If a crash ever happens on Homepage, the regex on the error page would have crashed too (error-ception) though from my tests that was only generating an error in the console. This will prevent it from happening.