### PR TITLE
Deactivate submitExpenses CTA and CreateExpenseForm for archived collectives

### DIFF
--- a/components/collective-page/index.js
+++ b/components/collective-page/index.js
@@ -126,12 +126,12 @@ class CollectivePage extends Component {
     }
   };
 
-  getCallsToAction = memoizeOne((type, isHost, isAdmin, isRoot, canApply, canContact) => {
+  getCallsToAction = memoizeOne((type, isHost, isAdmin, isRoot, canApply, canContact, isArchived) => {
     const isCollective = type === CollectiveType.COLLECTIVE;
     const isEvent = type === CollectiveType.EVENT;
     return {
       hasContact: !isAdmin && canContact,
-      hasSubmitExpense: isCollective || isEvent,
+      hasSubmitExpense: (isCollective || isEvent) && !isArchived,
       hasApply: canApply,
       hasDashboard: isHost && isAdmin,
       hasManageSubscriptions: isAdmin && !isCollective && !isEvent,
@@ -216,7 +216,15 @@ class CollectivePage extends Component {
     const { type, isHost, canApply, canContact } = collective;
     const { isFixed, selectedSection } = this.state;
     const sections = this.getSections(this.props);
-    const callsToAction = this.getCallsToAction(type, isHost, isAdmin, isRoot, canApply, canContact);
+    const callsToAction = this.getCallsToAction(
+      type,
+      isHost,
+      isAdmin,
+      isRoot,
+      canApply,
+      canContact,
+      collective.isArchived,
+    );
 
     return (
       <Container position="relative" css={collective.isArchived ? 'filter: grayscale(100%);' : undefined}>

--- a/components/expenses/CreateExpenseForm.js
+++ b/components/expenses/CreateExpenseForm.js
@@ -528,7 +528,7 @@ class CreateExpenseForm extends React.Component {
   }
 
   render() {
-    const { LoggedInUser } = this.props;
+    const { LoggedInUser, collective } = this.props;
 
     if (!LoggedInUser) {
       return (
@@ -537,6 +537,17 @@ class CreateExpenseForm extends React.Component {
             <FormattedMessage id="expenses.create.login" defaultMessage="Sign up or login to submit an expense." />
           </P>
           <SignInOrJoinFree />
+        </div>
+      );
+    } else if (collective.isArchived) {
+      return (
+        <div className="CreateExpenseForm">
+          <P textAlign="center" mt={4} fontSize="LeadParagraph" lineHeight="LeadParagraph">
+            <FormattedMessage
+              id="expenses.create.archived"
+              defaultMessage="Cannot submit expenses for an archived collective."
+            />
+          </P>
         </div>
       );
     } else {

--- a/lang/en.json
+++ b/lang/en.json
@@ -678,6 +678,7 @@
   "expenses.byRecipient": "Expenses by {recipient}",
   "expenses.collectivePicker.subtitle": "for {n} {n, plural, one {collective} other {collectives}}",
   "expenses.collectivePicker.title": "Finances",
+  "expenses.create.archived": "Cannot submit expenses for an archived collective.",
   "expenses.create.login": "Sign up or login to submit an expense.",
   "expenses.empty": "No expenses",
   "expenses.paid": "paid",

--- a/lang/es.json
+++ b/lang/es.json
@@ -678,6 +678,7 @@
   "expenses.byRecipient": "Expenses by {recipient}",
   "expenses.collectivePicker.subtitle": "{n} {n, plural, one {collective} other {collectives}}",
   "expenses.collectivePicker.title": "Finances",
+  "expenses.create.archived": "Cannot submit expenses for an archived collective.",
   "expenses.create.login": "Regístrese o acredítese para enviar un gasto.",
   "expenses.empty": "No expenses",
   "expenses.paid": "pagado",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -678,6 +678,7 @@
   "expenses.byRecipient": "Dépenses par {recipient}",
   "expenses.collectivePicker.subtitle": "pour {n} {n, plural, one {collectif} other {collectifs}}",
   "expenses.collectivePicker.title": "Finances",
+  "expenses.create.archived": "Cannot submit expenses for an archived collective.",
   "expenses.create.login": "Créez un compte ou identifiez-vous pour pouvoir ajouter une dépense.",
   "expenses.empty": "Pas de dépenses",
   "expenses.paid": "payé",

--- a/lang/it.json
+++ b/lang/it.json
@@ -678,6 +678,7 @@
   "expenses.byRecipient": "Expenses by {recipient}",
   "expenses.collectivePicker.subtitle": "for {n} {n, plural, one {collective} other {collectives}}",
   "expenses.collectivePicker.title": "Finances",
+  "expenses.create.archived": "Cannot submit expenses for an archived collective.",
   "expenses.create.login": "Sign up or login to submit an expense.",
   "expenses.empty": "No expenses",
   "expenses.paid": "pagato",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -678,6 +678,7 @@
   "expenses.byRecipient": "{recipient} の請求",
   "expenses.collectivePicker.subtitle": "{n} {n, plural, one {件のコレクティブ} other {件のコレクティブ}}",
   "expenses.collectivePicker.title": "ファイナンス",
+  "expenses.create.archived": "Cannot submit expenses for an archived collective.",
   "expenses.create.login": "アカウントを作成するかログインして請求の送信をしてください。",
   "expenses.empty": "請求がありません",
   "expenses.paid": "支払い済み",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -678,6 +678,7 @@
   "expenses.byRecipient": "Expenses by {recipient}",
   "expenses.collectivePicker.subtitle": "for {n} {n, plural, one {collective} other {collectives}}",
   "expenses.collectivePicker.title": "Finances",
+  "expenses.create.archived": "Cannot submit expenses for an archived collective.",
   "expenses.create.login": "Sign up or login to submit an expense.",
   "expenses.empty": "No expenses",
   "expenses.paid": "paid",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -678,6 +678,7 @@
   "expenses.byRecipient": "Despesas por {recipient}",
   "expenses.collectivePicker.subtitle": "para {n} {n, plural, one {coletivo} other {coletivos}}",
   "expenses.collectivePicker.title": "Finanças",
+  "expenses.create.archived": "Cannot submit expenses for an archived collective.",
   "expenses.create.login": "Cadastre-se ou entre para enviar uma despesa.",
   "expenses.empty": "Sem despesas",
   "expenses.paid": "pago",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -678,6 +678,7 @@
   "expenses.byRecipient": "Расходы по {recipient}",
   "expenses.collectivePicker.subtitle": "для {n} {n, plural, one {коллектива} other {коллективов}}",
   "expenses.collectivePicker.title": "Финансы",
+  "expenses.create.archived": "Cannot submit expenses for an archived collective.",
   "expenses.create.login": "Зарегистрируйтесь или войдите, чтобы учесть расходы.",
   "expenses.empty": "Нет расходов",
   "expenses.paid": "оплачено",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -678,6 +678,7 @@
   "expenses.byRecipient": "Expenses by {recipient}",
   "expenses.collectivePicker.subtitle": "for {n} {n, plural, one {collective} other {collectives}}",
   "expenses.collectivePicker.title": "Finances",
+  "expenses.create.archived": "Cannot submit expenses for an archived collective.",
   "expenses.create.login": "Sign up or login to submit an expense.",
   "expenses.empty": "No expenses",
   "expenses.paid": "paid",

--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -601,6 +601,7 @@ const getCollectiveCoverQuery = gql`
       backgroundImage
       isHost
       isActive
+      isArchived
       tags
       canContact
       stats {

--- a/pages/createExpense.js
+++ b/pages/createExpense.js
@@ -162,6 +162,7 @@ const getCollectiveQuery = gql`
       backgroundImage
       isHost
       isActive
+      isArchived
       tags
       stats {
         id

--- a/pages/expense.js
+++ b/pages/expense.js
@@ -86,7 +86,7 @@ class ExpensePage extends React.Component {
             collective={collective}
             LoggedInUser={LoggedInUser}
             displayContributeLink={collective.isActive && collective.host ? true : false}
-            callsToAction={{ hasSubmitExpense: true }}
+            callsToAction={{ hasSubmitExpense: !collective.isArchived }}
           />
 
           <Box maxWidth={1200} m="0 auto" px={[1, 3, 4]} py={[2, 3]}>
@@ -96,11 +96,13 @@ class ExpensePage extends React.Component {
                   ← <FormattedMessage id="expenses.viewAll" defaultMessage="View All Expenses" />
                 </StyledButton>
               </Link>
-              <Link route="createExpense" params={{ collectiveSlug: collective.slug }}>
-                <StyledButton my={1} mx={3} data-cy="submit-expense-btn">
-                  <FormattedMessage id="expenses.sendAnotherExpense" defaultMessage="Submit Another Expense" />
-                </StyledButton>
-              </Link>
+              {!collective.isArchived && (
+                <Link route="createExpense" params={{ collectiveSlug: collective.slug }}>
+                  <StyledButton my={1} mx={3} data-cy="submit-expense-btn">
+                    <FormattedMessage id="expenses.sendAnotherExpense" defaultMessage="Submit Another Expense" />
+                  </StyledButton>
+                </Link>
+              )}
             </Flex>
 
             <hr />

--- a/pages/expenses.js
+++ b/pages/expenses.js
@@ -110,7 +110,7 @@ class ExpensesPage extends React.Component {
             collective={collective}
             LoggedInUser={LoggedInUser}
             displayContributeLink={collective.isActive && collective.host ? true : false}
-            callsToAction={{ hasContact: collective.canContact, hasSubmitExpense: true }}
+            callsToAction={{ hasContact: collective.canContact, hasSubmitExpense: !collective.isArchived }}
           />
 
           <div className="content">

--- a/test/cypress/integration/30-archiveCollective.test.js
+++ b/test/cypress/integration/30-archiveCollective.test.js
@@ -23,6 +23,16 @@ describe('Archive Collective', () => {
         cy.get('[data-cy=action]').click();
         cy.wait(500);
         cy.contains('This collective has been archived');
+
+        // test to confirm expenses cannot be submitted for an archived collective
+        cy.visit(`${collectiveSlug}/expenses`);
+        cy.get('[data-cy=submit-expense-btn]').should('not.exist');
+
+        cy.visit(`${collectiveSlug}`);
+        cy.get('[data-cy=submit-expense-btn]').should('not.exist');
+
+        cy.visit(`${collectiveSlug}/expenses/new`);
+        cy.get('.CreateExpenseForm').contains('Cannot submit expenses for an archived collective.');
       });
     });
   });


### PR DESCRIPTION
### Resolves: opencollective/opencollective/issues/2819

This PR updates the logic that renders the call to actions on the Collective Page to ensure that the submitExpenses cta is not rendered on archived Collectives.

### Before archiving
![Screenshot 2020-01-17 at 13 16 28 (2)](https://user-images.githubusercontent.com/30657749/72604471-009f3700-392c-11ea-8f79-2fb8b7aab546.png)

### After archiving
![Screenshot 2020-01-17 at 13 15 50 (2)](https://user-images.githubusercontent.com/30657749/72604426-efeec100-392b-11ea-8648-6d2c7f4a36e0.png)
