### PR TITLE
InlineEditField: Improve default styles

### DIFF
--- a/components/InlineEditField.js
+++ b/components/InlineEditField.js
@@ -30,9 +30,7 @@ const EditIcon = styled(PencilAlt)`
 `;
 
 /** Component used for cancel / submit buttons */
-const FormButton = styled(StyledButton).attrs({
-  buttonSize: 'large',
-})`
+const FormButton = styled(StyledButton)`
   width: 35%;
   font-weight: normal;
   min-width: 225px;
@@ -211,6 +209,7 @@ class InlineEditField extends Component {
                     lineHeight="inherit"
                     maxLength={this.props.maxLength}
                     data-cy={`InlineEditField-Textarea-${field}`}
+                    withOutline
                   />
                 )}
                 <Box width={1}>

--- a/components/StyledTextarea.js
+++ b/components/StyledTextarea.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { space, layout, border, color, typography } from 'styled-system';
 import themeGet from '@styled-system/theme-get';
 
@@ -23,6 +23,22 @@ const TextArea = styled.textarea`
   ${typography}
 
   outline: none;
+
+  ${props => {
+    if (props.withOutline) {
+      return props.error
+        ? css`
+            outline: 1px dashed ${themeGet('colors.red.300')};
+            outline-offset: 0.25em;
+          `
+        : css`
+            &:focus {
+              outline: 1px dashed ${themeGet('colors.black.200')};
+              outline-offset: 0.25em;
+            }
+          `;
+    }
+  }}
 
   &:disabled {
     background-color: ${themeGet('colors.black.50')};
@@ -56,6 +72,10 @@ export default class StyledTextarea extends React.PureComponent {
     resize: PropTypes.oneOf(['vertical', 'horizontal', 'both', 'none']),
     /** If true, max text length will be displayed at the bottom right */
     showCount: PropTypes.bool,
+    /** if true, a default outline will be displayed when focused */
+    withOutline: PropTypes.bool,
+    /** If truthy, the outline will be red */
+    error: PropTypes.any,
     /** @ignore */
     px: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
     /** @ignore */

--- a/pages/conversation.js
+++ b/pages/conversation.js
@@ -247,7 +247,7 @@ class ConversationPage extends React.Component {
                     <Flex flexDirection={['column', null, null, 'row']} justifyContent="space-between">
                       <Box flex="1 1 50%" maxWidth={700} mb={5}>
                         <Container borderBottom="1px solid" borderColor="black.300" pb={4}>
-                          <H2 fontSize="H4" mb={3}>
+                          <H2 fontSize="H4" lineHeight="H4" mb={4}>
                             <InlineEditField
                               mutation={editConversationMutation}
                               mutationOptions={{ context: API_V2_CONTEXT }}


### PR DESCRIPTION
Motivated by https://github.com/opencollective/opencollective/issues/2722#issuecomment-565515423

This improves the default styles for `InlineEditField`.

- Use regular button size (instead of large)

![image](https://user-images.githubusercontent.com/1556356/71172767-6632d180-2261-11ea-9dce-089b1275c58c.png)

- Show an outline around edited fields

![image](https://user-images.githubusercontent.com/1556356/71172817-85316380-2261-11ea-92a9-7b0a7c477e80.png)
