### PR TITLE
GiftCards: Skip cache when fetching payment methods

### DIFF
--- a/components/CreateVirtualCardsForm.js
+++ b/components/CreateVirtualCardsForm.js
@@ -681,7 +681,10 @@ export const getCollectiveSourcePaymentMethodsQuery = gql`
 `;
 
 const addData = graphql(getCollectiveSourcePaymentMethodsQuery, {
-  options: props => ({ variables: { id: props.collectiveId } }),
+  options: props => ({
+    variables: { id: props.collectiveId },
+    fetchPolicy: 'network-only',
+  }),
 });
 
 const createVirtualCardsMutationQuery = gql`


### PR DESCRIPTION
Before this PR you needed to refresh the new gift cards form after adding a payment method to see it added