### PR TITLE
test: Adapt e2e after tier's members update

### DIFF
--- a/test/cypress/integration/05-user-legacy.test.js
+++ b/test/cypress/integration/05-user-legacy.test.js
@@ -6,7 +6,7 @@ describe('user profile page', () => {
     cy.get('#admin.organization .CollectiveCard').should('have.length', 2);
     cy.get('#admin.collective [data-cy=subtitle]').contains("I'm a Core Contributor and admin of these 2 Collectives");
     cy.get('#admin.collective .CollectiveCard').should('have.length', 2);
-    cy.get('#backer .CollectiveCard').should('have.length', 3);
+    cy.get('#backer .CollectiveCard').should('have.length', 4);
     cy.get('#backer .CollectiveCard')
       .first()
       .find('.totalDonations')

--- a/test/cypress/integration/06-widgets.test.js
+++ b/test/cypress/integration/06-widgets.test.js
@@ -8,7 +8,7 @@ describe('widgets', () => {
 
   it('shows the collectives backed by a user', () => {
     cy.visit('/xdamman/widget.html');
-    cy.get('.CollectiveCard').should('have.length', 16);
+    cy.get('.CollectiveCard').should('have.length', 17);
   });
 
   it('shows the latest events', () => {


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/2723

https://github.com/opencollective/opencollective-api/pull/3060/checks creates `Member` entries for tiers where they were previously missing. As a result, we need to update two tests for widgets and legacy collective page where we display **all** member entries (as opposed to the new collective page where we group memberships under the concept of contributor).

![image](https://user-images.githubusercontent.com/1556356/70937743-22638080-2045-11ea-92c6-6d227690dbc3.png)
