### PR TITLE
StyledMembershipCard: Add a space after amount contributed

### DIFF
--- a/components/CollectiveCard.js
+++ b/components/CollectiveCard.js
@@ -325,7 +325,7 @@ class CollectiveCard extends React.Component {
                     currency={get(membership, 'collective.currency')}
                   />
                 </div>
-                <FormattedMessage id="membership.totalDonations.title" defaultMessage={'amount contributed'} />
+                <FormattedMessage id="membership.totalDonations.title" defaultMessage={'Amount contributed'} />
               </div>
             )}
           </div>

--- a/components/StyledMembershipCard.js
+++ b/components/StyledMembershipCard.js
@@ -59,7 +59,7 @@ const StyledMembershipCard = ({ membership, intl, ...props }) => {
                   id="Membership.ContributorSince"
                   defaultMessage="{contributorType} since"
                   values={{ contributorType: formatMemberRole(intl.formatMessage, role) }}
-                />
+                />{' '}
                 <Span display="block" fontSize="LeadParagraph" fontWeight="bold">
                   <FormattedDate value={since} month="long" year="numeric" />
                 </Span>
@@ -67,13 +67,9 @@ const StyledMembershipCard = ({ membership, intl, ...props }) => {
             )}
             {role === roles.BACKER ? (
               <P mt={3} data-cy="amount-contributed">
-                <FormattedMessage id="membership.totalDonations.title" defaultMessage="amount contributed">
-                  {msg => (
-                    <Span textTransform="capitalize" fontSize="Caption">
-                      {msg}
-                    </Span>
-                  )}
-                </FormattedMessage>
+                <Span fontSize="Caption">
+                  <FormattedMessage id="membership.totalDonations.title" defaultMessage="Amount contributed" />{' '}
+                </Span>
                 <Span display="block" fontSize="LeadParagraph" fontWeight="bold">
                   {/** Ideally we should breakdown amounts donated per currency, but for now
                       the API only returns the total amount in collective's currency. */

--- a/lang/en.json
+++ b/lang/en.json
@@ -868,7 +868,7 @@
   "membership.role.host": "host",
   "membership.since": "since {date}",
   "membership.totalDonations": "Total amount contributed",
-  "membership.totalDonations.title": "amount contributed",
+  "membership.totalDonations.title": "Amount contributed",
   "menu.about": "about",
   "menu.addFunds": "Add funds",
   "menu.admin": "admin",

--- a/lang/es.json
+++ b/lang/es.json
@@ -868,7 +868,7 @@
   "membership.role.host": "host",
   "membership.since": "desde {date}",
   "membership.totalDonations": "Monto total contribuido",
-  "membership.totalDonations.title": "monto contribuido",
+  "membership.totalDonations.title": "Amount contributed",
   "menu.about": "sobre nuestro colectivo",
   "menu.addFunds": "Agregar fondos",
   "menu.admin": "administrador",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -868,7 +868,7 @@
   "membership.role.host": "hôte",
   "membership.since": "depuis {date}",
   "membership.totalDonations": "Montant total contribué",
-  "membership.totalDonations.title": "total des dons",
+  "membership.totalDonations.title": "Amount contributed",
   "menu.about": "à propos",
   "menu.addFunds": "Ajouter des fonds",
   "menu.admin": "administrateur",

--- a/lang/it.json
+++ b/lang/it.json
@@ -868,7 +868,7 @@
   "membership.role.host": "host",
   "membership.since": "dal {date}",
   "membership.totalDonations": "Total amount contributed",
-  "membership.totalDonations.title": "amount contributed",
+  "membership.totalDonations.title": "Amount contributed",
   "menu.about": "about",
   "menu.addFunds": "Add funds",
   "menu.admin": "admin",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -868,7 +868,7 @@
   "membership.role.host": "ホスト",
   "membership.since": "{date}から",
   "membership.totalDonations": "支援総額",
-  "membership.totalDonations.title": "支援額",
+  "membership.totalDonations.title": "Amount contributed",
   "menu.about": "About",
   "menu.addFunds": "資金を追加",
   "menu.admin": "管理",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -868,7 +868,7 @@
   "membership.role.host": "host",
   "membership.since": "since {date}",
   "membership.totalDonations": "Total amount contributed",
-  "membership.totalDonations.title": "amount contributed",
+  "membership.totalDonations.title": "Amount contributed",
   "menu.about": "about",
   "menu.addFunds": "Add funds",
   "menu.admin": "admin",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -868,7 +868,7 @@
   "membership.role.host": "organizador",
   "membership.since": "desde {date}",
   "membership.totalDonations": "Quantia total contribuída",
-  "membership.totalDonations.title": "quantia contribuída",
+  "membership.totalDonations.title": "Amount contributed",
   "menu.about": "sobre",
   "menu.addFunds": "Adicionar fundos",
   "menu.admin": "admin",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -868,7 +868,7 @@
   "membership.role.host": "представитель",
   "membership.since": "с {date}",
   "membership.totalDonations": "Total amount contributed",
-  "membership.totalDonations.title": "amount contributed",
+  "membership.totalDonations.title": "Amount contributed",
   "menu.about": "о нас",
   "menu.addFunds": "Добавить средства",
   "menu.admin": "admin",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -868,7 +868,7 @@
   "membership.role.host": "host",
   "membership.since": "since {date}",
   "membership.totalDonations": "Total amount contributed",
-  "membership.totalDonations.title": "amount contributed",
+  "membership.totalDonations.title": "Amount contributed",
   "menu.about": "关于",
   "menu.addFunds": "Add funds",
   "menu.admin": "管理",

--- a/test/cypress/integration/05-user_v2.test.js
+++ b/test/cypress/integration/05-user_v2.test.js
@@ -15,7 +15,7 @@ describe('New users profiles', () => {
         .contains('August 2016');
       cy.get('[data-cy=amount-contributed]')
         .first()
-        .contains('amount contributed');
+        .contains('Amount contributed');
       cy.get('[data-cy=amount-contributed]')
         .first()
         .contains('€267');


### PR DESCRIPTION
Add a missing space in the description that didn't cause any trouble in the interface but was messing with Google's descriptions.

![image](https://user-images.githubusercontent.com/1556356/72325357-384c7b80-36ad-11ea-94c4-80b2b58a19c3.png)
