### PR TITLE
User: Show warning when account is limited

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -6,6 +6,7 @@ import { get } from 'lodash';
 import TopBar from './TopBar';
 
 import { truncate, getCollectiveImage } from '../lib/utils';
+import UserWarnings from './UserWarnings';
 
 class Header extends React.Component {
   static propTypes = {
@@ -97,6 +98,7 @@ class Header extends React.Component {
         </Head>
         <div id="top" />
         <TopBar className={className} showSearch={this.props.showSearch} menuItems={this.props.menuItems} />
+        <UserWarnings />
       </header>
     );
   }

--- a/components/MessageBox.js
+++ b/components/MessageBox.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { display, layout, space, typography, shadow, color, flexbox } from 'styled-system';
+import { display, layout, space, typography, shadow, color, flexbox, borders } from 'styled-system';
 import themeGet from '@styled-system/theme-get';
 
 import { InfoCircle } from '@styled-icons/fa-solid/InfoCircle';
@@ -19,6 +19,7 @@ const Message = styled.div`
   border-radius: 8px;
   padding: ${themeGet('space.3')}px;
 
+  ${borders}
   ${shadow}
   ${display}
   ${layout}

--- a/components/UserWarnings.js
+++ b/components/UserWarnings.js
@@ -1,0 +1,32 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import MessageBox from './MessageBox';
+import { withUser } from './UserProvider';
+
+/**
+ * Displays warnings related to the user account.
+ */
+const UserWarnings = ({ LoggedInUser }) => {
+  if (LoggedInUser && LoggedInUser.isLimited) {
+    return (
+      <MessageBox type="warning" fontSize="LeadParagraph" textAlign="center" withIcon borderRadius={0}>
+        <FormattedMessage
+          id="warning.limitedAccount"
+          defaultMessage="Your account is currently limited. If you think this is a mistake, please contact support@opencollective.com."
+        />
+      </MessageBox>
+    );
+  }
+
+  return null;
+};
+
+UserWarnings.propTypes = {
+  LoggedInUser: PropTypes.shape({
+    isLimited: PropTypes.bool,
+  }),
+};
+
+export default withUser(UserWarnings);

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -1360,6 +1360,7 @@
   "virtualCards.sentTo": "sent to {email}",
   "virtualCards.viewDetails": "View Details",
   "warning.discardUnsavedChanges": "Are you sure you want to discard your unsaved changes?",
+  "warning.limitedAccount": "Your account is currently limited. If you think this is a mistake, please contact support@opencollective.com.",
   "WarningUnsavedChanges": "You are trying to leave this page with un-saved changes. Are you sure?",
   "webhooks.add": "Add another webhook",
   "webhooks.remove": "Remove webhook",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1360,6 +1360,7 @@
   "virtualCards.sentTo": "sent to {email}",
   "virtualCards.viewDetails": "View Details",
   "warning.discardUnsavedChanges": "Are you sure you want to discard your unsaved changes?",
+  "warning.limitedAccount": "Your account is currently limited. If you think this is a mistake, please contact support@opencollective.com.",
   "WarningUnsavedChanges": "You are trying to leave this page with un-saved changes. Are you sure?",
   "webhooks.add": "Add another webhook",
   "webhooks.remove": "Remove webhook",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1360,6 +1360,7 @@
   "virtualCards.sentTo": "sent to {email}",
   "virtualCards.viewDetails": "View Details",
   "warning.discardUnsavedChanges": "Are you sure you want to discard your unsaved changes?",
+  "warning.limitedAccount": "Your account is currently limited. If you think this is a mistake, please contact support@opencollective.com.",
   "WarningUnsavedChanges": "You are trying to leave this page with un-saved changes. Are you sure?",
   "webhooks.add": "Add another webhook",
   "webhooks.remove": "Remove webhook",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1360,6 +1360,7 @@
   "virtualCards.sentTo": "enviado a {email}",
   "virtualCards.viewDetails": "Ver Detalles",
   "warning.discardUnsavedChanges": "Are you sure you want to discard your unsaved changes?",
+  "warning.limitedAccount": "Your account is currently limited. If you think this is a mistake, please contact support@opencollective.com.",
   "WarningUnsavedChanges": "You are trying to leave this page with un-saved changes. Are you sure?",
   "webhooks.add": "Add another webhook",
   "webhooks.remove": "Remove webhook",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1360,6 +1360,7 @@
   "virtualCards.sentTo": "envoyé à {email}",
   "virtualCards.viewDetails": "Voir les détails",
   "warning.discardUnsavedChanges": "Êtes-vous sûr·e de vouloir annuler vos changements non sauvegardés ?",
+  "warning.limitedAccount": "Your account is currently limited. If you think this is a mistake, please contact support@opencollective.com.",
   "WarningUnsavedChanges": "Vous essayez de quitter cette page avec des modifications non-enregistrées. Êtes-vous sûr·e ?",
   "webhooks.add": "Ajouter un autre webhook",
   "webhooks.remove": "Supprimer ce webhook",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1360,6 +1360,7 @@
   "virtualCards.sentTo": "inviato a {email}",
   "virtualCards.viewDetails": "Vedi Dettagli",
   "warning.discardUnsavedChanges": "Are you sure you want to discard your unsaved changes?",
+  "warning.limitedAccount": "Your account is currently limited. If you think this is a mistake, please contact support@opencollective.com.",
   "WarningUnsavedChanges": "You are trying to leave this page with un-saved changes. Are you sure?",
   "webhooks.add": "Aggiungi un altro webhook",
   "webhooks.remove": "Rimuovi webhook",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1360,6 +1360,7 @@
   "virtualCards.sentTo": "{email} に送信された",
   "virtualCards.viewDetails": "詳細を表示する",
   "warning.discardUnsavedChanges": "Are you sure you want to discard your unsaved changes?",
+  "warning.limitedAccount": "Your account is currently limited. If you think this is a mistake, please contact support@opencollective.com.",
   "WarningUnsavedChanges": "You are trying to leave this page with un-saved changes. Are you sure?",
   "webhooks.add": "Add another webhook",
   "webhooks.remove": "Remove webhook",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1360,6 +1360,7 @@
   "virtualCards.sentTo": "sent to {email}",
   "virtualCards.viewDetails": "View Details",
   "warning.discardUnsavedChanges": "Are you sure you want to discard your unsaved changes?",
+  "warning.limitedAccount": "Your account is currently limited. If you think this is a mistake, please contact support@opencollective.com.",
   "WarningUnsavedChanges": "You are trying to leave this page with un-saved changes. Are you sure?",
   "webhooks.add": "Add another webhook",
   "webhooks.remove": "Remove webhook",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1360,6 +1360,7 @@
   "virtualCards.sentTo": "sent to {email}",
   "virtualCards.viewDetails": "View Details",
   "warning.discardUnsavedChanges": "Are you sure you want to discard your unsaved changes?",
+  "warning.limitedAccount": "Your account is currently limited. If you think this is a mistake, please contact support@opencollective.com.",
   "WarningUnsavedChanges": "You are trying to leave this page with un-saved changes. Are you sure?",
   "webhooks.add": "Add another webhook",
   "webhooks.remove": "Remove webhook",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1360,6 +1360,7 @@
   "virtualCards.sentTo": "enviar para {email}",
   "virtualCards.viewDetails": "Ver detalhes",
   "warning.discardUnsavedChanges": "Are you sure you want to discard your unsaved changes?",
+  "warning.limitedAccount": "Your account is currently limited. If you think this is a mistake, please contact support@opencollective.com.",
   "WarningUnsavedChanges": "Você está tentando sair desta página com alterações não salvas. Você tem certeza?",
   "webhooks.add": "Adicionar outro webhook",
   "webhooks.remove": "Remover webhook",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1360,6 +1360,7 @@
   "virtualCards.sentTo": "отправлено на {email}",
   "virtualCards.viewDetails": "Показать детали",
   "warning.discardUnsavedChanges": "Are you sure you want to discard your unsaved changes?",
+  "warning.limitedAccount": "Your account is currently limited. If you think this is a mistake, please contact support@opencollective.com.",
   "WarningUnsavedChanges": "You are trying to leave this page with un-saved changes. Are you sure?",
   "webhooks.add": "Add another webhook",
   "webhooks.remove": "Remove webhook",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1360,6 +1360,7 @@
   "virtualCards.sentTo": "sent to {email}",
   "virtualCards.viewDetails": "View Details",
   "warning.discardUnsavedChanges": "Are you sure you want to discard your unsaved changes?",
+  "warning.limitedAccount": "Your account is currently limited. If you think this is a mistake, please contact support@opencollective.com.",
   "WarningUnsavedChanges": "You are trying to leave this page with un-saved changes. Are you sure?",
   "webhooks.add": "Add another webhook",
   "webhooks.remove": "Remove webhook",

--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -91,6 +91,7 @@ export const getLoggedInUserQuery = gql`
       email
       paypalEmail
       image
+      isLimited
       CollectiveId
       collective {
         id

--- a/lib/graphql/schema.graphql
+++ b/lib/graphql/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:3060/graphql
-# timestamp: Thu Dec 05 2019 17:41:56 GMT+0100 (GMT+01:00)
+# timestamp: Thu Dec 12 2019 20:59:40 GMT+0100 (GMT+01:00)
 
 """
 Application model
@@ -3310,6 +3310,11 @@ type UserDetails {
   emailWaitingForValidation: String
   memberOf: [Member]
   paypalEmail: String
+
+  """
+  Returns true if user account is limited (user can't use any feature)
+  """
+  isLimited: Boolean
 }
 
 """


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2695
Require https://github.com/opencollective/opencollective-api/pull/3044
Admin documentation: https://docs.opencollective.com/help/internal/moderation
User documentation: https://docs.opencollective.com/help/product/moderation

Adds a small message at the top on all pages when user account is limited.

![image](https://user-images.githubusercontent.com/1556356/70735158-ed39f400-1d0d-11ea-9b6a-814e43f0be47.png)
