### PR TITLE
CollectivePage: use darker color for background section

### DIFF
--- a/components/RichTextEditor.js
+++ b/components/RichTextEditor.js
@@ -47,7 +47,7 @@ const TrixEditorContainer = styled.div`
 
   trix-toolbar {
     min-height: 40px;
-    background: white;
+    background: ${props => props.toolbarBackgroundColor};
     box-shadow: 0px 5px 3px -3px rgba(0, 0, 0, 0.1);
     z-index: 2;
     margin-bottom: 8px;
@@ -56,6 +56,7 @@ const TrixEditorContainer = styled.div`
       border-radius: 6px;
       border-color: #c4c7cc;
       margin-bottom: 0;
+      background: white;
     }
 
     .trix-button {
@@ -128,6 +129,7 @@ export default class RichTextEditor extends React.Component {
     id: PropTypes.string,
     defaultValue: PropTypes.string,
     placeholder: PropTypes.string,
+    toolbarBackgroundColor: PropTypes.string.isRequired,
     /** Font size for the text */
     fontSize: PropTypes.string,
     autoFocus: PropTypes.bool,
@@ -160,6 +162,7 @@ export default class RichTextEditor extends React.Component {
     toolbarTop: 0,
     toolbarOffsetY: -62, // Default Trix toolbar height
     inputName: 'content',
+    toolbarBackgroundColor: 'white',
   };
 
   constructor(props) {
@@ -251,6 +254,7 @@ export default class RichTextEditor extends React.Component {
       withStickyToolbar,
       toolbarTop,
       toolbarOffsetY,
+      toolbarBackgroundColor,
       autoFocus,
       placeholder,
       editorMinHeight,
@@ -268,6 +272,7 @@ export default class RichTextEditor extends React.Component {
         withStickyToolbar={withStickyToolbar}
         toolbarTop={toolbarTop}
         toolbarOffsetY={toolbarOffsetY}
+        toolbarBackgroundColor={toolbarBackgroundColor}
         editorMinHeight={editorMinHeight}
         withBorders={withBorders}
         isDisabled={disabled}

--- a/components/collective-page/SectionContainer.js
+++ b/components/collective-page/SectionContainer.js
@@ -1,7 +1,12 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 const SectionContainer = styled.section`
   margin: 0;
+  ${props =>
+    props.withPaddingBottom &&
+    css`
+      padding-bottom: 64px;
+    `}
 `;
 
 export default SectionContainer;

--- a/components/collective-page/SectionsWithoutPaddingBottom.js
+++ b/components/collective-page/SectionsWithoutPaddingBottom.js
@@ -1,0 +1,13 @@
+import { Sections } from './_constants';
+
+/**
+ * The following sections don't require a padding bottom when put at the end of the
+ * page, usually because they end with a darker background.
+ */
+const sectionsWithoutPaddingBottom = {
+  [Sections.ABOUT]: true,
+  [Sections.CONTRIBUTE]: true,
+  [Sections.GOALS]: true,
+};
+
+export default sectionsWithoutPaddingBottom;

--- a/components/collective-page/index.js
+++ b/components/collective-page/index.js
@@ -24,6 +24,7 @@ import SectionTickets from './sections/Tickets';
 import SectionParticipants from './sections/SponsorsAndParticipants';
 import SectionLocation from './sections/Location';
 import SectionContainer from './SectionContainer';
+import sectionsWithoutPaddingBottom from './SectionsWithoutPaddingBottom';
 
 /**
  * This is the collective page main layout, holding different blocks together
@@ -218,7 +219,7 @@ class CollectivePage extends Component {
     const callsToAction = this.getCallsToAction(type, isHost, isAdmin, isRoot, canApply, canContact);
 
     return (
-      <Container position="relative" css={collective.isArchived ? 'filter: grayscale(100%);' : undefined} pb={5}>
+      <Container position="relative" css={collective.isArchived ? 'filter: grayscale(100%);' : undefined}>
         <Hero
           collective={collective}
           host={host}
@@ -249,13 +250,14 @@ class CollectivePage extends Component {
             )}
           />
         </Container>
-        {sections.map(section => (
+        {sections.map((section, idx) => (
           <SectionContainer
             key={section}
             ref={sectionRef => (this.sectionsRefs[section] = sectionRef)}
             id={`section-${section}`}
+            withPaddingBottom={idx === sections.length - 1 && !sectionsWithoutPaddingBottom[section]}
           >
-            {this.renderSection(section)}
+            {this.renderSection(section, idx === sections.length - 1)}
           </SectionContainer>
         ))}
       </Container>

--- a/components/collective-page/sections/About.js
+++ b/components/collective-page/sections/About.js
@@ -42,7 +42,7 @@ const SectionAbout = ({ collective, canEdit, intl }) => {
   canEdit = collective.isArchived ? false : canEdit;
 
   return (
-    <Flex flexDirection="column" alignItems="center" px={2} pt={[4, 5]}>
+    <Container display="flex" flexDirection="column" alignItems="center" px={2} py={[4, 5]} background="#f5f7fa">
       <SectionTitle textAlign="center" mb={5}>
         <FormattedMessage id="collective.about.title" defaultMessage="About" />
       </SectionTitle>
@@ -69,6 +69,7 @@ const SectionAbout = ({ collective, canEdit, intl }) => {
                   onChange={e => setValue(e.target.value)}
                   placeholder={intl.formatMessage(messages.placeholder)}
                   toolbarTop={[60, null, 119]}
+                  toolbarBackgroundColor="#F7F8FA"
                   withStickyToolbar
                   autoFocus
                 />
@@ -115,7 +116,7 @@ const SectionAbout = ({ collective, canEdit, intl }) => {
           }}
         </InlineEditField>
       </Container>
-    </Flex>
+    </Container>
   );
 };
 

--- a/components/collective-page/sections/Budget.js
+++ b/components/collective-page/sections/Budget.js
@@ -49,7 +49,7 @@ const TransactionsAndExpensesQuery = gql`
  */
 const SectionBudget = ({ collective, stats }) => {
   return (
-    <ContainerSectionContent pt={[4, 5]}>
+    <ContainerSectionContent pt={[4, 5]} pb={3}>
       <SectionTitle>
         <FormattedMessage id="CollectivePage.SectionBudget.Title" defaultMessage="Budget" />
       </SectionTitle>
@@ -129,12 +129,11 @@ const SectionBudget = ({ collective, stats }) => {
 
         <StyledCard
           display="flex"
-          flex="1"
+          flex={[null, null, '1 1 300px']}
           width="100%"
           flexDirection={['column', 'row', 'column']}
           mb={2}
           mx={[null, null, 3]}
-          minWidth={300}
         >
           <Box data-cy="budgetSection-today-balance" flex="1" py={16} px={4}>
             <P fontSize="Tiny" textTransform="uppercase" color="black.700">

--- a/components/collective-page/sections/Contributions.js
+++ b/components/collective-page/sections/Contributions.js
@@ -267,7 +267,7 @@ class SectionContributions extends React.PureComponent {
     const isOrganization = collective.type === CollectiveType.ORGANIZATION;
     const superCollectiveTags = get(collective, 'settings.superCollectiveTags', []);
     return (
-      <Box pt={5}>
+      <Box pt={5} pb={3}>
         {data.Collective.memberOf.length === 0 ? (
           <Flex flexDirection="column" alignItems="center">
             <img src={EmptyCollectivesSectionImageSVG} alt="" />

--- a/components/collective-page/sections/Conversations.js
+++ b/components/collective-page/sections/Conversations.js
@@ -56,7 +56,7 @@ class SectionConversations extends React.PureComponent {
     const conversations = get(data, 'collective.conversations', {});
 
     return (
-      <ContainerSectionContent pt={5}>
+      <ContainerSectionContent pt={5} pb={3}>
         <SectionTitle mb={24}>
           <FormattedMessage id="CollectivePage.SectionConversations.Title" defaultMessage="Conversations" />
         </SectionTitle>

--- a/components/collective-page/sections/Transactions.js
+++ b/components/collective-page/sections/Transactions.js
@@ -157,7 +157,7 @@ class SectionTransactions extends React.Component {
 
     const budgetItems = this.getBudgetItems(contributions, expenses, filter);
     return (
-      <Box pt={5}>
+      <Box py={5}>
         <ContainerSectionContent>
           <SectionTitle data-cy="section-transactions-title" mb={4} textAlign="left">
             <FormattedMessage id="SectionTransactions.Title" defaultMessage="Transactions" />

--- a/components/collective-page/sections/Updates.js
+++ b/components/collective-page/sections/Updates.js
@@ -113,7 +113,7 @@ class SectionUpdates extends React.PureComponent {
     }
 
     return (
-      <ContainerSectionContent pt={5}>
+      <ContainerSectionContent pt={5} pb={3}>
         <SectionTitle mb={24}>
           <FormattedMessage
             id="CollectivePage.SectionUpdates.Title"


### PR DESCRIPTION
According to Raul's feedback on https://opencollective.slack.com/archives/C0YFZ3MHP/p1575543684059700, this implements a darker background for the about section which makes a clearer distinction and reduce the inconsistency feeling created by having the title centered (vs left-aligned for other sections).

## Collective
![localhost_3000_captainfact_io](https://user-images.githubusercontent.com/1556356/70730460-50735880-1d05-11ea-9d02-dac736393d06.png)


## User
![localhost_3000_betree](https://user-images.githubusercontent.com/1556356/70730415-333e8a00-1d05-11ea-91ad-570814e1d6e6.png)


## Event page
![localhost_3000_captainfact_io_events_big-party-2-16658ev](https://user-images.githubusercontent.com/1556356/70730438-3d608880-1d05-11ea-9277-232d37f09372.png)

