### PR TITLE
feat(homepage): add missing navigation in OC users carousel

### DIFF
--- a/components/home/sections/OCUsers.js
+++ b/components/home/sections/OCUsers.js
@@ -95,7 +95,7 @@ const User = ({ id, name, picture, type, collectivePath }) => {
         >
           {type}
         </P>
-        <Box width={id === 'opensource' ? '150px' : null} mb={[2, null, 4]}>
+        <Box width={[null, null, id === 'opensource' ? '150px' : null]} mb={[2, null, 4]}>
           <P
             fontSize={['H5', null, 'H4', null, 'H3']}
             lineHeight={['28px', null, 'H4', null, '40px']}
@@ -147,7 +147,7 @@ const OCUsers = () => {
           </HomeStandardLink>
         </Box>
       </Container>
-      <StyledCarousel showArrowController={false} options={users} display={[null, null, 'none']} width={1}>
+      <StyledCarousel options={users} display={[null, null, 'none']} width={1}>
         {users.map(user => (
           <User key={user.id} {...user} />
         ))}


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/2889

<img width="323" alt="Screenshot 2020-02-07 at 11 31 00 AM" src="https://user-images.githubusercontent.com/15707013/74022486-ee01a600-499d-11ea-9427-d2fc6406d27f.png">
