### PR TITLE
feat(location.js & map.js): replace Google/Apple Map with OpenStreetMap

### DIFF
--- a/components/Location.js
+++ b/components/Location.js
@@ -37,7 +37,10 @@ class Location extends React.Component {
           {this.props.showTitle && <h1>Location</h1>}
           <div className="name">{name}</div>
           <div className="address" style={{ color: colors.darkgray }}>
-            <ExternalLink href={`https://maps.apple.com/?q=${lat},${long}`} openInNewTab>
+            <ExternalLink
+              href={`https://www.openstreetmap.org/?mlat=${lat}&amp;mlon=${long}#map=16/${lat}/${long}`}
+              openInNewTab
+            >
               {address}
               {country ? `, ${country}` : ''}
             </ExternalLink>

--- a/components/Map.js
+++ b/components/Map.js
@@ -1,8 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Gmaps, Marker } from 'react-gmaps';
-
-import { getEnvVar } from '../lib/utils';
 
 class Map extends React.Component {
   static propTypes = {
@@ -17,36 +14,27 @@ class Map extends React.Component {
     });
   }
 
-  getApiKey() {
-    return getEnvVar('GOOGLE_MAPS_API_KEY');
-  }
-
   render() {
     const { lat, long } = this.props;
-
     return (
       <div style={{ width: '100%', height: '100%' }}>
-        <Gmaps
+        <iframe
           width={'100%'}
           height={'100%'}
-          lat={lat}
-          lng={long}
-          zoom={16}
-          loadingMessage={'Loading map'}
-          params={{
-            v: '3.exp',
-            key: this.getApiKey(),
-          }}
-          onMapCreated={this.onMapCreated}
-        >
-          <Marker lat={lat} lng={long} draggable={false} />
-        </Gmaps>
-        <a
-          className="map-overlay"
-          href={`http://maps.apple.com/?q=${lat},${long}`}
-          target="_blank"
-          rel="noopener noreferrer"
-        />
+          frameBorder="0"
+          scrolling="no"
+          src={`http://www.openstreetmap.org/export/embed.html?bbox=${long}%2C${lat}&marker=${lat}%2C${long}&layers=ND`}
+        ></iframe>
+        <br />
+        <small>
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href={`https://www.openstreetmap.org/?mlat=${lat}&amp;mlon=${long}#map=16/${lat}/${long}`}
+          >
+            View Larger Map
+          </a>
+        </small>
       </div>
     );
   }


### PR DESCRIPTION
Replace react-gmaps component with OpenStreetMap iframe

re #2799


- [ ] For addresses, one can use `https://osmnames.org/api/` or `https://openaddresses.io`
- [x] A simple iframe (see `export > html` on OSM) will replace the map
- [x] Replacing the Apple link is the easiest


<img width="748" alt="Screenshot 2020-01-13 at 20 39 07" src="https://user-images.githubusercontent.com/29008971/72288807-208fdb80-364a-11ea-9eb6-b501f79793cd.png">
