### PR TITLE
fix(component): fix HTML showing on Collective card

### DIFF
--- a/components/CollectiveCard.js
+++ b/components/CollectiveCard.js
@@ -58,9 +58,7 @@ class CollectiveCard extends React.Component {
       coverStyle.backgroundPosition = 'center center';
     }
 
-    const truncatedDescription =
-      (collective.description && firstSentence(collective.description, 80)) ||
-      (collective.longDescription && firstSentence(collective.longDescription, 80));
+    const truncatedDescription = collective.description && firstSentence(collective.description, 80);
     const description = collective.description;
 
     let route, params;


### PR DESCRIPTION
Addresses opencollective/opencollective#2554

Screenshots of before and after. I logged in as `testuser+admin@opencollective.com` locally, added a `longDescription` to the Test Collective, and then deleted the `description` as @Betree advised to recreate the bug (bottom right).

![Screen Shot 2019-11-12 at 12 11 17](https://user-images.githubusercontent.com/37520401/68687834-b3869980-0565-11ea-81f1-f1ae07d1cfd7.png)

The code in `CollectiveCard.js` has been amended to sanitize and truncate the `longDescription` to 255 characters.

![Screen Shot 2019-11-12 at 12 15 16](https://user-images.githubusercontent.com/37520401/68688107-2132c580-0566-11ea-8f71-1826695739c9.png)

I realise this misses a few steps that you described @Betree but I thought this was the most simple - just sanitizing the `longDescription` rather than adding new fields? If this still needs work then let me know and I'll do that.