### PR TITLE
Remove link to create a GitHub issue on error page

### DIFF
--- a/components/ErrorPage.js
+++ b/components/ErrorPage.js
@@ -1,15 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { get, truncate } from 'lodash';
+import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import { Flex } from '@rebass/grid';
 import { Router } from '../server/pages';
 
 import { Support } from '@styled-icons/boxicons-regular/Support';
-import { Github } from '@styled-icons/fa-brands/Github';
 import { Redo } from '@styled-icons/fa-solid/Redo';
 
-import { objectToQueryString } from '../lib/url_helpers';
 import Header from './Header';
 import Body from './Body';
 import Footer from './Footer';
@@ -138,48 +136,11 @@ class ErrorPage extends React.Component {
     );
   }
 
-  getGithubIssueURL(stackTrace) {
-    const navigatorInfo = typeof navigator === 'undefined' ? {} : navigator;
-    const pageUrl = typeof window === 'undefined' ? '___________' : window.location;
-
-    const title = 'Unexpected error when ___________';
-    const body = `
-# Describe the bug
-
-<!-- A clear and concise description of what the bug is. -->
-<!-- If applicable, add screenshots to help explain your problem. -->
-
-I got an unexpected error on ${pageUrl} while I was trying to __________
-
-# To Reproduce
-
-<!-- Steps to reproduce the behavior -->
-
-1. Go to ________
-2. Click on ________
-3. Scroll down to ________
-4. See error
-
-# Device
-- OS: ${navigatorInfo.platform}
-- Browser: \`${navigatorInfo.appVersion}\`
-
-# Technical details
-
-<!-- PLEASE REMOVE ANY PERSONAL INFORMATION FROM THE LOGS BELOW -->
-
-\`\`\`
-${truncate(stackTrace, { length: 6000 })}
-\`\`\`
-    `;
-    return `https://github.com/opencollective/opencollective/issues/new${objectToQueryString({ title, body })}`;
-  }
-
   unknownError() {
     const message = get(this.props, 'data.error.message');
     const stackTrace = get(this.props, 'data.error.stack');
     const expandError = process.env.NODE_ENV !== 'production';
-    const fontSize = ['circleci', 'test'].includes(process.env.NODE_ENV) ? 22 : 13;
+    const fontSize = ['ci', 'circleci', 'e2e', 'test'].includes(process.env.NODE_ENV) ? 22 : 13;
 
     return (
       <Flex flexDirection="column" alignItems="center" px={2} py={[4, 6]}>
@@ -190,9 +151,6 @@ ${truncate(stackTrace, { length: 6000 })}
         <Flex mt={5} flexWrap="wrap" alignItems="center" justifyContent="center">
           <StyledLink my={2} href="mailto:support@opencollective.com" mx={2} buttonStyle="standard" buttonSize="large">
             <Support size="1em" /> <FormattedMessage id="error.contactSupport" defaultMessage="Contact support" />
-          </StyledLink>
-          <StyledLink my={2} href={this.getGithubIssueURL(stackTrace)} mx={2} buttonStyle="standard" buttonSize="large">
-            <Github size="1em" /> <FormattedMessage id="error.addOnGithub" defaultMessage="Add an issue on Github" />
           </StyledLink>
           <StyledButton my={2} mx={2} buttonSize="large" onClick={() => location.reload()}>
             <Redo size="0.8em" /> <FormattedMessage id="error.reload" defaultMessage="Reload the page" />

--- a/lang/en.json
+++ b/lang/en.json
@@ -554,7 +554,6 @@
   "EditUserEmailForm.title": "Email address",
   "EditWebhooks.ZapierAd": "NEW! You can now use the Beta {zapierLink} app to manage your integrations.",
   "Email": "Email",
-  "error.addOnGithub": "Add an issue on Github",
   "Error.BadCollectiveType": "This profile type is not supported",
   "error.code.invalid": "Invalid Gift Card code",
   "error.contactSupport": "Contact support",

--- a/lang/es.json
+++ b/lang/es.json
@@ -554,7 +554,6 @@
   "EditUserEmailForm.title": "Dirección de correo electrónico",
   "EditWebhooks.ZapierAd": "NEW! You can now use the Beta {zapierLink} app to manage your integrations.",
   "Email": "Email",
-  "error.addOnGithub": "Añadir un problema en Github",
   "Error.BadCollectiveType": "This profile type is not supported",
   "error.code.invalid": "Invalid gift card code",
   "error.contactSupport": "Contactar con el soporte",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -554,7 +554,6 @@
   "EditUserEmailForm.title": "Adresse email",
   "EditWebhooks.ZapierAd": "NOUVEAU! Vous pouvez maintenant utiliser l'application {zapierLink} pour gérer vos intégrations.",
   "Email": "Email",
-  "error.addOnGithub": "Ajouter un ticket sur Github",
   "Error.BadCollectiveType": "Ce type de profil n'est pas supporté",
   "error.code.invalid": "Code de carte cadeau invalide",
   "error.contactSupport": "Contacter le support",

--- a/lang/it.json
+++ b/lang/it.json
@@ -554,7 +554,6 @@
   "EditUserEmailForm.title": "Indirizzo email",
   "EditWebhooks.ZapierAd": "NEW! You can now use the Beta {zapierLink} app to manage your integrations.",
   "Email": "Email",
-  "error.addOnGithub": "Add an issue on Github",
   "Error.BadCollectiveType": "This profile type is not supported",
   "error.code.invalid": "Invalid Gift Card code",
   "error.contactSupport": "Contatta supporto",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -554,7 +554,6 @@
   "EditUserEmailForm.title": "メールアドレス",
   "EditWebhooks.ZapierAd": "NEW! You can now use the Beta {zapierLink} app to manage your integrations.",
   "Email": "Email",
-  "error.addOnGithub": "GitHub に Issue を作る",
   "Error.BadCollectiveType": "This profile type is not supported",
   "error.code.invalid": "無効なギフトカードのコード",
   "error.contactSupport": "サポートに問い合わせ",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -554,7 +554,6 @@
   "EditUserEmailForm.title": "Email address",
   "EditWebhooks.ZapierAd": "NEW! You can now use the Beta {zapierLink} app to manage your integrations.",
   "Email": "Email",
-  "error.addOnGithub": "Add an issue on Github",
   "Error.BadCollectiveType": "This profile type is not supported",
   "error.code.invalid": "Ongeldige code voor Cadeaubon",
   "error.contactSupport": "Contact support",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -554,7 +554,6 @@
   "EditUserEmailForm.title": "Endereço de e-mail",
   "EditWebhooks.ZapierAd": "NOVO! Você pode agora usar o app Beta {zapierLink} para gerenciar suas integrações.",
   "Email": "Email",
-  "error.addOnGithub": "Criar uma issue no Github",
   "Error.BadCollectiveType": "Este tipo de perfil não é aceito",
   "error.code.invalid": "Vale-presente inválido",
   "error.contactSupport": "Contate o suporte",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -554,7 +554,6 @@
   "EditUserEmailForm.title": "Электронная почта",
   "EditWebhooks.ZapierAd": "NEW! You can now use the Beta {zapierLink} app to manage your integrations.",
   "Email": "Email",
-  "error.addOnGithub": "Добавить задачу на Github",
   "Error.BadCollectiveType": "This profile type is not supported",
   "error.code.invalid": "Неверный код подарочной карты",
   "error.contactSupport": "Обратитесь в службу поддержки",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -554,7 +554,6 @@
   "EditUserEmailForm.title": "邮箱地址",
   "EditWebhooks.ZapierAd": "NEW! You can now use the Beta {zapierLink} app to manage your integrations.",
   "Email": "Email",
-  "error.addOnGithub": "在Github提交issue",
   "Error.BadCollectiveType": "This profile type is not supported",
   "error.code.invalid": "Invalid Gift Card code",
   "error.contactSupport": "联系支持",


### PR DESCRIPTION
We unfortunately haven't got good feedback with it so far.

Also, Sentry should automatize that for us.