### PR TITLE
Expense comments: use standard rich text components

### DIFF
--- a/components/Comment.js
+++ b/components/Comment.js
@@ -6,8 +6,9 @@ import Avatar from './Avatar';
 import Link from './Link';
 import SmallButton from './SmallButton';
 import { pick } from 'lodash';
-import InputField from './InputField';
 import ConfirmationModal from './ConfirmationModal';
+import HTMLContent from './HTMLContent';
+import RichTextEditor from './RichTextEditor';
 
 class Comment extends React.Component {
   static propTypes = {
@@ -213,13 +214,13 @@ class Comment extends React.Component {
               )}
             </div>
             <div className="description">
-              {this.state.mode !== 'edit' && <div dangerouslySetInnerHTML={{ __html: comment.html }} />}
+              {this.state.mode !== 'edit' && <HTMLContent content={comment.html} fontSize="13px" />}
               {this.state.mode === 'edit' && (
-                <InputField
+                <RichTextEditor
                   name={`comment-${comment.id}`}
-                  type="html"
                   defaultValue={comment.html}
-                  onChange={value => this.handleChange('html', value)}
+                  onChange={e => this.handleChange('html', e.target.value)}
+                  fontSize="13px"
                 />
               )}
             </div>

--- a/components/CommentForm.js
+++ b/components/CommentForm.js
@@ -2,11 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get, pick } from 'lodash';
 import { defineMessages, FormattedMessage, FormattedDate } from 'react-intl';
-import InputField from './InputField';
 import SmallButton from './SmallButton';
 import Avatar from './Avatar';
 import Link from './Link';
 import MessageBox from './MessageBox';
+import RichTextEditor from './RichTextEditor';
+import { Box } from '@rebass/grid';
 
 /**
  * Component to render for for **new** comments. Comment Edit form is created
@@ -39,7 +40,7 @@ class CommentForm extends React.Component {
       },
     });
 
-    this.state = { comment: {}, error: null };
+    this.state = { comment: {}, postedComment: null, error: null };
   }
 
   async onSubmit() {
@@ -47,8 +48,7 @@ class CommentForm extends React.Component {
     try {
       const comment = await this.props.onSubmit(pick(this.state.comment, ['html']));
       if (comment) {
-        const newEmptyComment = { id: comment.id++ };
-        this.setState({ comment: newEmptyComment });
+        this.setState({ comment, postedComment: comment });
       }
     } catch (e) {
       this.setState({ error: e });
@@ -133,15 +133,15 @@ class CommentForm extends React.Component {
               </span>
             </div>
             <div className="description">
-              <div className="comment">
-                <InputField
+              <Box className="comment" my={2}>
+                <RichTextEditor
                   name="comment-new"
-                  type="html"
-                  value={get(this.state, 'comment.html', '')}
-                  onChange={value => this.handleChange('html', value)}
-                  className="small"
+                  onChange={e => this.handleChange('html', e.target.value)}
+                  editorMinHeight={150}
+                  reset={get(this.state, 'postedComment.id', 0)}
+                  withBorders
                 />
-              </div>
+              </Box>
               {this.state.error && (
                 <MessageBox type="error" withIcon mb={2}>
                   {this.state.error.toString()}

--- a/test/cypress/integration/34-expenses.comment.test.js
+++ b/test/cypress/integration/34-expenses.comment.test.js
@@ -21,9 +21,9 @@ describe('Expense Comments', () => {
 
   function SubmitComment(description) {
     cy.getByDataCy('CommentForm').within(() => {
-      cy.get('.ql-editor')
-        .type(description)
-        .blur();
+      cy.get('[data-cy="RichTextEditor"] trix-editor').as('editor');
+      cy.get('@editor').type(description);
+      cy.wait(50);
       cy.getByDataCy('SaveCommentButton').click();
     });
   }
@@ -47,9 +47,8 @@ describe('Expense Comments', () => {
     // Edit comment
     cy.get('.Comments .itemsList .comment:first').within(() => {
       cy.getByDataCy('ToggleEditComment').click();
-      cy.get('.ql-editor')
-        .clear()
-        .type('Modifying my first comment');
+      cy.get('[data-cy="RichTextEditor"] trix-editor').as('editor');
+      cy.get('@editor').type('Modifying my first comment');
       cy.getByDataCy('SaveEditionCommentButton').click();
     });
 
@@ -82,6 +81,7 @@ describe('Expense Comments', () => {
     for (let i = 0; i < TOTAL_COMMENTS; i++) {
       SubmitComment(i);
     }
+    cy.wait(100);
     cy.reload();
 
     const checkCommentCount = count => cy.get('.Comments .itemsList .comment').should('have.length', count);


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2767 by using the defaults `HTMLContent` and `RichTextEditor` for expense's comments.

![Peek 02-01-2020 18-17](https://user-images.githubusercontent.com/1556356/71681115-294ffa00-2d8c-11ea-9c42-9f8888b85ba6.gif)
