### PR TITLE
RichTextEditor: Hide image caption input

### DIFF
--- a/components/RichTextEditor.js
+++ b/components/RichTextEditor.js
@@ -42,6 +42,11 @@ const TrixEditorContainer = styled.div`
       color: ${props => props.theme.colors.black[400]};
     }
 
+    // Image captions are disabled
+    figcaption {
+      display: none;
+    }
+
     ${props => css({ minHeight: props.editorMinHeight })}
   }
 


### PR DESCRIPTION
Following up on https://github.com/opencollective/opencollective-frontend/pull/3179

This removes the caption input. We'll re-implement properly if we want to support that in the future.