### PR TITLE
Fix Expense filters ButtonGroup's max-width bug

### DIFF
--- a/components/expenses/Expenses.js
+++ b/components/expenses/Expenses.js
@@ -84,7 +84,7 @@ class Expenses extends React.Component {
               text-align: center;
             }
             .filter {
-              max-width: 500px;
+              max-width: 600px;
               width: 100%;
               margin: 0 auto;
               margin-bottom: 20px;


### PR DESCRIPTION
Borders are being cut out after the two new buttons were added.
![image](https://user-images.githubusercontent.com/2119706/74755603-29c82580-5252-11ea-94ae-302728c31f28.png)
