### PR TITLE
Hide 'Contact' button from collective admin

### DIFF
--- a/components/collective-page/index.js
+++ b/components/collective-page/index.js
@@ -123,7 +123,7 @@ class CollectivePage extends Component {
   getCallsToAction = memoizeOne((type, isHost, isAdmin, isRoot, canApply, canContact) => {
     const isCollective = type === CollectiveType.COLLECTIVE;
     return {
-      hasContact: canContact,
+      hasContact: !isAdmin && canContact,
       hasSubmitExpense: isCollective,
       hasApply: canApply,
       hasDashboard: isHost && isAdmin,


### PR DESCRIPTION
This was initially done in https://github.com/opencollective/opencollective-frontend/pull/2750 but due to recent addition of [contact form ](https://github.com/opencollective/opencollective-frontend/pull/2848)it was updated. 