### PR TITLE
Fix missing budget section

### DIFF
--- a/components/collective-page/graphql/queries.js
+++ b/components/collective-page/graphql/queries.js
@@ -46,6 +46,9 @@ export const getCollectivePageQuery = gql`
           users
           organizations
         }
+        transactions {
+          all
+        }
       }
       parentCollective {
         id


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/2671

Because the `transaction` stats was not fetched, budget section was hidden for non-collective admins with a `0` balance. 