### PR TITLE
HostDashboard: Improve responsiveness

### DIFF
--- a/components/expenses/ApproveExpenseBtn.js
+++ b/components/expenses/ApproveExpenseBtn.js
@@ -27,7 +27,7 @@ class ApproveExpenseBtn extends React.Component {
   render() {
     return (
       <div className="ApproveExpenseBtn" data-cy="approve-expense-btn">
-        <StyledButton className="approve" mr={2} buttonStyle="primary" onClick={this.onClick}>
+        <StyledButton className="approve" mr={2} my={1} buttonStyle="primary" onClick={this.onClick}>
           <FormattedMessage id="expense.approve.btn" defaultMessage="Approve" />
         </StyledButton>
       </div>

--- a/components/expenses/Expense.js
+++ b/components/expenses/Expense.js
@@ -23,6 +23,7 @@ import MarkExpenseAsUnpaidBtn from './MarkExpenseAsUnpaidBtn';
 import EditPayExpenseFeesForm from './EditPayExpenseFeesForm';
 import ConfirmationModal from '../ConfirmationModal';
 import StyledButton from '../StyledButton';
+import MarkExpenseAsPaidBtn from './MarkExpenseAsPaidBtn';
 
 class Expense extends React.Component {
   static propTypes = {
@@ -321,7 +322,6 @@ class Expense extends React.Component {
 
             @media (max-width: 600px) {
               .expense {
-                max-height: 50rem;
                 padding: 2rem 0.5rem;
               }
               .expense.detailsView {
@@ -371,15 +371,17 @@ class Expense extends React.Component {
         </div>
         <div className="body">
           <div className="header">
-            <div className="amount pullRight">
-              <AmountCurrency amount={-expense.amount} currency={expense.currency} precision={2} />
-            </div>
-            <div className="description">
-              <Link route={`/${collective.slug}/expenses/${expense.id}`} title={capitalize(title)}>
-                {capitalize(title)}
-                {view !== 'compact' && <span className="ExpenseId">#{expense.id}</span>}
-              </Link>
-            </div>
+            <Flex flexWrap="wrap" justifyContent="space-between">
+              <div className="description">
+                <Link route={`/${collective.slug}/expenses/${expense.id}`} title={capitalize(title)}>
+                  {capitalize(title)}
+                  {view !== 'compact' && <span className="ExpenseId">#{expense.id}</span>}
+                </Link>
+              </div>
+              <div className="amount">
+                <AmountCurrency amount={-expense.amount} currency={expense.currency} precision={2} />
+              </div>
+            </Flex>
             <div className="meta">
               <Moment relative={true} value={expense.incurredAt} />
               {' | '}
@@ -475,7 +477,7 @@ class Expense extends React.Component {
                 <Span color="red.500">{intl.formatMessage(this.messages['expenseTypeMissing'])}</Span>
               )}
               {mode !== 'edit' && (canPay || canApprove || canReject || canMarkExpenseAsUnpaid || canDelete) && (
-                <Flex flexDirection="column">
+                <Flex flexDirection="column" width="100%">
                   {canPay && (
                     <EditPayExpenseFeesForm
                       canEditPlatformFee={LoggedInUser.isRoot()}
@@ -484,27 +486,39 @@ class Expense extends React.Component {
                       payoutMethod={expense.payoutMethod}
                     />
                   )}
-                  <Flex data-cy="expense-actions">
+                  <Flex data-cy="expense-actions" flexDirection={['column', 'row']} flexWrap="wrap" width="100%">
                     {canPay && (
-                      <PayExpenseBtn
-                        expense={expense}
-                        collective={collective}
-                        host={host}
-                        {...this.state.fees}
-                        refetch={this.props.refetch}
-                        disabled={!this.props.allowPayAction}
-                        lock={this.props.lockPayAction}
-                        unlock={this.props.unlockPayAction}
-                      />
-                    )}
-                    {canPay && (
-                      <StyledButton
-                        mr={2}
-                        buttonStyle="standard"
-                        onClick={() => this.setState({ showUnapproveModal: true })}
-                      >
-                        <FormattedMessage id="expense.unapprove.btn" defaultMessage="Unapprove" />
-                      </StyledButton>
+                      <React.Fragment>
+                        <MarkExpenseAsPaidBtn
+                          expense={expense}
+                          collective={collective}
+                          {...this.state.fees}
+                          refetch={this.props.refetch}
+                          disabled={!this.props.allowPayAction}
+                          lock={this.props.lockPayAction}
+                          unlock={this.props.unlockPayAction}
+                        />
+                        {expense.payoutMethod !== 'other' && (
+                          <PayExpenseBtn
+                            expense={expense}
+                            collective={collective}
+                            host={host}
+                            {...this.state.fees}
+                            refetch={this.props.refetch}
+                            disabled={!this.props.allowPayAction}
+                            lock={this.props.lockPayAction}
+                            unlock={this.props.unlockPayAction}
+                          />
+                        )}
+                        <StyledButton
+                          mr={2}
+                          my={1}
+                          buttonStyle="standard"
+                          onClick={() => this.setState({ showUnapproveModal: true })}
+                        >
+                          <FormattedMessage id="expense.unapprove.btn" defaultMessage="Unapprove" />
+                        </StyledButton>
+                      </React.Fragment>
                     )}
                     {canMarkExpenseAsUnpaid && <MarkExpenseAsUnpaidBtn refetch={this.props.refetch} id={expense.id} />}
                     {canApprove && <ApproveExpenseBtn refetch={this.props.refetch} id={expense.id} />}
@@ -513,6 +527,8 @@ class Expense extends React.Component {
                       <StyledButton
                         buttonStyle="danger"
                         onClick={() => this.setState({ showDeleteExpenseModal: true })}
+                        mr={2}
+                        my={1}
                       >
                         <FormattedMessage id="expense.delete.btn" defaultMessage="Delete" />
                       </StyledButton>

--- a/components/expenses/ExpenseNeedsTaxFormBadge.js
+++ b/components/expenses/ExpenseNeedsTaxFormBadge.js
@@ -4,6 +4,7 @@ import { defineMessages, injectIntl } from 'react-intl';
 
 import MessageBox from '../MessageBox';
 import StyledLink from '../StyledLink';
+import { Span } from '../Text';
 
 class ExpenseNeedsTaxFormBadge extends React.Component {
   static propTypes = {
@@ -32,8 +33,8 @@ class ExpenseNeedsTaxFormBadge extends React.Component {
 
     return (
       !!isTaxFormRequired && (
-        <span>
-          <span className="taxFormRequired " data-toggle="tooltip" data-placement="bottom" title={hoverMessage}>
+        <Span display="inline-block">
+          <span data-toggle="tooltip" data-placement="bottom" title={hoverMessage}>
             <MessageBox type="warning" display="inline" css={{ padding: '4px', borderRadius: '5px' }} withIcon={true}>
               <StyledLink
                 css={{ textTransform: 'uppercase' }}
@@ -44,7 +45,7 @@ class ExpenseNeedsTaxFormBadge extends React.Component {
             </MessageBox>
           </span>
           {' | '}
-        </span>
+        </Span>
       )
     );
   }

--- a/components/expenses/Expenses.js
+++ b/components/expenses/Expenses.js
@@ -3,10 +3,12 @@ import PropTypes from 'prop-types';
 import { ButtonGroup, Button } from 'react-bootstrap';
 import { FormattedMessage } from 'react-intl';
 import { get } from 'lodash';
+import { Box } from '@rebass/grid';
 
 import colors from '../../lib/constants/colors';
 
 import Expense from './Expense';
+import Loading from '../Loading';
 
 class Expenses extends React.Component {
   static propTypes = {
@@ -61,12 +63,8 @@ class Expenses extends React.Component {
   render() {
     const { collective, expenses, filters, status, loading, updateVariables } = this.props;
 
-    if (!expenses) {
-      return <div />;
-    }
-
     let filteredExpenses;
-    if (status === 'READY') {
+    if (expenses && status === 'READY') {
       // Don't show expense when collective doesn't have enough fund in "ready to pay" filter
       filteredExpenses = expenses.filter(
         expense => get(expense.collective || collective, 'stats.balance') >= expense.amount,
@@ -74,26 +72,23 @@ class Expenses extends React.Component {
       // Don't show expense that requires tax form in "ready to pay" filter
       filteredExpenses = filteredExpenses.filter(expense => !expense.userTaxFormRequiredBeforePayment);
     } else {
-      filteredExpenses = expenses;
+      filteredExpenses = expenses || [];
     }
 
     return (
-      <div className="Expenses">
+      <Box className="Expenses" mx="auto" maxWidth="80rem">
         <style jsx>
           {`
-            .Expenses {
-              min-width: 30rem;
-              max-width: 80rem;
-            }
             :global(.loadMoreBtn) {
               margin: 1rem;
               text-align: center;
             }
             .filter {
+              max-width: 500px;
               width: 100%;
-              max-width: 400px;
               margin: 0 auto;
               margin-bottom: 20px;
+              overflow-x: auto;
             }
             :global(.filterBtnGroup) {
               width: 100%;
@@ -113,24 +108,6 @@ class Expenses extends React.Component {
             }
             .itemsList .item {
               border-bottom: 1px solid #e8e9eb;
-            }
-            .loading {
-              color: ${colors.darkgray};
-              position: absolute;
-              top: 0;
-              left: 0;
-              width: 100%;
-              height: 100%;
-              display: flex;
-              justify-content: center;
-              align-items: center;
-              background: rgba(255, 255, 255, 0.85);
-              text-transform: uppercase;
-              letter-spacing: 3px;
-              font-weight: bold;
-              z-index: 10;
-              -webkit-backdrop-filter: blur(2px);
-              backdrop-filter: blur(5px);
             }
           `}
         </style>
@@ -191,27 +168,30 @@ class Expenses extends React.Component {
         )}
 
         <div className="itemsList">
-          {loading && (
-            <div className="loading">
-              <FormattedMessage id="loading" defaultMessage="loading" />
-            </div>
-          )}
-          {filteredExpenses.map(expense => this.renderExpense(expense))}
-          {filteredExpenses.length === 0 && (
-            <div className="empty">
-              <FormattedMessage id="expenses.empty" defaultMessage="No expenses" />
-            </div>
-          )}
-          {filteredExpenses.length >= 10 && filteredExpenses.length % 10 === 0 && (
-            <div className="loadMoreBtn">
-              <Button bsStyle="default" onClick={this.props.fetchMore}>
-                {loading && <FormattedMessage id="loading" defaultMessage="loading" />}
-                {!loading && <FormattedMessage id="loadMore" defaultMessage="load more" />}
-              </Button>
-            </div>
+          {loading ? (
+            <Box my={5}>
+              <Loading />
+            </Box>
+          ) : (
+            <React.Fragment>
+              {filteredExpenses.map(expense => this.renderExpense(expense))}
+              {filteredExpenses.length === 0 && (
+                <div className="empty">
+                  <FormattedMessage id="expenses.empty" defaultMessage="No expenses" />
+                </div>
+              )}
+              {filteredExpenses.length >= 10 && filteredExpenses.length % 10 === 0 && (
+                <div className="loadMoreBtn">
+                  <Button bsStyle="default" onClick={this.props.fetchMore}>
+                    {loading && <FormattedMessage id="loading" defaultMessage="loading" />}
+                    {!loading && <FormattedMessage id="loadMore" defaultMessage="load more" />}
+                  </Button>
+                </div>
+              )}
+            </React.Fragment>
           )}
         </div>
-      </div>
+      </Box>
     );
   }
 }

--- a/components/expenses/Order.js
+++ b/components/expenses/Order.js
@@ -185,7 +185,6 @@ class Order extends React.Component {
 
             @media (max-width: 600px) {
               .order {
-                max-height: 50rem;
                 padding: 2rem 0.5rem;
               }
               .order.detailsView {

--- a/components/expenses/Orders.js
+++ b/components/expenses/Orders.js
@@ -4,6 +4,7 @@ import gql from 'graphql-tag';
 import { ButtonGroup, Button } from 'react-bootstrap';
 import { FormattedMessage } from 'react-intl';
 import { graphql } from 'react-apollo';
+import { Box } from '@rebass/grid';
 
 import colors from '../../lib/constants/colors';
 
@@ -78,13 +79,9 @@ class Orders extends React.Component {
     }
 
     return (
-      <div className="Orders">
+      <Box className="Orders" mx="auto" maxWidth="80rem">
         <style jsx>
           {`
-            .Orders {
-              min-width: 30rem;
-              max-width: 80rem;
-            }
             :global(.loadMoreBtn) {
               margin: 1rem;
               text-align: center;
@@ -241,7 +238,7 @@ class Orders extends React.Component {
             </Container>
           </ModalFooter>
         </Modal>
-      </div>
+      </Box>
     );
   }
 }

--- a/components/expenses/RejectExpenseBtn.js
+++ b/components/expenses/RejectExpenseBtn.js
@@ -27,7 +27,7 @@ class RejectExpenseBtn extends React.Component {
   render() {
     return (
       <div className="RejectExpenseBtn" data-cy="reject-expense-btn">
-        <StyledButton className="reject" buttonStyle="danger" onClick={this.onClick}>
+        <StyledButton mr={2} my={1} width="100%" className="reject" buttonStyle="danger" onClick={this.onClick}>
           <FormattedMessage id="expense.reject.btn" defaultMessage="Reject" />
         </StyledButton>
       </div>

--- a/components/expenses/__tests__/Expenses.test.js
+++ b/components/expenses/__tests__/Expenses.test.js
@@ -39,6 +39,9 @@ describe('Expenses component', () => {
     category: 'Travel',
     collective,
     fromCollective,
+    user: {
+      paypalEmail: 'oc-test@opencollective.com',
+    },
   };
 
   const expenses = [
@@ -73,24 +76,25 @@ describe('Expenses component', () => {
   describe('Paying expenses', () => {
     it('disables all buttons while one expense is being paid', done => {
       // make sure there are two pay buttons on the page
-      expect(component.find('.PayExpenseBtn button').length).toEqual(4);
+      expect(component.find('[data-cy="pay-expense-btn"]')).not.toBeFalsy();
+      expect(component.find('[data-cy="mark-expense-as-paid-btn"]')).not.toBeFalsy();
 
       // make sure none are disabled
-      expect(component.find('.PayExpenseBtn button[disabled]').lenght).toEqual(undefined);
+      expect(component.find('[data-cy="expense-actions"] button[disabled]').lenght).toEqual(undefined);
 
       // click on the first one
       component
-        .find('.PayExpenseBtn button')
+        .find('[data-cy="expense-actions"] button')
         .first()
         .simulate('click');
 
       // expect two disabled buttons again
-      expect(component.find('.PayExpenseBtn button[disabled]').length).toEqual(4);
+      expect(component.find('[data-cy="expense-actions"] button[disabled]').length).toEqual(4);
 
       // after timeout, make sure there is only button and it's not disabled.
       setTimeout(() => {
-        expect(component.find('.PayExpenseBtn button').length).toEqual(1);
-        expect(component.find('.PayExpenseBtn button[disabled]').length).toEqual(undefined);
+        expect(component.find('[data-cy="expense-actions"] button').length).toEqual(1);
+        expect(component.find('[data-cy="expense-actions"] button[disabled]').length).toEqual(undefined);
       }, 2000);
       done();
     });

--- a/components/expenses/graphql/mutations.js
+++ b/components/expenses/graphql/mutations.js
@@ -1,0 +1,36 @@
+import gql from 'graphql-tag';
+
+export const payExpenseMutation = gql`
+  mutation payExpense(
+    $id: Int!
+    $paymentProcessorFeeInCollectiveCurrency: Int
+    $hostFeeInCollectiveCurrency: Int
+    $platformFeeInCollectiveCurrency: Int
+    $forceManual: Boolean
+  ) {
+    payExpense(
+      id: $id
+      paymentProcessorFeeInCollectiveCurrency: $paymentProcessorFeeInCollectiveCurrency
+      hostFeeInCollectiveCurrency: $hostFeeInCollectiveCurrency
+      platformFeeInCollectiveCurrency: $platformFeeInCollectiveCurrency
+      forceManual: $forceManual
+    ) {
+      id
+      status
+      collective {
+        id
+        stats {
+          id
+          balance
+        }
+        host {
+          id
+          paymentMethods {
+            id
+            balance
+          }
+        }
+      }
+    }
+  }
+`;

--- a/components/host-dashboard/Dashboard.js
+++ b/components/host-dashboard/Dashboard.js
@@ -69,9 +69,9 @@ class HostDashboard extends React.Component {
 
     return (
       <Fragment>
-        <div id="expenses" className="col first center-block">
+        <div id="expenses">
           <div className="header">
-            <H5 my={3}>
+            <H5 my={3} textAlign="center">
               <FormattedMessage id="host.expenses.title" defaultMessage="Expenses" />
             </H5>
           </div>
@@ -100,7 +100,7 @@ class HostDashboard extends React.Component {
     return (
       <div id="orders" className="col center-block">
         <div className="header">
-          <H5 my={3}>
+          <H5 my={3} textAlign="center">
             <FormattedMessage
               id="collective.orders.title"
               values={{ n: this.totalOrders }}
@@ -200,10 +200,8 @@ class HostDashboard extends React.Component {
           />
         )}
         <div className="content">
-          <div className="columns">
-            {view === 'expenses' && this.renderExpenses(selectedCollective, includeHostedCollectives)}
-            {view === 'donations' && this.renderDonations(selectedCollective, includeHostedCollectives)}
-          </div>
+          {view === 'expenses' && this.renderExpenses(selectedCollective, includeHostedCollectives)}
+          {view === 'donations' && this.renderDonations(selectedCollective, includeHostedCollectives)}
         </div>
       </div>
     );

--- a/components/host-dashboard/PendingApplications.js
+++ b/components/host-dashboard/PendingApplications.js
@@ -100,7 +100,7 @@ class HostPendingApplications extends React.Component {
               </Container>
             </Flex>
             <StyledHr my={3} borderColor="black.200" />
-            <Flex justifyContent="center">
+            <Flex justifyContent="space-evenly" flexWrap="wrap">
               {c.isActive ? (
                 <Box color="green.700" data-cy={`${c.slug}-approved`}>
                   <Check size={39} />
@@ -110,19 +110,21 @@ class HostPendingApplications extends React.Component {
                   <Mutation mutation={ApproveCollectiveMutation}>
                     {(approveCollective, { loading }) => (
                       <StyledButton
-                        mx={4}
+                        m={1}
                         loading={loading}
                         onClick={() => approveCollective({ variables: { id: c.id } })}
                         data-cy={`${c.slug}-approve`}
+                        buttonStyle="success"
+                        minWidth={125}
                       >
                         <FormattedMessage id="host.pending-applications.approve" defaultMessage="Approve" />
                       </StyledButton>
                     )}
                   </Mutation>
                   <StyledButton
-                    color="#fff"
-                    bg="red.500"
-                    mx={4}
+                    buttonStyle="danger"
+                    minWidth={125}
+                    m={1}
                     onClick={() => this.setState({ showRejectionModal: true, collectiveId: c.id })}
                   >
                     <FormattedMessage id="host.pending-applications.reject" defaultMessage="Reject" />
@@ -151,7 +153,7 @@ class HostPendingApplications extends React.Component {
     return (
       <Query query={getHostPendingApplicationsQuery} variables={{ hostCollectiveSlug }}>
         {({ loading, error, data }) =>
-          !data || error ? (
+          error ? (
             <MessageBox type="error" withIcon>
               {error ? error.message : 'Unknown error'}
             </MessageBox>

--- a/pages/host.dashboard.js
+++ b/pages/host.dashboard.js
@@ -23,7 +23,7 @@ import { Dashboard, PendingApplications } from '../components/host-dashboard';
 const MenuLink = styled(props => <Link {...omit(props, ['isActive'])} />)`
   padding: 4px 20px 0 20px;
   color: #71757a;
-  height: 100%;
+  height: 60px;
   display: flex;
   align-items: center;
   border-bottom: 4px solid rgb(0, 0, 0, 0);
@@ -45,6 +45,7 @@ const MenuLink = styled(props => <Link {...omit(props, ['isActive'])} />)`
     css`
       color: #090a0a;
       border-bottom: 4px solid #090a0a;
+      font-weight: 600;
     `}
 `;
 
@@ -136,7 +137,8 @@ class HostDashboardPage extends React.Component {
               background="white"
               borderBottom="#E6E8EB"
               boxShadow="0px 6px 10px 1px #E6E8EB"
-              height={60}
+              minHeight={60}
+              flexWrap="wrap"
               data-cy="host-dashboard-menu-bar"
             >
               <MenuLink


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/2567

Misc changes:
- Add loading states
- Remove error message while pending application loads
- Split `PayExpenseBtn` and `MarkAsPaidBtn`

# (partially) improve error display

Only for messages about disabled mode

### Before

![image](https://user-images.githubusercontent.com/1556356/70986134-9c375080-20bd-11ea-86e3-5d1616b6fe83.png)

### After

![image](https://user-images.githubusercontent.com/1556356/70986155-a6f1e580-20bd-11ea-9e66-eee7c69008a7.png)


# Fix buttons alignments and responsiveness

### Before
![image](https://user-images.githubusercontent.com/1556356/70986045-7316c000-20bd-11ea-846d-6d96c5ff4dc3.png)

### After
![image](https://user-images.githubusercontent.com/1556356/70985961-524e6a80-20bd-11ea-933e-7f9209a2aef9.png)
