### PR TITLE
Restore ability for collectives to edit expense policy

### DIFF
--- a/components/edit-collective/MenuEditCollective.js
+++ b/components/edit-collective/MenuEditCollective.js
@@ -124,7 +124,7 @@ const isFeatureAllowed = feature => ({ type }) => isFeatureAllowedForCollectiveT
 const sectionsDisplayConditions = {
   [EDIT_COLLECTIVE_SECTIONS.COLLECTIVE_GOALS]: isType(CollectiveType.COLLECTIVE),
   [EDIT_COLLECTIVE_SECTIONS.CONVERSATIONS]: isFeatureAllowed(FEATURES.CONVERSATIONS),
-  [EDIT_COLLECTIVE_SECTIONS.EXPENSES]: () => false,
+  [EDIT_COLLECTIVE_SECTIONS.EXPENSES]: isType(CollectiveType.COLLECTIVE),
   [EDIT_COLLECTIVE_SECTIONS.EXPORT]: isType(CollectiveType.COLLECTIVE),
   [EDIT_COLLECTIVE_SECTIONS.HOST]: isType(CollectiveType.COLLECTIVE),
   [EDIT_COLLECTIVE_SECTIONS.HOST_SETTINGS]: () => false,
@@ -173,8 +173,7 @@ const MenuEditCollective = ({ collective, selectedSection }) => {
       {collective.isHost && (
         <React.Fragment>
           <MenuDivider />
-          {collective.type === CollectiveType.COLLECTIVE &&
-            renderMenuItem(getSectionInfo(EDIT_COLLECTIVE_SECTIONS.EXPENSES))}
+          {renderMenuItem(getSectionInfo(EDIT_COLLECTIVE_SECTIONS.EXPENSES))}
           {renderMenuItem(getSectionInfo(EDIT_COLLECTIVE_SECTIONS.HOST_SETTINGS))}
           {renderMenuItem(getSectionInfo(EDIT_COLLECTIVE_SECTIONS.INVOICES))}
         </React.Fragment>


### PR DESCRIPTION
https://github.com/opencollective/opencollective-frontend/pull/3222/files#diff-620ed3652e34f7aadd64cfa8b27ac2efR127 made the section disappear for collectives. Expense policy can be edited both at the host and at the collective level (we merge them when displaying to the users). 