### PR TITLE
(Fix) Fix hanging loading screen on update payment page

### DIFF
--- a/pages/updatePaymentMethod.js
+++ b/pages/updatePaymentMethod.js
@@ -147,17 +147,7 @@ class UpdatePaymentPage extends React.Component {
     const { showCreditCardForm, submitting } = this.state;
     const { LoggedInUser, loadingLoggedInUser, data } = this.props;
 
-    if (!data || (data && data.loading) || loadingLoggedInUser) {
-      return (
-        <Page>
-          <Flex justifyContent="center" py={6}>
-            <Loading />
-          </Flex>
-        </Page>
-      );
-    } else if (data && data.error) {
-      return <ErrorPage data={data} />;
-    } else if (!LoggedInUser) {
+    if (!LoggedInUser && !loadingLoggedInUser) {
       return (
         <Page>
           <Flex justifyContent="center" p={5}>
@@ -165,6 +155,18 @@ class UpdatePaymentPage extends React.Component {
           </Flex>
         </Page>
       );
+    } else if (loadingLoggedInUser || (data && data.loading)) {
+      return (
+        <Page>
+          <Flex justifyContent="center" py={6}>
+            <Loading />
+          </Flex>
+        </Page>
+      );
+    } else if (!data) {
+      return <ErrorPage />;
+    } else if (data && data.error) {
+      return <ErrorPage data={data} />;
     }
 
     const filteredSubscriptions = this.props.subscriptions.filter(


### PR DESCRIPTION
Due to a bug, this was happening with the update payment page:

* If the user was not logged in, the page hung on the loading indicator rather than moving on to the sign in prompt

This was due to the conditions under which we were skipping the `addSubscriptionsData` GraphQL query. If we commented the skip out completely, though, then the page would load but the user's subscriptions attached to the payment method would not.

By removing one of the conditions the skip was checking, we fix it so that:

* If the user is logged in, we wait for the subscription data before we load the page
* If the user is not logged in, we skip the query and go on to display the sign in prompt