### PR TITLE
Improve graphql exceptions handling

### DIFF
--- a/components/CancelSubscriptionBtn.js
+++ b/components/CancelSubscriptionBtn.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { graphql } from 'react-apollo';
 import { FormattedMessage } from 'react-intl';
 import gql from 'graphql-tag';
+import { getErrorFromGraphqlException } from '../lib/utils';
 import SmallButton from './SmallButton';
 
 class CancelSubscriptionBtn extends React.Component {
@@ -27,7 +28,7 @@ class CancelSubscriptionBtn extends React.Component {
     try {
       await this.props.cancelSubscription(id);
     } catch (err) {
-      onError(err.graphQLErrors[0].message);
+      onError(getErrorFromGraphqlException(err).message);
     }
     this.setState({ loading: false });
   }

--- a/components/CreateCollective.js
+++ b/components/CreateCollective.js
@@ -12,6 +12,7 @@ import { get } from 'lodash';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import { Router } from '../server/pages';
 import { withUser } from './UserProvider';
+import { getErrorFromGraphqlException } from '../lib/utils';
 
 class CreateCollective extends React.Component {
   static propTypes = {
@@ -142,7 +143,7 @@ class CreateCollective extends React.Component {
       }
     } catch (err) {
       console.error('>>> createCollective error: ', JSON.stringify(err));
-      const errorMsg = err.graphQLErrors && err.graphQLErrors[0] ? err.graphQLErrors[0].message : err.message;
+      const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({ status: 'idle', result: { error: errorMsg } });
       throw new Error(errorMsg);
     }

--- a/components/CreateEvent.js
+++ b/components/CreateEvent.js
@@ -11,6 +11,7 @@ import EditEventForm from './EditEventForm';
 import CollectiveNavbar from './CollectiveNavbar';
 
 import { addCreateCollectiveMutation } from '../lib/graphql/mutations';
+import { getErrorFromGraphqlException } from '../lib/utils';
 
 class CreateEvent extends React.Component {
   static propTypes = {
@@ -60,7 +61,7 @@ class CreateEvent extends React.Component {
       window.location.replace(eventUrl);
     } catch (err) {
       console.error('>>> createEvent error: ', JSON.stringify(err));
-      const errorMsg = err.graphQLErrors && err.graphQLErrors[0] ? err.graphQLErrors[0].message : err.message;
+      const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({
         status: 'idle',
         result: { error: errorMsg },

--- a/components/CreateHostFormWithData.js
+++ b/components/CreateHostFormWithData.js
@@ -6,7 +6,7 @@ import gql from 'graphql-tag';
 
 import { Flex } from '@rebass/grid';
 
-import { compose } from '../lib/utils';
+import { compose, getErrorFromGraphqlException } from '../lib/utils';
 
 import LoadingGrid from './LoadingGrid';
 import CreateHostForm from './CreateHostForm';
@@ -35,7 +35,7 @@ class CreateHostFormWithData extends React.Component {
       return collective;
     } catch (err) {
       console.error('>>> createOrganization error: ', JSON.stringify(err));
-      const errorMsg = err.graphQLErrors && err.graphQLErrors[0] ? err.graphQLErrors[0].message : err.message;
+      const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({ result: { error: errorMsg } });
       throw new Error(errorMsg);
     }

--- a/components/CreateOrganization.js
+++ b/components/CreateOrganization.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Header from './Header';
 import Body from './Body';
 import Footer from './Footer';
+import { getErrorFromGraphqlException } from '../lib/utils';
 import { addCreateCollectiveMutation } from '../lib/graphql/mutations';
 import CreateCollectiveForm from './CreateCollectiveForm';
 import CollectiveCover from './CollectiveCover';
@@ -69,7 +70,7 @@ class CreateOrganization extends React.Component {
       });
     } catch (err) {
       console.error('>>> createOrganization error: ', JSON.stringify(err));
-      const errorMsg = err.graphQLErrors && err.graphQLErrors[0] ? err.graphQLErrors[0].message : err.message;
+      const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({ result: { error: errorMsg } });
       throw new Error(errorMsg);
     }

--- a/components/EditEvent.js
+++ b/components/EditEvent.js
@@ -10,6 +10,7 @@ import Body from './Body';
 import Footer from './Footer';
 import EditEventForm from './EditEventForm';
 import CollectiveNavbar from './CollectiveNavbar';
+import { getErrorFromGraphqlException } from '../lib/utils';
 
 class EditEvent extends React.Component {
   static propTypes = {
@@ -41,7 +42,7 @@ class EditEvent extends React.Component {
       this.setState({ result: { success: 'Event edited successfully' } });
     } catch (err) {
       console.error('>>> editEvent error: ', JSON.stringify(err));
-      const errorMsg = err.graphQLErrors && err.graphQLErrors[0] ? err.graphQLErrors[0].message : err.message;
+      const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({ status: 'idle', result: { error: errorMsg } });
     }
   }
@@ -55,7 +56,7 @@ class EditEvent extends React.Component {
       Router.pushRoute(`/${event.parentCollective.slug}`);
     } catch (err) {
       console.error('>>> deleteEvent error: ', JSON.stringify(err));
-      const errorMsg = err.graphQLErrors && err.graphQLErrors[0] ? err.graphQLErrors[0].message : err.message;
+      const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({ result: { error: errorMsg } });
     }
   }

--- a/components/SubscriptionCard.js
+++ b/components/SubscriptionCard.js
@@ -6,7 +6,7 @@ import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import Currency from './Currency';
 import { get, cloneDeep } from 'lodash';
 import Link from './Link';
-import { firstSentence, getCurrencySymbol, imagePreview } from '../lib/utils';
+import { firstSentence, getCurrencySymbol, imagePreview, getErrorFromGraphqlException } from '../lib/utils';
 import { getStripe } from '../lib/stripe';
 import { defaultBackgroundImage } from '../lib/constants/collectives';
 import colors from '../lib/constants/colors';
@@ -89,7 +89,7 @@ class SubscriptionCard extends React.Component {
     } catch (e) {
       this.setState({
         loading: false,
-        result: { error: e.graphQLErrors[0].message },
+        result: { error: getErrorFromGraphqlException(e).message },
       });
     }
   };

--- a/components/edit-collective/EditCollective.js
+++ b/components/edit-collective/EditCollective.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
 
+import { getErrorFromGraphqlException } from '../../lib/utils';
 import Header from '../Header';
 import Body from '../Body';
 import Footer from '../Footer';
@@ -89,7 +90,7 @@ class EditCollective extends React.Component {
       }, 3000);
     } catch (err) {
       console.error('>>> editCollective error:', JSON.stringify(err));
-      const errorMsg = err.graphQLErrors && err.graphQLErrors[0] ? err.graphQLErrors[0].message : err.message;
+      const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({ status: null, result: { error: errorMsg } });
     }
   }

--- a/components/edit-collective/EditCollectiveArchive.js
+++ b/components/edit-collective/EditCollectiveArchive.js
@@ -9,6 +9,7 @@ import Container from '../Container';
 import StyledButton from '../StyledButton';
 import MessageBox from '../MessageBox';
 import Modal, { ModalBody, ModalHeader, ModalFooter } from '../StyledModal';
+import { getErrorFromGraphqlException } from '../../lib/utils';
 
 const getCollectiveType = type => {
   switch (type) {
@@ -45,7 +46,7 @@ const ArchiveCollective = ({ collective, archiveCollective, unarchiveCollective 
       });
     } catch (err) {
       console.error('>>> archiveCollective error: ', JSON.stringify(err));
-      const errorMsg = err.graphQLErrors && err.graphQLErrors[0] ? err.graphQLErrors[0].message : err.message;
+      const errorMsg = getErrorFromGraphqlException(err).message;
       setArchiveStatus({ ...archiveStatus, processing: false, error: errorMsg });
     }
   };
@@ -62,7 +63,7 @@ const ArchiveCollective = ({ collective, archiveCollective, unarchiveCollective 
       });
     } catch (err) {
       console.error('>>> archiveCollective error: ', JSON.stringify(err));
-      const errorMsg = err.graphQLErrors && err.graphQLErrors[0] ? err.graphQLErrors[0].message : err.message;
+      const errorMsg = getErrorFromGraphqlException(err).message;
       setArchiveStatus({ ...archiveStatus, processing: false, error: errorMsg });
     }
   };

--- a/components/edit-collective/EditCollectiveDelete.js
+++ b/components/edit-collective/EditCollectiveDelete.js
@@ -3,6 +3,7 @@ import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 
 import { withUser } from '../UserProvider';
+import { getErrorFromGraphqlException } from '../../lib/utils';
 import { addDeleteCollectiveMutation, addDeleteUserCollectiveMutation } from '../../lib/graphql/mutations';
 import { H2, P } from '../Text';
 import Container from '../Container';
@@ -41,7 +42,7 @@ const DeleteCollective = ({ collective, deleteCollective, deleteUserCollective, 
       await Router.pushRoute(`/deleteCollective/confirmed?type=${collective.type}`);
     } catch (err) {
       console.error('>>> deleteUserCollective error: ', JSON.stringify(err));
-      const errorMsg = err.graphQLErrors && err.graphQLErrors[0] ? err.graphQLErrors[0].message : err.message;
+      const errorMsg = getErrorFromGraphqlException(err).message;
       setDeleteStatus({ deleting: false, error: errorMsg });
     }
   };

--- a/components/edit-collective/EditWebhooks.js
+++ b/components/edit-collective/EditWebhooks.js
@@ -10,7 +10,7 @@ import memoizeOne from 'memoize-one';
 
 import events from '../../lib/constants/notificationEvents';
 
-import { compose } from '../../lib/utils';
+import { compose, getErrorFromGraphqlException } from '../../lib/utils';
 import { CollectiveType } from '../../lib/constants/collectives';
 
 import Loading from '../Loading';
@@ -161,14 +161,7 @@ class EditWebhooks extends React.Component {
         this.setState({ status: null });
       }, 3000);
     } catch (e) {
-      let message = '';
-      if (e && e.errors) {
-        message = e.errors[0].message;
-      } else if (e && e.graphQLErrors && e.graphQLErrors.length > 0) {
-        message = e.graphQLErrors[0].message;
-      } else {
-        message = e.message;
-      }
+      const message = getErrorFromGraphqlException(e).message;
       this.setState({ status: 'error', error: message });
     }
   };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -274,17 +274,16 @@ export const getGraphqlUrl = apiVersion => {
  */
 export const getErrorFromGraphqlException = exception => {
   const firstError = get(exception, 'graphQLErrors.0') || get(exception, 'networkError.result.errors.0');
+  const defaultId = 'unknown';
+  const defaultMessage = 'An unknown error occured';
 
   if (!firstError) {
-    return {
-      id: 'unknown',
-      message: 'An unknown error occured',
-    };
+    return { id: defaultId, message: defaultMessage };
   }
 
   return {
-    id: get(firstError, 'data.errorId'),
-    message: firstError.message,
+    id: get(firstError, 'data.errorId') || defaultId,
+    message: get(firstError, 'message') || defaultMessage,
   };
 };
 

--- a/pages/action.js
+++ b/pages/action.js
@@ -5,7 +5,7 @@ import { graphql } from 'react-apollo';
 import gql from 'graphql-tag';
 import { Flex } from '@rebass/grid';
 
-import { capitalize, compose } from '../lib/utils';
+import { capitalize, compose, getErrorFromGraphqlException } from '../lib/utils';
 
 import Header from '../components/Header';
 import Body from '../components/Body';
@@ -156,7 +156,7 @@ class ActionPage extends React.Component {
         this.setState({ loading: false, result: res.data[mutationName] });
       } catch (error) {
         console.log('>>> error', JSON.stringify(error));
-        this.setState({ loading: false, error: error.graphQLErrors[0] });
+        this.setState({ loading: false, error: getErrorFromGraphqlException(error) });
       }
     }
   }

--- a/pages/openSourceApply.js
+++ b/pages/openSourceApply.js
@@ -20,7 +20,7 @@ import GithubRepositoriesFAQ from '../components/faqs/GithubRepositoriesFAQ';
 import { Router } from '../server/pages';
 
 import { getGithubRepos } from '../lib/api';
-import { getWebsiteUrl } from '../lib/utils';
+import { getWebsiteUrl, getErrorFromGraphqlException } from '../lib/utils';
 import { LOCAL_STORAGE_KEYS, getFromLocalStorage } from '../lib/local-storage';
 
 class OpenSourceApplyPage extends Component {
@@ -106,7 +106,7 @@ class OpenSourceApplyPage extends Component {
       });
     } catch (err) {
       console.error('>>> createCollective error: ', JSON.stringify(err)); // TODO - Remove
-      const errorMsg = err.graphQLErrors && err.graphQLErrors[0] ? err.graphQLErrors[0].message : err.message;
+      const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({
         creatingCollective: false,
         result: { type: 'error', mesg: errorMsg },


### PR DESCRIPTION
Resolve https://sentry.io/organizations/open-collective/issues/1389442858 and similar issues

Our way of checking graphql errors in these parts of the code was wrong, mainly because a network error will leave an empty `graphQLErrors` to fill `networkError` instead. As a result error handling code was crashing.

The `getErrorFromGraphqlException` helper is meant for that, and it should be the default for handling GraphQL exceptions in the frontend.

Also updated `getErrorFromGraphqlException` to make it more resistant (out of safety, haven't seen it crash yet).