### PR TITLE
GithubFlow: Show error message when repos list fetch fails

### DIFF
--- a/pages/openSourceApply.js
+++ b/pages/openSourceApply.js
@@ -76,7 +76,7 @@ class OpenSourceApplyPage extends Component {
     } catch (error) {
       this.setState({
         loadingRepos: false,
-        result: { type: 'error', mesg: 'Error: An unknown error occured' },
+        result: { type: 'error', mesg: error.toString() },
       });
     }
   }


### PR DESCRIPTION
It's difficult to investigate https://opencollective.freshdesk.com/a/tickets/2381 because the error message is not displayed. A proper error logger plugged to Sentry will be really appreciated here.