### PR TITLE
fix -2577 : Explicitly display the cause for not able to delete a collective

### DIFF
--- a/components/EditCollectiveDelete.js
+++ b/components/EditCollectiveDelete.js
@@ -80,7 +80,7 @@ const DeleteCollective = ({ collective, deleteCollective, deleteUserCollective, 
             values={{ type: collectiveType }}
             id="collective.delete.isNotDeletable-message"
             defaultMessage={
-              '{type}s with transactions, orders, or paid expenses cannot be deleted. Please archive it instead.'
+              '{type}s with transactions, orders, events or paid expenses cannot be deleted. Please archive it instead.'
             }
           />{' '}
         </P>

--- a/lang/en.json
+++ b/lang/en.json
@@ -131,7 +131,7 @@
   "collective.delete.cancel.btn": "Cancel",
   "collective.delete.confirm.btn": "Delete",
   "collective.delete.description": "This {type} will be deleted, along with all related data like Core Contributor roles and payment methods.",
-  "collective.delete.isNotDeletable-message": "{type}s with transactions, orders, or paid expenses cannot be deleted. Please archive it instead.",
+  "collective.delete.isNotDeletable-message": "{type}s with transactions, orders, events or paid expenses cannot be deleted. Please archive it instead.",
   "collective.delete.modal.body": "Are you sure you want to delete this {type}?",
   "collective.delete.modal.header": "Delete {name}",
   "collective.delete.title": "Delete this {type}",


### PR DESCRIPTION
handling : https://github.com/opencollective/opencollective/issues/2577

Dependent on : https://github.com/opencollective/opencollective-api/pull/2864