### PR TITLE
fix(styled-icons): Fix icons from conversations PR

### DIFF
--- a/components/StyledTag.js
+++ b/components/StyledTag.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { background, border, color, space, typography, layout, position } from 'styled-system';
 
-import { Times } from 'styled-icons/fa-solid/Times';
+import { Times } from '@styled-icons/fa-solid/Times';
 
 import { messageType } from '../lib/theme';
 import { Span } from './Text';

--- a/components/conversations/Comment.js
+++ b/components/conversations/Comment.js
@@ -5,8 +5,8 @@ import styled from 'styled-components';
 import { FormattedMessage } from 'react-intl';
 import { useMutation } from 'react-apollo';
 
-import { Edit } from 'styled-icons/feather/Edit';
-import { X } from 'styled-icons/feather/X';
+import { Edit } from '@styled-icons/feather/Edit';
+import { X } from '@styled-icons/feather/X';
 
 import { API_V2_CONTEXT, gqlV2 } from '../../lib/graphql/helpers';
 import { getErrorFromGraphqlException } from '../../lib/utils';

--- a/components/conversations/Thread.js
+++ b/components/conversations/Thread.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Flex, Box } from '@rebass/grid';
 import styled, { css } from 'styled-components';
 
-import { MessageSquare } from 'styled-icons/feather/MessageSquare';
+import { MessageSquare } from '@styled-icons/feather/MessageSquare';
 
 import { withUser } from '../UserProvider';
 import Comment from './Comment';

--- a/pages/conversation.js
+++ b/pages/conversation.js
@@ -4,7 +4,7 @@ import { graphql, withApollo } from 'react-apollo';
 import { Flex, Box } from '@rebass/grid';
 import { get, isEmpty, cloneDeep, update } from 'lodash';
 
-import { MessageSquare } from 'styled-icons/feather/MessageSquare';
+import { MessageSquare } from '@styled-icons/feather/MessageSquare';
 
 import { Router } from '../server/pages';
 import { CollectiveType } from '../lib/constants/collectives';


### PR DESCRIPTION
https://github.com/opencollective/opencollective-frontend/pull/3109 was implemented before https://github.com/opencollective/opencollective-frontend/pull/3005 merge, thus it did not migrate the icons used there.