### PR TITLE
About section: Add inset box-shadow at the top

### DIFF
--- a/components/collective-page/sections/About.js
+++ b/components/collective-page/sections/About.js
@@ -42,7 +42,15 @@ const SectionAbout = ({ collective, canEdit, intl }) => {
   canEdit = collective.isArchived ? false : canEdit;
 
   return (
-    <Container display="flex" flexDirection="column" alignItems="center" px={2} py={[4, 5]} background="#f5f7fa">
+    <Container
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+      px={2}
+      py={[4, 5]}
+      background="#f5f7fa"
+      boxShadow="0px 11px 15px -5px #bfbfbf2b inset"
+    >
       <SectionTitle textAlign="center" mb={5}>
         <FormattedMessage id="collective.about.title" defaultMessage="About" />
       </SectionTitle>


### PR DESCRIPTION
The grey background introduced in https://github.com/opencollective/opencollective-frontend/pull/3168 looks great, but I found the separation with the previous section a little strange. Adding a box-shadow on the top seems to make it smoother.

### Before

![localhost_3000_captainfact_io (2)](https://user-images.githubusercontent.com/1556356/71021784-5dc28580-20ff-11ea-8cc6-f650627fedce.png)

### After

![localhost_3000_captainfact_io (1)](https://user-images.githubusercontent.com/1556356/71021792-6024df80-20ff-11ea-986a-47d97dec37d5.png)
