### PR TITLE
EditCollective: Remove markdown editor toggle

### DIFF
--- a/components/edit-collective/EditCollectiveForm.js
+++ b/components/edit-collective/EditCollectiveForm.js
@@ -153,14 +153,6 @@ class EditCollectiveForm extends React.Component {
         id: 'Fields.website',
         defaultMessage: 'Website',
       },
-      'markdown.label': {
-        id: 'collective.markdown.label',
-        defaultMessage: 'Default editor',
-      },
-      'markdown.description': {
-        id: 'collective.markdown.description',
-        defaultMessage: 'Use markdown editor',
-      },
       'sendInvoiceByEmail.label': {
         id: 'collective.sendInvoiceByEmail.label',
         defaultMessage: 'Invoices',
@@ -605,14 +597,6 @@ class EditCollectiveForm extends React.Component {
           post: '%',
           defaultValue: get(this.state.collective, 'settings.hostFeePercent'),
           when: () => this.state.section === 'advanced' && collective.isHost,
-        },
-        {
-          name: 'markdown',
-          className: 'horizontal',
-          type: 'switch',
-          defaultValue: get(this.state.collective, 'settings.editor') === 'markdown',
-          when: () =>
-            this.state.section === 'advanced' && (collective.type === 'USER' || collective.type === 'COLLECTIVE'),
         },
       ],
     };

--- a/lang/en.json
+++ b/lang/en.json
@@ -176,8 +176,6 @@
   "collective.isArchived.description": "This collective has been archived and can no longer be used for any activities.",
   "collective.isArchived.edit.description": "This {type} has been archived and can no longer be used for any activities.",
   "collective.location.label": "City",
-  "collective.markdown.description": "Use markdown editor",
-  "collective.markdown.label": "Default editor",
   "collective.meetup.label": "Meetup URL",
   "collective.members.admin.title": "{n} {n, plural, one {core contributor} other {core contributors}}",
   "collective.members.backer.title": "{n} {n, plural, one {backer} other {backers}}",

--- a/lang/es.json
+++ b/lang/es.json
@@ -176,8 +176,6 @@
   "collective.isArchived.description": "Este colectivo ha sido archivado y no podrá seguir siendo usado para ninguna actividad.",
   "collective.isArchived.edit.description": "Este {type} ha sido archivado y no podrá seguir siendo usado para ninguna actividad.",
   "collective.location.label": "Ciudad",
-  "collective.markdown.description": "Utilizar el editor de markdown",
-  "collective.markdown.label": "Editor por defecto",
   "collective.meetup.label": "URL de reunión",
   "collective.members.admin.title": "{n} {n, plural, one {colaborador} other {colaboradores}}",
   "collective.members.backer.title": "{n} {n, plural, one {patrocinador} other {patrocinadores}}",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -176,8 +176,6 @@
   "collective.isArchived.description": "Ce collectif a été archivé et ne peut plus être utilisé.",
   "collective.isArchived.edit.description": "Ce {type} a été archivé et ne peut plus être utilisé.",
   "collective.location.label": "Lieux",
-  "collective.markdown.description": "Utiliser markdown comme éditeur",
-  "collective.markdown.label": "Éditeur de texte par défaut",
   "collective.meetup.label": "URL du Meetup",
   "collective.members.admin.title": "{n} {n, plural, one {administrateur} other {administrateurs}}",
   "collective.members.backer.title": "{n} {n, plural, one {contributeur} other {contributeurs}}",

--- a/lang/it.json
+++ b/lang/it.json
@@ -176,8 +176,6 @@
   "collective.isArchived.description": "This collective has been archived and can no longer be used for any activities.",
   "collective.isArchived.edit.description": "This {type} has been archived and can no longer be used for any activities.",
   "collective.location.label": "Città",
-  "collective.markdown.description": "Usa editor markdown",
-  "collective.markdown.label": "Editor predefinito",
   "collective.meetup.label": "Meetup URL",
   "collective.members.admin.title": "{n} {n, plural, one {core contributor} other {core contributors}}",
   "collective.members.backer.title": "{n} {n, plural, one {backer} other {backers}}",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -176,8 +176,6 @@
   "collective.isArchived.description": "This collective has been archived and can no longer be used for any activities.",
   "collective.isArchived.edit.description": "This {type} has been archived and can no longer be used for any activities.",
   "collective.location.label": "都市",
-  "collective.markdown.description": "Markdown エディターを使う",
-  "collective.markdown.label": "デフォルトエディター",
   "collective.meetup.label": "ミートアップ URL",
   "collective.members.admin.title": "{n} {n, plural, one {人のコアコントリビューター} other {人のコアコントリビューター}}",
   "collective.members.backer.title": "{n} {n, plural, one {人のバッカー} other {人のバッカー}}",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -176,8 +176,6 @@
   "collective.isArchived.description": "Dit collectief is gearchiveerd en kan niet meer gebruikt worden voor enige activiteiten.",
   "collective.isArchived.edit.description": "Deze {type} is gearchiveerd en kan niet meer gebruikt worden voor enige activiteiten.",
   "collective.location.label": "Stad",
-  "collective.markdown.description": "Gebruik prijsverlagingsbewerker",
-  "collective.markdown.label": "Standaard editor",
   "collective.meetup.label": "Bijeenkomst URL",
   "collective.members.admin.title": "{n} {n, plural, one {essentiële bijdrager} other {essentiële bijdragers}}",
   "collective.members.backer.title": "{n} {n, plural, one {supporter} other {supporters}}",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -176,8 +176,6 @@
   "collective.isArchived.description": "Este coletivo foi arquivado e não pode ser mais usado para nenhuma atividade.",
   "collective.isArchived.edit.description": "Este {type} foi arquivado e não pode ser mais usado para nenhuma atividade.",
   "collective.location.label": "Cidade",
-  "collective.markdown.description": "Use editor markdown",
-  "collective.markdown.label": "Editor padrão",
   "collective.meetup.label": "URL do Meetup",
   "collective.members.admin.title": "{n} {n, plural, one {contribuínte central} other {colaboradores centrais}}",
   "collective.members.backer.title": "{n} {n, plural, one {apoiador} other {apoiadores}}",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -176,8 +176,6 @@
   "collective.isArchived.description": "Этот коллектив добавили в архив, и он не может быть использован.",
   "collective.isArchived.edit.description": "Этот {type} был добавлен в архив и больше не может быть использован.",
   "collective.location.label": "Город",
-  "collective.markdown.description": "Использовать редактор markdown",
-  "collective.markdown.label": "Редактор по умолчанию",
   "collective.meetup.label": "URL митапа",
   "collective.members.admin.title": "{n} {n, plural, one {core contributor} other {core contributors}}",
   "collective.members.backer.title": "{n} {n, plural, one {попечитель} other {попечители}}",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -176,8 +176,6 @@
   "collective.isArchived.description": "此集体已存档, 不能再用于任何活动。",
   "collective.isArchived.edit.description": "此 {type} 已存档, 不能再用于任何活动。",
   "collective.location.label": "城市",
-  "collective.markdown.description": "使用 markdown 编辑器",
-  "collective.markdown.label": "默认编辑器",
   "collective.meetup.label": "Meetup 链接",
   "collective.members.admin.title": "{n} {n, plural, one {core contributor} other {core contributors}}",
   "collective.members.backer.title": "{n} {n, plural, one {backer} other {backers}}",


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/1805

# Description

This setting has almost no effect as it only impacts the editor for updates which creates confusion for users. (see https://opencollective.com/sandstormcommunity/conversations/what-do-yall-think-of-this-so-far-x96ez6om)

# Screenshots

![image](https://user-images.githubusercontent.com/1556356/72884909-387cf480-3d07-11ea-900b-9cc8a9243268.png)
