### PR TITLE
feat(host.terms.js): set up redirect for fiscal host tos

### DIFF
--- a/components/collective-page/hero/Hero.js
+++ b/components/collective-page/hero/Hero.js
@@ -213,7 +213,7 @@ const Hero = ({ collective, host, isAdmin, onPrimaryColorChange, callsToAction, 
                     <StyledLink
                       target="_blank"
                       rel="noopener noreferrer"
-                      href={collective.settings.tos}
+                      href={`${collective.slug}/terms`}
                       borderBottom="2px dotted #969ba3"
                       color="black.700"
                       textDecoration="none"

--- a/lang/en.json
+++ b/lang/en.json
@@ -813,6 +813,8 @@
   "host.pending-applications.noPending": "No collective waiting for approval",
   "host.pending-applications.reject": "Reject",
   "host.tos": "Terms of fiscal sponsorship",
+  "host.tos.missing": "This host didn't specify any TOS.",
+  "host.tos.title": "{collective} - Terms of fiscal sponsorship.",
   "host.types.label": "Type of host entity",
   "host.types.organization.description": "Legal entity (ideally a non profit organization) that will receive the funds and issue invoices on behalf of the collective. Recommended if you plan to host more than one collective or if your collective expects to collect more than $10,000/year.",
   "host.types.organization.label": "an organization",

--- a/lang/es.json
+++ b/lang/es.json
@@ -813,6 +813,8 @@
   "host.pending-applications.noPending": "Sin colectivos en espera de aprobación",
   "host.pending-applications.reject": "Reject",
   "host.tos": "Términos de patrocinio fiscal",
+  "host.tos.missing": "This host didn't specify any TOS.",
+  "host.tos.title": "{collective} - Terms of fiscal sponsorship.",
   "host.types.label": "Tipo de entidad anfitriona",
   "host.types.organization.description": "Entidad legal (idealmente una organización sin fines de lucro) que recibirá los fondos y emitirá facturas en nombre del colectivo. Recomendado si planea hospedar más de un colectivo o si su colectivo espera recaudar más de $ 10,000 / año.",
   "host.types.organization.label": "organización",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -813,6 +813,8 @@
   "host.pending-applications.noPending": "Aucun collectif n'est en attente d'approbation",
   "host.pending-applications.reject": "Refuser",
   "host.tos": "Conditions de l'hôte fiscal",
+  "host.tos.missing": "This host didn't specify any TOS.",
+  "host.tos.title": "{collective} - Terms of fiscal sponsorship.",
   "host.types.label": "Catégorie de l'entité de l'hôte",
   "host.types.organization.description": "L’entité légale (idéalement une organisation non gouvernementale) recevra des fonds et des factures d’émission au nom du collectif. Une solution recommandée si vous envisagez d’animer plusieurs collectifs ou si vous anticipez d’encaisser plus que $10,000/an pour votre collectif.",
   "host.types.organization.label": "une entreprise",

--- a/lang/it.json
+++ b/lang/it.json
@@ -813,6 +813,8 @@
   "host.pending-applications.noPending": "Nessun collettivo in attesa di approvazione",
   "host.pending-applications.reject": "Reject",
   "host.tos": "Terms of fiscal sponsorship",
+  "host.tos.missing": "This host didn't specify any TOS.",
+  "host.tos.title": "{collective} - Terms of fiscal sponsorship.",
   "host.types.label": "Type of host entity",
   "host.types.organization.description": "Legal entity (ideally a non profit organization) that will receive the funds and issue invoices on behalf of the collective. Recommended if you plan to host more than one collective or if your collective expects to collect more than $10,000/year.",
   "host.types.organization.label": "una organizzazione",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -813,6 +813,8 @@
   "host.pending-applications.noPending": "No collective waiting for approval",
   "host.pending-applications.reject": "Reject",
   "host.tos": "Terms of fiscal sponsorship",
+  "host.tos.missing": "This host didn't specify any TOS.",
+  "host.tos.title": "{collective} - Terms of fiscal sponsorship.",
   "host.types.label": "ホストエンティティの種類",
   "host.types.organization.description": "Legal entity (ideally a non profit organization) that will receive the funds and issue invoices on behalf of the collective. Recommended if you plan to host more than one collective or if your collective expects to collect more than $10,000/year.",
   "host.types.organization.label": "組織",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -813,6 +813,8 @@
   "host.pending-applications.noPending": "No collective waiting for approval",
   "host.pending-applications.reject": "Reject",
   "host.tos": "Terms of fiscal sponsorship",
+  "host.tos.missing": "This host didn't specify any TOS.",
+  "host.tos.title": "{collective} - Terms of fiscal sponsorship.",
   "host.types.label": "Type of host entity",
   "host.types.organization.description": "Legal entity (ideally a non profit organization) that will receive the funds and issue invoices on behalf of the collective. Recommended if you plan to host more than one collective or if your collective expects to collect more than $10,000/year.",
   "host.types.organization.label": "an organization",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -813,6 +813,8 @@
   "host.pending-applications.noPending": "Nenhum coletivo aguardando aprovação",
   "host.pending-applications.reject": "Rejeitar",
   "host.tos": "Termos de patrocínio fiscal",
+  "host.tos.missing": "This host didn't specify any TOS.",
+  "host.tos.title": "{collective} - Terms of fiscal sponsorship.",
   "host.types.label": "Tipo de entidade administrativa",
   "host.types.organization.description": "Entidade legal (de preferência uma organização sem fins lucrativos) que receberá os fundos e emitirá faturas em nome do coletivo. Recomendado se você planeja hospedar mais de um coletivo ou se espera coletar mais de US$ 10.000/ano.",
   "host.types.organization.label": "uma organização",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -813,6 +813,8 @@
   "host.pending-applications.noPending": "Нет коллективов ждущих подтверждения",
   "host.pending-applications.reject": "Reject",
   "host.tos": "Terms of fiscal sponsorship",
+  "host.tos.missing": "This host didn't specify any TOS.",
+  "host.tos.title": "{collective} - Terms of fiscal sponsorship.",
   "host.types.label": "Тип юридического лица",
   "host.types.organization.description": "Legal entity (ideally a non profit organization) that will receive the funds and issue invoices on behalf of the collective. Recommended if you plan to host more than one collective or if your collective expects to collect more than $10,000/year.",
   "host.types.organization.label": "организация",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -813,6 +813,8 @@
   "host.pending-applications.noPending": "No collective waiting for approval",
   "host.pending-applications.reject": "Reject",
   "host.tos": "Terms of fiscal sponsorship",
+  "host.tos.missing": "This host didn't specify any TOS.",
+  "host.tos.title": "{collective} - Terms of fiscal sponsorship.",
   "host.types.label": "Type of host entity",
   "host.types.organization.description": "Legal entity (ideally a non profit organization) that will receive the funds and issue invoices on behalf of the collective. Recommended if you plan to host more than one collective or if your collective expects to collect more than $10,000/year.",
   "host.types.organization.label": "an organization",

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -176,6 +176,11 @@ export function prettyUrl(url) {
     .replace(/\/$/, '');
 }
 
+export const isUrl = str => {
+  const regexp = /^(?:(?:https?|ftp):\/\/)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:\/\S*)?$/;
+  return regexp.test(str);
+};
+
 function getLocaleFromCurrency(currency) {
   let locale;
   switch (currency) {

--- a/pages/host.terms.js
+++ b/pages/host.terms.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Flex } from '@rebass/grid';
+
+import { addCollectiveCoverData } from '../lib/graphql/queries';
+import { isUrl, prettyUrl } from '../lib/utils';
+
+import Page from '../components/Page';
+import LinkCollective from '../components/LinkCollective';
+import { H2 } from '../components/Text';
+import Logo from '../components/Logo';
+import { FormattedMessage } from 'react-intl';
+import MessageBox from '../components/MessageBox';
+import Container from '../components/Container';
+
+class HostTermsPage extends React.Component {
+  static getInitialProps({ query: { hostCollectiveSlug } }) {
+    return { slug: hostCollectiveSlug };
+  }
+
+  static propTypes = {
+    slug: PropTypes.string,
+    data: PropTypes.object,
+  };
+
+  componentDidMount() {
+    if (isUrl(this.props.data.Collective.settings.tos)) {
+      window.location.search = `redirect=${prettyUrl(this.props.data.Collective.settings.tos)}`;
+    }
+  }
+
+  render() {
+    const { data } = this.props;
+    const host = data.Collective || {};
+
+    if (data.loading) {
+      return null;
+    }
+    if (isUrl(host.settings.tos)) {
+      return null;
+    } else {
+      return (
+        <Page collective={host} title={host.name || 'TOS'}>
+          <Container pt={[4, 5]} mb={4}>
+            <Flex alignItems="center" flexDirection="column" mx="auto" width="100%" maxWidth={320}>
+              <LinkCollective collective={host}>
+                <Logo collective={host} className="logo" height="10rem" style={{ margin: '0 auto' }} />
+                <H2 as="h1" color="black.900" textAlign="center">
+                  <FormattedMessage
+                    id="host.tos.title"
+                    defaultMessage="{collective} - Terms of fiscal sponsorship."
+                    values={{ collective: host.name }}
+                  />
+                </H2>
+              </LinkCollective>
+            </Flex>
+          </Container>
+          <Container>
+            {!host.settings.tos ? (
+              <Flex px={2} py={5} justifyContent="center">
+                <MessageBox type="info">
+                  <FormattedMessage id="host.tos.missing" defaultMessage="This host didn't specify any TOS." />
+                </MessageBox>
+              </Flex>
+            ) : (
+              <Flex px={2} py={5} justifyContent="center">
+                <MessageBox type="white">{host.settings.tos}</MessageBox>
+              </Flex>
+            )}
+          </Container>
+        </Page>
+      );
+    }
+  }
+}
+
+export default addCollectiveCoverData(HostTermsPage);

--- a/server/pages.js
+++ b/server/pages.js
@@ -39,6 +39,7 @@ const pages = routes()
     '/:hostCollectiveSlug/dashboard/:view(expenses|pending-applications|donations)?',
     'host.dashboard',
   )
+  .add('host.terms', '/:hostCollectiveSlug/terms', 'host.terms')
   .add(
     'host.expenses.approve',
     '/:parentCollectiveSlug?/:collectiveType(events)?/:collectiveSlug/:table(expenses)/:id/:action(approve|reject)',

--- a/server/routes.js
+++ b/server/routes.js
@@ -155,5 +155,16 @@ module.exports = (server, app) => {
     );
   });
 
+  server.get('/:collectiveSlug/terms', (req, res) => {
+    const params = { ...req.params, ...req.query };
+    if (req.query.redirect) {
+      res.redirect(`https://${req.query.redirect}`);
+      return;
+    }
+    app.renderToHTML(req, res, '/host.terms', params).then(html => {
+      return res.send(html);
+    });
+  });
+
   return pages.getRequestHandler(app);
 };


### PR DESCRIPTION
Add new url that will help collective admins find fiscal host terms of sponsorship easier.

Fix: https://github.com/opencollective/opencollective/issues/2757

I've had some progress however having a misunderstanding of how to go about redirecting above Nextjs