### PR TITLE
fix-2560 : Correct precision for expense

### DIFF
--- a/components/expenses/Expense.js
+++ b/components/expenses/Expense.js
@@ -171,6 +171,14 @@ class Expense extends React.Component {
           (Date.now() - new Date(expense.updatedAt).getTime() < 60 * 1000 * 15 || // admin of collective can reject the expense for up to 10mn after approving it
             LoggedInUser.canEditCollective(collective.host))));
 
+    let precision = 0;
+
+    // Check if the remainder is not 0, this check is important in order to know the amount that needs precision
+    // i.e display $10.21 as $10.21 instead of $10
+    if ((expense.amount / 100) % 1 !== 0) {
+      precision = 2;
+    }
+
     const canApprove =
       LoggedInUser &&
       LoggedInUser.canApproveExpense(expense) &&
@@ -318,7 +326,7 @@ class Expense extends React.Component {
         <div className="body">
           <div className="header">
             <div className="amount pullRight">
-              <AmountCurrency amount={-expense.amount} currency={expense.currency} />
+              <AmountCurrency amount={-expense.amount} currency={expense.currency} precision={precision} />
             </div>
             <div className="description">
               <Link route={`/${collective.slug}/expenses/${expense.id}`} title={capitalize(title)}>


### PR DESCRIPTION
handling : https://github.com/opencollective/opencollective/issues/2560

Set precision=2 for amount, so that amount is consistent everywhere - budget, transaction, expense, mail


**Particular expense**

![Screenshot from 2019-10-25 23-00-19](https://user-images.githubusercontent.com/21286134/67591840-f1b94600-f77b-11e9-9f94-6ed30060433b.png)


**View all expense** 

![Screenshot from 2019-10-25 23-00-09](https://user-images.githubusercontent.com/21286134/67591845-f54ccd00-f77b-11e9-86e7-6b9cdefd1671.png)
