### PR TITLE
Remove most console.log in pages and components

### DIFF
--- a/components/AddFundsForm.js
+++ b/components/AddFundsForm.js
@@ -157,6 +157,7 @@ class AddFundsForm extends React.Component {
       const { hostFeePercent } = result.data.Collective;
       return hostFeePercent;
     } catch (error) {
+      // TODO: this should be reported to the user
       console.error(error);
     }
   };

--- a/components/AddFundsModal.js
+++ b/components/AddFundsModal.js
@@ -86,7 +86,6 @@ const AddFundsModal = ({ LoggedInUser, show, setShow, collective }) => {
                         setError(null);
                         return null;
                       } catch (e) {
-                        console.error(e);
                         return finalizeWithError(e.message && e.message.replace(/GraphQL error:/, ''));
                       }
                     }}

--- a/components/ApplyToHostBtnLoggedIn.js
+++ b/components/ApplyToHostBtnLoggedIn.js
@@ -56,11 +56,8 @@ class ApplyToHostBtnLoggedIn extends React.Component {
       id: this.inactiveCollective.id,
       HostCollectiveId: host.id,
     };
-    // console.log('>>> editCollective', CollectiveInputType);
-    // const res =
     await this.props.editCollective(CollectiveInputType);
     this.setState({ showModal: false });
-    // console.log('>>> res', res);
   };
 
   handleModalDisplay() {

--- a/components/ApplyToHostBtnLoggedIn.js
+++ b/components/ApplyToHostBtnLoggedIn.js
@@ -56,10 +56,11 @@ class ApplyToHostBtnLoggedIn extends React.Component {
       id: this.inactiveCollective.id,
       HostCollectiveId: host.id,
     };
-    console.log('>>> editCollective', CollectiveInputType);
-    const res = await this.props.editCollective(CollectiveInputType);
+    // console.log('>>> editCollective', CollectiveInputType);
+    // const res =
+    await this.props.editCollective(CollectiveInputType);
     this.setState({ showModal: false });
-    console.log('>>> res', res);
+    // console.log('>>> res', res);
   };
 
   handleModalDisplay() {

--- a/components/CollectivesWithData.js
+++ b/components/CollectivesWithData.js
@@ -60,8 +60,7 @@ class CollectivesWithData extends React.Component {
     const { data } = this.props;
 
     if (data.error) {
-      console.error('graphql error>>>', data.error.message);
-      return <Error message="GraphQL error" />;
+      return <Error message={data.error.message} />;
     }
     if (!data.allCollectives || !data.allCollectives.collectives) {
       return <div />;

--- a/components/Comment.js
+++ b/components/Comment.js
@@ -73,6 +73,7 @@ class Comment extends React.Component {
       await this.props.deleteComment(this.state.comment.id);
       this.setState({ showDeleteModal: false });
     } catch (err) {
+      // TODO: this should be reported to the user
       console.error(err);
       this.setState({ showDeleteModal: false });
     }

--- a/components/CommentsWithData.js
+++ b/components/CommentsWithData.js
@@ -70,8 +70,7 @@ class CommentsWithData extends React.Component {
     const { data, LoggedInUser, collective, expense, view, fetchMore, deleteComment, editComment } = this.props;
     const { expense: expenseComments, error } = data;
     if (error) {
-      console.error('graphql error>>>', data.error.message);
-      return <Error message="GraphQL error" />;
+      return <Error message={error.message} />;
     }
 
     let comments;

--- a/components/ConnectPaypal.js
+++ b/components/ConnectPaypal.js
@@ -34,8 +34,9 @@ class ConnectPaypal extends React.Component {
       this.props.onClickRefillBalance(); // save the current filter preferences before redirect
       window.location.replace(json.redirectUrl);
     } catch (e) {
-      this.setState({ connectingPaypal: false });
+      // TODO: this should be reported to the user
       console.error(e);
+      this.setState({ connectingPaypal: false });
     }
   }
 

--- a/components/CreateCollective.js
+++ b/components/CreateCollective.js
@@ -115,7 +115,6 @@ class CreateCollective extends React.Component {
     delete CollectiveInputType.category;
     delete CollectiveInputType.tos;
     delete CollectiveInputType.hostTos;
-    // console.log('>>> creating collective ', CollectiveInputType);
     try {
       const res = await this.props.createCollective(CollectiveInputType);
       const collective = res.data.createCollective;
@@ -142,7 +141,6 @@ class CreateCollective extends React.Component {
         Router.pushRoute('editCollective', { slug: collective.slug, section: 'host' });
       }
     } catch (err) {
-      // console.error('>>> createCollective error: ', JSON.stringify(err));
       const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({ status: 'idle', result: { error: errorMsg } });
       throw new Error(errorMsg);

--- a/components/CreateCollective.js
+++ b/components/CreateCollective.js
@@ -115,7 +115,7 @@ class CreateCollective extends React.Component {
     delete CollectiveInputType.category;
     delete CollectiveInputType.tos;
     delete CollectiveInputType.hostTos;
-    console.log('>>> creating collective ', CollectiveInputType);
+    // console.log('>>> creating collective ', CollectiveInputType);
     try {
       const res = await this.props.createCollective(CollectiveInputType);
       const collective = res.data.createCollective;
@@ -142,7 +142,7 @@ class CreateCollective extends React.Component {
         Router.pushRoute('editCollective', { slug: collective.slug, section: 'host' });
       }
     } catch (err) {
-      console.error('>>> createCollective error: ', JSON.stringify(err));
+      // console.error('>>> createCollective error: ', JSON.stringify(err));
       const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({ status: 'idle', result: { error: errorMsg } });
       throw new Error(errorMsg);

--- a/components/CreateEvent.js
+++ b/components/CreateEvent.js
@@ -49,7 +49,7 @@ class CreateEvent extends React.Component {
     this.setState({ status: 'loading' });
     EventInputType.type = 'EVENT';
     EventInputType.ParentCollectiveId = parentCollective.id;
-    console.log('>>> createEvent', EventInputType);
+    // console.log('>>> createEvent', EventInputType);
     try {
       const res = await this.props.createCollective(EventInputType);
       const event = res.data.createCollective;
@@ -60,7 +60,7 @@ class CreateEvent extends React.Component {
       });
       window.location.replace(eventUrl);
     } catch (err) {
-      console.error('>>> createEvent error: ', JSON.stringify(err));
+      // console.error('>>> createEvent error: ', JSON.stringify(err));
       const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({
         status: 'idle',

--- a/components/CreateEvent.js
+++ b/components/CreateEvent.js
@@ -49,7 +49,6 @@ class CreateEvent extends React.Component {
     this.setState({ status: 'loading' });
     EventInputType.type = 'EVENT';
     EventInputType.ParentCollectiveId = parentCollective.id;
-    // console.log('>>> createEvent', EventInputType);
     try {
       const res = await this.props.createCollective(EventInputType);
       const event = res.data.createCollective;
@@ -60,7 +59,6 @@ class CreateEvent extends React.Component {
       });
       window.location.replace(eventUrl);
     } catch (err) {
-      // console.error('>>> createEvent error: ', JSON.stringify(err));
       const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({
         status: 'idle',
@@ -134,7 +132,7 @@ class CreateEvent extends React.Component {
             )}
             {canCreateEvent && (
               <div>
-                {/* Hide event template picker to avoid getting old markdown content into events 
+                {/* Hide event template picker to avoid getting old markdown content into events
                    while transitioning to the new editor
                   <div className="EventTemplatePicker">
                     <div className="field">

--- a/components/CreateHostForm.js
+++ b/components/CreateHostForm.js
@@ -93,7 +93,7 @@ class CreateHostForm extends React.Component {
   }
 
   static getDerivedStateFromProps(newProps) {
-    console.log('>>> getDerivedStateFromProps', newProps);
+    // console.log('>>> getDerivedStateFromProps', newProps);
     const { intl } = newProps;
     const organizationsOptions = [];
     newProps.organizations.map(collective => {
@@ -128,13 +128,13 @@ class CreateHostForm extends React.Component {
   handleChange(attr, value) {
     const { form } = this.state;
     form[attr] = value;
-    console.log('>>> CreateHostForm.handleChange', attr, value, 'state.form', form);
+    // console.log('>>> CreateHostForm.handleChange', attr, value, 'state.form', form);
     if (attr === 'hostType') {
       const defaultHostCollectiveId = {
         user: this.props.userCollective.id,
         organization: this.state.organizationsOptions[0].value,
       };
-      console.log('>>> defaultHostCollectiveId', defaultHostCollectiveId);
+      // console.log('>>> defaultHostCollectiveId', defaultHostCollectiveId);
       form['HostCollectiveId'] = defaultHostCollectiveId[value];
     }
     this.setState({ form });
@@ -159,7 +159,7 @@ class CreateHostForm extends React.Component {
         when: form => form.hostType === 'organization',
       },
     ];
-    console.log('>>> generateInputFields', this.state, this.fields);
+    // console.log('>>> generateInputFields', this.state, this.fields);
     this.fields = this.fields.map(field => {
       if (this.messages[`${field.name}.label`]) {
         field.label = intl.formatMessage(this.messages[`${field.name}.label`]);

--- a/components/CreateHostForm.js
+++ b/components/CreateHostForm.js
@@ -93,7 +93,6 @@ class CreateHostForm extends React.Component {
   }
 
   static getDerivedStateFromProps(newProps) {
-    // console.log('>>> getDerivedStateFromProps', newProps);
     const { intl } = newProps;
     const organizationsOptions = [];
     newProps.organizations.map(collective => {
@@ -128,13 +127,11 @@ class CreateHostForm extends React.Component {
   handleChange(attr, value) {
     const { form } = this.state;
     form[attr] = value;
-    // console.log('>>> CreateHostForm.handleChange', attr, value, 'state.form', form);
     if (attr === 'hostType') {
       const defaultHostCollectiveId = {
         user: this.props.userCollective.id,
         organization: this.state.organizationsOptions[0].value,
       };
-      // console.log('>>> defaultHostCollectiveId', defaultHostCollectiveId);
       form['HostCollectiveId'] = defaultHostCollectiveId[value];
     }
     this.setState({ form });
@@ -159,7 +156,6 @@ class CreateHostForm extends React.Component {
         when: form => form.hostType === 'organization',
       },
     ];
-    // console.log('>>> generateInputFields', this.state, this.fields);
     this.fields = this.fields.map(field => {
       if (this.messages[`${field.name}.label`]) {
         field.label = intl.formatMessage(this.messages[`${field.name}.label`]);

--- a/components/CreateHostFormWithData.js
+++ b/components/CreateHostFormWithData.js
@@ -28,13 +28,13 @@ class CreateHostFormWithData extends React.Component {
   async createOrganization(CollectiveInputType) {
     this.setState({ status: 'loading' });
     CollectiveInputType.type = 'ORGANIZATION';
-    console.log('>>> createOrganization', CollectiveInputType);
+    // console.log('>>> createOrganization', CollectiveInputType);
     try {
       const res = await this.props.createCollective(CollectiveInputType);
       const collective = res.data.createCollective;
       return collective;
     } catch (err) {
-      console.error('>>> createOrganization error: ', JSON.stringify(err));
+      // console.error('>>> createOrganization error: ', JSON.stringify(err));
       const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({ result: { error: errorMsg } });
       throw new Error(errorMsg);

--- a/components/CreateHostFormWithData.js
+++ b/components/CreateHostFormWithData.js
@@ -28,13 +28,11 @@ class CreateHostFormWithData extends React.Component {
   async createOrganization(CollectiveInputType) {
     this.setState({ status: 'loading' });
     CollectiveInputType.type = 'ORGANIZATION';
-    // console.log('>>> createOrganization', CollectiveInputType);
     try {
       const res = await this.props.createCollective(CollectiveInputType);
       const collective = res.data.createCollective;
       return collective;
     } catch (err) {
-      // console.error('>>> createOrganization error: ', JSON.stringify(err));
       const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({ result: { error: errorMsg } });
       throw new Error(errorMsg);

--- a/components/CreateOrganization.js
+++ b/components/CreateOrganization.js
@@ -52,7 +52,6 @@ class CreateOrganization extends React.Component {
 
     this.setState({ status: 'loading' });
     CollectiveInputType.type = 'ORGANIZATION';
-    // console.log('>>> createOrganization', CollectiveInputType);
 
     try {
       const res = await this.props.createCollective(CollectiveInputType);
@@ -71,7 +70,6 @@ class CreateOrganization extends React.Component {
         status: 'collectiveCreated',
       });
     } catch (err) {
-      // console.error('>>> createOrganization error: ', JSON.stringify(err));
       const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({ result: { error: errorMsg } });
       throw new Error(errorMsg);

--- a/components/CreateOrganization.js
+++ b/components/CreateOrganization.js
@@ -52,7 +52,7 @@ class CreateOrganization extends React.Component {
 
     this.setState({ status: 'loading' });
     CollectiveInputType.type = 'ORGANIZATION';
-    console.log('>>> createOrganization', CollectiveInputType);
+    // console.log('>>> createOrganization', CollectiveInputType);
 
     try {
       const res = await this.props.createCollective(CollectiveInputType);
@@ -71,7 +71,7 @@ class CreateOrganization extends React.Component {
         status: 'collectiveCreated',
       });
     } catch (err) {
-      console.error('>>> createOrganization error: ', JSON.stringify(err));
+      // console.error('>>> createOrganization error: ', JSON.stringify(err));
       const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({ result: { error: errorMsg } });
       throw new Error(errorMsg);

--- a/components/CreateVirtualCardsSuccess.js
+++ b/components/CreateVirtualCardsSuccess.js
@@ -56,6 +56,7 @@ export default class CreateVirtualCardsSuccess extends React.Component {
       this.redeemLinkTextareaRef.current.select();
       document.execCommand('copy');
     } catch (e) {
+      // TODO: this should be reported to the user
       console.error('Cannot copy to clipboard', e);
     }
   };

--- a/components/EditEvent.js
+++ b/components/EditEvent.js
@@ -41,7 +41,6 @@ class EditEvent extends React.Component {
       Router.pushRoute(eventRoute);
       this.setState({ result: { success: 'Event edited successfully' } });
     } catch (err) {
-      // console.error('>>> editEvent error: ', JSON.stringify(err));
       const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({ status: 'idle', result: { error: errorMsg } });
     }
@@ -55,7 +54,6 @@ class EditEvent extends React.Component {
       this.setState({ result: { success: 'Event deleted successfully' } });
       Router.pushRoute(`/${event.parentCollective.slug}`);
     } catch (err) {
-      // console.error('>>> deleteEvent error: ', JSON.stringify(err));
       const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({ result: { error: errorMsg } });
     }

--- a/components/EditEvent.js
+++ b/components/EditEvent.js
@@ -41,7 +41,7 @@ class EditEvent extends React.Component {
       Router.pushRoute(eventRoute);
       this.setState({ result: { success: 'Event edited successfully' } });
     } catch (err) {
-      console.error('>>> editEvent error: ', JSON.stringify(err));
+      // console.error('>>> editEvent error: ', JSON.stringify(err));
       const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({ status: 'idle', result: { error: errorMsg } });
     }
@@ -55,7 +55,7 @@ class EditEvent extends React.Component {
       this.setState({ result: { success: 'Event deleted successfully' } });
       Router.pushRoute(`/${event.parentCollective.slug}`);
     } catch (err) {
-      console.error('>>> deleteEvent error: ', JSON.stringify(err));
+      // console.error('>>> deleteEvent error: ', JSON.stringify(err));
       const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({ result: { error: errorMsg } });
     }

--- a/components/EditUpdateForm.js
+++ b/components/EditUpdateForm.js
@@ -65,7 +65,7 @@ class EditUpdateForm extends React.Component {
   componentDidMount() {
     const savedState = storage.get(this.storageKey);
     if (savedState && !this.props.update) {
-      console.log('>>> restoring EditUpdateForm state', savedState);
+      // console.log('>>> restoring EditUpdateForm state', savedState);
       this.setState(savedState);
     }
     this._isMounted = true;

--- a/components/EditUpdateForm.js
+++ b/components/EditUpdateForm.js
@@ -65,7 +65,6 @@ class EditUpdateForm extends React.Component {
   componentDidMount() {
     const savedState = storage.get(this.storageKey);
     if (savedState && !this.props.update) {
-      // console.log('>>> restoring EditUpdateForm state', savedState);
       this.setState(savedState);
     }
     this._isMounted = true;
@@ -101,9 +100,8 @@ class EditUpdateForm extends React.Component {
       await this.props.onSubmit(this.state.update);
       this.setState({ modified: false, loading: false });
       storage.set(this.storageKey, null);
-    } catch (e) {
-      this.setState({ loading: false, error: `${e}` });
-      console.error('EditUpdateForm onSubmit error', e);
+    } catch (error) {
+      this.setState({ loading: false, error: error.message });
     }
     return false;
   }

--- a/components/Event.js
+++ b/components/Event.js
@@ -119,7 +119,7 @@ class Event extends React.Component {
     guests.interested = [];
     filterCollection(event.members, { role: 'FOLLOWER' }).map(follower => {
       if (!follower.member) {
-        console.error('>>> no user collective for membership', follower);
+        // console.error('>>> no user collective for membership', follower);
         return;
       }
       guests.interested.push({
@@ -130,7 +130,7 @@ class Event extends React.Component {
     guests.confirmed = [];
     event.orders.map(order => {
       if (!order.fromCollective) {
-        console.error('>>> no user collective for order', order);
+        // console.error('>>> no user collective for order', order);
         return;
       }
       if (get(order, 'tier.name', '').match(/sponsor/i)) {

--- a/components/Event.js
+++ b/components/Event.js
@@ -119,7 +119,6 @@ class Event extends React.Component {
     guests.interested = [];
     filterCollection(event.members, { role: 'FOLLOWER' }).map(follower => {
       if (!follower.member) {
-        // console.error('>>> no user collective for membership', follower);
         return;
       }
       guests.interested.push({
@@ -130,7 +129,6 @@ class Event extends React.Component {
     guests.confirmed = [];
     event.orders.map(order => {
       if (!order.fromCollective) {
-        // console.error('>>> no user collective for order', order);
         return;
       }
       if (get(order, 'tier.name', '').match(/sponsor/i)) {

--- a/components/HTMLEditor.js
+++ b/components/HTMLEditor.js
@@ -111,7 +111,8 @@ class HTMLEditor extends React.Component {
       if (/^image\//.test(file.type)) {
         this.saveToServer(file);
       } else {
-        console.warn('You can only upload images.');
+        // TODO: this should be reported to the user
+        console.error('HTMLEditor > File not an image', file);
       }
     };
   }
@@ -127,7 +128,8 @@ class HTMLEditor extends React.Component {
         return this.insertToEditor(fileUrl);
       })
       .catch(e => {
-        console.error('Error uploading image', e);
+        // TODO: this should be reported to the user
+        console.error('HTMLEditor > Error uploading image', e);
       });
   }
 

--- a/components/HostsWithData.js
+++ b/components/HostsWithData.js
@@ -54,8 +54,7 @@ class HostsWithData extends React.Component {
     const { data } = this.props;
 
     if (data.error) {
-      console.error('graphql error>>>', data.error.message);
-      return <Error message="GraphQL error" />;
+      return <Error message={data.error.message} />;
     }
     if (!data.allHosts || !data.allHosts.collectives) {
       return <div />;

--- a/components/InputTypeDropzone.js
+++ b/components/InputTypeDropzone.js
@@ -61,7 +61,6 @@ const InputTypeDropzone = props => {
         return onChange(fileUrl);
       })
       .catch(err => {
-        console.error('>>> error uploading image', file, err);
         const message = get(err, ['json', 'error', 'fields', 'file']);
         setError(message || 'error uploading image, please try again');
         setLoading(false);

--- a/components/MembersWithData.js
+++ b/components/MembersWithData.js
@@ -61,8 +61,7 @@ class MembersWithData extends React.Component {
     const { data, LoggedInUser, collective, tier, role, type } = this.props;
 
     if (data.error) {
-      console.error('graphql error>>>', data.error.message);
-      return <Error message="GraphQL error" />;
+      return <Error message={data.error.message} />;
     }
     if (!data.allMembers) {
       return <div />;

--- a/components/Membership.js
+++ b/components/Membership.js
@@ -17,7 +17,7 @@ class Membership extends React.Component {
     const { collective } = memberships[0];
 
     if (!collective) {
-      console.error('>>> no collective attached to this membership:', memberships[0]);
+      console.warn('Membership -> no collective attached', memberships[0]);
       return <div />;
     }
 

--- a/components/MembershipsWithData.js
+++ b/components/MembershipsWithData.js
@@ -59,8 +59,7 @@ class MembershipsWithData extends React.Component {
     const { data, LoggedInUser } = this.props;
 
     if (data.error) {
-      console.error('graphql error>>>', data.error.message);
-      return <Error message="GraphQL error" />;
+      return <Error message={data.error.message} />;
     }
     if (!data.allMembers) {
       return <div />;

--- a/components/MenuBar.js
+++ b/components/MenuBar.js
@@ -134,7 +134,6 @@ class MenuBar extends React.Component {
 
     const { collective } = this.props;
     if (!collective) {
-      console.error('>>> this is a weird error, collective should always be set', this.props);
       return;
     }
 

--- a/components/PaymentMethodChooser.js
+++ b/components/PaymentMethodChooser.js
@@ -145,7 +145,6 @@ class PaymentMethodChooser extends React.Component {
       try {
         res = await getStripeToken('cc', card);
       } catch (e) {
-        console.log('>>> error: ', typeof e, e);
         this.error(e);
         return false;
       }

--- a/components/SendMoneyToCollectiveBtn.js
+++ b/components/SendMoneyToCollectiveBtn.js
@@ -48,7 +48,6 @@ class SendMoneyToCollectiveBtn extends React.Component {
     } = this.props;
     if (!paymentMethods || paymentMethods.length === 0) {
       const error = "We couldn't find a payment method to make this transaction";
-      console.error(error);
       this.setState({ error });
       return;
     }
@@ -62,8 +61,7 @@ class SendMoneyToCollectiveBtn extends React.Component {
       paymentMethod: { uuid: paymentMethods[0].uuid },
     };
     try {
-      const res = await this.props.createOrder(order);
-      console.log('>>> createOrder result:', res);
+      await this.props.createOrder(order);
       this.setState({ loading: false });
     } catch (e) {
       const error = e.message && e.message.replace(/GraphQL error:/, '');

--- a/components/StyledUpdate.js
+++ b/components/StyledUpdate.js
@@ -118,16 +118,14 @@ class StyledUpdate extends Component {
       await this.props.deleteUpdate(this.props.update.id);
       Router.pushRoute('collective', { slug: this.props.collective.slug });
     } catch (err) {
-      console.error('>>> deleteUpdate error: ', JSON.stringify(err));
+      // TODO: this should be reported to the user
+      console.error('Update -> deleteUpdate -> error: ', err);
     }
   };
 
   save = async update => {
     update.id = get(this.props, 'update.id');
-    // console.log('>>> updating ', update);
-    // const res =
     await this.props.editUpdate(update);
-    // console.log('>>> save res', res);
     this.setState({ modified: false, mode: 'details' });
   };
 

--- a/components/StyledUpdate.js
+++ b/components/StyledUpdate.js
@@ -124,9 +124,10 @@ class StyledUpdate extends Component {
 
   save = async update => {
     update.id = get(this.props, 'update.id');
-    console.log('>>> updating ', update);
-    const res = await this.props.editUpdate(update);
-    console.log('>>> save res', res);
+    // console.log('>>> updating ', update);
+    // const res =
+    await this.props.editUpdate(update);
+    // console.log('>>> save res', res);
     this.setState({ modified: false, mode: 'details' });
   };
 

--- a/components/SubscriptionsWithData.js
+++ b/components/SubscriptionsWithData.js
@@ -22,8 +22,7 @@ class SubscriptionsWithData extends React.Component {
     const { data, LoggedInUser, subscriptions } = this.props;
 
     if (data.error) {
-      console.error('graphql error>>>', data.error.message);
-      return <Error message="GraphQL error" />;
+      return <Error message={data.error.message} />;
     }
 
     return (

--- a/components/TopBackersCoverWithData.js
+++ b/components/TopBackersCoverWithData.js
@@ -101,8 +101,7 @@ class TopBackersCoverWithData extends React.Component {
     const { data, collective } = this.props;
 
     if (data.error) {
-      console.error('graphql error>>>', data.error.message);
-      return <Error message="GraphQL error" />;
+      return <Error message={data.error.message} />;
     }
 
     if (!data.allMembers) {

--- a/components/Update.js
+++ b/components/Update.js
@@ -75,7 +75,7 @@ class Update extends React.Component {
       await this.props.deleteUpdate(this.props.update.id);
       Router.pushRoute('collective', { slug: this.props.collective.slug });
     } catch (err) {
-      console.error('>>> deleteUpdate error: ', JSON.stringify(err));
+      // console.error('>>> deleteUpdate error: ', JSON.stringify(err));
     }
   }
 
@@ -85,9 +85,10 @@ class Update extends React.Component {
 
   async save(update) {
     update.id = get(this.props, 'update.id');
-    console.log('>>> updating ', update);
-    const res = await this.props.editUpdate(update);
-    console.log('>>> save res', res);
+    // console.log('>>> updating ', update);
+    // const res =
+    await this.props.editUpdate(update);
+    // console.log('>>> save res', res);
     this.setState({ modified: false, mode: 'details' });
   }
 

--- a/components/Update.js
+++ b/components/Update.js
@@ -75,7 +75,8 @@ class Update extends React.Component {
       await this.props.deleteUpdate(this.props.update.id);
       Router.pushRoute('collective', { slug: this.props.collective.slug });
     } catch (err) {
-      // console.error('>>> deleteUpdate error: ', JSON.stringify(err));
+      // TODO: this should be reported to the user
+      console.error('Update > deleteUpdate > error: ', err);
     }
   }
 
@@ -85,10 +86,7 @@ class Update extends React.Component {
 
   async save(update) {
     update.id = get(this.props, 'update.id');
-    // console.log('>>> updating ', update);
-    // const res =
     await this.props.editUpdate(update);
-    // console.log('>>> save res', res);
     this.setState({ modified: false, mode: 'details' });
   }
 

--- a/components/UpdatesWithData.js
+++ b/components/UpdatesWithData.js
@@ -40,8 +40,7 @@ class UpdatesWithData extends React.Component {
     const { data, LoggedInUser, collective, compact, includeHostedCollectives } = this.props;
 
     if (data.error) {
-      console.error('graphql error>>>', data.error.message);
-      return <Error message="GraphQL error" />;
+      return <Error message={data.error.message} />;
     }
 
     const updates = data.allUpdates;

--- a/components/__tests__/EditEventForm.test.js
+++ b/components/__tests__/EditEventForm.test.js
@@ -34,7 +34,6 @@ describe('EditEventForm component', () => {
       .first()
       .simulate('click');
     component.find('.actions Button').simulate('click');
-    // console.log("labels", component.find('label').map(node => node.text()));
     expect(
       component
         .find('label')

--- a/components/collective-page/sections/Contributions.js
+++ b/components/collective-page/sections/Contributions.js
@@ -216,7 +216,6 @@ class SectionContributions extends React.PureComponent {
     if (data.loading) {
       return <LoadingPlaceholder height={600} borderRadius={0} />;
     } else if (!data.Collective) {
-      console.error(`Empty collective data #${collective.id} in Contributions section`);
       return (
         <Container display="flex" border="1px dashed #d1d1d1" justifyContent="center" py={[6, 7]} background="#f8f8f8">
           <MessageBox type="error" withIcon>

--- a/components/edit-collective/EditCollective.js
+++ b/components/edit-collective/EditCollective.js
@@ -89,7 +89,7 @@ class EditCollective extends React.Component {
         this.setState({ status: null });
       }, 3000);
     } catch (err) {
-      console.error('>>> editCollective error:', JSON.stringify(err));
+      // console.error('>>> editCollective error:', JSON.stringify(err));
       const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({ status: null, result: { error: errorMsg } });
     }

--- a/components/edit-collective/EditCollective.js
+++ b/components/edit-collective/EditCollective.js
@@ -89,7 +89,6 @@ class EditCollective extends React.Component {
         this.setState({ status: null });
       }, 3000);
     } catch (err) {
-      // console.error('>>> editCollective error:', JSON.stringify(err));
       const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({ status: null, result: { error: errorMsg } });
     }

--- a/components/edit-collective/EditCollectiveArchive.js
+++ b/components/edit-collective/EditCollectiveArchive.js
@@ -45,7 +45,6 @@ const ArchiveCollective = ({ collective, archiveCollective, unarchiveCollective 
         isArchived: true,
       });
     } catch (err) {
-      console.error('>>> archiveCollective error: ', JSON.stringify(err));
       const errorMsg = getErrorFromGraphqlException(err).message;
       setArchiveStatus({ ...archiveStatus, processing: false, error: errorMsg });
     }
@@ -62,7 +61,6 @@ const ArchiveCollective = ({ collective, archiveCollective, unarchiveCollective 
         isArchived: false,
       });
     } catch (err) {
-      console.error('>>> archiveCollective error: ', JSON.stringify(err));
       const errorMsg = getErrorFromGraphqlException(err).message;
       setArchiveStatus({ ...archiveStatus, processing: false, error: errorMsg });
     }

--- a/components/edit-collective/EditCollectiveDelete.js
+++ b/components/edit-collective/EditCollectiveDelete.js
@@ -41,7 +41,6 @@ const DeleteCollective = ({ collective, deleteCollective, deleteUserCollective, 
       }
       await Router.pushRoute(`/deleteCollective/confirmed?type=${collective.type}`);
     } catch (err) {
-      console.error('>>> deleteUserCollective error: ', JSON.stringify(err));
       const errorMsg = getErrorFromGraphqlException(err).message;
       setDeleteStatus({ deleting: false, error: errorMsg });
     }

--- a/components/edit-collective/EditPaymentMethods.js
+++ b/components/edit-collective/EditPaymentMethods.js
@@ -68,8 +68,6 @@ class EditPaymentMethods extends React.Component {
 
   updateBankDetails = async () => {
     if (!this.state.bankDetails) {
-      // we haven't modified anything, return
-      console.info('>>> updateBankDetails: no change to save, skipping');
       this.setState({ showCreditCardForm: false, error: null, showManualPaymentMethodForm: false, submitting: false });
       return;
     }
@@ -81,7 +79,6 @@ class EditPaymentMethods extends React.Component {
       await this.props.editCollective(CollectiveInputType);
       this.handleSuccess();
     } catch (e) {
-      console.error('>>> EditPaymentMethods > error to save collective', e);
       this.setState({ error: e.message });
     } finally {
       this.setState({ submitting: false });

--- a/components/expenses/CreateExpenseForm.js
+++ b/components/expenses/CreateExpenseForm.js
@@ -181,8 +181,9 @@ class CreateExpenseForm extends React.Component {
         loading: false,
       });
     } catch (e) {
+      // TODO: this should be reported to the user
+      console.error('CreateExpenseForm > onSubmit > error', e);
       this.setState({ loading: false });
-      console.error('CreateExpenseForm onSubmit error', e);
     }
     return false;
   }

--- a/components/expenses/Expense.js
+++ b/components/expenses/Expense.js
@@ -163,7 +163,6 @@ class Expense extends React.Component {
       this.setState({ showUnapproveModal: false });
       await this.props.refetch();
     } catch (err) {
-      console.error(err);
       this.setState({ showUnapproveModal: false, error: err.message });
     }
   };
@@ -174,7 +173,6 @@ class Expense extends React.Component {
       this.setState({ showDeleteExpenseModal: false, error: null });
       await this.props.refetch();
     } catch (err) {
-      console.error(err);
       this.setState({ showDeleteExpenseModal: false, error: err.message });
     }
   };
@@ -198,7 +196,7 @@ class Expense extends React.Component {
     const { intl, collective, host, expense, includeHostedCollectives, LoggedInUser, editable } = this.props;
 
     if (!expense.fromCollective) {
-      console.error('No FromCollective for expense', expense);
+      console.warn('No FromCollective for expense', expense);
       return <div />;
     }
 

--- a/components/expenses/ExpenseWithData.js
+++ b/components/expenses/ExpenseWithData.js
@@ -31,8 +31,7 @@ class ExpenseWithData extends React.Component {
     const { data, LoggedInUser, collective, view, allowPayAction, lockPayAction, unlockPayAction } = this.props;
 
     if (data.error) {
-      console.error('graphql error>>>', data.error.message);
-      return <Error message="GraphQL error" />;
+      return <Error message={data.error.message} />;
     } else if (data.loading) {
       return (
         <div>

--- a/components/expenses/ExpensesWithData.js
+++ b/components/expenses/ExpensesWithData.js
@@ -37,8 +37,7 @@ class ExpensesWithData extends React.Component {
     const { data, LoggedInUser, collective, host, view, includeHostedCollectives } = this.props;
 
     if (data.error) {
-      console.error('graphql error>>>', data.error.message);
-      return <Error message="GraphQL error" />;
+      return <Error message={data.error.message} />;
     }
 
     const expenses = data.allExpenses;

--- a/components/expenses/MarkExpenseAsUnpaidBtn.js
+++ b/components/expenses/MarkExpenseAsUnpaidBtn.js
@@ -31,7 +31,6 @@ const MarkExpenseAsUnpaidBtn = ({ id, markExpenseAsUnpaid, refetch, onError }) =
       await markExpenseAsUnpaid(id, state.processorFeeRefunded);
       await refetch();
     } catch (err) {
-      console.log('>>> payExpense error: ', err);
       const error = getErrorFromGraphqlException(err).message;
       onError(error);
       setState({ ...state, disableBtn: false });

--- a/components/expenses/MarkOrderAsPaidBtn.js
+++ b/components/expenses/MarkOrderAsPaidBtn.js
@@ -33,7 +33,6 @@ class MarkOrderAsPaidBtn extends React.Component {
       await this.props.markOrderAsPaid(order.id, this.state.paymentProcessorFeeInHostCurrency);
       this.setState({ loading: false });
     } catch (e) {
-      console.log('>>> markOrderAsPaid error: ', e);
       const error = e.message && e.message.replace(/GraphQL error:/, '');
       this.setState({ error, loading: false });
     }

--- a/components/expenses/Order.js
+++ b/components/expenses/Order.js
@@ -85,7 +85,6 @@ class Order extends React.Component {
         showCancelOrderModal: false,
         error: err.message,
       });
-      console.error(err);
     }
   };
 

--- a/components/expenses/OrderWithData.js
+++ b/components/expenses/OrderWithData.js
@@ -24,9 +24,10 @@ class OrderWithData extends React.Component {
   render() {
     const { data, LoggedInUser, collective, view } = this.props;
 
-    if (!data || data.error) {
-      console.error('graphql error>>>', data);
-      return <Error message="GraphQL error" />;
+    if (!data) {
+      return <Error message="Data error: no data" />;
+    } else if (data.error) {
+      return <Error message={data.error.message} />;
     } else if (data.loading) {
       return (
         <div>

--- a/components/expenses/OrdersWithData.js
+++ b/components/expenses/OrdersWithData.js
@@ -26,8 +26,7 @@ class OrdersWithData extends React.Component {
     const { data, LoggedInUser, collective, view, includeHostedCollectives, filters } = this.props;
 
     if (data.error) {
-      console.error('graphql error>>>', data.error.message);
-      return <Error message="GraphQL error" />;
+      return <Error message={data.error.message} />;
     }
 
     const orders = data.allOrders;

--- a/components/expenses/Transaction.js
+++ b/components/expenses/Transaction.js
@@ -128,7 +128,7 @@ class Transaction extends React.Component {
     } = this.props;
 
     if (!fromCollective) {
-      console.error('No FromCollective for transaction', this.props);
+      console.warn('No FromCollective for transaction', this.props);
       return <div />;
     }
 

--- a/components/expenses/TransactionsWithData.js
+++ b/components/expenses/TransactionsWithData.js
@@ -33,8 +33,7 @@ class TransactionsWithData extends React.Component {
     const { data, LoggedInUser, collective, fetchMore, showCSVlink, filters } = this.props;
 
     if (data.error) {
-      console.error('graphql error>>>', data.error.message);
-      return <Error message="GraphQL error" />;
+      return <Error message={data.error.message} />;
     }
 
     const transactions = data.allTransactions;

--- a/components/host-dashboard/HostDashboardActionsBanner.js
+++ b/components/host-dashboard/HostDashboardActionsBanner.js
@@ -94,11 +94,11 @@ class HostDashboardActionsBanner extends React.Component {
     if (form.totalAmount === 0) {
       const error = intl.formatMessage(this.messages['addFunds.error.amountMustBeGreatherThanZero']);
       this.setState({ error });
-      return console.error(error);
+      return;
     } else if (!form.FromCollectiveId) {
       const error = intl.formatMessage(this.messages.addFundsMissingFromCollective);
       this.setState({ error });
-      return console.error(error);
+      return;
     }
 
     this.setState({ loading: true });
@@ -113,7 +113,7 @@ class HostDashboardActionsBanner extends React.Component {
         error: "This host doesn't have an opencollective payment method",
         loading: false,
       });
-      return console.error('>>> payment methods: ', hostCollective.paymentMethods);
+      return;
     }
     order.paymentMethod = {
       uuid: pm.uuid,

--- a/pages/action.js
+++ b/pages/action.js
@@ -152,10 +152,10 @@ class ActionPage extends React.Component {
       this.setState({ actionTriggered: true });
       try {
         const res = await this.props[mutationName](this.props.id);
-        console.log('>>> res', JSON.stringify(res));
+        // console.log('>>> res', JSON.stringify(res));
         this.setState({ loading: false, result: res.data[mutationName] });
       } catch (error) {
-        console.log('>>> error', JSON.stringify(error));
+        // console.log('>>> error', JSON.stringify(error));
         this.setState({ loading: false, error: getErrorFromGraphqlException(error) });
       }
     }

--- a/pages/action.js
+++ b/pages/action.js
@@ -152,10 +152,8 @@ class ActionPage extends React.Component {
       this.setState({ actionTriggered: true });
       try {
         const res = await this.props[mutationName](this.props.id);
-        // console.log('>>> res', JSON.stringify(res));
         this.setState({ loading: false, result: res.data[mutationName] });
       } catch (error) {
-        // console.log('>>> error', JSON.stringify(error));
         this.setState({ loading: false, error: getErrorFromGraphqlException(error) });
       }
     }

--- a/pages/createExpense.js
+++ b/pages/createExpense.js
@@ -47,9 +47,9 @@ class CreateExpensePage extends React.Component {
       if (LoggedInUser) {
         expense.user.id = LoggedInUser.id;
       }
-      console.log('>>> createExpense', expense);
+      // console.log('>>> createExpense', expense);
       const res = await this.props.createExpense(expense);
-      console.log('>>> createExpense res', res);
+      // console.log('>>> createExpense res', res);
       const expenseCreated = res.data.createExpense;
       Router.pushRoute(`/${this.props.slug}/expenses/${expenseCreated.id}/?createSuccess=true`);
     } catch (e) {

--- a/pages/createExpense.js
+++ b/pages/createExpense.js
@@ -47,12 +47,11 @@ class CreateExpensePage extends React.Component {
       if (LoggedInUser) {
         expense.user.id = LoggedInUser.id;
       }
-      // console.log('>>> createExpense', expense);
       const res = await this.props.createExpense(expense);
-      // console.log('>>> createExpense res', res);
       const expenseCreated = res.data.createExpense;
       Router.pushRoute(`/${this.props.slug}/expenses/${expenseCreated.id}/?createSuccess=true`);
     } catch (e) {
+      // TODO: this should be reported to the user
       console.error(e);
     }
   };

--- a/pages/createOrder.js
+++ b/pages/createOrder.js
@@ -66,6 +66,7 @@ class CreateOrderPage extends React.Component {
       try {
         query.data = JSON.parse(query.data);
       } catch (err) {
+        // TODO: this should be reported to the user
         console.error(err);
       }
     }

--- a/pages/createUpdate.js
+++ b/pages/createUpdate.js
@@ -64,14 +64,11 @@ class CreateUpdatePage extends React.Component {
     } = this.props;
     try {
       update.collective = { id: Collective.id };
-      // console.log('>>> createUpdate', update);
       const res = await this.props.createUpdate(update);
-      // console.log('>>> createUpdate res', res);
       this.setState({ isModified: false });
       return Router.pushRoute(`/${Collective.slug}/updates/${res.data.createUpdate.slug}`);
     } catch (e) {
-      console.error(e);
-      this.setState({ status: 'error', error: `${e}` });
+      this.setState({ status: 'error', error: e.message });
     }
   };
 

--- a/pages/createUpdate.js
+++ b/pages/createUpdate.js
@@ -64,9 +64,9 @@ class CreateUpdatePage extends React.Component {
     } = this.props;
     try {
       update.collective = { id: Collective.id };
-      console.log('>>> createUpdate', update);
+      // console.log('>>> createUpdate', update);
       const res = await this.props.createUpdate(update);
-      console.log('>>> createUpdate res', res);
+      // console.log('>>> createUpdate res', res);
       this.setState({ isModified: false });
       return Router.pushRoute(`/${Collective.slug}/updates/${res.data.createUpdate.slug}`);
     } catch (e) {

--- a/pages/openSourceApply.js
+++ b/pages/openSourceApply.js
@@ -105,7 +105,7 @@ class OpenSourceApplyPage extends Component {
         status: 'collectiveCreated',
       });
     } catch (err) {
-      console.error('>>> createCollective error: ', JSON.stringify(err)); // TODO - Remove
+      // console.error('>>> createCollective error: ', JSON.stringify(err)); // TODO - Remove
       const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({
         creatingCollective: false,

--- a/pages/openSourceApply.js
+++ b/pages/openSourceApply.js
@@ -105,7 +105,6 @@ class OpenSourceApplyPage extends Component {
         status: 'collectiveCreated',
       });
     } catch (err) {
-      // console.error('>>> createCollective error: ', JSON.stringify(err)); // TODO - Remove
       const errorMsg = getErrorFromGraphqlException(err).message;
       this.setState({
         creatingCollective: false,

--- a/pages/redeem.js
+++ b/pages/redeem.js
@@ -109,18 +109,20 @@ class RedeemPage extends React.Component {
     this.setState({ loading: true });
     const { code, email, name } = this.state.form;
     try {
-      let res;
+      // let res;
       if (this.props.LoggedInUser) {
-        res = await this.props.claimPaymentMethod(code);
+        // res =
+        await this.props.claimPaymentMethod(code);
 
         // Refresh LoggedInUser
         this.props.refetchLoggedInUser();
         Router.pushRoute('redeemed', { code, collectiveSlug: this.props.collectiveSlug });
         return;
       } else {
-        res = await this.props.claimPaymentMethod(code, { email, name });
+        // res =
+        await this.props.claimPaymentMethod(code, { email, name });
       }
-      console.log('>>> res graphql: ', JSON.stringify(res, null, '  '));
+      // console.log('>>> res graphql: ', JSON.stringify(res, null, '  '));
       // TODO: need to know from API if an account was created or not
       // TODO: or refuse to create an account automatically and ask to sign in
       this.setState({ loading: false, view: 'success' });
@@ -128,7 +130,7 @@ class RedeemPage extends React.Component {
       const error = getErrorFromGraphqlException(e).message;
       this.setState({ loading: false, error });
       // console.log(">>> error graphql: ", JSON.stringify(error, null, '  '));
-      console.log('>>> error graphql: ', error);
+      // console.log('>>> error graphql: ', error);
     }
   }
 

--- a/pages/redeem.js
+++ b/pages/redeem.js
@@ -109,9 +109,7 @@ class RedeemPage extends React.Component {
     this.setState({ loading: true });
     const { code, email, name } = this.state.form;
     try {
-      // let res;
       if (this.props.LoggedInUser) {
-        // res =
         await this.props.claimPaymentMethod(code);
 
         // Refresh LoggedInUser
@@ -119,18 +117,14 @@ class RedeemPage extends React.Component {
         Router.pushRoute('redeemed', { code, collectiveSlug: this.props.collectiveSlug });
         return;
       } else {
-        // res =
         await this.props.claimPaymentMethod(code, { email, name });
       }
-      // console.log('>>> res graphql: ', JSON.stringify(res, null, '  '));
       // TODO: need to know from API if an account was created or not
       // TODO: or refuse to create an account automatically and ask to sign in
       this.setState({ loading: false, view: 'success' });
     } catch (e) {
       const error = getErrorFromGraphqlException(e).message;
       this.setState({ loading: false, error });
-      // console.log(">>> error graphql: ", JSON.stringify(error, null, '  '));
-      // console.log('>>> error graphql: ', error);
     }
   }
 


### PR DESCRIPTION
I think it's better when we don't have any noise by default, make it easier to find the real warnings and errors that require attention.

While working on our E2E setup, I started removing console.logs to have a cleaner output. Going the extra mile with this PR.