### PR TITLE
Revert "test(e2e): Ignore 'cannot clear timer' exceptions"

### DIFF
--- a/test/cypress/support/index.js
+++ b/test/cypress/support/index.js
@@ -16,8 +16,7 @@
 // Import commands.js using ES2015 syntax:
 import './commands';
 
-// See https://github.com/opencollective/opencollective/issues/2676
-Cypress.on('uncaught:exception', err => {
+cy.on('uncaught:exception', err => {
   if (err.message.includes('Cannot clear timer: timer created with')) {
     // See https://github.com/cypress-io/cypress/issues/3170
     // Ignore this error


### PR DESCRIPTION
Reverts opencollective/opencollective-frontend#3148

Investigating the Cypress crashes.