### PR TITLE
Incognito: Enforce no-robots

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -69,6 +69,10 @@ class Header extends React.Component {
       ...this.props.metas,
     };
 
+    if (collective && collective.isIncognito) {
+      metas.robots = 'none';
+    }
+
     return Object.keys(metas).map(key => ({ key, value: metas[key] }));
   }
 

--- a/components/IncognitoUserCollective.js
+++ b/components/IncognitoUserCollective.js
@@ -8,12 +8,10 @@ import { IncognitoAvatar } from './Avatar';
 import { defineMessages, injectIntl } from 'react-intl';
 import { Flex } from '@rebass/grid';
 
-class UserCollective extends React.Component {
+class IncognitoUserCollective extends React.Component {
   static propTypes = {
-    LoggedInUser: PropTypes.object,
-    query: PropTypes.object,
+    collective: PropTypes.object,
     intl: PropTypes.object.isRequired,
-    message: PropTypes.string,
   };
 
   constructor(props) {
@@ -29,7 +27,7 @@ class UserCollective extends React.Component {
   }
 
   render() {
-    const { intl } = this.props;
+    const { intl, collective } = this.props;
 
     return (
       <div className={classNames('UserCollectivePage')}>
@@ -44,7 +42,7 @@ class UserCollective extends React.Component {
         <Header
           title={intl.formatMessage(this.messages['incognito.title'])}
           description={intl.formatMessage(this.messages['incognito.description'])}
-          metas={{ robots: 'noindex' }}
+          collective={{ collective }}
         />
 
         <Body>
@@ -61,4 +59,4 @@ class UserCollective extends React.Component {
   }
 }
 
-export default injectIntl(UserCollective);
+export default injectIntl(IncognitoUserCollective);

--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -627,6 +627,7 @@ const getCollectiveCoverQuery = gql`
       currency
       settings
       imageUrl
+      isIncognito
       backgroundImage
       isHost
       isActive

--- a/pages/new-collective-page.js
+++ b/pages/new-collective-page.js
@@ -136,7 +136,7 @@ class NewCollectivePage extends React.Component {
       } else if (data.Collective.isPledged && !data.Collective.isActive) {
         return <PledgedCollectivePage collective={data.Collective} />;
       } else if (data.Collective.isIncognito) {
-        return <IncognitoUserCollective />;
+        return <IncognitoUserCollective collective={data.Collective} />;
       }
     }
 


### PR DESCRIPTION
Enforce `none` value for `robots` meta (equivalent of `noindex` + `nofollow`) in `Header` when user is incognito. This will make sure pages like [Transactions](https://opencollective.com/incognito-58f47536/transactions) are not referenced by Google.