### PR TITLE
HTMLContent: Display paragraphs in list inline

### DIFF
--- a/components/HTMLContent.js
+++ b/components/HTMLContent.js
@@ -78,6 +78,10 @@ const HTMLContent = styled(({ content, ...props }) => {
       position: relative;
       padding: 0 0 0 1em;
       margin-bottom: 0.4em;
+
+      & > p:first-child {
+        display: inline;
+      }
       
       &::before {
         content: "◯";


### PR DESCRIPTION
Fix a styling issue with old long descriptions that made list items not appear inline. Example with `/europe`:

**Before**

![image](https://user-images.githubusercontent.com/1556356/67847530-515c7c00-fb03-11e9-8b69-044cd386eb48.png)


**After**

![image](https://user-images.githubusercontent.com/1556356/67847436-2540fb00-fb03-11e9-8dd1-5f25562ca26c.png)
