### PR TITLE
chore(hostDashboard): show paymentProcessorFeeInput paypal payout method

### DIFF
--- a/components/expenses/Expense.js
+++ b/components/expenses/Expense.js
@@ -476,7 +476,7 @@ class Expense extends React.Component {
               )}
               {mode !== 'edit' && (canPay || canApprove || canReject || canMarkExpenseAsUnpaid || canDelete) && (
                 <Flex flexDirection="column">
-                  {canPay && expense.payoutMethod === 'other' && (
+                  {canPay && (
                     <EditPayExpenseFeesForm
                       canEditPlatformFee={LoggedInUser.isRoot()}
                       currency={collective.currency}


### PR DESCRIPTION
Following up https://github.com/opencollective/opencollective-frontend/pull/2781 I think somewhere we mistakenly overwrote a change that displays the "Payment Processor Fee" input.

#### Current
<img width="906" alt="Screenshot 2019-12-06 at 10 00 39 AM" src="https://user-images.githubusercontent.com/15707013/70310149-46d28800-180f-11ea-81ea-ceb6983ccec2.png">


#### Now
<img width="868" alt="Screenshot 2019-12-06 at 9 56 39 AM" src="https://user-images.githubusercontent.com/15707013/70310102-31f5f480-180f-11ea-9ebe-e04d98d06432.png">

