### PR TITLE
Revert "chore(deps-dev): bump cypress from 3.7.0 to 3.8.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8584,9 +8584,9 @@
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
     },
     "cypress": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.8.0.tgz",
-      "integrity": "sha512-gtEbqCgKETRc3pQFMsELRgIBNgiQg7vbOWTrCi7WE7bgOwNCaW9PEX8Jb3UN8z/maIp9WwzoFfeySfelYY7nRA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.7.0.tgz",
+      "integrity": "sha512-o+vfRxqAba8TduelzfZQ4WHmj2yNEjaoO2EuZ8dZ9pJpuW+WGtBGheKIp6zkoQsp8ZgFe8OoHh1i2mY8BDnMAw==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
     "commitizen": "^4.0.3",
     "cross-env": "^6.0.3",
-    "cypress": "^3.8.0",
+    "cypress": "^3.7.0",
     "cypress-file-upload": "^3.5.1",
     "cz-conventional-changelog": "^3.0.2",
     "enzyme": "^3.10.0",


### PR DESCRIPTION
Reverts opencollective/opencollective-frontend#3175

Investigating the Cypress crashes.