### PR TITLE
Migrate sub collectives to members

### DIFF
--- a/components/collective-page/graphql/queries.js
+++ b/components/collective-page/graphql/queries.js
@@ -133,28 +133,31 @@ export const getCollectivePageQuery = gql`
           }
         }
       }
-      childCollectives {
+      subCollectives: members(role: "SUB_COLLECTIVE") {
         id
-        slug
-        name
-        type
-        description
-        backgroundImageUrl(height: 208)
-        stats {
+        collective: member {
           id
-          backers {
-            id
-            all
-            users
-            organizations
-          }
-        }
-        contributors(limit: $nbContributorsPerContributeCard) {
-          id
-          image
-          collectiveSlug
+          slug
           name
           type
+          description
+          backgroundImageUrl(height: 208)
+          stats {
+            id
+            backers {
+              id
+              all
+              users
+              organizations
+            }
+          }
+          contributors(limit: $nbContributorsPerContributeCard) {
+            id
+            image
+            collectiveSlug
+            name
+            type
+          }
         }
       }
       transactions(limit: 3, includeExpenseTransactions: false) {

--- a/components/collective-page/index.js
+++ b/components/collective-page/index.js
@@ -46,7 +46,7 @@ class CollectivePage extends Component {
     expenses: PropTypes.arrayOf(PropTypes.object),
     updates: PropTypes.arrayOf(PropTypes.object),
     events: PropTypes.arrayOf(PropTypes.object),
-    childCollectives: PropTypes.arrayOf(PropTypes.object),
+    subCollectives: PropTypes.arrayOf(PropTypes.object),
     LoggedInUser: PropTypes.object,
     isAdmin: PropTypes.bool.isRequired,
     isRoot: PropTypes.bool.isRequired,
@@ -162,7 +162,7 @@ class CollectivePage extends Component {
             collective={this.props.collective}
             tiers={this.props.tiers}
             events={this.props.events}
-            childCollectives={this.props.childCollectives}
+            subCollectives={this.props.subCollectives}
             contributors={this.props.financialContributors}
             contributorsStats={this.props.stats.backers}
             isAdmin={this.props.isAdmin}

--- a/components/collective-page/sections/Contribute.js
+++ b/components/collective-page/sections/Contribute.js
@@ -38,9 +38,12 @@ class SectionContribute extends React.PureComponent {
         contributors: PropTypes.arrayOf(PropTypes.object),
       }),
     ),
-    childCollectives: PropTypes.arrayOf(
+    subCollectives: PropTypes.arrayOf(
       PropTypes.shape({
         id: PropTypes.number.isRequired,
+        collective: PropTypes.shape({
+          id: PropTypes.number.isRequired,
+        }),
       }),
     ),
     collective: PropTypes.shape({
@@ -128,7 +131,7 @@ class SectionContribute extends React.PureComponent {
   }
 
   render() {
-    const { collective, tiers, events, childCollectives, contributors, contributorsStats, isAdmin } = this.props;
+    const { collective, tiers, events, subCollectives, contributors, contributorsStats, isAdmin } = this.props;
     const [topOrganizations, topIndividuals] = this.getTopContributors(contributors);
     const financialContributorsWithoutTier = this.getFinancialContributorsWithoutTier(contributors);
     const hasNoContributor = !this.hasContributors(contributors);
@@ -189,14 +192,14 @@ class SectionContribute extends React.PureComponent {
             )}
           </HorizontalScroller>
         </Box>
-        {!isEvent && (isAdmin || events.length > 0 || childCollectives.length > 0) && (
+        {!isEvent && (isAdmin || events.length > 0 || subCollectives.length > 0) && (
           <HorizontalScroller getScrollDistance={this.getContributeCardsScrollDistance}>
             {(ref, Chevrons) => (
               <div>
                 <ContainerSectionContent>
                   <Flex justifyContent="space-between" alignItems="center" mb={3}>
                     <H3 fontSize="H5" fontWeight="600" color="black.700">
-                      {childCollectives.length > 0 ? (
+                      {subCollectives.length > 0 ? (
                         <FormattedMessage id="SectionContribute.MoreWays" defaultMessage="More ways to contribute" />
                       ) : (
                         <FormattedMessage id="section.events.title" defaultMessage="Events" />
@@ -209,9 +212,9 @@ class SectionContribute extends React.PureComponent {
                 </ContainerSectionContent>
 
                 <ContributeCardsContainer ref={ref}>
-                  {childCollectives.map(childCollective => (
-                    <Box key={childCollective.id} px={CONTRIBUTE_CARD_PADDING_X}>
-                      <ContributeCollective collective={childCollective} />
+                  {subCollectives.map(({ id, collective }) => (
+                    <Box key={id} px={CONTRIBUTE_CARD_PADDING_X}>
+                      <ContributeCollective collective={collective} />
                     </Box>
                   ))}
                   {events.map(event => (

--- a/lang/en.json
+++ b/lang/en.json
@@ -432,6 +432,7 @@
   "CP.Contribute.Financial": "Financial contributions",
   "CP.Contribute.Title": "Become a contributor",
   "CP.Contributions.PartOfOrg": "{n, plural, one {This Collective is} other {These Collectives are}} part of our Organization",
+  "CP.Contributions.SubCollective": "{n, plural, one {This Collective is} other {These Collectives are}} part of what we do",
   "create.pledge.stats": "by {orgCount, plural, =0 {} one {# sponsor} other {# sponsors}} {both, plural, =0 {} one { and }} {userCount, plural, =0 {} one {# backer } other {# backers }}",
   "createAccount.alreadyLoggedIn": "It seems like you're already signed in as \"{email}\". If you want to create a new account, please log out first.",
   "CreateConversation.Body.Placeholder": "You can add links, lists, code snipets and more using this text editor. Type and start adding content to your conversation here.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -432,6 +432,7 @@
   "CP.Contribute.Financial": "Financial contributions",
   "CP.Contribute.Title": "Become a contributor",
   "CP.Contributions.PartOfOrg": "{n, plural, one {This Collective is} other {These Collectives are}} part of our Organization",
+  "CP.Contributions.SubCollective": "{n, plural, one {This Collective is} other {These Collectives are}} part of what we do",
   "create.pledge.stats": "by {orgCount, plural, =0 {} one {# sponsor} other {# sponsors}} {both, plural, =0 {} one { and }} {userCount, plural, =0 {} one {# backer } other {# backers }}",
   "createAccount.alreadyLoggedIn": "It seems like you're already signed in as \"{email}\". If you want to create a new account, please log out first.",
   "CreateConversation.Body.Placeholder": "You can add links, lists, code snipets and more using this text editor. Type and start adding content to your conversation here.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -432,6 +432,7 @@
   "CP.Contribute.Financial": "Contributions financières",
   "CP.Contribute.Title": "Contribuez",
   "CP.Contributions.PartOfOrg": "{n, plural, one {Ce Collectif fait} other {Ces Collectifs font}} partie de notre Organisation",
+  "CP.Contributions.SubCollective": "{n, plural, one {This Collective is} other {These Collectives are}} part of what we do",
   "create.pledge.stats": "par {orgCount, plural, =0 {} one {# sponsor} other {# sponsors}} {both, plural, =0 {} one { and }} {userCount, plural, =0 {} one {# personne } other {# personnes }}",
   "createAccount.alreadyLoggedIn": "Il semble que vous soyez déjà connecté en tant que « {email} ». Pour créer un nouveau compte, veuillez d'abord vous déconnecter.",
   "CreateConversation.Body.Placeholder": "Vous pouvez ajouter des liens, des listes, des extraits de code et plus en utilisant cet éditeur. Tapez et ajoutez du contenu pour votre conversation ici.",

--- a/lang/it.json
+++ b/lang/it.json
@@ -432,6 +432,7 @@
   "CP.Contribute.Financial": "Contributi finanziari",
   "CP.Contribute.Title": "Diventa un collaboratore",
   "CP.Contributions.PartOfOrg": "{n, plural, one {Questo Collettivo è} other {Questi Collettivi sono}} parte della nostra Organizzazione",
+  "CP.Contributions.SubCollective": "{n, plural, one {This Collective is} other {These Collectives are}} part of what we do",
   "create.pledge.stats": "by {orgCount, plural, =0 {} one {# sponsor} other {# sponsors}} {both, plural, =0 {} one { and }} {userCount, plural, =0 {} one {# backer } other {# backers }}",
   "createAccount.alreadyLoggedIn": "It seems like you're already signed in as \"{email}\". If you want to create a new account, please log out first.",
   "CreateConversation.Body.Placeholder": "You can add links, lists, code snipets and more using this text editor. Type and start adding content to your conversation here.",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -432,6 +432,7 @@
   "CP.Contribute.Financial": "Financial contributions",
   "CP.Contribute.Title": "Become a contributor",
   "CP.Contributions.PartOfOrg": "{n, plural, one {This Collective is} other {These Collectives are}} part of our Organization",
+  "CP.Contributions.SubCollective": "{n, plural, one {This Collective is} other {These Collectives are}} part of what we do",
   "create.pledge.stats": "by {orgCount, plural, =0 {} one {# sponsor} other {# sponsors}} {both, plural, =0 {} one { and }} {userCount, plural, =0 {} one {# backer } other {# backers }}",
   "createAccount.alreadyLoggedIn": "It seems like you're already signed in as \"{email}\". If you want to create a new account, please log out first.",
   "CreateConversation.Body.Placeholder": "You can add links, lists, code snipets and more using this text editor. Type and start adding content to your conversation here.",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -432,6 +432,7 @@
   "CP.Contribute.Financial": "Financial contributions",
   "CP.Contribute.Title": "Become a contributor",
   "CP.Contributions.PartOfOrg": "{n, plural, one {This Collective is} other {These Collectives are}} part of our Organization",
+  "CP.Contributions.SubCollective": "{n, plural, one {This Collective is} other {These Collectives are}} part of what we do",
   "create.pledge.stats": "by {orgCount, plural, =0 {} one {# sponsor} other {# sponsors}} {both, plural, =0 {} one { and }} {userCount, plural, =0 {} one {# backer } other {# backers }}",
   "createAccount.alreadyLoggedIn": "It seems like you're already signed in as \"{email}\". If you want to create a new account, please log out first.",
   "CreateConversation.Body.Placeholder": "You can add links, lists, code snipets and more using this text editor. Type and start adding content to your conversation here.",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -432,6 +432,7 @@
   "CP.Contribute.Financial": "Contribuições financeiras",
   "CP.Contribute.Title": "Seja um colaborador",
   "CP.Contributions.PartOfOrg": "{n, plural, one {Este coletivo é} other {Estes coletivos são}} parte de nossa organização",
+  "CP.Contributions.SubCollective": "{n, plural, one {This Collective is} other {These Collectives are}} part of what we do",
   "create.pledge.stats": "by {orgCount, plural, =0 {} one {# sponsor} other {# sponsors}} {both, plural, =0 {} one {and }} {userCount, plural, =0 {} one {# backer } other {# backers }}",
   "createAccount.alreadyLoggedIn": "Parece que você já está conectado com o email \"{email}\". Se você deseja criar uma nova conta, por favor faça o logout primeiro.",
   "CreateConversation.Body.Placeholder": "Você pode adicionar links, listas, snippets de código e mais com este editor de texto. Digite e comece a adicionar conteúdo à sua conversa aqui.",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -432,6 +432,7 @@
   "CP.Contribute.Financial": "Financial contributions",
   "CP.Contribute.Title": "Become a contributor",
   "CP.Contributions.PartOfOrg": "{n, plural, one {This Collective is} other {These Collectives are}} part of our Organization",
+  "CP.Contributions.SubCollective": "{n, plural, one {This Collective is} other {These Collectives are}} part of what we do",
   "create.pledge.stats": "by {orgCount, plural, =0 {} one {# sponsor} other {# sponsors}} {both, plural, =0 {} one { and }} {userCount, plural, =0 {} one {# backer } other {# backers }}",
   "createAccount.alreadyLoggedIn": "It seems like you're already signed in as \"{email}\". If you want to create a new account, please log out first.",
   "CreateConversation.Body.Placeholder": "You can add links, lists, code snipets and more using this text editor. Type and start adding content to your conversation here.",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -432,6 +432,7 @@
   "CP.Contribute.Financial": "Financial contributions",
   "CP.Contribute.Title": "Become a contributor",
   "CP.Contributions.PartOfOrg": "{n, plural, one {This Collective is} other {These Collectives are}} part of our Organization",
+  "CP.Contributions.SubCollective": "{n, plural, one {This Collective is} other {These Collectives are}} part of what we do",
   "create.pledge.stats": "by {orgCount, plural, =0 {} one {# sponsor} other {# sponsors}} {both, plural, =0 {} one {and }} {userCount, plural, =0 {} one {# backer } other {# backers }}",
   "createAccount.alreadyLoggedIn": "It seems like you're already signed in as \"{email}\". If you want to create a new account, please log out first.",
   "CreateConversation.Body.Placeholder": "You can add links, lists, code snipets and more using this text editor. Type and start adding content to your conversation here.",

--- a/lib/constants/roles.js
+++ b/lib/constants/roles.js
@@ -7,4 +7,5 @@ export default {
   FUNDRAISER: 'FUNDRAISER', // someone helping to raise money (using referral)
   ATTENDEE: 'ATTENDEE', // someone who registered for a free tier (typically a free event ticket)
   FOLLOWER: 'FOLLOWER', // someone interested to follow the activities of the collective/event
+  SUB_COLLECTIVE: 'SUB_COLLECTIVE', // this memberCollective is a sub-collective of the collective
 };

--- a/pages/new-collective-page.js
+++ b/pages/new-collective-page.js
@@ -82,7 +82,7 @@ class NewCollectivePage extends React.Component {
         financialContributors: PropTypes.arrayOf(PropTypes.object),
         tiers: PropTypes.arrayOf(PropTypes.object),
         events: PropTypes.arrayOf(PropTypes.object),
-        childCollectives: PropTypes.arrayOf(PropTypes.object),
+        subCollectives: PropTypes.arrayOf(PropTypes.object),
         transactions: PropTypes.arrayOf(PropTypes.object),
         expenses: PropTypes.arrayOf(PropTypes.object),
         updates: PropTypes.arrayOf(PropTypes.object),
@@ -142,7 +142,7 @@ class NewCollectivePage extends React.Component {
                   financialContributors={collective.financialContributors}
                   tiers={collective.tiers}
                   events={collective.events}
-                  childCollectives={collective.childCollectives}
+                  subCollectives={collective.subCollectives}
                   transactions={collective.transactions}
                   expenses={collective.expenses}
                   stats={collective.stats}


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-api/pull/3153
Resolve https://github.com/opencollective/opencollective/issues/2633

---

1. Move away from using `ParentCollectiveId` to show subcollectives on the collective page to rather use members with role=`SUB_COLLECTIVE`.

2. Move away from using `tags` for super-collectives (organizations with `These x collectives are part of our oganization`) to rather use members with role=`SUB_COLLECTIVE`.