### PR TITLE
Adjust lint commands for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
       - <<: *restore_npm_cache
       - run: CYPRESS_INSTALL_BINARY=0 npm ci
       - <<: *persist_npm_cache
-      - run: npm run lint
+      - run: npm run lint:quiet
       - run: npm run prettier:check
 
   jest:

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "lint:quiet": "npm run lint -- --quiet",
     "optimize-png": "npm install --no-save imagemin imagemin-optipng && babel-node ./scripts/optimize-png",
     "prettier": "prettier \"*.@(js|json|md)\" \"@(components|lib|pages|scripts|server|test)/**/*.@(js|json|md)\"",
-    "prettier:check": "npm run prettier -- --list-different",
+    "prettier:check": "npm run prettier -- --check",
     "prettier:write": "npm run prettier -- --write",
     "start": "node dist/server",
     "styleguide:build": "styleguidist build",


### PR DESCRIPTION
- `lint:quiet` because warnings in CI are noisy
- `prettier --check` because the semantic looks clearer