### PR TITLE
Revert react-easy-crop-2.0.0 update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24040,123 +24040,12 @@
       }
     },
     "react-easy-crop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-2.0.0.tgz",
-      "integrity": "sha512-LhTJt4T9+vQQ5QBGAST1Gif/Qv+JoJyKa9qaXalIhRac1Q6Wp4YmKR19kJeVPokC1787P9uh+uSlPZ2DYIeRvQ==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-1.17.1.tgz",
+      "integrity": "sha512-PxvyVvHIGjvfqz1VgxeTohWqRkxuvkQyGTJpuCWzlYzWaFN3mjFNOlh9avbCELmhXAQc59WHsgUIDEzEevcVYg==",
       "requires": {
-        "@emotion/core": "^10.0.27",
-        "@emotion/styled": "^10.0.27",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "@emotion/cache": {
-          "version": "10.0.27",
-          "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.27.tgz",
-          "integrity": "sha512-Zp8BEpbMunFsTcqAK4D7YTm3MvCp1SekflSLJH8lze2fCcSZ/yMkXHo8kb3t1/1Tdd3hAqf3Fb7z9VZ+FMiC9w==",
-          "requires": {
-            "@emotion/sheet": "0.9.4",
-            "@emotion/stylis": "0.8.5",
-            "@emotion/utils": "0.11.3",
-            "@emotion/weak-memoize": "0.2.5"
-          }
-        },
-        "@emotion/core": {
-          "version": "10.0.27",
-          "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.27.tgz",
-          "integrity": "sha512-XbD5R36pVbohQMnKfajHv43g8EbN4NHdF6Zh9zg/C0nr0jqwOw3gYnC07Xj3yG43OYSRyrGsoQ5qPwc8ycvLZw==",
-          "requires": {
-            "@babel/runtime": "^7.5.5",
-            "@emotion/cache": "^10.0.27",
-            "@emotion/css": "^10.0.27",
-            "@emotion/serialize": "^0.11.15",
-            "@emotion/sheet": "0.9.4",
-            "@emotion/utils": "0.11.3"
-          }
-        },
-        "@emotion/css": {
-          "version": "10.0.27",
-          "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
-          "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
-          "requires": {
-            "@emotion/serialize": "^0.11.15",
-            "@emotion/utils": "0.11.3",
-            "babel-plugin-emotion": "^10.0.27"
-          }
-        },
-        "@emotion/hash": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.4.tgz",
-          "integrity": "sha512-fxfMSBMX3tlIbKUdtGKxqB1fyrH6gVrX39Gsv3y8lRYKUqlgDt3UMqQyGnR1bQMa2B8aGnhLZokZgg8vT0Le+A=="
-        },
-        "@emotion/memoize": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-          "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
-        },
-        "@emotion/serialize": {
-          "version": "0.11.15",
-          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.15.tgz",
-          "integrity": "sha512-YE+qnrmGwyR+XB5j7Bi+0GT1JWsdcjM/d4POu+TXkcnrRs4RFCCsi3d/Ebf+wSStHqAlTT2+dfd+b9N9EO2KBg==",
-          "requires": {
-            "@emotion/hash": "0.7.4",
-            "@emotion/memoize": "0.7.4",
-            "@emotion/unitless": "0.7.5",
-            "@emotion/utils": "0.11.3",
-            "csstype": "^2.5.7"
-          }
-        },
-        "@emotion/sheet": {
-          "version": "0.9.4",
-          "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
-          "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
-        },
-        "@emotion/stylis": {
-          "version": "0.8.5",
-          "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-          "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
-        },
-        "@emotion/unitless": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-          "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
-        },
-        "@emotion/utils": {
-          "version": "0.11.3",
-          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-          "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
-        },
-        "@emotion/weak-memoize": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
-          "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
-        },
-        "babel-plugin-emotion": {
-          "version": "10.0.27",
-          "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.27.tgz",
-          "integrity": "sha512-SUNYcT4FqhOqvwv0z1oeYhqgheU8qrceLojuHyX17ngo7WtWqN5I9l3IGHzf21Xraj465CVzF4IvOlAF+3ed0A==",
-          "requires": {
-            "@babel/helper-module-imports": "^7.0.0",
-            "@emotion/hash": "0.7.4",
-            "@emotion/memoize": "0.7.4",
-            "@emotion/serialize": "^0.11.15",
-            "babel-plugin-macros": "^2.0.0",
-            "babel-plugin-syntax-jsx": "^6.18.0",
-            "convert-source-map": "^1.5.0",
-            "escape-string-regexp": "^1.0.5",
-            "find-root": "^1.1.0",
-            "source-map": "^0.5.7"
-          }
-        },
-        "csstype": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.8.tgz",
-          "integrity": "sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA=="
-        },
-        "tslib": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
-        }
+        "@emotion/core": "^10.0.7",
+        "@emotion/styled": "^10.0.7"
       }
     },
     "react-error-overlay": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "react-dnd-html5-backend": "3.0.2",
     "react-dom": "16.12.0",
     "react-dropzone": "10.2.1",
-    "react-easy-crop": "2.0.0",
+    "react-easy-crop": "1.17.1",
     "react-geosuggest": "2.12.1",
     "react-gmaps": "1.9.0",
     "react-hook-form": "3.29.4",


### PR DESCRIPTION
This reverts commit 0c52f112d063f14c8693872a59c04713ec21008c (#3256). I initially tested with smaller images, which worked fine, but doing some more testing with larger images I noticed a misalignment. Will open an issue to follow up.

![Peek 06-01-2020 21-52](https://user-images.githubusercontent.com/1556356/71848079-d8fbd380-30ce-11ea-9e31-9b1e46bd5e4a.gif)
