### PR TITLE
feat(geosuggest): react-select component with geo-address suggestion options

### DIFF
--- a/components/Geosuggest.js
+++ b/components/Geosuggest.js
@@ -1,0 +1,65 @@
+import React, { Fragment } from 'react';
+import PropType from 'prop-types';
+import fetch from 'node-fetch';
+import { debounce } from 'lodash';
+import AsyncSelect from 'react-select/async';
+
+import { getEnvVar } from '../lib/utils';
+
+const apiKey = getEnvVar('MAPTILER_MAPS_API_KEY');
+
+const exportLocationData = data => ({
+  name: data.text,
+  address: data.place_name,
+  bbox: data.bbox,
+  lat: data.center[1],
+  long: data.center[0],
+});
+
+const debounced = debounce(async (query, callback) => {
+  let result = null;
+  const url = `https://api.maptiler.com/geocoding/${query}.json?key=${apiKey}`;
+
+  try {
+    const res = await fetch(url);
+    const data = await res.json();
+    result = data.features.map(s => ({ label: s.place_name, value: s }));
+  } catch (err) {
+    result = null;
+  } finally {
+    callback(result);
+  }
+}, 500);
+
+export default function Geosuggest({ onSuggestSelect, placeholder, defaultOptions }) {
+  const getOption = (input, callback) => {
+    if (!input) return Promise.resolve([]);
+    debounced(input, callback);
+  };
+
+  return (
+    <Fragment>
+      <style jsx global>
+        {`
+          .geosuggest {
+            z-index: 5;
+          }
+        `}
+      </style>
+      <AsyncSelect
+        className="geosuggest"
+        cacheOptions
+        loadOptions={getOption}
+        placeholder={placeholder}
+        defaultOptions={defaultOptions}
+        onChange={({ value }) => onSuggestSelect(exportLocationData(value))}
+      />
+    </Fragment>
+  );
+}
+
+Geosuggest.propTypes = {
+  placeholder: PropType.string,
+  onSuggestSelect: PropType.func,
+  defaultOptions: PropType.array,
+};


### PR DESCRIPTION
Consumes [`osmnames`](osmnames.org/api) & [`maptiler`](maptiler.com) APIs
* requires  [`maptiler api_key`](https://cloud.maptiler.com/geocoding/)

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/29008971/72468945-8dd47580-37de-11ea-9541-7cb3151eef69.gif)

re [#3332](https://github.com/opencollective/opencollective-frontend/pull/3332)