### PR TITLE
CollectivePage: Disable sections when appropriate

### DIFF
--- a/components/CollectiveNavbar.js
+++ b/components/CollectiveNavbar.js
@@ -261,7 +261,7 @@ export const getSectionsForCollective = (collective, isAdmin) => {
   const toRemove = new Set();
 
   // Can't contribute anymore if the collective is archived or has no host
-  if (collective.isArchived || !collective.host) {
+  if (!collective.isApproved && !isAdmin) {
     toRemove.add(Sections.CONTRIBUTE);
   }
 
@@ -290,7 +290,7 @@ export const getSectionsForCollective = (collective, isAdmin) => {
 
   if (collective.type === CollectiveType.EVENT) {
     // Should not see tickets section if you can't order them
-    if (!canOrderTicketsFromEvent(collective)) {
+    if ((!collective.isApproved && !isAdmin) || !canOrderTicketsFromEvent(collective)) {
       toRemove.add(Sections.TICKETS);
     }
 

--- a/components/collective-page/CollectiveNotificationBar.js
+++ b/components/collective-page/CollectiveNotificationBar.js
@@ -86,9 +86,6 @@ const getNotification = (intl, status, collective, host) => {
  * Adds a notification bar for the collective.
  */
 const CollectiveNotificationBar = ({ intl, status, collective, host }) => {
-  // Quickfix for events (as they are not inheriting isApproved status)
-  if (collective.type === CollectiveType.EVENT) return null;
-
   const notification = getNotification(intl, status, collective, host);
 
   return !notification ? null : (

--- a/components/collective-page/graphql/queries.js
+++ b/components/collective-page/graphql/queries.js
@@ -107,12 +107,13 @@ export const getCollectivePageQuery = gql`
           type
         }
       }
-      events(includePastEvents: true) {
+      events(includePastEvents: true, includeInactive: true) {
         id
         slug
         name
         description
         image
+        isActive
         startsAt
         endsAt
         backgroundImageUrl(height: 208)

--- a/components/collective-page/sections/Contribute.js
+++ b/components/collective-page/sections/Contribute.js
@@ -49,6 +49,7 @@ class SectionContribute extends React.PureComponent {
     collective: PropTypes.shape({
       slug: PropTypes.string.isRequired,
       type: PropTypes.string.isRequired,
+      isActive: PropTypes.bool,
       currency: PropTypes.string,
       parentCollective: PropTypes.shape({
         slug: PropTypes.string.isRequired,
@@ -138,10 +139,16 @@ class SectionContribute extends React.PureComponent {
     const hasNoContributorForEvents = !events.find(event => event.contributors.length > 0);
     const sortedTiers = this.sortTiers(this.removeTickets(tiers));
     const isEvent = collective.type === CollectiveType.EVENT;
+    const hasContribute = collective.isActive || isAdmin;
+    const hasOtherWaysToContribute = !isEvent && (isAdmin || events.length > 0 || subCollectives.length > 0);
 
     const createContributionTierRoute = isEvent
       ? `/${collective.parentCollective.slug}/events/${collective.slug}/edit#tiers`
       : `/${collective.slug}/edit/tiers`;
+
+    if (!hasContribute && !hasOtherWaysToContribute) {
+      return null;
+    }
 
     return (
       <Box pt={[4, 5]}>
@@ -151,48 +158,56 @@ class SectionContribute extends React.PureComponent {
           </SectionTitle>
         </ContainerSectionContent>
 
-        <Box mb={4} data-cy="financial-contributions">
-          <HorizontalScroller getScrollDistance={this.getContributeCardsScrollDistance}>
-            {(ref, Chevrons) => (
-              <div>
-                <ContainerSectionContent>
-                  <Flex justifyContent="space-between" alignItems="center" mb={3}>
-                    <H3 fontSize="H5" fontWeight="600" color="black.700">
-                      <FormattedMessage id="CP.Contribute.Financial" defaultMessage="Financial contributions" />
-                    </H3>
-                    <Box m={2} flex="0 0 50px">
-                      <Chevrons />
-                    </Box>
-                  </Flex>
-                </ContainerSectionContent>
+        {hasContribute && (
+          <Box mb={4} data-cy="financial-contributions">
+            <HorizontalScroller getScrollDistance={this.getContributeCardsScrollDistance}>
+              {(ref, Chevrons) => (
+                <div>
+                  <ContainerSectionContent>
+                    <Flex justifyContent="space-between" alignItems="center" mb={3}>
+                      <H3 fontSize="H5" fontWeight="600" color="black.700">
+                        <FormattedMessage id="CP.Contribute.Financial" defaultMessage="Financial contributions" />
+                      </H3>
+                      <Box m={2} flex="0 0 50px">
+                        <Chevrons />
+                      </Box>
+                    </Flex>
+                  </ContainerSectionContent>
 
-                <ContributeCardsContainer ref={ref}>
-                  <Box px={CONTRIBUTE_CARD_PADDING_X}>
-                    <ContributeCustom
-                      collective={collective}
-                      contributors={financialContributorsWithoutTier}
-                      stats={contributorsStats}
-                      hideContributors={hasNoContributor}
-                    />
-                  </Box>
-                  {sortedTiers.map(tier => (
-                    <Box key={tier.id} px={CONTRIBUTE_CARD_PADDING_X}>
-                      <ContributeTier collective={collective} tier={tier} hideContributors={hasNoContributor} />
-                    </Box>
-                  ))}
-                  {isAdmin && (
+                  <ContributeCardsContainer ref={ref}>
                     <Box px={CONTRIBUTE_CARD_PADDING_X}>
-                      <CreateNew data-cy="create-contribute-tier" route={createContributionTierRoute}>
-                        <FormattedMessage id="Contribute.CreateTier" defaultMessage="Create Contribution Tier" />
-                      </CreateNew>
+                      <ContributeCustom
+                        collective={collective}
+                        contributors={financialContributorsWithoutTier}
+                        stats={contributorsStats}
+                        hideContributors={hasNoContributor}
+                        disableCTA={!collective.isActive}
+                      />
                     </Box>
-                  )}
-                </ContributeCardsContainer>
-              </div>
-            )}
-          </HorizontalScroller>
-        </Box>
-        {!isEvent && (isAdmin || events.length > 0 || subCollectives.length > 0) && (
+                    {sortedTiers.map(tier => (
+                      <Box key={tier.id} px={CONTRIBUTE_CARD_PADDING_X}>
+                        <ContributeTier
+                          collective={collective}
+                          tier={tier}
+                          hideContributors={hasNoContributor}
+                          disableCTA={!collective.isActive}
+                        />
+                      </Box>
+                    ))}
+                    {isAdmin && (
+                      <Box px={CONTRIBUTE_CARD_PADDING_X}>
+                        <CreateNew data-cy="create-contribute-tier" route={createContributionTierRoute}>
+                          <FormattedMessage id="Contribute.CreateTier" defaultMessage="Create Contribution Tier" />
+                        </CreateNew>
+                      </Box>
+                    )}
+                  </ContributeCardsContainer>
+                </div>
+              )}
+            </HorizontalScroller>
+          </Box>
+        )}
+        {hasOtherWaysToContribute && (
           <HorizontalScroller getScrollDistance={this.getContributeCardsScrollDistance}>
             {(ref, Chevrons) => (
               <div>
@@ -223,6 +238,7 @@ class SectionContribute extends React.PureComponent {
                         collective={collective}
                         event={event}
                         hideContributors={hasNoContributorForEvents}
+                        disableCTA={!collective.isActive || !event.isActive}
                       />
                     </Box>
                   ))}

--- a/components/collective-page/sections/Tickets.js
+++ b/components/collective-page/sections/Tickets.js
@@ -27,6 +27,7 @@ class SectionTickets extends React.PureComponent {
     collective: PropTypes.shape({
       slug: PropTypes.string.isRequired,
       currency: PropTypes.string,
+      isActive: PropTypes.bool,
       parentCollective: PropTypes.shape({
         slug: PropTypes.string.isRequired,
       }),
@@ -69,7 +70,7 @@ class SectionTickets extends React.PureComponent {
     const hasNoContributor = !this.hasContributors(contributors);
     const sortedTiers = this.sortTiers(this.filterTickets(tiers));
 
-    if (sortedTiers.length === 0 && !isAdmin) {
+    if ((sortedTiers.length === 0 || !collective.isActive) && !isAdmin) {
       return null;
     }
 
@@ -96,7 +97,12 @@ class SectionTickets extends React.PureComponent {
                 <ContributeCardsContainer ref={ref}>
                   {sortedTiers.map(tier => (
                     <Box key={tier.id} px={CONTRIBUTE_CARD_PADDING_X}>
-                      <ContributeTier collective={collective} tier={tier} hideContributors={hasNoContributor} />
+                      <ContributeTier
+                        collective={collective}
+                        tier={tier}
+                        hideContributors={hasNoContributor}
+                        disableCTA={!collective.isActive}
+                      />
                     </Box>
                   ))}
                   {isAdmin && (

--- a/components/contribute-cards/ContributeEvent.js
+++ b/components/contribute-cards/ContributeEvent.js
@@ -13,6 +13,7 @@ import { Span } from '../Text';
 import Link from '../Link';
 import Contribute from './Contribute';
 import Container from '../Container';
+import StyledLink from '../StyledLink';
 
 const ContributeEvent = ({ collective, event, ...props }) => {
   const { startsAt, endsAt } = event;
@@ -20,15 +21,20 @@ const ContributeEvent = ({ collective, event, ...props }) => {
   const isTruncated = description && description.length < event.description.length;
   const isPassed = !canOrderTicketsFromEvent(event);
   const showYearOnStartDate = endsAt ? undefined : 'numeric'; // only if there's no end date
+  const eventRouteParams = { parentCollectiveSlug: collective.slug, eventSlug: event.slug };
   return (
     <Contribute
       route="event"
-      routeParams={{ parentCollectiveSlug: collective.slug, eventSlug: event.slug }}
+      routeParams={eventRouteParams}
       type={isPassed ? ContributionTypes.EVENT_PASSED : ContributionTypes.EVENT_PARTICIPATE}
-      title={event.name}
       contributors={event.contributors}
       stats={event.stats.backers}
       image={event.backgroundImageUrl}
+      title={
+        <StyledLink as={Link} color="black.800" route="event" params={eventRouteParams}>
+          {event.name}
+        </StyledLink>
+      }
       {...props}
     >
       {(startsAt || endsAt) && (

--- a/lib/graphql/schema.graphql
+++ b/lib/graphql/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:3060/graphql
-# timestamp: Tue Jan 07 2020 18:59:03 GMT+0100 (GMT+01:00)
+# timestamp: Fri Jan 10 2020 10:50:28 GMT+0100 (GMT+01:00)
 
 """
 Application model
@@ -237,7 +237,7 @@ type Collective implements CollectiveInterface {
   """
   Get all child collectives (with type=COLLECTIVE, doesn't return events)
   """
-  childCollectives: [Collective]
+  childCollectives: [Collective] @deprecated(reason: "2020/01/08 - Sub-collectives are now handled through members")
   paymentMethods(
     service: String
     limit: Int
@@ -500,7 +500,7 @@ interface CollectiveInterface {
   """
   Get all child collectives (with type=COLLECTIVE, doesn't return events)
   """
-  childCollectives: [Collective]
+  childCollectives: [Collective] @deprecated(reason: "2020/01/08 - Sub-collectives are now handled through members")
   paymentMethods(
     service: String
     limit: Int
@@ -882,6 +882,7 @@ enum ContributorRole {
   FUNDRAISER
   ATTENDEE
   FOLLOWER
+  SUB_COLLECTIVE
 }
 
 """
@@ -1118,7 +1119,7 @@ type Event implements CollectiveInterface {
   """
   Get all child collectives (with type=COLLECTIVE, doesn't return events)
   """
-  childCollectives: [Collective]
+  childCollectives: [Collective] @deprecated(reason: "2020/01/08 - Sub-collectives are now handled through members")
   paymentMethods(
     service: String
     limit: Int
@@ -2280,7 +2281,7 @@ type Organization implements CollectiveInterface {
   """
   Get all child collectives (with type=COLLECTIVE, doesn't return events)
   """
-  childCollectives: [Collective]
+  childCollectives: [Collective] @deprecated(reason: "2020/01/08 - Sub-collectives are now handled through members")
   paymentMethods(
     service: String
     limit: Int
@@ -3302,7 +3303,7 @@ type User implements CollectiveInterface {
   """
   Get all child collectives (with type=COLLECTIVE, doesn't return events)
   """
-  childCollectives: [Collective]
+  childCollectives: [Collective] @deprecated(reason: "2020/01/08 - Sub-collectives are now handled through members")
   paymentMethods(
     service: String
     limit: Int

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -282,6 +282,11 @@ type Collective implements Account {
   Get the host collective that is receiving the money on behalf of this collective
   """
   host: Account
+
+  """
+  Returns whether this collective is approved
+  """
+  isApproved: Boolean
 }
 
 """
@@ -540,6 +545,11 @@ type Event implements Account {
   Returns conversation's tags for collective sorted by popularity
   """
   conversationsTags(limit: Int = 30): [TagStat]
+
+  """
+  Returns whether this collective is approved
+  """
+  isApproved: Boolean
 }
 
 """

--- a/pages/conversation.js
+++ b/pages/conversation.js
@@ -45,6 +45,9 @@ const conversationPageQuery = gqlV2`
       settings
       imageUrl
       twitterHandle
+      ... on Collective {
+        isApproved
+      }
     }
     conversation(id: $id) {
       id

--- a/pages/conversations.js
+++ b/pages/conversations.js
@@ -210,6 +210,9 @@ const getData = graphql(
           id
           tag
         }
+        ... on Collective {
+          isApproved
+        }
       }
     }
     ${ConversationListFragment}

--- a/pages/create-conversation.js
+++ b/pages/create-conversation.js
@@ -142,6 +142,10 @@ const getCollective = graphql(
           id
           tag
         }
+
+        ... on Collective {
+          isApproved
+        }
       }
     }
   `,


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2758
Require https://github.com/opencollective/opencollective-api/pull/3169 for the `isApproved` check to work with events.

## User view

### Collectives

If collective is inactive, users will not be able to see `Contribute`

![image](https://user-images.githubusercontent.com/1556356/72142212-7e939900-3394-11ea-91f3-6f77482ba9f9.png)

## Events

If event is inactive, the `Contribute` and the `Tickets` sections will not be displayed.

## Admin view

### Collectives

The `Contribute` section will be displayed, however the `disableCTA` will be set on all contribute cards, hidding their `Contribute` button.

![image](https://user-images.githubusercontent.com/1556356/72142442-fcf03b00-3394-11ea-8ccb-dee5cb3b16a3.png)

### Events

Same for events:

![image](https://user-images.githubusercontent.com/1556356/72142475-0f6a7480-3395-11ea-8ae7-a3774ccac8b8.png)
