### PR TITLE
reset stripe token if the order fails

### DIFF
--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -437,7 +437,16 @@ class CreateOrderPage extends React.Component {
         this.handleSuccess(orderCreated);
       }
     } catch (e) {
-      this.setState({ submitting: false, error: e.message });
+      this.setState(state => {
+        const stepPayment = {
+          ...state.stepPayment,
+          paymentMethod: {
+            ...state.stepPayment.paymentMethod,
+            token: null,
+          },
+        };
+        return { submitting: false, error: e.message, stepPayment };
+      });
     }
   };
 


### PR DESCRIPTION
Issue: https://github.com/opencollective/opencollective/issues/2782
I am only setting `state.stepPayment.paymentMethod.token = null `if request fails
I couldn't reproduce the error completely but as @znarf suggested after setting `token = null` I have seen now token is changing in every attempt (with same card number)

- I haven't changed anything else except token (maybe some values also might be changed inside paymentMethod) because I don't know the flow exactly if you need more please let me know. 
- Also I don't have so much experience in react, I tried to use similar approach with the code inside project while updating state but if this isn't the best practice for updating nested objects, waiting your suggestions. 