### PR TITLE
CollectiveNavBar: Make Submit Expense button opt-in

### DIFF
--- a/components/CollectiveNavbar.js
+++ b/components/CollectiveNavbar.js
@@ -309,7 +309,6 @@ const getDefaultCallsToactions = (collective, isAdmin) => {
   const isEvent = collective.type === CollectiveType.EVENT;
   return {
     hasContact: collective.canContact,
-    hasSubmitExpense: isCollective || isEvent,
     hasApply: collective.canApply,
     hasManageSubscriptions: isAdmin && !isCollective && !isEvent,
   };

--- a/pages/expense.js
+++ b/pages/expense.js
@@ -86,6 +86,7 @@ class ExpensePage extends React.Component {
             collective={collective}
             LoggedInUser={LoggedInUser}
             displayContributeLink={collective.isActive && collective.host ? true : false}
+            callsToAction={{ hasSubmitExpense: true }}
           />
 
           <Box maxWidth={1200} m="0 auto" px={[1, 3, 4]} py={[2, 3]}>

--- a/pages/transactions.js
+++ b/pages/transactions.js
@@ -86,6 +86,9 @@ class TransactionsPage extends React.Component {
             LoggedInUser={LoggedInUser}
             key={collective.slug}
             selectedSection={collective.type === CollectiveType.COLLECTIVE ? Sections.BUDGET : Sections.TRANSACTIONS}
+            callsToAction={{
+              hasSubmitExpense: [CollectiveType.COLLECTIVE, CollectiveType.EVENT].includes(collective.type),
+            }}
             displayContributeLink={
               collective.isActive && collective.host && !['USER', 'ORGANIZATION'].includes(collective.type)
             }


### PR DESCRIPTION
As suggested by @piamancini, this makes the `Submit Expense` opt-in (instead of added by default). Concretely, the button will only be displayed on:
- Collective page
- Transactions page (for collectives and events)
- Expense(s) pages

The button will **not** be displayed on all the other pages, including Conversations, Updates...etc

## Examples

![image](https://user-images.githubusercontent.com/1556356/71981859-8bdd4600-3223-11ea-9195-0b687e2ee866.png)

![image](https://user-images.githubusercontent.com/1556356/71981895-9e577f80-3223-11ea-982c-75d1ee50530f.png)

