### PR TITLE
HostDashboard: Add loading state for expense refetch

### DIFF
--- a/components/expenses/ApproveExpenseBtn.js
+++ b/components/expenses/ApproveExpenseBtn.js
@@ -35,6 +35,7 @@ class ApproveExpenseBtn extends React.Component {
           buttonStyle="primary"
           onClick={this.onClick}
           disabled={this.props.disabled}
+          data-cy="approveBtn"
         >
           <FormattedMessage id="expense.approve.btn" defaultMessage="Approve" />
         </StyledButton>

--- a/components/expenses/ApproveExpenseBtn.js
+++ b/components/expenses/ApproveExpenseBtn.js
@@ -10,7 +10,8 @@ class ApproveExpenseBtn extends React.Component {
   static propTypes = {
     id: PropTypes.number.isRequired,
     approveExpense: PropTypes.func.isRequired,
-    refetch: PropTypes.func.isRequired,
+    updateExpensesInCurrentTab: PropTypes.func.isRequired,
+    disabled: PropTypes.bool,
   };
 
   constructor(props) {
@@ -21,13 +22,20 @@ class ApproveExpenseBtn extends React.Component {
   async onClick() {
     const { id } = this.props;
     await this.props.approveExpense(id);
-    await this.props.refetch();
+    await this.props.updateExpensesInCurrentTab();
   }
 
   render() {
     return (
       <div className="ApproveExpenseBtn" data-cy="approve-expense-btn">
-        <StyledButton className="approve" mr={2} my={1} buttonStyle="primary" onClick={this.onClick}>
+        <StyledButton
+          className="approve"
+          mr={2}
+          my={1}
+          buttonStyle="primary"
+          onClick={this.onClick}
+          disabled={this.props.disabled}
+        >
           <FormattedMessage id="expense.approve.btn" defaultMessage="Approve" />
         </StyledButton>
       </div>

--- a/components/expenses/Expense.js
+++ b/components/expenses/Expense.js
@@ -561,6 +561,7 @@ class Expense extends React.Component {
                               buttonStyle="standard"
                               disabled={this.state.disableActionButtons}
                               onClick={() => this.setState({ showUnapproveModal: true })}
+                              data-cy="unapproveBtn"
                             >
                               <FormattedMessage id="expense.unapprove.btn" defaultMessage="Unapprove" />
                             </StyledButton>

--- a/components/expenses/Expenses.js
+++ b/components/expenses/Expenses.js
@@ -48,6 +48,7 @@ class Expenses extends React.Component {
           editable={editable}
           refetch={this.props.refetch}
           view={view}
+          inFilterTab={this.props.status}
           includeHostedCollectives={includeHostedCollectives}
           LoggedInUser={LoggedInUser}
           allowPayAction={!this.state.isPayActionLocked[(expense.collective || collective).id]}

--- a/components/expenses/MarkExpenseAsPaidBtn.js
+++ b/components/expenses/MarkExpenseAsPaidBtn.js
@@ -23,7 +23,7 @@ class MarkExpenseAsPaidBtn extends React.Component {
     lock: PropTypes.func,
     unlock: PropTypes.func,
     mutate: PropTypes.func,
-    refetch: PropTypes.func,
+    updateExpensesInCurrentTab: PropTypes.func,
     intl: PropTypes.object.isRequired,
   };
 
@@ -60,7 +60,7 @@ class MarkExpenseAsPaidBtn extends React.Component {
         },
       });
       this.setState({ loading: false });
-      await this.props.refetch();
+      await this.props.updateExpensesInCurrentTab();
       unlock();
     } catch (e) {
       const error = getErrorFromGraphqlException(e).message;

--- a/components/expenses/MarkExpenseAsUnpaidBtn.js
+++ b/components/expenses/MarkExpenseAsUnpaidBtn.js
@@ -14,7 +14,7 @@ const messages = defineMessages({
   },
 });
 
-const MarkExpenseAsUnpaidBtn = ({ id, markExpenseAsUnpaid, refetch }) => {
+const MarkExpenseAsUnpaidBtn = ({ id, markExpenseAsUnpaid, updateExpensesInCurrentTab, disabled }) => {
   const [state, setState] = useState({
     showProcessorFeeConfirmation: false,
     processorFeeRefunded: false,
@@ -27,7 +27,7 @@ const MarkExpenseAsUnpaidBtn = ({ id, markExpenseAsUnpaid, refetch }) => {
     try {
       setState({ ...state, disableBtn: true });
       await markExpenseAsUnpaid(id, state.processorFeeRefunded);
-      await refetch();
+      await updateExpensesInCurrentTab();
     } catch (err) {
       console.log('>>> payExpense error: ', err);
       setState({ ...state, disableBtn: false });
@@ -54,7 +54,11 @@ const MarkExpenseAsUnpaidBtn = ({ id, markExpenseAsUnpaid, refetch }) => {
           </StyledButton>
         </Fragment>
       ) : (
-        <StyledButton onClick={() => setState({ ...state, showProcessorFeeConfirmation: true })} mt={2}>
+        <StyledButton
+          onClick={() => setState({ ...state, showProcessorFeeConfirmation: true })}
+          mt={2}
+          disabled={disabled}
+        >
           <FormattedMessage id="expense.markAsUnpaid.btn" defaultMessage="Mark as unpaid" />
         </StyledButton>
       )}
@@ -65,7 +69,8 @@ const MarkExpenseAsUnpaidBtn = ({ id, markExpenseAsUnpaid, refetch }) => {
 MarkExpenseAsUnpaidBtn.propTypes = {
   id: PropTypes.number.isRequired,
   markExpenseAsUnpaid: PropTypes.func.isRequired,
-  refetch: PropTypes.func,
+  updateExpensesInCurrentTab: PropTypes.func,
+  disabled: PropTypes.bool,
 };
 
 const markExpenseAsUnpaidQuery = gql`

--- a/components/expenses/PayExpenseBtn.js
+++ b/components/expenses/PayExpenseBtn.js
@@ -24,7 +24,7 @@ class PayExpenseBtn extends React.Component {
     lock: PropTypes.func,
     unlock: PropTypes.func,
     mutate: PropTypes.func,
-    refetch: PropTypes.func,
+    updateExpensesInCurrentTab: PropTypes.func,
     intl: PropTypes.object.isRequired,
   };
 
@@ -60,7 +60,7 @@ class PayExpenseBtn extends React.Component {
         },
       });
       this.setState({ loading: false });
-      await this.props.refetch();
+      await this.props.updateExpensesInCurrentTab();
       unlock();
     } catch (e) {
       const error = getErrorFromGraphqlException(e).message;

--- a/components/expenses/RejectExpenseBtn.js
+++ b/components/expenses/RejectExpenseBtn.js
@@ -36,6 +36,7 @@ class RejectExpenseBtn extends React.Component {
           buttonStyle="danger"
           onClick={this.onClick}
           disabled={this.props.disabled}
+          data-cy="rejectBtn"
         >
           <FormattedMessage id="expense.reject.btn" defaultMessage="Reject" />
         </StyledButton>

--- a/components/expenses/RejectExpenseBtn.js
+++ b/components/expenses/RejectExpenseBtn.js
@@ -10,7 +10,8 @@ class RejectExpenseBtn extends React.Component {
   static propTypes = {
     id: PropTypes.number.isRequired,
     rejectExpense: PropTypes.func.isRequired,
-    refetch: PropTypes.func,
+    updateExpensesInCurrentTab: PropTypes.func,
+    disabled: PropTypes.bool,
   };
 
   constructor(props) {
@@ -21,13 +22,21 @@ class RejectExpenseBtn extends React.Component {
   async onClick() {
     const { id } = this.props;
     await this.props.rejectExpense(id);
-    await this.props.refetch();
+    await this.props.updateExpensesInCurrentTab();
   }
 
   render() {
     return (
       <div className="RejectExpenseBtn" data-cy="reject-expense-btn">
-        <StyledButton mr={2} my={1} width="100%" className="reject" buttonStyle="danger" onClick={this.onClick}>
+        <StyledButton
+          mr={2}
+          my={1}
+          width="100%"
+          className="reject"
+          buttonStyle="danger"
+          onClick={this.onClick}
+          disabled={this.props.disabled}
+        >
           <FormattedMessage id="expense.reject.btn" defaultMessage="Reject" />
         </StyledButton>
       </div>

--- a/components/expenses/__tests__/Expenses.test.js
+++ b/components/expenses/__tests__/Expenses.test.js
@@ -68,6 +68,7 @@ describe('Expenses component', () => {
         host={host}
         editable={true}
         LoggedInUser={loggedInUser}
+        refetch={() => {}}
         payExpense={() => setTimeout(() => Promise.resolve(), 2000)}
       />,
     ),
@@ -89,7 +90,7 @@ describe('Expenses component', () => {
         .simulate('click');
 
       // expect two disabled buttons again
-      expect(component.find('[data-cy="expense-actions"] button[disabled]').length).toEqual(4);
+      expect(component.find('[data-cy="expense-actions"] button[disabled]').length).toEqual(8);
 
       // after timeout, make sure there is only button and it's not disabled.
       setTimeout(() => {

--- a/lang/en.json
+++ b/lang/en.json
@@ -647,6 +647,7 @@
   "expense.privateMessage": "Private instructions",
   "expense.privateMessage.description": "Private instructions for the host to reimburse your expense",
   "expense.privateNote": "private note",
+  "expense.refreshing": "Refreshing",
   "expense.reject.btn": "Reject",
   "expense.rejected": "rejected",
   "expense.save": "save",

--- a/lang/es.json
+++ b/lang/es.json
@@ -647,6 +647,7 @@
   "expense.privateMessage": "Private instructions",
   "expense.privateMessage.description": "Private instructions for the host to reimburse your expense",
   "expense.privateNote": "nota privada",
+  "expense.refreshing": "Refreshing",
   "expense.reject.btn": "Reject",
   "expense.rejected": "rechazado",
   "expense.save": "guardar",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -647,6 +647,7 @@
   "expense.privateMessage": "Instructions privées",
   "expense.privateMessage.description": "Les instructions privées sont uniquement visible pour les administrateurs du compte en banque de votre collectif",
   "expense.privateNote": "note privée",
+  "expense.refreshing": "Refreshing",
   "expense.reject.btn": "Refuser",
   "expense.rejected": "refusé",
   "expense.save": "sauvegarder",

--- a/lang/it.json
+++ b/lang/it.json
@@ -647,6 +647,7 @@
   "expense.privateMessage": "Private instructions",
   "expense.privateMessage.description": "Private instructions for the host to reimburse your expense",
   "expense.privateNote": "private note",
+  "expense.refreshing": "Refreshing",
   "expense.reject.btn": "Reject",
   "expense.rejected": "respinto",
   "expense.save": "salva",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -647,6 +647,7 @@
   "expense.privateMessage": "私的な指示",
   "expense.privateMessage.description": "ホストが請求を払い戻すための私的な指示",
   "expense.privateNote": "プライベートノート",
+  "expense.refreshing": "Refreshing",
   "expense.reject.btn": "Reject",
   "expense.rejected": "拒否されました",
   "expense.save": "保存",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -647,6 +647,7 @@
   "expense.privateMessage": "Private instructions",
   "expense.privateMessage.description": "Private instructions for the host to reimburse your expense",
   "expense.privateNote": "private note",
+  "expense.refreshing": "Refreshing",
   "expense.reject.btn": "Reject",
   "expense.rejected": "rejected",
   "expense.save": "save",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -647,6 +647,7 @@
   "expense.privateMessage": "Instruções privadas",
   "expense.privateMessage.description": "Instruções privadas para o organizador reembolsar sua despesa",
   "expense.privateNote": "nota privada",
+  "expense.refreshing": "Refreshing",
   "expense.reject.btn": "Rejeitar",
   "expense.rejected": "rejeitado",
   "expense.save": "salvar",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -647,6 +647,7 @@
   "expense.privateMessage": "Личные инструкции",
   "expense.privateMessage.description": "Личные инструкции для представителя для возмещения ваших расходов",
   "expense.privateNote": "личная заметка",
+  "expense.refreshing": "Refreshing",
   "expense.reject.btn": "Reject",
   "expense.rejected": "отказано",
   "expense.save": "сохранить",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -647,6 +647,7 @@
   "expense.privateMessage": "Private instructions",
   "expense.privateMessage.description": "Private instructions for the host to reimburse your expense",
   "expense.privateNote": "private note",
+  "expense.refreshing": "Refreshing",
   "expense.reject.btn": "Reject",
   "expense.rejected": "rejected",
   "expense.save": "保存",

--- a/test/cypress/integration/29-host.dashboard.test.js
+++ b/test/cypress/integration/29-host.dashboard.test.js
@@ -36,20 +36,35 @@ describe('host dashboard', () => {
     cy.wait(1000);
   });
 
-  it('approve expense and reject expense', () => {
+  it('unapprove expense', () => {
     cy.login({ redirect: '/brusselstogetherasbl/dashboard/expenses' });
-    cy.get('[data-cy="expense-paid"]').as('currentExpense');
-    cy.get('[data-cy="expense-actions"]')
-      .contains('button', 'Unapprove')
+    cy.get('[data-cy="expense-approved"]').as('currentExpense');
+    cy.get('[data-cy="unapproveBtn"]')
+      .first()
       .click({ force: true });
     cy.get('[data-cy="confirmation-modal-continue"]').click({ force: true });
     cy.wait(500);
-    cy.get('[data-cy="reject-expense-btn"]').within(() => {
-      cy.get('button').click({ force: true });
-    });
-    cy.get('[data-cy="approve-expense-btn"]').within(() => {
-      cy.get('button').click({ force: true });
-    });
+    cy.get('@currentExpense').should('have.attr', 'data-cy', 'expense-pending');
+  });
+
+  it('reject expense', () => {
+    cy.login({ redirect: '/brusselstogetherasbl/dashboard/expenses' });
+    cy.get('[data-cy="expense-pending"]').as('currentExpense');
+    cy.get('[data-cy="rejectBtn"]')
+      .first()
+      .click({ force: true });
+    cy.wait(200);
+    cy.get('@currentExpense').should('have.attr', 'data-cy', 'expense-rejected');
+  });
+
+  it('approves expense', () => {
+    cy.login({ redirect: '/brusselstogetherasbl/dashboard/expenses' });
+    cy.get('[data-cy="expense-rejected"]').as('currentExpense');
+    cy.get('[data-cy="approveBtn"]')
+      .first()
+      .click({ force: true });
+    cy.wait(200);
+    cy.get('@currentExpense').should('have.attr', 'data-cy', 'expense-approved');
   });
 
   it('record expense as paid', () => {


### PR DESCRIPTION
Previously in https://github.com/opencollective/opencollective-frontend/pull/3096

Resolves https://github.com/opencollective/opencollective/issues/2583

The idea behind this PR is to show a non-blocking loading state during expenses refetch, only the expense that is behind updated will show a loading state.

<img width="1040" alt="Screenshot 2019-12-02 at 2 21 00 PM" src="https://user-images.githubusercontent.com/15707013/69963930-949a7800-1511-11ea-9e95-5b72bae9f041.png">