### PR TITLE
Improve background image upload behavior

### DIFF
--- a/components/collective-page/graphql/mutations.js
+++ b/components/collective-page/graphql/mutations.js
@@ -35,6 +35,7 @@ export const EditCollectiveBackgroundMutation = gql`
       id
       settings
       backgroundImage
+      backgroundImageUrl
     }
   }
 `;

--- a/components/collective-page/graphql/queries.js
+++ b/components/collective-page/graphql/queries.js
@@ -16,6 +16,7 @@ export const getCollectivePageQuery = gql`
       description
       longDescription
       backgroundImage
+      backgroundImageUrl
       twitterHandle
       githubHandle
       website

--- a/components/collective-page/hero/Hero.js
+++ b/components/collective-page/hero/Hero.js
@@ -273,6 +273,7 @@ Hero.propTypes = {
     isApproved: PropTypes.bool,
     canApply: PropTypes.bool,
     backgroundImage: PropTypes.string,
+    backgroundImageUrl: PropTypes.string,
     twitterHandle: PropTypes.string,
     githubHandle: PropTypes.string,
     website: PropTypes.string,

--- a/components/collective-page/hero/HeroBackground.js
+++ b/components/collective-page/hero/HeroBackground.js
@@ -149,15 +149,17 @@ const HeroBackground = ({ collective, isEditing, onEditCancel }) => {
           />
           <Container display={['none', 'flex']} position="absolute" right={25} top={25} zIndex={222}>
             <Dropzone
-              onDrop={acceptedFiles =>
+              onDrop={acceptedFiles => {
+                onZoomChange(1);
+                onCropChange(DEFAULT_CROP);
                 setUploadedImage(
                   ...acceptedFiles.map(file =>
                     Object.assign(file, {
                       preview: URL.createObjectURL(file),
                     }),
                   ),
-                )
-              }
+                );
+              }}
               multiple={false}
               accept="image/jpeg, image/png"
               style={{}}

--- a/components/collective-page/hero/HeroBackground.js
+++ b/components/collective-page/hero/HeroBackground.js
@@ -110,10 +110,10 @@ const HeroBackground = ({ collective, isEditing, onEditCancel }) => {
 
   return !isEditing ? (
     <StyledBackground>
-      {collective.backgroundImage && (
+      {collective.backgroundImageUrl && (
         <ImageContainer>
           <BackgroundImage
-            src={collective.backgroundImage}
+            src={collective.backgroundImageUrl}
             style={
               hasBackgroundSettings
                 ? { transform: `translate(${crop.x}px, ${crop.y}px) scale(${zoom})` }
@@ -128,11 +128,11 @@ const HeroBackground = ({ collective, isEditing, onEditCancel }) => {
       {editBackground => (
         <StyledBackground
           data-cy="collective-background-image-styledBackground"
-          backgroundImage={collective.backgroundImage}
+          backgroundImage={collective.backgroundImageUrl}
           isEditing
         >
           <Cropper
-            image={uploadedImage ? uploadedImage.preview : collective.backgroundImage}
+            image={uploadedImage ? uploadedImage.preview : collective.backgroundImageUrl}
             cropSize={{ width: BASE_WIDTH, height: BASE_HEIGHT }}
             crop={crop}
             zoom={zoom}
@@ -190,7 +190,7 @@ const HeroBackground = ({ collective, isEditing, onEditCancel }) => {
                 </div>
               )}
             </Dropzone>
-            {((collective.backgroundImage && uploadedImage !== KEY_IMG_REMOVE) || uploadedImage !== KEY_IMG_REMOVE) && (
+            {uploadedImage !== KEY_IMG_REMOVE && collective.backgroundImage && (
               <StyledButton
                 minWidth={150}
                 ml={3}
@@ -226,6 +226,9 @@ const HeroBackground = ({ collective, isEditing, onEditCancel }) => {
                 setSubmitting(true); // Need this because `upload` is not a graphql function
 
                 try {
+                  // We intentionally use the raw image URL rather than image service here
+                  // because the `backgroundImage` column is not supposed to store the
+                  // images service address
                   let imgURL = collective.backgroundImage;
 
                   // Upload image if changed or remove it
@@ -280,6 +283,7 @@ HeroBackground.propTypes = {
     id: PropTypes.number,
     /** The background image */
     backgroundImage: PropTypes.string,
+    backgroundImageUrl: PropTypes.string,
     /** Collective settings */
     settings: PropTypes.shape({
       collectivePage: PropTypes.shape({

--- a/components/collective-page/sections/Contributions.js
+++ b/components/collective-page/sections/Contributions.js
@@ -104,7 +104,7 @@ const ParentedCollectivesQuery = gql`
         settings
         parentCollective {
           id
-          backgroundImage
+          backgroundImageUrl
           name
           slug
         }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react-dnd-html5-backend": "3.0.2",
     "react-dom": "16.12.0",
     "react-dropzone": "10.2.1",
-    "react-easy-crop": "^1.17.0",
+    "react-easy-crop": "1.17.0",
     "react-geosuggest": "2.12.1",
     "react-gmaps": "1.9.0",
     "react-hook-form": "3.28.15",


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/2708 and https://github.com/opencollective/opencollective/issues/2471

- Reset zoom/crop when uploading a new image
- Use image service for background image URL
- react-easy-crop: Use fixed version