### PR TITLE
"git add" is now automatic with lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -228,8 +228,7 @@
   },
   "lint-staged": {
     "*.{js,json,md,graphql}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "cacheDirectories": [


### PR DESCRIPTION
Remove it.

<img width="1179" alt="Capture d’écran 2020-01-24 à 10 06 55" src="https://user-images.githubusercontent.com/806/73057239-4494bd80-3e91-11ea-8564-f1809f75a90a.png">
