### PR TITLE
ExpensesPage: Limit to collectives and events

### DIFF
--- a/lib/allowed-features.js
+++ b/lib/allowed-features.js
@@ -8,10 +8,12 @@ import { CollectiveType } from './constants/collectives';
 export const FEATURES = {
   CONVERSATIONS: 'CONVERSATIONS',
   COLLECTIVE_GOALS: 'COLLECTIVE_GOALS',
+  RECEIVE_EXPENSES: 'RECEIVE_EXPENSES',
 };
 
 const FeatureAllowedForTypes = {
   [FEATURES.CONVERSATIONS]: [CollectiveType.COLLECTIVE, CollectiveType.ORGANIZATION],
+  [FEATURES.RECEIVE_EXPENSES]: [CollectiveType.COLLECTIVE, CollectiveType.EVENT],
 };
 
 /**

--- a/pages/expenses.js
+++ b/pages/expenses.js
@@ -16,6 +16,8 @@ import { addCollectiveCoverData } from '../lib/graphql/queries';
 
 import { withUser } from '../components/UserProvider';
 import { ssrNotFoundError } from '../lib/nextjs_utils';
+import hasFeature, { FEATURES } from '../lib/allowed-features';
+import PageFeatureNotSupported from '../components/PageFeatureNotSupported';
 
 class ExpensesPage extends React.Component {
   static getInitialProps({ query: { collectiveSlug, filter, value } }) {
@@ -39,6 +41,8 @@ class ExpensesPage extends React.Component {
     } else if (!data.Collective) {
       ssrNotFoundError(); // Force 404 when rendered server side
       return <ErrorPage error={generateError.notFound(slug)} log={false} />;
+    } else if (!hasFeature(data.Collective, FEATURES.RECEIVE_EXPENSES)) {
+      return <PageFeatureNotSupported />;
     }
 
     const collective = data.Collective;


### PR DESCRIPTION
Removes the ability to see the expenses page for users, which was a glitch - not a feature.

### Before

![image](https://user-images.githubusercontent.com/1556356/71982487-dc08d800-3224-11ea-8061-f367705bfa32.png)


### After

![image](https://user-images.githubusercontent.com/1556356/71982412-b085ed80-3224-11ea-83ad-f943c5f49b53.png)
