### PR TITLE
Add accept/reject buttons on "Collective pending approval" banner

### DIFF
--- a/components/NotificationBar.js
+++ b/components/NotificationBar.js
@@ -2,6 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+import AcceptRejectButtons from './host-dashboard/AcceptRejectButtons';
+import { Flex } from './Grid';
+
 const logo = '/static/images/opencollective-icon.svg';
 
 class NotificationBar extends React.Component {
@@ -11,10 +14,20 @@ class NotificationBar extends React.Component {
     description: PropTypes.string,
     error: PropTypes.string,
     actions: PropTypes.arrayOf(PropTypes.node),
+    /** Collective */
+    collective: PropTypes.shape({
+      id: PropTypes.number,
+      slug: PropTypes.string,
+    }),
+    LoggedInUser: PropTypes.shape({
+      roles: PropTypes.arrayOf(PropTypes.node),
+      isHostAdmin: PropTypes.bool.isRequired,
+    }),
   };
 
   render() {
-    const { status, error, title, description, actions } = this.props;
+    const { status, error, title, description, actions, collective, LoggedInUser } = this.props;
+    const isHostAdmin = LoggedInUser && LoggedInUser.isHostAdmin(collective);
 
     return (
       <div className={classNames(status, 'NotificationBar')}>
@@ -87,9 +100,6 @@ class NotificationBar extends React.Component {
               align-items: center;
               flex-direction: column;
             }
-            .collectivePending {
-              background: #ff8c00;
-            }
             .NotificationLine h1 {
               font-size: 1.8rem;
               margin: 1rem;
@@ -117,6 +127,12 @@ class NotificationBar extends React.Component {
           <div className={`NotificationLine ${status}`}>
             <h1>{title}</h1>
             <p className="description">{description}</p>
+
+            {status === 'collectivePending' && isHostAdmin && (
+              <Flex flexWrap="wrap" alignItems="center" justifyContent="center">
+                <AcceptRejectButtons collective={collective} />
+              </Flex>
+            )}
             {actions && (
               <div className="actions">
                 {actions.map(action => (

--- a/components/collective-page/CollectiveNotificationBar.js
+++ b/components/collective-page/CollectiveNotificationBar.js
@@ -158,10 +158,12 @@ const CollectiveNotificationBar = ({ intl, status, collective, host, LoggedInUse
 
   return !notification ? null : (
     <NotificationBar
-      status={notification.status}
+      status={status || notification.status}
+      collective={collective}
       title={notification.title}
       description={notification.description}
       actions={notification.actions}
+      LoggedInUser={LoggedInUser}
     />
   );
 };

--- a/components/host-dashboard/AcceptRejectButtons.js
+++ b/components/host-dashboard/AcceptRejectButtons.js
@@ -1,0 +1,70 @@
+import React, { Fragment, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Mutation } from '@apollo/react-components';
+import gql from 'graphql-tag';
+import { FormattedMessage } from 'react-intl';
+
+import StyledButton from '../StyledButton';
+
+import ApplicationRejectionReasonModal from './ApplicationRejectionReasonModal';
+
+const ApproveCollectiveMutation = gql`
+  mutation approveCollective($id: Int!) {
+    approveCollective(id: $id) {
+      id
+      isActive
+      isApproved
+      host {
+        id
+        name
+        slug
+        type
+        settings
+      }
+    }
+  }
+`;
+
+const AcceptRejectButtons = ({ collective }) => {
+  const [showRejectionModal, setShowRejectionModal] = useState(false);
+  return (
+    <Fragment>
+      <Mutation mutation={ApproveCollectiveMutation}>
+        {(approveCollective, { loading }) => (
+          <StyledButton
+            m={1}
+            loading={loading}
+            onClick={() => approveCollective({ variables: { id: collective.id } })}
+            data-cy={`${collective.slug}-approve`}
+            buttonStyle="success"
+            minWidth={125}
+          >
+            <FormattedMessage id="actions.approve" defaultMessage="Approve" />
+          </StyledButton>
+        )}
+      </Mutation>
+      <StyledButton buttonStyle="danger" minWidth={125} m={1} onClick={() => setShowRejectionModal(true)}>
+        <FormattedMessage id="actions.reject" defaultMessage="Reject" />
+      </StyledButton>
+      {showRejectionModal && (
+        <ApplicationRejectionReasonModal
+          show={showRejectionModal}
+          onClose={() => setShowRejectionModal(false)}
+          collectiveId={collective.id}
+        />
+      )}
+    </Fragment>
+  );
+};
+
+AcceptRejectButtons.propTypes = {
+  collective: PropTypes.shape({
+    id: PropTypes.number,
+    slug: PropTypes.string,
+  }),
+  host: PropTypes.shape({
+    slug: PropTypes.string,
+  }),
+};
+
+export default AcceptRejectButtons;

--- a/components/host-dashboard/ApplicationRejectionReasonModal.js
+++ b/components/host-dashboard/ApplicationRejectionReasonModal.js
@@ -4,8 +4,6 @@ import { useMutation } from '@apollo/react-hooks';
 import gql from 'graphql-tag';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
-import { getHostPendingApplicationsQuery } from '../../lib/graphql/queries';
-
 import Container from '../Container';
 import MessageBox from '../MessageBox';
 import StyledButton from '../StyledButton';
@@ -16,6 +14,15 @@ const rejectCollectiveQuery = gql`
   mutation rejectCollective($id: Int!, $rejectionReason: String) {
     rejectCollective(id: $id, rejectionReason: $rejectionReason) {
       id
+      isActive
+      isApproved
+      host {
+        id
+        name
+        slug
+        type
+        settings
+      }
     }
   }
 `;
@@ -27,7 +34,7 @@ const messages = defineMessages({
   },
 });
 
-const AppRejectionReasonModal = ({ show, onClose, collectiveId, hostCollectiveSlug }) => {
+const ApplicationRejectionReasonModal = ({ show, onClose, collectiveId }) => {
   const [rejectionReason, setRejectionReason] = useState('');
   const [rejectCollective, { loading, error }] = useMutation(rejectCollectiveQuery);
   const intl = useIntl();
@@ -67,9 +74,6 @@ const AppRejectionReasonModal = ({ show, onClose, collectiveId, hostCollectiveSl
             onClick={async () => {
               await rejectCollective({
                 variables: { id: collectiveId, rejectionReason },
-                refetchQueries: [{ query: getHostPendingApplicationsQuery, variables: { hostCollectiveSlug } }],
-                awaitRefetchQueries: true,
-                ignoreResults: true,
               });
               onClose();
             }}
@@ -82,11 +86,10 @@ const AppRejectionReasonModal = ({ show, onClose, collectiveId, hostCollectiveSl
   );
 };
 
-AppRejectionReasonModal.propTypes = {
+ApplicationRejectionReasonModal.propTypes = {
   show: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   collectiveId: PropTypes.number.isRequired,
-  hostCollectiveSlug: PropTypes.string.isRequired,
 };
 
-export default AppRejectionReasonModal;
+export default ApplicationRejectionReasonModal;

--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -900,6 +900,10 @@ export const getHostPendingApplicationsQuery = gql`
           githubHandle
           type
           isActive
+          isApproved
+          host {
+            id
+          }
         }
       }
     }


### PR DESCRIPTION
Resolve: opencollective/opencollective/issues/2766

Screenshots
- When Admin of the host is logged in
![Screen Shot 2020-01-09 at 2 16 40 PM](https://user-images.githubusercontent.com/29824008/72064610-4dac5900-32ed-11ea-8e34-1c4b87f8c695.png)

- when ordinary user is logged in
<img width="1438" alt="Screen Shot 2020-01-08 at 11 16 19 PM" src="https://user-images.githubusercontent.com/29824008/72064657-60bf2900-32ed-11ea-9cd2-bbea032c6f8e.png">

- when admin clicks reject
<img width="1440" alt="Screen Shot 2020-01-09 at 12 36 24 PM" src="https://user-images.githubusercontent.com/29824008/72064695-7896ad00-32ed-11ea-9737-8fb477c5e4a4.png">

