### PR TITLE
Fix approve expense button crash

### DIFF
--- a/components/expenses/ApproveExpenseBtn.js
+++ b/components/expenses/ApproveExpenseBtn.js
@@ -10,7 +10,7 @@ class ApproveExpenseBtn extends React.Component {
   static propTypes = {
     id: PropTypes.number.isRequired,
     approveExpense: PropTypes.func.isRequired,
-    refetch: PropTypes.func,
+    refetch: PropTypes.func.isRequired,
   };
 
   constructor(props) {

--- a/components/expenses/Expense.js
+++ b/components/expenses/Expense.js
@@ -61,7 +61,7 @@ class Expense extends React.Component {
     unlockPayAction: PropTypes.func,
     editExpense: PropTypes.func,
     unapproveExpense: PropTypes.func,
-    refetch: PropTypes.func,
+    refetch: PropTypes.func.isRequired,
     intl: PropTypes.object.isRequired,
   };
 

--- a/components/expenses/ExpenseWithData.js
+++ b/components/expenses/ExpenseWithData.js
@@ -68,6 +68,7 @@ class ExpenseWithData extends React.Component {
           allowPayAction={allowPayAction}
           lockPayAction={lockPayAction}
           unlockPayAction={unlockPayAction}
+          refetch={data.refetch}
         />
 
         {view === 'details' && (


### PR DESCRIPTION
Resolve https://sentry.io/organizations/open-collective/issues/1330087062/

Added missing `refetch` prop in `components/expenses/ExpenseWithData.js` and marked it as required for `Expense` and `ApproveExpenseBtn` because the code has no logic to handle missing `refetch`.
