### PR TITLE
EditWebhooks: Remove broken numbers

### DIFF
--- a/components/EditWebhooks.js
+++ b/components/EditWebhooks.js
@@ -207,9 +207,6 @@ class EditWebhooks extends React.Component {
             <Span fontSize="Paragraph" mb={1}>
               {intl.formatMessage(messages['webhooks.url.label'])}
             </Span>
-            <Span fontSize="3rem" color="#D7D9E0" css={'transform: translate(-60px, 23px); position: absolute;'}>
-              {index + 1}
-            </Span>
             <StyledInputGroup
               type="type"
               name="webhookUrl"


### PR DESCRIPTION
This was implemented with a position absolute, which is usually risky if you want some resilience. Best fix would be to display this number properly (I didn't want to invest too much time here).

![image](https://user-images.githubusercontent.com/1556356/67933841-eeccb400-fbc6-11e9-92d7-07e0109ea180.png)
