### PR TITLE
fix(collective-page): display transactions for archived collectives

### DIFF
--- a/components/collective-page/graphql/queries.js
+++ b/components/collective-page/graphql/queries.js
@@ -40,6 +40,9 @@ export const getCollectivePageQuery = gql`
         balance
         yearlyBudget
         updates
+        transactions {
+          all
+        }
         backers {
           id
           all


### PR DESCRIPTION
The graphql query for the collective was missing a parameter (transactions.all). The "budget"
section is displayed based on this parameter + the current balance. Since the balance is always 0
for archived collectives, the section was never displayed.

In other words, the conditional in [this line](https://github.com/opencollective/opencollective-frontend/blob/master/components/CollectiveNavbar.js#L272) was never met when the collectives were archived. 

Fixes [#opencollective/2637](https://github.com/opencollective/opencollective/issues/2637)