### PR TITLE
fix(expense.js): display error above buttons

### DIFF
--- a/components/expenses/ApproveExpenseBtn.js
+++ b/components/expenses/ApproveExpenseBtn.js
@@ -4,6 +4,8 @@ import gql from 'graphql-tag';
 import { graphql } from 'react-apollo';
 import { FormattedMessage } from 'react-intl';
 
+import { getErrorFromGraphqlException } from '../../lib/utils';
+
 import StyledButton from '../StyledButton';
 
 class ApproveExpenseBtn extends React.Component {
@@ -11,6 +13,7 @@ class ApproveExpenseBtn extends React.Component {
     id: PropTypes.number.isRequired,
     approveExpense: PropTypes.func.isRequired,
     refetch: PropTypes.func.isRequired,
+    onError: PropTypes.func.isRequired,
   };
 
   constructor(props) {
@@ -20,8 +23,13 @@ class ApproveExpenseBtn extends React.Component {
 
   async onClick() {
     const { id } = this.props;
-    await this.props.approveExpense(id);
-    await this.props.refetch();
+    try {
+      await this.props.approveExpense(id);
+      await this.props.refetch();
+    } catch (e) {
+      const error = getErrorFromGraphqlException(e).message;
+      this.props.onError(error);
+    }
   }
 
   render() {

--- a/components/expenses/Expense.js
+++ b/components/expenses/Expense.js
@@ -9,7 +9,7 @@ import { capitalize, formatCurrency, compose } from '../../lib/utils';
 import colors from '../../lib/constants/colors';
 
 import Avatar from '../Avatar';
-import { Span, P } from '../Text';
+import { Span } from '../Text';
 import Link from '../Link';
 import SmallButton from '../SmallButton';
 import Moment from '../Moment';
@@ -24,6 +24,7 @@ import EditPayExpenseFeesForm from './EditPayExpenseFeesForm';
 import ConfirmationModal from '../ConfirmationModal';
 import StyledButton from '../StyledButton';
 import MarkExpenseAsPaidBtn from './MarkExpenseAsPaidBtn';
+import MessageBox from '../MessageBox';
 
 class Expense extends React.Component {
   static propTypes = {
@@ -85,6 +86,8 @@ class Expense extends React.Component {
     this.handleChange = this.handleChange.bind(this);
     this.toggleDetails = this.toggleDetails.bind(this);
     this.toggleEdit = this.toggleEdit.bind(this);
+    this.handleErrorMessage = this.handleErrorMessage.bind(this);
+
     this.messages = defineMessages({
       pending: { id: 'expense.pending', defaultMessage: 'pending' },
       paid: { id: 'expense.paid', defaultMessage: 'paid' },
@@ -183,6 +186,12 @@ class Expense extends React.Component {
     };
     await this.props.editExpense(expense);
     this.setState({ modified: false, mode: 'details' });
+  }
+
+  handleErrorMessage(errorMessage) {
+    this.setState({
+      error: errorMessage,
+    });
   }
 
   render() {
@@ -429,7 +438,6 @@ class Expense extends React.Component {
               )}
             </div>
           </div>
-
           <ExpenseDetails
             LoggedInUser={LoggedInUser}
             expense={expense}
@@ -486,6 +494,12 @@ class Expense extends React.Component {
                       payoutMethod={expense.payoutMethod}
                     />
                   )}
+                  {this.state.error && (
+                    <MessageBox type="error" withIcon mb={2}>
+                      {this.state.error}
+                    </MessageBox>
+                  )}
+
                   <Flex data-cy="expense-actions" flexDirection={['column', 'row']} flexWrap="wrap" width="100%">
                     {canPay && (
                       <React.Fragment>
@@ -497,6 +511,7 @@ class Expense extends React.Component {
                           disabled={!this.props.allowPayAction}
                           lock={this.props.lockPayAction}
                           unlock={this.props.unlockPayAction}
+                          onError={this.handleErrorMessage}
                         />
                         {expense.payoutMethod !== 'other' && (
                           <PayExpenseBtn
@@ -508,6 +523,7 @@ class Expense extends React.Component {
                             disabled={!this.props.allowPayAction}
                             lock={this.props.lockPayAction}
                             unlock={this.props.unlockPayAction}
+                            onError={this.handleErrorMessage}
                           />
                         )}
                         <StyledButton
@@ -520,9 +536,27 @@ class Expense extends React.Component {
                         </StyledButton>
                       </React.Fragment>
                     )}
-                    {canMarkExpenseAsUnpaid && <MarkExpenseAsUnpaidBtn refetch={this.props.refetch} id={expense.id} />}
-                    {canApprove && <ApproveExpenseBtn refetch={this.props.refetch} id={expense.id} />}
-                    {canReject && <RejectExpenseBtn refetch={this.props.refetch} id={expense.id} />}
+                    {canMarkExpenseAsUnpaid && (
+                      <MarkExpenseAsUnpaidBtn
+                        refetch={this.props.refetch}
+                        id={expense.id}
+                        onError={this.handleErrorMessage}
+                      />
+                    )}
+                    {canApprove && (
+                      <ApproveExpenseBtn
+                        refetch={this.props.refetch}
+                        id={expense.id}
+                        onError={this.handleErrorMessage}
+                      />
+                    )}
+                    {canReject && (
+                      <RejectExpenseBtn
+                        refetch={this.props.refetch}
+                        id={expense.id}
+                        onError={this.handleErrorMessage}
+                      />
+                    )}
                     {canDelete && (
                       <StyledButton
                         buttonStyle="danger"
@@ -537,11 +571,6 @@ class Expense extends React.Component {
                 </Flex>
               )}
             </div>
-          )}
-          {this.state.error && (
-            <P color="red.500" data-cy="errorMessage">
-              {this.state.error}
-            </P>
           )}
         </div>
       </div>

--- a/components/expenses/MarkExpenseAsPaidBtn.js
+++ b/components/expenses/MarkExpenseAsPaidBtn.js
@@ -7,7 +7,6 @@ import { get } from 'lodash';
 import { isValidEmail, getErrorFromGraphqlException } from '../../lib/utils';
 
 import StyledButton from '../StyledButton';
-import { P } from '../Text';
 import StyledTooltip from '../StyledTooltip';
 import { payExpenseMutation } from './graphql/mutations';
 import StyledSpinner from '../StyledSpinner';
@@ -25,6 +24,7 @@ class MarkExpenseAsPaidBtn extends React.Component {
     mutate: PropTypes.func,
     refetch: PropTypes.func,
     intl: PropTypes.object.isRequired,
+    onError: PropTypes.func,
   };
 
   constructor(props) {
@@ -64,14 +64,15 @@ class MarkExpenseAsPaidBtn extends React.Component {
       unlock();
     } catch (e) {
       const error = getErrorFromGraphqlException(e).message;
-      this.setState({ error, loading: false });
+      this.props.onError(error);
+      this.setState({ loading: false });
       unlock();
     }
   }
 
   render() {
     const { collective, expense, intl } = this.props;
-    const { loading, error } = this.state;
+    const { loading } = this.state;
     let disabled = this.state.loading || this.props.disabled;
     let disabledMessage = '';
 
@@ -115,11 +116,6 @@ class MarkExpenseAsPaidBtn extends React.Component {
           <StyledTooltip display="grid" content={disabledMessage}>
             {button}
           </StyledTooltip>
-        )}
-        {error && (
-          <P color="red.500" pr={2}>
-            {error}
-          </P>
         )}
       </React.Fragment>
     );

--- a/components/expenses/MarkExpenseAsUnpaidBtn.js
+++ b/components/expenses/MarkExpenseAsUnpaidBtn.js
@@ -4,6 +4,8 @@ import gql from 'graphql-tag';
 import { graphql } from 'react-apollo';
 import { FormattedMessage, defineMessages, useIntl } from 'react-intl';
 
+import { getErrorFromGraphqlException } from '../../lib/utils';
+
 import StyledButton from '../StyledButton';
 import StyledCheckBox from '../StyledCheckbox';
 
@@ -14,7 +16,7 @@ const messages = defineMessages({
   },
 });
 
-const MarkExpenseAsUnpaidBtn = ({ id, markExpenseAsUnpaid, refetch }) => {
+const MarkExpenseAsUnpaidBtn = ({ id, markExpenseAsUnpaid, refetch, onError }) => {
   const [state, setState] = useState({
     showProcessorFeeConfirmation: false,
     processorFeeRefunded: false,
@@ -30,6 +32,8 @@ const MarkExpenseAsUnpaidBtn = ({ id, markExpenseAsUnpaid, refetch }) => {
       await refetch();
     } catch (err) {
       console.log('>>> payExpense error: ', err);
+      const error = getErrorFromGraphqlException(err).message;
+      onError(error);
       setState({ ...state, disableBtn: false });
     }
   }
@@ -66,6 +70,7 @@ MarkExpenseAsUnpaidBtn.propTypes = {
   id: PropTypes.number.isRequired,
   markExpenseAsUnpaid: PropTypes.func.isRequired,
   refetch: PropTypes.func,
+  onError: PropTypes.func.isRequired,
 };
 
 const markExpenseAsUnpaidQuery = gql`

--- a/components/expenses/PayExpenseBtn.js
+++ b/components/expenses/PayExpenseBtn.js
@@ -8,7 +8,6 @@ import { isValidEmail, getErrorFromGraphqlException } from '../../lib/utils';
 
 import StyledButton from '../StyledButton';
 import StyledSpinner from '../StyledSpinner';
-import { P } from '../Text';
 import StyledTooltip from '../StyledTooltip';
 import { payExpenseMutation } from './graphql/mutations';
 
@@ -26,6 +25,7 @@ class PayExpenseBtn extends React.Component {
     mutate: PropTypes.func,
     refetch: PropTypes.func,
     intl: PropTypes.object.isRequired,
+    onError: PropTypes.func,
   };
 
   constructor(props) {
@@ -64,14 +64,15 @@ class PayExpenseBtn extends React.Component {
       unlock();
     } catch (e) {
       const error = getErrorFromGraphqlException(e).message;
-      this.setState({ error, loading: false });
+      this.props.onError(error);
+      this.setState({ loading: false });
       unlock();
     }
   }
 
   render() {
     const { collective, expense, intl, host } = this.props;
-    const { loading, error } = this.state;
+    const { loading } = this.state;
     let disabled = this.state.loading || this.props.disabled,
       selectedPayoutMethod = expense.payoutMethod,
       disabledMessage;
@@ -130,11 +131,6 @@ class PayExpenseBtn extends React.Component {
           <StyledTooltip display="grid" content={disabledMessage}>
             {button}
           </StyledTooltip>
-        )}
-        {error && (
-          <P color="red.500" pr={2}>
-            {error}
-          </P>
         )}
       </React.Fragment>
     );

--- a/components/expenses/RejectExpenseBtn.js
+++ b/components/expenses/RejectExpenseBtn.js
@@ -5,12 +5,14 @@ import { graphql } from 'react-apollo';
 import { FormattedMessage } from 'react-intl';
 
 import StyledButton from '../StyledButton';
+import { getErrorFromGraphqlException } from '../../lib/utils';
 
 class RejectExpenseBtn extends React.Component {
   static propTypes = {
     id: PropTypes.number.isRequired,
     rejectExpense: PropTypes.func.isRequired,
     refetch: PropTypes.func,
+    onError: PropTypes.func.isRequired,
   };
 
   constructor(props) {
@@ -20,8 +22,13 @@ class RejectExpenseBtn extends React.Component {
 
   async onClick() {
     const { id } = this.props;
-    await this.props.rejectExpense(id);
-    await this.props.refetch();
+    try {
+      await this.props.rejectExpense(id);
+      await this.props.refetch();
+    } catch (e) {
+      const error = getErrorFromGraphqlException(e).message;
+      this.props.onError(error);
+    }
   }
 
   render() {


### PR DESCRIPTION
# Description:

Move error messages that are breaking the layout of the expense approval form, moving the messages above the buttons in the form.

**Resolve**: [#2746](https://github.com/opencollective/opencollective/issues/2746)

# Changes:


Desktop solution:
<img width="842" alt="Desktop solution" src="https://raw.githubusercontent.com/brymut/github-gifs/master/opencollective_opencollective_2746(4).png">

Mobile solution:

<img width="342" alt="Mobile solution" src="https://raw.githubusercontent.com/brymut/github-gifs/master/opencollective_opencollective_2746(3).jpg">