### PR TITLE
CollectivePage > Contribute: enable scroll snapping

### DIFF
--- a/components/collective-page/ContributeCardsContainer.js
+++ b/components/collective-page/ContributeCardsContainer.js
@@ -8,6 +8,7 @@ const ContributeCardsContainer = styled.div`
   padding: 16px 0;
   overflow-x: auto;
   scroll-behavior: smooth;
+  scroll-snap-type: x mandatory;
 
   ${CustomScrollbarCSS}
 

--- a/components/collective-page/sections/Contribute.js
+++ b/components/collective-page/sections/Contribute.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import { Flex, Box } from '@rebass/grid';
 import memoizeOne from 'memoize-one';
 import { orderBy } from 'lodash';
+import styled from 'styled-components';
+import css from '@styled-system/css';
 
 import { CollectiveType } from '../../../lib/constants/collectives';
 import { TierTypes } from '../../../lib/constants/tiers-types';
@@ -24,6 +26,12 @@ import TopContributors from '../TopContributors';
 import SectionTitle from '../SectionTitle';
 
 const CONTRIBUTE_CARD_PADDING_X = [15, 18];
+
+const ContributeCardContainer = styled(Box).attrs({ px: CONTRIBUTE_CARD_PADDING_X })(
+  css({
+    scrollSnapAlign: ['center', null, 'start'],
+  }),
+);
 
 /**
  * The contribute section, implemented as a pure component to avoid unnecessary
@@ -175,7 +183,7 @@ class SectionContribute extends React.PureComponent {
                   </ContainerSectionContent>
 
                   <ContributeCardsContainer ref={ref}>
-                    <Box px={CONTRIBUTE_CARD_PADDING_X}>
+                    <ContributeCardContainer>
                       <ContributeCustom
                         collective={collective}
                         contributors={financialContributorsWithoutTier}
@@ -183,23 +191,23 @@ class SectionContribute extends React.PureComponent {
                         hideContributors={hasNoContributor}
                         disableCTA={!collective.isActive}
                       />
-                    </Box>
+                    </ContributeCardContainer>
                     {sortedTiers.map(tier => (
-                      <Box key={tier.id} px={CONTRIBUTE_CARD_PADDING_X}>
+                      <ContributeCardContainer key={tier.id}>
                         <ContributeTier
                           collective={collective}
                           tier={tier}
                           hideContributors={hasNoContributor}
                           disableCTA={!collective.isActive}
                         />
-                      </Box>
+                      </ContributeCardContainer>
                     ))}
                     {isAdmin && (
-                      <Box px={CONTRIBUTE_CARD_PADDING_X}>
+                      <ContributeCardContainer>
                         <CreateNew data-cy="create-contribute-tier" route={createContributionTierRoute}>
                           <FormattedMessage id="Contribute.CreateTier" defaultMessage="Create Contribution Tier" />
                         </CreateNew>
-                      </Box>
+                      </ContributeCardContainer>
                     )}
                   </ContributeCardsContainer>
                 </div>

--- a/components/collective-page/sections/Tickets.js
+++ b/components/collective-page/sections/Tickets.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import { Flex, Box } from '@rebass/grid';
 import memoizeOne from 'memoize-one';
 import { orderBy } from 'lodash';
+import styled from 'styled-components';
+import css from '@styled-system/css';
 
 import { CollectiveType } from '../../../lib/constants/collectives';
 import { TierTypes } from '../../../lib/constants/tiers-types';
@@ -16,6 +18,12 @@ import ContainerSectionContent from '../ContainerSectionContent';
 import SectionTitle from '../SectionTitle';
 
 const CONTRIBUTE_CARD_PADDING_X = [15, 18];
+
+const ContributeCardContainer = styled(Box).attrs({ px: CONTRIBUTE_CARD_PADDING_X })(
+  css({
+    scrollSnapAlign: ['center', null, 'start'],
+  }),
+);
 
 /**
  * The tickets section, implemented as a pure component to avoid unnecessary
@@ -96,21 +104,21 @@ class SectionTickets extends React.PureComponent {
 
                 <ContributeCardsContainer ref={ref}>
                   {sortedTiers.map(tier => (
-                    <Box key={tier.id} px={CONTRIBUTE_CARD_PADDING_X}>
+                    <ContributeCardContainer key={tier.id}>
                       <ContributeTier
                         collective={collective}
                         tier={tier}
                         hideContributors={hasNoContributor}
                         disableCTA={!collective.isActive}
                       />
-                    </Box>
+                    </ContributeCardContainer>
                   ))}
                   {isAdmin && (
-                    <Box px={CONTRIBUTE_CARD_PADDING_X} minHeight={150}>
+                    <ContributeCardContainer minHeight={150}>
                       <CreateNew route={`/${collective.parentCollective.slug}/events/${collective.slug}/edit#tiers`}>
                         <FormattedMessage id="SectionTickets.CreateTicket" defaultMessage="Create Ticket" />
                       </CreateNew>
-                    </Box>
+                    </ContributeCardContainer>
                   )}
                 </ContributeCardsContainer>
               </div>


### PR DESCRIPTION
I recently learned about [CSS scroll snapping](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-type) and thought it may improve the experience on the collective page, especially on mobile. It basically ensures that cards always end up at the center of the screen when scrolled.

It's pretty easy to use, so we should probably consider it whenever we implement a list scrollable horizontally.

![Peek 11-02-2020 10-17](https://user-images.githubusercontent.com/1556356/74223787-bf464100-4cb7-11ea-9924-718bd0aaee56.gif)
