### PR TITLE
Revert "chore(deps-dev): bump file-loader from 4.3.0 to 5.0.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10726,9 +10726,9 @@
       }
     },
     "file-loader": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-5.0.2.tgz",
-      "integrity": "sha512-QMiQ+WBkGLejKe81HU8SZ9PovsU/5uaLo0JdTCEXOYv7i7jfAjHZi1tcwp9tSASJPOmmHZtbdCervFmXMH/Dcg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-4.3.0.tgz",
+      "integrity": "sha512-aKrYPYjF1yG3oX0kWRrqrSMfgftm7oJW5M+m4owoldH5C51C0RkIwB++JbRvEW3IU6/ZG5n8UvEcdgwOt2UOWA==",
       "dev": true,
       "requires": {
         "loader-utils": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-react": "^7.16.0",
     "eslint-plugin-react-hooks": "^2.3.0",
-    "file-loader": "^5.0.2",
+    "file-loader": "^4.3.0",
     "html-loader": "^0.5.5",
     "husky": "^3.1.0",
     "jest": "^24.9.0",


### PR DESCRIPTION
Reverts opencollective/opencollective-frontend#3051

Fix "How it Works" images loading. See: https://github.com/opencollective/opencollective/issues/2666