### PR TITLE
Deployment: stop caching build folders on heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -240,9 +240,5 @@
     "*.{js,json,md,graphql}": [
       "prettier --write"
     ]
-  },
-  "cacheDirectories": [
-    "node_modules",
-    ".next/cache"
-  ]
+  }
 }


### PR DESCRIPTION
We're reaching the 500MB limit with this strategy because `.next/cache` is always growing.