### PR TITLE
StyledLink: Fix border colors

### DIFF
--- a/components/StyledLink.js
+++ b/components/StyledLink.js
@@ -40,7 +40,8 @@ const StyledLink = styled.a`
     props.buttonStyle &&
     css`
       outline: 0;
-      border: 1px solid;
+      border-style: solid;
+      border-width: 1px;
       border-radius: 100px;
 
       &:disabled {


### PR DESCRIPTION
Fix the borders appearing as black for styled buttons

![image](https://user-images.githubusercontent.com/1556356/71413106-f3ef3200-2650-11ea-8851-5430209d7ad1.png)
