### PR TITLE
Add missing Expense Status Filters

### DIFF
--- a/components/expenses/Expenses.js
+++ b/components/expenses/Expenses.js
@@ -156,6 +156,22 @@ class Expenses extends React.Component {
                 <FormattedMessage id="expenses.ready" defaultMessage="ready to pay" />
               </Button>
               <Button
+                className="filterBtn processing"
+                bsSize="small"
+                bsStyle={status === 'PROCESSING' ? 'primary' : 'default'}
+                onClick={() => updateVariables({ status: 'PROCESSING' })}
+              >
+                <FormattedMessage id="expenses.processing" defaultMessage="processing" />
+              </Button>
+              <Button
+                className="filterBtn error"
+                bsSize="small"
+                bsStyle={status === 'ERROR' ? 'primary' : 'default'}
+                onClick={() => updateVariables({ status: 'ERROR' })}
+              >
+                <FormattedMessage id="expenses.error" defaultMessage="error" />
+              </Button>
+              <Button
                 className="filterBtn paid"
                 bsSize="small"
                 bsStyle={status === 'PAID' ? 'primary' : 'default'}

--- a/lang/en.json
+++ b/lang/en.json
@@ -628,6 +628,8 @@
   "expenses.create.archived": "Cannot submit expenses for an archived collective.",
   "expenses.create.login": "Sign up or login to submit an expense.",
   "expenses.empty": "No expenses",
+  "expenses.error": "error",
+  "expenses.processing": "processing",
   "expenses.ready": "ready to pay",
   "expenses.sendAnotherExpense": "Submit Another Expense",
   "expenses.stats.byCategory.title": "By category",

--- a/lang/es.json
+++ b/lang/es.json
@@ -628,6 +628,8 @@
   "expenses.create.archived": "Cannot submit expenses for an archived collective.",
   "expenses.create.login": "Regístrese o acredítese para enviar un gasto.",
   "expenses.empty": "No expenses",
+  "expenses.error": "error",
+  "expenses.processing": "processing",
   "expenses.ready": "listo para pagar",
   "expenses.sendAnotherExpense": "Enviar otro gasto",
   "expenses.stats.byCategory.title": "Por categoría",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -628,6 +628,8 @@
   "expenses.create.archived": "Ce Collectif est archivé, vous ne pouvez pas soumettre de dépense.",
   "expenses.create.login": "Créez un compte ou identifiez-vous pour pouvoir ajouter une dépense.",
   "expenses.empty": "Pas de dépenses",
+  "expenses.error": "error",
+  "expenses.processing": "processing",
   "expenses.ready": "prêt à payer",
   "expenses.sendAnotherExpense": "Ajouter une autre dépense",
   "expenses.stats.byCategory.title": "Par catégorie",

--- a/lang/it.json
+++ b/lang/it.json
@@ -628,6 +628,8 @@
   "expenses.create.archived": "Cannot submit expenses for an archived collective.",
   "expenses.create.login": "Sign up or login to submit an expense.",
   "expenses.empty": "No expenses",
+  "expenses.error": "error",
+  "expenses.processing": "processing",
   "expenses.ready": "pronto a pagare",
   "expenses.sendAnotherExpense": "Invia un'altra spesa",
   "expenses.stats.byCategory.title": "Per categoria",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -628,6 +628,8 @@
   "expenses.create.archived": "Cannot submit expenses for an archived collective.",
   "expenses.create.login": "アカウントを作成するかログインして請求の送信をしてください。",
   "expenses.empty": "請求がありません",
+  "expenses.error": "error",
+  "expenses.processing": "processing",
   "expenses.ready": "支払う準備ができています",
   "expenses.sendAnotherExpense": "ほかの経費を申請する",
   "expenses.stats.byCategory.title": "カテゴリ",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -628,6 +628,8 @@
   "expenses.create.archived": "Cannot submit expenses for an archived collective.",
   "expenses.create.login": "Sign up or login to submit an expense.",
   "expenses.empty": "No expenses",
+  "expenses.error": "error",
+  "expenses.processing": "processing",
   "expenses.ready": "ready to pay",
   "expenses.sendAnotherExpense": "Submit Another Expense",
   "expenses.stats.byCategory.title": "By category",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -628,6 +628,8 @@
   "expenses.create.archived": "Não é possível enviar despesas para um Coletivo arquivado.",
   "expenses.create.login": "Cadastre-se ou entre para enviar uma despesa.",
   "expenses.empty": "Sem despesas",
+  "expenses.error": "error",
+  "expenses.processing": "processing",
   "expenses.ready": "pronto para pagar",
   "expenses.sendAnotherExpense": "Enviar outra despesa",
   "expenses.stats.byCategory.title": "Por categoria",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -628,6 +628,8 @@
   "expenses.create.archived": "Cannot submit expenses for an archived collective.",
   "expenses.create.login": "Зарегистрируйтесь или войдите, чтобы учесть расходы.",
   "expenses.empty": "Нет расходов",
+  "expenses.error": "error",
+  "expenses.processing": "processing",
   "expenses.ready": "готово к оплате",
   "expenses.sendAnotherExpense": "Добавить новый Расход",
   "expenses.stats.byCategory.title": "По категории",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -628,6 +628,8 @@
   "expenses.create.archived": "Cannot submit expenses for an archived collective.",
   "expenses.create.login": "Sign up or login to submit an expense.",
   "expenses.empty": "No expenses",
+  "expenses.error": "error",
+  "expenses.processing": "processing",
   "expenses.ready": "ready to pay",
   "expenses.sendAnotherExpense": "Submit Another Expense",
   "expenses.stats.byCategory.title": "By category",


### PR DESCRIPTION
Fixes: https://github.com/opencollective/opencollective/issues/2921

Added both new statuses as filters, I think it will be very useful to list which orders are still being processed and which didn't go through since it may require manual intervention.