### PR TITLE
fix(Map): fix map zoom

### DIFF
--- a/components/Map.js
+++ b/components/Map.js
@@ -4,6 +4,7 @@ import ExternalLink from './ExternalLink';
 import { FormattedMessage } from 'react-intl';
 
 const tile2Long = (tile, zoom) => {
+  // see https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#ECMAScript_.28JavaScript.2FActionScript.2C_etc..29
   return (tile / Math.pow(2, zoom)) * 360 - 180;
 };
 
@@ -24,6 +25,7 @@ const lat2tile = (lat, zoom) => {
 };
 
 const makeBbox = ({ x, y, zoom }) => {
+  // https://wiki.openstreetmap.org/wiki/Slippy_Map
   const south = tile2Lat(y + 1, zoom);
   const north = tile2Lat(y, zoom);
   const west = tile2Long(x, zoom);
@@ -40,6 +42,8 @@ const Map = ({ lat, long }) => {
     const x = long2tile(long, zoom);
     const y = lat2tile(lat, zoom);
     const bbox = makeBbox({ x, y, zoom });
+
+    // Set iframe url after component has mounted to prevent https://github.com/opencollective/opencollective/issues/2845
     const src = `https://www.openstreetmap.org/export/embed.html?bbox=${bbox}&marker=${lat}%2C${long}&layers=ND`;
 
     prepareMap(src);

--- a/components/Map.js
+++ b/components/Map.js
@@ -1,49 +1,67 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import ExternalLink from './ExternalLink';
 import { FormattedMessage } from 'react-intl';
 
-class Map extends React.Component {
-  static propTypes = {
-    lat: PropTypes.number,
-    long: PropTypes.number,
-    address: PropTypes.string,
-  };
+const tile2Long = (tile, zoom) => {
+  return (tile / Math.pow(2, zoom)) * 360 - 180;
+};
 
-  onMapCreated(map) {
-    map.setOptions({
-      disableDefaultUI: false,
-    });
-  }
+const tile2Lat = (tile, zoom) => {
+  const n = Math.PI - (2 * Math.PI * tile) / Math.pow(2, zoom);
+  return (180 / Math.PI) * Math.atan(0.5 * (Math.exp(n) - Math.exp(-n)));
+};
 
-  makeBbox(long, lat, zoomValue) {
-    return [long - zoomValue, lat - zoomValue, long + zoomValue, lat + zoomValue];
-  }
+const long2tile = (long, zoom) => {
+  return Math.floor(((long + 180) / 360) * Math.pow(2, zoom));
+};
 
-  render() {
-    const { lat, long } = this.props;
-    const bbox = this.makeBbox(long, lat, 0.003);
+const lat2tile = (lat, zoom) => {
+  return Math.floor(
+    ((1 - Math.log(Math.tan((lat * Math.PI) / 180) + 1 / Math.cos((lat * Math.PI) / 180)) / Math.PI) / 2) *
+      Math.pow(2, zoom),
+  );
+};
 
-    return (
-      <div style={{ width: '100%', height: '100%' }}>
-        <iframe
-          width={'100%'}
-          height={'100%'}
-          frameBorder="0"
-          scrolling="no"
-          src={`https://www.openstreetmap.org/export/embed.html?bbox=${bbox}&marker=${lat}%2C${long}&layers=ND`}
-        ></iframe>
-        <br />
+const makeBbox = ({ x, y, zoom }) => {
+  const south = tile2Lat(y + 1, zoom);
+  const north = tile2Lat(y, zoom);
+  const west = tile2Long(x, zoom);
+  const east = tile2Long(x + 1, zoom);
 
-        <ExternalLink
-          openInNewTab
-          href={`https://www.openstreetmap.org/?mlat=${lat}&amp;mlon=${long}#map=16/${lat}/${long}`}
-        >
-          <FormattedMessage id="map.viewLarger" defaultMessage="View Larger Map" />
-        </ExternalLink>
-      </div>
-    );
-  }
-}
+  return `${west}%2C${south}%2C${east}%2C${north}`;
+};
+
+const Map = ({ lat, long }) => {
+  const [src, prepareMap] = useState(null);
+
+  useEffect(() => {
+    const zoom = 16;
+    const x = long2tile(long, zoom);
+    const y = lat2tile(lat, zoom);
+    const bbox = makeBbox({ x, y, zoom });
+    const src = `https://www.openstreetmap.org/export/embed.html?bbox=${bbox}&marker=${lat}%2C${long}&layers=ND`;
+
+    prepareMap(src);
+  }, [lat, long]);
+
+  return (
+    <div style={{ width: '100%', height: '100%' }}>
+      <iframe width="100%" height="100%" frameBorder="0" scrolling="no" src={src}></iframe>
+      <ExternalLink
+        openInNewTab
+        href={`https://www.openstreetmap.org/?mlat=${lat}&amp;mlon=${long}#map=16/${lat}/${long}`}
+      >
+        <FormattedMessage id="map.viewLarger" defaultMessage="View Larger Map" />
+      </ExternalLink>
+    </div>
+  );
+};
+
+Map.propTypes = {
+  lat: PropTypes.number,
+  long: PropTypes.number,
+  address: PropTypes.string,
+};
 
 export default Map;


### PR DESCRIPTION
    - makeBbox:
        * calculate boundingbox [south, north, west, east] using long,
          lat, zoom.

    issue #2845

<!-- If there's an issue associated with this pull request, add it here -->

Resolve [#2845](https://github.com/opencollective/opencollective/issues/2845)

# Description
* Fixes weird map zoom behaviour by _properly_ [calculating](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Tile_bounding_box) the [BoundingBox](https://wiki.openstreetmap.org/wiki/Bounding_Box).
<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->


