### PR TITLE
RichTextEditor: Don't show default caption

### DIFF
--- a/components/RichTextEditor.js
+++ b/components/RichTextEditor.js
@@ -174,6 +174,7 @@ export default class RichTextEditor extends React.Component {
     if (typeof window !== 'undefined') {
       this.Trix = require('trix');
       this.Trix.config.blockAttributes.heading1 = { tagName: 'h3' };
+      this.Trix.config.attachments.preview.caption = { name: false, size: false };
     }
   }
 


### PR DESCRIPTION
Whenever removed, the caption was set to filename + size by default. This PR removes this behavior.

![image](https://user-images.githubusercontent.com/1556356/70824019-8e45af00-1de1-11ea-9a77-55f38d36f070.png)
