### PR TITLE
test(host-dashboard): add tests for host dashboard actions

### DIFF
--- a/components/ConfirmationModal.js
+++ b/components/ConfirmationModal.js
@@ -26,10 +26,10 @@ const ConfirmationModal = ({
     </ModalBody>
     <ModalFooter>
       <Container display="flex" justifyContent="flex-end">
-        <StyledButton mx={20} onClick={() => cancelHandler()}>
+        <StyledButton mx={20} onClick={() => cancelHandler()} data-cy="confirmation-modal-cancel">
           {cancelLabel}
         </StyledButton>
-        <StyledButton data-cy="action" buttonStyle="primary" onClick={() => continueHandler()}>
+        <StyledButton buttonStyle="primary" onClick={() => continueHandler()} data-cy="confirmation-modal-continue">
           {continueLabel}
         </StyledButton>
       </Container>

--- a/components/expenses/ApproveExpenseBtn.js
+++ b/components/expenses/ApproveExpenseBtn.js
@@ -26,7 +26,7 @@ class ApproveExpenseBtn extends React.Component {
 
   render() {
     return (
-      <div className="ApproveExpenseBtn">
+      <div className="ApproveExpenseBtn" data-cy="approve-expense-btn">
         <SmallButton className="approve" bsStyle="success" onClick={this.onClick}>
           <FormattedMessage id="expense.approve.btn" defaultMessage="approve" />
         </SmallButton>

--- a/components/expenses/Expense.js
+++ b/components/expenses/Expense.js
@@ -211,7 +211,7 @@ class Expense extends React.Component {
         (expense.status === 'REJECTED' && Date.now() - new Date(expense.updatedAt).getTime() < 60 * 1000 * 15)); // we can approve an expense for up to 10mn after rejecting it
 
     return (
-      <div className={`expense ${status} ${this.state.mode}View`}>
+      <div className={`expense ${status} ${this.state.mode}View`} data-cy={`expense-${status}`}>
         <style jsx>
           {`
             .expense {
@@ -368,7 +368,9 @@ class Expense extends React.Component {
                   {formatCurrency(expense.collective.stats.balance, expense.collective.currency)}){' | '}
                 </span>
               )}
-              <span className="status">{intl.formatMessage(this.messages[status])}</span>
+              <span className="status" data-cy="expense-status-div">
+                {intl.formatMessage(this.messages[status])}
+              </span>
               {' | '}
               {editable && LoggedInUser && LoggedInUser.canEditExpense(expense) && (
                 <ExpenseNeedsTaxFormBadge isTaxFormRequired={expense.userTaxFormRequiredBeforePayment} />
@@ -445,7 +447,7 @@ class Expense extends React.Component {
                       onChange={fees => this.handleChange({ fees })}
                     />
                   )}
-                  <div className="expenseActions">
+                  <div className="expenseActions" data-cy="expense-actions">
                     {canPay && (
                       <PayExpenseBtn
                         expense={expense}

--- a/components/expenses/RejectExpenseBtn.js
+++ b/components/expenses/RejectExpenseBtn.js
@@ -26,7 +26,7 @@ class RejectExpenseBtn extends React.Component {
 
   render() {
     return (
-      <div className="RejectExpenseBtn">
+      <div className="RejectExpenseBtn" data-cy="reject-expense-btn">
         <SmallButton className="reject" bsStyle="danger" onClick={this.onClick}>
           <FormattedMessage id="expense.reject.btn" defaultMessage="reject" />
         </SmallButton>

--- a/components/host-dashboard/PendingApplications.js
+++ b/components/host-dashboard/PendingApplications.js
@@ -102,7 +102,7 @@ class HostPendingApplications extends React.Component {
             <StyledHr my={3} borderColor="black.200" />
             <Flex justifyContent="center">
               {c.isActive ? (
-                <Box color="green.700">
+                <Box color="green.700" data-cy={`${c.slug}-approved`}>
                   <Check size={39} />
                 </Box>
               ) : (
@@ -113,6 +113,7 @@ class HostPendingApplications extends React.Component {
                         mx={4}
                         loading={loading}
                         onClick={() => approveCollective({ variables: { id: c.id } })}
+                        data-cy={`${c.slug}-approve`}
                       >
                         <FormattedMessage id="host.pending-applications.approve" defaultMessage="Approve" />
                       </StyledButton>

--- a/pages/host.dashboard.js
+++ b/pages/host.dashboard.js
@@ -137,6 +137,7 @@ class HostDashboardPage extends React.Component {
               borderBottom="#E6E8EB"
               boxShadow="0px 6px 10px 1px #E6E8EB"
               height={60}
+              data-cy="host-dashboard-menu-bar"
             >
               <MenuLink
                 route="host.dashboard"

--- a/test/cypress/integration/29-host.dashboard.js
+++ b/test/cypress/integration/29-host.dashboard.js
@@ -1,4 +1,33 @@
 describe('host dashboard', () => {
+  let user = null;
+
+  before(() => {
+    cy.signup({ redirect: '/brusselstogetherasbl' }).then(u => (user = u));
+  });
+
+  it('mark pending application approved', () => {
+    cy.wait(2000);
+    cy.contains('[data-cy="host-apply-btn"]', 'Apply').click({ force: true });
+    cy.wait(1000);
+    cy.fillInputField('name', 'Cavies United');
+    cy.fillInputField('description', 'We will rule the world with our cute squeaks');
+    cy.fillInputField('website', 'https://guineapi.gs');
+    cy.get('.tos input[type="checkbox"]').click();
+    cy.wait(300);
+    cy.get('.actions button').click();
+    cy.wait(1000);
+    cy.url().then(currentUrl => {
+      // positive lookbehind regex to get the collective slug from the url
+      const CollectiveSlug = currentUrl.match(/(?<=CollectiveSlug=)([A-z-]+)/)[0];
+      cy.login({ redirect: '/brusselstogetherasbl/dashboard' });
+      cy.get('[data-cy="host-dashboard-menu-bar"]')
+        .contains('Pending applications')
+        .click({ force: true });
+      cy.get(`[data-cy="${CollectiveSlug}-approve"]`).click({ force: true });
+      cy.get(`[data-cy="${CollectiveSlug}-approved"]`).should('have.attr', 'color', 'green.700');
+    });
+  });
+
   it('mark pending order as paid', () => {
     cy.login({ redirect: '/brusselstogetherasbl/dashboard/donations' });
     cy.get('.Orders .item:first .status').contains('pending');
@@ -7,5 +36,43 @@ describe('host dashboard', () => {
       .click();
     cy.get('.Orders .item:first .status').contains('paid');
     cy.wait(1000);
+  });
+
+  it('approve expense and reject expense', () => {
+    cy.login({ redirect: '/brusselstogetherasbl/dashboard/expenses' });
+    cy.get('[data-cy="expense-paid"]').as('currentExpense');
+    cy.get('[data-cy="expense-actions"]')
+      .contains('button', 'Unapprove')
+      .click({ force: true });
+    cy.get('[data-cy="confirmation-modal-continue"]').click({ force: true });
+    cy.wait(500);
+    cy.get('[data-cy="reject-expense-btn"]').within(() => {
+      cy.get('button').click({ force: true });
+    });
+    cy.get('[data-cy="approve-expense-btn"]').within(() => {
+      cy.get('button').click({ force: true });
+    });
+  });
+
+  it('record expense as paid', () => {
+    cy.login({ redirect: '/brusselstogetherasbl/dashboard' });
+    cy.get('[data-cy="expense-approved"]').as('currentExpense');
+    cy.get('[data-cy="expense-actions"]')
+      .contains('button', 'record as paid')
+      .click({ force: true });
+    cy.get('@currentExpense').should('have.attr', 'data-cy', 'expense-paid');
+  });
+
+  it('mark expense as unpaid', () => {
+    cy.login({ redirect: '/brusselstogetherasbl/dashboard' });
+    cy.get('[data-cy="expense-paid"]').as('currentExpense');
+    cy.get('[data-cy="expense-actions"]')
+      .as('currentExpenseActions')
+      .contains('button', 'Mark as unpaid')
+      .click({ force: true });
+    cy.get('@currentExpenseActions')
+      .contains('button', 'Continue')
+      .click({ force: true });
+    cy.get('@currentExpense').should('have.attr', 'data-cy', 'expense-approved');
   });
 });


### PR DESCRIPTION
Addresses opencollective/opencollective#2553

This adds tests that cover host dashboard actions like: approve/reject expense, mark expense unpaid, record expense paid, and approve pending application.

I did my best to follow Cypress best practices where I could, but oddly enough I sometimes found that adding `data-cy` to certain components wouldn't render in the HTML? So I usually would target the next closest component up that I could and then honed in using selectors and text.

I figure there's probably still work to be done but would like to get people's feedback on the work so far and how it can be improved.