### PR TITLE
Revert "chore(deps-dev): bump url-loader from 2.3.0 to 3.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27663,9 +27663,9 @@
       }
     },
     "url-loader": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-3.0.0.tgz",
-      "integrity": "sha512-a84JJbIA5xTFTWyjjcPdnsu+41o/SNE8SpXMdUvXs6Q+LuhCD9E2+0VCiuDWqgo3GGXVlFHzArDmBpj9PgWn4A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-2.3.0.tgz",
+      "integrity": "sha512-goSdg8VY+7nPZKUEChZSEtW5gjbS66USIGCeSJ1OVOJ7Yfuh/36YxCwMi5HVEJh6mqUYOoy3NJ0vlOMrWsSHog==",
       "dev": true,
       "requires": {
         "loader-utils": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "shx": "^0.3.2",
     "sinon": "^7.5.0",
     "style-loader": "^1.0.0",
-    "url-loader": "^3.0.0",
+    "url-loader": "^2.3.0",
     "webpack-bundle-analyzer": "^3.6.0"
   },
   "jest": {


### PR DESCRIPTION
Reverts opencollective/opencollective-frontend#3056

Tentatively fix "How it Works" images loading?