### PR TITLE
editCollective: Don't load memberships

### DIFF
--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -243,35 +243,6 @@ export const getCollectiveToEditQueryFields = `
     maxQuantity
     button
   }
-  memberOf {
-    id
-    createdAt
-    role
-    stats {
-      totalDonations
-    }
-    tier {
-      id
-      name
-    }
-    collective {
-      id
-      type
-      slug
-      name
-      currency
-      description
-      settings
-      imageUrl
-      stats {
-        id
-        backers {
-          all
-        }
-        yearlyBudget
-      }
-    }
-  }
   members(roles: ["ADMIN", "MEMBER", "HOST"]) {
     id
     createdAt


### PR DESCRIPTION
Fix a crash happening to Triplebyte (https://opencollective.freshdesk.com/a/tickets/3648) because we tried to load all their memberships (they have a lot). I couldn't find any usage of `memberOf` in the edit pages so I just removed the field. Quickly tried the edit endpoints, everything seems to work fine.

This should speed up the load of the edit page, especially for collectives with a lot of memberships.

