### PR TITLE
ContributionFlow: Always show manual payment method for root users

### DIFF
--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -655,7 +655,9 @@ class CreateOrderPage extends React.Component {
   /** Returns manual payment method if supported by the host and not using an interval, null otherwise */
   getManualPaymentMethod() {
     const pm = get(this.props.host.settings, 'paymentMethods.manual');
-    if (!pm || get(this.state, 'stepDetails.interval')) {
+    const interval = get(this.state, 'stepDetails.interval');
+
+    if (interval || (!pm && !this.props.LoggedInUser.isRoot())) {
       return null;
     }
 


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2573 by always enabling the manual payment method in the contribution flow if user is root (except in an interval is provided because manual PM doesn't support subscriptions).

We don't require the host to have a manual payment method on the API, so this PR is enough to unlock the feature.