### PR TITLE
Remove @babel/runtime and regenerator-runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "npm": "6.12.0"
   },
   "dependencies": {
-    "@babel/runtime": "7.7.2",
     "@formatjs/intl-relativetimeformat": "4.5.7",
     "@material-ui/core": "4.8.3",
     "@opencollective/taxes": "2.3.0",
@@ -97,7 +96,6 @@
     "react-tag-input": "6.4.2",
     "react-tooltip": "3.11.2",
     "react-window": "1.8.5",
-    "regenerator-runtime": "0.13.3",
     "rehype-react": "4.0.1",
     "rehype-sanitize": "3.0.0",
     "remark-parse": "7.0.2",


### PR DESCRIPTION
They should always be available because they are core dependencies of next.js.

I can't figure anymore any reason why they should be required in `package.json`.