### PR TITLE
Enable host admin to add fund from organization page

### DIFF
--- a/components/collective-page/index.js
+++ b/components/collective-page/index.js
@@ -128,7 +128,7 @@ class CollectivePage extends Component {
       hasApply: canApply,
       hasDashboard: isHost && isAdmin,
       hasManageSubscriptions: isAdmin && !isCollective,
-      addFunds: isRoot && type === CollectiveType.ORGANIZATION,
+      addFunds: (isRoot || isAdmin) && type === CollectiveType.ORGANIZATION,
     };
   });
 


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/1919

Currently, only the root user can add fund from organization page, this PR gives host admin the same privilege. 