### PR TITLE
fix: gracefully handle google domain block

### DIFF
--- a/components/InputTypeLocation.js
+++ b/components/InputTypeLocation.js
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Geosuggest from 'react-geosuggest';
 import classNames from 'classnames';
 import Location from './Location';
+import MessageBox from './MessageBox';
+import { FormattedMessage } from 'react-intl';
+import { get } from 'lodash';
 
 class InputTypeLocation extends React.Component {
   static propTypes = {
@@ -54,8 +57,13 @@ class InputTypeLocation extends React.Component {
     return this.props.onChange(location);
   }
 
+  isAutocompleteServiceAvailable() {
+    return window && Boolean(get(window, 'google.maps.places.AutocompleteService'));
+  }
+
   render() {
     const options = this.props.options || {};
+    const autoCompleteNotAvailable = !this.isAutocompleteServiceAvailable();
 
     return (
       <div className={classNames('InputTypeLocation', this.props.className)}>
@@ -131,12 +139,26 @@ class InputTypeLocation extends React.Component {
             }
           `}
         </style>
-        <Geosuggest
-          onSuggestSelect={event => this.handleChange(event)}
-          placeholder={this.props.placeholder}
-          {...options}
-        />
-        <Location location={this.state.value} showTitle={false} />
+        {autoCompleteNotAvailable ? (
+          <MessageBox withIcon type="warning">
+            <FormattedMessage
+              id="location.googleAutocompleteService.unavailable"
+              values={{ service: 'Google Autocomplete Service', domain: 'maps.googleapis.com' }}
+              defaultMessage={
+                'Location field requires "{service}" to function properly.\n Make sure "{domain}" is not blocked by your browser.'
+              }
+            />
+          </MessageBox>
+        ) : (
+          <Fragment>
+            <Geosuggest
+              onSuggestSelect={event => this.handleChange(event)}
+              placeholder={this.props.placeholder}
+              {...options}
+            />
+            <Location location={this.state.value} showTitle={false} />
+          </Fragment>
+        )}
       </div>
     );
   }

--- a/lang/en.json
+++ b/lang/en.json
@@ -797,6 +797,7 @@
   "Invitation.Declined": "Declined",
   "loading": "loading",
   "loadMore": "load more",
+  "location.googleAutocompleteService.unavailable": "Location field requires \"{service}\" to function properly.\n Make sure \"{domain}\" is not blocked by your browser.",
   "loggingout": "logging out",
   "login.askAnother": "You can ask for a new sign in link using the form below.",
   "login.failed": "Sign In failed: {message}.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -797,6 +797,7 @@
   "Invitation.Declined": "Declined",
   "loading": "cargando",
   "loadMore": "cargar más",
+  "location.googleAutocompleteService.unavailable": "Location field requires \"{service}\" to function properly.\n Make sure \"{domain}\" is not blocked by your browser.",
   "loggingout": "desconectando",
   "login.askAnother": "Puede solicitar un nuevo enlace de inicio de sesión utilizando el siguiente formulario.",
   "login.failed": "Registro fallido: {message}.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -797,6 +797,7 @@
   "Invitation.Declined": "Refusée",
   "loading": "chargement",
   "loadMore": "voir plus",
+  "location.googleAutocompleteService.unavailable": "Location field requires \"{service}\" to function properly.\n Make sure \"{domain}\" is not blocked by your browser.",
   "loggingout": "se déconnecter",
   "login.askAnother": "Vous pouvez demander un nouveau lien en utilisant le formulaire ci-dessous.",
   "login.failed": "Connexion échouée : {message}.",

--- a/lang/it.json
+++ b/lang/it.json
@@ -797,6 +797,7 @@
   "Invitation.Declined": "Declined",
   "loading": "caricamento",
   "loadMore": "carica altro",
+  "location.googleAutocompleteService.unavailable": "Location field requires \"{service}\" to function properly.\n Make sure \"{domain}\" is not blocked by your browser.",
   "loggingout": "logging out",
   "login.askAnother": "You can ask for a new sign in link using the form below.",
   "login.failed": "Sign In failed: {message}.",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -797,6 +797,7 @@
   "Invitation.Declined": "辞退済",
   "loading": "読み込み中",
   "loadMore": "もっと見る",
+  "location.googleAutocompleteService.unavailable": "Location field requires \"{service}\" to function properly.\n Make sure \"{domain}\" is not blocked by your browser.",
   "loggingout": "ログアウト",
   "login.askAnother": "You can ask for a new sign in link using the form below.",
   "login.failed": "ログインに失敗しました: {message}",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -797,6 +797,7 @@
   "Invitation.Declined": "Declined",
   "loading": "loading",
   "loadMore": "load more",
+  "location.googleAutocompleteService.unavailable": "Location field requires \"{service}\" to function properly.\n Make sure \"{domain}\" is not blocked by your browser.",
   "loggingout": "logging out",
   "login.askAnother": "You can ask for a new sign in link using the form below.",
   "login.failed": "Sign In failed: {message}.",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -797,6 +797,7 @@
   "Invitation.Declined": "Recusado",
   "loading": "carregando",
   "loadMore": "carregar mais",
+  "location.googleAutocompleteService.unavailable": "Location field requires \"{service}\" to function properly.\n Make sure \"{domain}\" is not blocked by your browser.",
   "loggingout": "saindo",
   "login.askAnother": "Você pode pedir um novo link para entrar usando o formulário abaixo.",
   "login.failed": "Falha no login: {message}.",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -797,6 +797,7 @@
   "Invitation.Declined": "Declined",
   "loading": "загрузка",
   "loadMore": "загрузить ещё",
+  "location.googleAutocompleteService.unavailable": "Location field requires \"{service}\" to function properly.\n Make sure \"{domain}\" is not blocked by your browser.",
   "loggingout": "выйти",
   "login.askAnother": "You can ask for a new sign in link using the form below.",
   "login.failed": "Выход не удался: {message}.",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -797,6 +797,7 @@
   "Invitation.Declined": "Declined",
   "loading": "loading",
   "loadMore": "load more",
+  "location.googleAutocompleteService.unavailable": "Location field requires \"{service}\" to function properly.\n Make sure \"{domain}\" is not blocked by your browser.",
   "loggingout": "注销",
   "login.askAnother": "You can ask for a new sign in link using the form below.",
   "login.failed": "Sign In failed: {message}.",


### PR DESCRIPTION
    - display helpful error message if google.AutocompleteService is not avaliable.
    - update langs for error message.
    re #1819

<!-- If there's an issue associated with this pull request, add it here -->

Resolve [#1819](https://github.com/opencollective/opencollective/issues/1819)

# Description
Display Error message when google autocompleteService is not available. 

## Test
use `ublock` or `no-script` to block `maps.googleapis.com` and hard reload page.
<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots
<img width="744" alt="Screenshot 2020-02-17 at 15 12 11" src="https://user-images.githubusercontent.com/29008971/74661497-5a4b8900-5198-11ea-8039-90b06bbb0010.png">


<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
