### PR TITLE
fix(hostDashboard): fix broken loadmore button in Ready filter tab

### DIFF
--- a/components/expenses/Expenses.js
+++ b/components/expenses/Expenses.js
@@ -197,12 +197,12 @@ class Expenses extends React.Component {
             </div>
           )}
           {filteredExpenses.map(expense => this.renderExpense(expense))}
-          {expenses.length === 0 && (
+          {filteredExpenses.length === 0 && (
             <div className="empty">
               <FormattedMessage id="expenses.empty" defaultMessage="No expenses" />
             </div>
           )}
-          {expenses.length >= 10 && expenses.length % 10 === 0 && (
+          {filteredExpenses.length >= 10 && filteredExpenses.length % 10 === 0 && (
             <div className="loadMoreBtn">
               <Button bsStyle="default" onClick={this.props.fetchMore}>
                 {loading && <FormattedMessage id="loading" defaultMessage="loading" />}


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/2690 and potentially resolve https://github.com/opencollective/opencollective/issues/2689

This got broken from https://github.com/opencollective/opencollective-frontend/pull/3030