### PR TITLE
ContribtionFlow: Improve checkboxes styles for custom fields

### DIFF
--- a/components/StyledInputField.js
+++ b/components/StyledInputField.js
@@ -1,33 +1,44 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box } from '@rebass/grid';
+import { Flex, Box } from '@rebass/grid';
 import { FormattedMessage } from 'react-intl';
 import { P, Span } from './Text';
 
 /**
  * Form field to display an input element with a label and errors. Uses [renderProps](https://reactjs.org/docs/render-props.html#using-props-other-than-render) to pass field props like 'name' and 'id' to child input.
  */
-const StyledInputField = ({ children, label, htmlFor, error, success, disabled, required, ...props }) => {
+const StyledInputField = ({ children, label, htmlFor, error, success, disabled, required, inputType, ...props }) => {
   const labelContent = label && <Span color="black.800">{label}</Span>;
+  const isCheckbox = inputType === 'checkbox';
 
   return (
     <Box {...props}>
-      {label && (
-        <P as="label" htmlFor={htmlFor} display="block" fontWeight="normal" mb={1}>
-          {required === false ? (
-            <Span color="black.500">
-              <FormattedMessage
-                id="OptionalFieldLabel"
-                defaultMessage="{field} (optional)"
-                values={{ field: labelContent }}
-              />
-            </Span>
-          ) : (
-            labelContent
-          )}
-        </P>
-      )}
-      {children({ name: htmlFor, id: htmlFor, error: Boolean(error) || undefined, success, disabled, required })}
+      <Flex flexDirection={isCheckbox ? 'row' : 'column'}>
+        {label && (
+          <P as="label" htmlFor={htmlFor} display="block" fontWeight="normal" mb={isCheckbox ? 0 : 1} mr={2}>
+            {required === false && !isCheckbox ? (
+              <Span color="black.500">
+                <FormattedMessage
+                  id="OptionalFieldLabel"
+                  defaultMessage="{field} (optional)"
+                  values={{ field: labelContent }}
+                />
+              </Span>
+            ) : (
+              labelContent
+            )}
+          </P>
+        )}
+        {children({
+          name: htmlFor,
+          type: inputType,
+          id: htmlFor,
+          error: Boolean(error) || undefined,
+          success,
+          disabled,
+          required,
+        })}
+      </Flex>
       {error && (
         <Span display="block" color="red.500" pt={2} fontSize="Tiny">
           {error}
@@ -48,6 +59,8 @@ StyledInputField.propTypes = {
   htmlFor: PropTypes.string,
   /** text to display above the input */
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  /** Passed to input as `type`. Adapts layout for checkboxes */
+  inputType: PropTypes.string,
   /** Show success state for field */
   success: PropTypes.bool,
   /** If set to false, the field will be marked as optional */

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -162,10 +162,10 @@ const StepDetails = ({
           >
             {fieldProps => (
               <StyledInputAmount
+                {...fieldProps}
                 type="number"
                 currency={currency}
                 min={minAmount / 100}
-                {...fieldProps}
                 value={amount / 100}
                 width={1}
                 onChange={({ target }) => dispatchChange({ amount: Math.round(parseFloat(target.value) * 100) })}
@@ -184,10 +184,10 @@ const StepDetails = ({
           >
             {fieldProps => (
               <StyledInput
+                {...fieldProps}
                 type="number"
                 min={1}
                 max={maxQuantity}
-                {...fieldProps}
                 value={quantity}
                 width={1}
                 maxWidth={80}
@@ -272,16 +272,17 @@ const StepDetails = ({
               key={customField.name}
               htmlFor={customField.name}
               label={customField.label}
+              inputType={customField.type}
               width="100%"
             >
               {fieldProps => (
                 <StyledInput
-                  type={customField.type}
                   {...fieldProps}
                   value={value}
                   width={1}
                   required={customField.required}
                   onChange={({ target }) => onCustomFieldsChange(customField.name, target.value)}
+                  css={customField.type === 'checkbox' ? { flex: '0 0 1em', margin: 0 } : undefined}
                 />
               )}
             </StyledInputField>


### PR DESCRIPTION
CaptainFact is structured as a French 1901's law non-profit. We want to use Open Collective to handle the memberships. The only thing that we need to do that in conformity with the law was to ensure people accepts the statuses of the association.

`CustomFields` provide a great path to do that, but the checkboxes were not looking great.

## Before

![Screenshot_2019-12-05 Contribuer à Open Potatoez - Open Collective](https://user-images.githubusercontent.com/1556356/70266668-3d103c80-179d-11ea-897b-da3e3a6eabd4.png)


## After

![image](https://user-images.githubusercontent.com/1556356/70309382-b3e51e00-180d-11ea-9724-e32210209763.png)
