### PR TITLE
Fix width and height of buttons(link/unlink) in rich text editor

### DIFF
--- a/components/RichTextEditor.js
+++ b/components/RichTextEditor.js
@@ -61,9 +61,8 @@ const TrixEditorContainer = styled.div`
 
     .trix-button {
       border-bottom: none;
-      width: 2.6em;
-      height: 1.8em;
-      padding: 0.75em;
+      display: inline-block;
+      height: auto;
 
       &:hover {
         background: ${props => props.theme.colors.blue[100]};


### PR DESCRIPTION
Resolve: opencollective/opencollective/issues/2724
<img width="1050" alt="Screen Shot 2019-12-17 at 4 11 40 PM" src="https://user-images.githubusercontent.com/29824008/70999164-e9c9b280-20e9-11ea-9ada-e1367950e2ae.png">
