### PR TITLE
feat(createOrder): Adds ?contributeAs query parameter to createOrder page

### DIFF
--- a/components/contribution-flow/StepProfile.js
+++ b/components/contribution-flow/StepProfile.js
@@ -133,8 +133,8 @@ const useForm = ({ onProfileChange }) => {
 const StepProfile = ({
   intl,
   onProfileChange,
-  personal,
-  profiles,
+  personalProfile,
+  otherProfiles,
   defaultSelectedProfile,
   canUseIncognito,
   ...fieldProps
@@ -142,10 +142,10 @@ const StepProfile = ({
   const { getFieldError, getFieldProps, onFieldChange, onSearch, onChange, state } = useForm({ onProfileChange });
   if (state.search) {
     const test = new RegExp(escapeInput(state.search), 'i');
-    profiles = profiles.filter(profile => profile.name.match(test));
+    otherProfiles = otherProfiles.filter(profile => profile.name.match(test));
   }
 
-  const options = uniqBy([personal, ...profiles], 'id');
+  const options = uniqBy([personalProfile, ...otherProfiles], 'id');
 
   // if the user doesn't have an incognito profile yet, we offer to create one
   if (canUseIncognito) {
@@ -165,7 +165,7 @@ const StepProfile = ({
   options.push({ id: 'org.new', type: 'ORGANIZATION', name: intl.formatMessage(messages['org.new']) });
 
   const lastIndex = Object.keys(options).length - 1;
-  const showSearch = Object.keys(profiles).length >= 5 || state.search;
+  const showSearch = Object.keys(otherProfiles).length >= 5 || state.search;
 
   return (
     <StyledCard maxWidth={500}>
@@ -320,14 +320,14 @@ StepProfile.propTypes = {
   defaultSelectedProfile: PropTypes.shape({
     id: PropTypes.number,
   }),
-  personal: PropTypes.shape({
+  personalProfile: PropTypes.shape({
     id: PropTypes.number.isRequired,
     email: PropTypes.string,
     image: PropTypes.string,
     name: PropTypes.string,
     type: PropTypes.string,
   }),
-  profiles: PropTypes.arrayOf(
+  otherProfiles: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.number.isRequired,
       email: PropTypes.string,

--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -491,22 +491,17 @@ class CreateOrderPage extends React.Component {
   }
 
   getLoggedInUserDefaultContibuteProfile() {
-    const { LoggedInUser } = this.props;
-    let profile = null;
-
-    if (get(this.state, 'stepProfile')) {
-      profile = this.state.stepProfile;
-    } else if (LoggedInUser) {
-      profile = this.getPersonalProfile();
-    }
-
     if (this.props.contributeAs) {
-      const profiles = this.getOtherProfiles();
-      const contributorProfile = profiles.find(profile => profile.slug === this.props.contributeAs);
-      if (contributorProfile) profile = contributorProfile;
+      const otherProfiles = this.getOtherProfiles();
+      const contributorProfile = otherProfiles.find(profile => profile.slug === this.props.contributeAs);
+      if (contributorProfile) return contributorProfile;
     }
-
-    return profile;
+    if (get(this.state, 'stepProfile')) {
+      return this.state.stepProfile;
+    }
+    if (this.props.LoggedInUser) {
+      return this.getPersonalProfile();
+    }
   }
 
   /** Returns logged-in user profile */

--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -733,8 +733,8 @@ class CreateOrderPage extends React.Component {
   renderStep(step) {
     const { collective, tier, host } = this.props;
     const { stepProfile, stepDetails, stepPayment, customData } = this.state;
-    const personal = this.getPersonalProfile();
-    const profiles = this.getOtherProfiles();
+    const personalProfile = this.getPersonalProfile();
+    const otherProfiles = this.getOtherProfiles();
     const customFields = tier && tier.customFields ? tier.customFields : [];
     const defaultStepDetails = this.getDefaultStepDetails(tier);
     const interval = get(stepDetails, 'interval') || defaultStepDetails.interval;
@@ -757,8 +757,8 @@ class CreateOrderPage extends React.Component {
                   <StepProfile
                     {...fieldProps}
                     onProfileChange={this.updateProfile}
-                    profiles={profiles}
-                    personal={personal}
+                    otherProfiles={otherProfiles}
+                    personalProfile={personalProfile}
                     defaultSelectedProfile={this.getLoggedInUserDefaultContibuteProfile()}
                     canUseIncognito={collective.type !== CollectiveType.EVENT && (!tier || tier.type !== 'TICKET')}
                   />

--- a/pages/createOrder.js
+++ b/pages/createOrder.js
@@ -82,6 +82,7 @@ class CreateOrderPage extends React.Component {
       redirect: query.redirect,
       customData: query.data,
       skipStepDetails: query.skipStepDetails ? parseToBoolean(query.skipStepDetails) : false,
+      contributeAs: query.contributeAs,
     };
   }
 
@@ -99,6 +100,7 @@ class CreateOrderPage extends React.Component {
     data: PropTypes.object.isRequired, // from withData
     intl: PropTypes.object.isRequired, // from injectIntl
     skipStepDetails: PropTypes.bool,
+    contributeAs: PropTypes.string,
   };
 
   getCanonicalURL(collective, tier) {
@@ -175,6 +177,7 @@ class CreateOrderPage extends React.Component {
           fixedAmount={this.props.totalAmount}
           customData={this.props.customData}
           skipStepDetails={this.props.skipStepDetails}
+          contributeAs={this.props.contributeAs}
         />
       );
     }

--- a/styleguide/examples/contribution-flow/StepProfile.md
+++ b/styleguide/examples/contribution-flow/StepProfile.md
@@ -9,8 +9,8 @@ initialState = null;
 <div style={{ display: 'flex', flexWrap: 'wrap' }}>
   <StepProfile
     onProfileChange={setState}
-    profiles={profiles}
-    personal={personalProfile}
+    otherProfiles={profiles}
+    personalProfile={personalProfile}
     defaultSelectedProfile={state || personalProfile}
     id="contribute-as"
     name="contribute-as"


### PR DESCRIPTION
Skips `contributeAs` step when a valid collective slug is provided through the `?contributeAs=` query parameter.

Example:
If you have access, http://localhost:3000/apex/contribute/backers-469/checkout?contributeAs=brusselstogetherasbl will automatically pick BrusselsTogether profile and skip to the `contributeAs` step.