### PR TITLE
Conversations: Remove admin ability to edit comments

### DIFF
--- a/components/conversations/Comment.js
+++ b/components/conversations/Comment.js
@@ -56,21 +56,25 @@ const mutationOptions = { context: API_V2_CONTEXT };
 /**
  * Action buttons for the comment owner. Styles change between mobile and desktop.
  */
-const AdminActionButtons = ({ comment, isConversationRoot, onDelete, onEdit }) => {
+const AdminActionButtons = ({ comment, canEdit, canDelete, isConversationRoot, onDelete, onEdit }) => {
   const [isDeleting, setDeleting] = React.useState(null);
   const [deleteComment, { error: deleteError }] = useMutation(deleteCommentMutation, mutationOptions);
 
   return (
     <React.Fragment>
       {/** Buttons */}
-      <CommentBtn onClick={onEdit} ml={2}>
-        <Edit size="1em" />
-        <FormattedMessage tagName="span" id="comment.edit" defaultMessage="Edit" />
-      </CommentBtn>
-      <CommentBtn onClick={() => setDeleting(true)} ml={2}>
-        <X size="1em" />
-        <FormattedMessage tagName="span" id="comment.delete" defaultMessage="Delete" />
-      </CommentBtn>
+      {canEdit && (
+        <CommentBtn onClick={onEdit} ml={2}>
+          <Edit size="1em" />
+          <FormattedMessage tagName="span" id="comment.edit" defaultMessage="Edit" />
+        </CommentBtn>
+      )}
+      {canDelete && (
+        <CommentBtn onClick={() => setDeleting(true)} ml={2}>
+          <X size="1em" />
+          <FormattedMessage tagName="span" id="comment.delete" defaultMessage="Delete" />
+        </CommentBtn>
+      )}
       {/** Confirm Modals */}
       {isDeleting && (
         <ConfirmationModal
@@ -118,6 +122,8 @@ AdminActionButtons.propTypes = {
   onDelete: PropTypes.func,
   onEdit: PropTypes.func,
   isConversationRoot: PropTypes.bool,
+  canEdit: PropTypes.bool,
+  canDelete: PropTypes.bool,
 };
 
 /**
@@ -125,18 +131,21 @@ AdminActionButtons.propTypes = {
  *
  * /!\ Can only be used with data from API V2.
  */
-const Comment = ({ comment, canEdit, withoutActions, maxCommentHeight, isConversationRoot, onDelete }) => {
+const Comment = ({ comment, canEdit, canDelete, withoutActions, maxCommentHeight, isConversationRoot, onDelete }) => {
   const [isEditing, setEditing] = React.useState(false);
+  const hasActions = !withoutActions && !isEditing && (canEdit || canDelete);
 
   const actionButtons =
     withoutActions || isEditing ? null : (
       <Flex>
-        {canEdit && (
+        {hasActions && (
           <AdminActionButtons
             comment={comment}
             isConversationRoot={isConversationRoot}
             onDelete={onDelete}
             onEdit={() => setEditing(true)}
+            canEdit={canEdit}
+            canDelete={canDelete}
           />
         )}
       </Flex>
@@ -177,6 +186,7 @@ const Comment = ({ comment, canEdit, withoutActions, maxCommentHeight, isConvers
           values={comment}
           field="html"
           canEdit={canEdit}
+          canDelete={canDelete}
           isEditing={isEditing}
           showEditIcon={false}
           prepareVariables={(comment, html) => ({ comment: { id: comment.id, html } })}
@@ -213,8 +223,10 @@ Comment.propTypes = {
       name: PropTypes.string,
     }),
   }).isRequired,
-  /** Can current user edit/delete this comment? */
+  /** Can current user edit this comment? */
   canEdit: PropTypes.bool,
+  /** Can current user delete this comment? */
+  canDelete: PropTypes.bool,
   /** Set this to true if the comment is the root comment of a conversation */
   isConversationRoot: PropTypes.bool,
   /** Set this to true to disable actions */

--- a/components/conversations/Thread.js
+++ b/components/conversations/Thread.js
@@ -53,7 +53,8 @@ const Thread = ({ collective, items, onCommentDeleted, LoggedInUser }) => {
                   <CommentContainer isLast={idx + 1 === items.length}>
                     <Comment
                       comment={item}
-                      canEdit={isAdmin || Boolean(LoggedInUser && LoggedInUser.canEditComment(item))}
+                      canDelete={isAdmin || Boolean(LoggedInUser && LoggedInUser.canEditComment(item))}
+                      canEdit={Boolean(LoggedInUser && LoggedInUser.canEditComment(item))}
                       onDelete={onCommentDeleted}
                     />
                   </CommentContainer>

--- a/pages/conversation.js
+++ b/pages/conversation.js
@@ -221,6 +221,7 @@ class ConversationPage extends React.Component {
     const followers = get(conversation, 'followers');
     const hasFollowers = followers && followers.nodes && followers.nodes.length > 0;
     const canEdit = LoggedInUser && body && LoggedInUser.canEditComment(body);
+    const canDelete = canEdit || (LoggedInUser && LoggedInUser.canEditCollective(collective));
     return (
       <Page collective={collective} {...this.getPageMetaData(collective)} withoutGlobalStyles>
         {data.loading ? (
@@ -266,6 +267,7 @@ class ConversationPage extends React.Component {
                           <Comment
                             comment={body}
                             canEdit={canEdit}
+                            canDelete={canDelete}
                             onDelete={this.onConversationDeleted}
                             isConversationRoot
                           />


### PR DESCRIPTION
As described in https://github.com/opencollective/opencollective/issues/2722#issuecomment-565515632. Note that this is only a frontend limitation, we're not enforcing that in the API.

![image](https://user-images.githubusercontent.com/1556356/71177381-2cb39380-226c-11ea-99d5-34da351b47de.png)
