### PR TITLE
WIP: test(e2e tests): getting rid of .click({force: true}); 

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,5 @@
 {
-  "viewportWidth": 1000,
+  "viewportWidth": 1200,
   "viewportHeight": 1660,
   "projectId": "yt5kwm",
   "defaultCommandTimeout": 15000,

--- a/test/cypress/integration/04-collective_v2.test.js
+++ b/test/cypress/integration/04-collective_v2.test.js
@@ -61,7 +61,7 @@ describe('New collective page', () => {
     it('Can edit primary color', () => {
       let color = null;
 
-      cy.get('[data-cy=edit-collective-display-features] [data-cy=edit-main-color-btn]').click({ force: true });
+      cy.get('[data-cy=edit-collective-display-features] [data-cy=edit-main-color-btn]').click();
       cy.get('[data-cy=collective-color-picker-card] [data-cy=collective-color-picker-options-btn]').then($colorBtn => {
         const randomPick = Math.round(Math.random() * $colorBtn.length);
         const withFailSafe = $colorBtn[randomPick] || $colorBtn[0];
@@ -77,7 +77,7 @@ describe('New collective page', () => {
     });
 
     it('Can change cover background image', () => {
-      cy.get('[data-cy=edit-collective-display-features] [data-cy=edit-cover-btn]').click({ force: true });
+      cy.get('[data-cy=edit-collective-display-features] [data-cy=edit-cover-btn]').click();
       uploadImage({
         dropzone: '[data-cy=heroBackgroundDropzone]',
         fileName: 'gopherBack.png',

--- a/test/cypress/integration/04-organization_v2.test.js
+++ b/test/cypress/integration/04-organization_v2.test.js
@@ -3,7 +3,7 @@ describe('New organization profile', () => {
    * Contributions section is already tested in `05-user_v2.test.js`
    * About section is already tested in `04-collective_v2.test.js`
    */
-  before(() => {
+  beforeEach(() => {
     cy.createCollective({ type: 'ORGANIZATION' }).then(collective => {
       const collectiveSlug = collective.slug;
       cy.visit(`/${collectiveSlug}/`);

--- a/test/cypress/integration/04-organization_v2.test.js
+++ b/test/cypress/integration/04-organization_v2.test.js
@@ -12,7 +12,7 @@ describe('New organization profile', () => {
   describe('Contributors section', () => {
     it('Only shows core contributors without any filter', () => {
       cy.getByDataCy('filters').should('not.exist');
-      cy.getByDataCy('section-contributors').click({ force: true });
+      cy.getByDataCy('section-contributors').click();
       cy.hash().should('eq', '#section-contributors');
       cy.getByDataCy('section-contributors-title').contains('Core contributors');
       cy.getByDataCy('ContributorsGrid_ContributorCard').contains('Collective Admin');
@@ -23,7 +23,7 @@ describe('New organization profile', () => {
     // The rest of the transactions section tests are in `05-user_v2.test.js`
     it("Has no filters (because organizations don't have expenses)", () => {
       cy.getByDataCy('filters').should('not.exist');
-      cy.getByDataCy('section-transactions').click({ force: true });
+      cy.getByDataCy('section-transactions').click();
       cy.hash().should('eq', '#section-transactions');
       cy.contains('h2', 'Transactions');
       cy.contains('No transaction yet');

--- a/test/cypress/integration/05-user_v2.test.js
+++ b/test/cypress/integration/05-user_v2.test.js
@@ -4,7 +4,7 @@ describe('New users profiles', () => {
   });
   describe('Contributions section', () => {
     it('Shows contributions with date since and amount contributed', () => {
-      cy.get('[data-cy=section-contributions]').click({ force: true });
+      cy.get('[data-cy=section-contributions]').click();
       cy.hash().should('eq', '#section-contributions');
       cy.get('[data-cy=section-contributions-title]').contains('Contributions');
       cy.get('[data-cy=contribution-date-since]')
@@ -27,17 +27,17 @@ describe('New users profiles', () => {
 
     it('Can filter by contribution type (admin, financial...etc)', () => {
       cy.get('[data-cy=filters]');
-      cy.get('[data-cy="filter-button core"]').click({ force: true });
+      cy.get('[data-cy="filter-button core"]').click();
       cy.get('[data-cy=collective-contribution]')
         .first()
         .get('[data-cy=caption]')
         .contains('Collective Admin since');
-      cy.get('[data-cy="filter-button financial"]').click({ force: true });
+      cy.get('[data-cy="filter-button financial"]').click();
       cy.get('[data-cy=collective-contribution]')
         .first()
         .get('[data-cy=caption]')
         .contains('Financial Contributor since');
-      cy.get('[data-cy="filter-button events"]').click({ force: true });
+      cy.get('[data-cy="filter-button events"]').click();
       cy.get('[data-cy=collective-contribution]')
         .first()
         .get('[data-cy=caption]')
@@ -47,15 +47,15 @@ describe('New users profiles', () => {
 
   describe('Transactions section', () => {
     it('Can filter by expense/contributions', () => {
-      cy.get('[data-cy=section-transactions]').click({ force: true });
+      cy.get('[data-cy=section-transactions]').click();
       cy.hash().should('eq', '#section-transactions');
       cy.get('[data-cy=section-transactions-title]').contains('Transactions');
-      cy.get('button[data-cy="filter-button expenses"]').click({ force: true });
+      cy.get('button[data-cy="filter-button expenses"]').click();
       cy.get('[data-cy="expenses transactions"]');
       cy.get('[data-cy="transaction-sign"]')
         .first()
         .contains('+');
-      cy.get('button[data-cy="filter-button contributions"]').click({ force: true });
+      cy.get('button[data-cy="filter-button contributions"]').click();
       cy.get('[data-cy="contributions transactions"]');
       cy.get('[data-cy="transaction-sign"]')
         .first()

--- a/test/cypress/integration/06-host_v2.test.js
+++ b/test/cypress/integration/06-host_v2.test.js
@@ -11,7 +11,7 @@ describe('New host page', () => {
     it('Show fiscally hosted collectives', () => {
       cy.get('[data-cy~="filter-button"]')
         .contains('Fiscal Host')
-        .click({ force: true });
+        .click();
       cy.contains('[data-cy=Contributions]', 'Open Source Collective');
       cy.contains('[data-cy=Contributions]', 'APEX');
       cy.contains('[data-cy=Contributions]', 'tipbox');

--- a/test/cypress/integration/21-collective.create.test.js
+++ b/test/cypress/integration/21-collective.create.test.js
@@ -12,7 +12,7 @@ describe('create a collective', () => {
     cy.wait(100);
     cy.get('.actions button').click();
     cy.get('.error').contains('Please accept the terms of service');
-    cy.get('.tos input[name="tos"]').click({ force: true });
+    cy.get('.tos input[name="tos"]').click();
     cy.get('.actions button').click();
     cy.get('.result').contains('Collective created successfully');
     cy.wait(800);
@@ -40,14 +40,14 @@ describe('create a collective', () => {
     cy.wait(300);
     cy.contains('Host fee: 0%');
     cy.get('[data-cy="host-apply-btn"]').should('not.be.disabled');
-    cy.contains('[data-cy="host-apply-btn"]', 'Apply with New collective').click({ force: true });
+    cy.contains('[data-cy="host-apply-btn"]:visible', 'Apply with New collective').click();
     cy.get('.ApplyToHostBtn').contains(`Application pending for ${collectiveName}`);
     // Go back to collective page
-    cy.get('.ApplyToHostBtn a')
+    cy.get('.ApplyToHostBtn:visible a')
       .first()
-      .click({ force: true });
+      .click();
     // Click on edit collective
-    cy.get('[data-cy="edit-collective-btn"]').click({ force: true });
+    cy.get('[data-cy="edit-collective-btn"]').click();
     cy.getByDataCy('menu-item-host', { timeout: 10000 }).click();
     cy.get('.removeHostBtn').click();
     cy.get('[data-cy=continue]').click();

--- a/test/cypress/integration/22-collective.edit.test.js
+++ b/test/cypress/integration/22-collective.edit.test.js
@@ -78,6 +78,7 @@ describe('edit collective', () => {
     cy.get('.actions > .btn').click(); // save changes
     cy.get('.backToProfile a').click(); // back to profile
     const tierCardSelector = '[data-cy="financial-contributions"] [data-cy="contribute-card-tier"]';
+    cy.disableSmoothScroll();
     cy.get(tierCardSelector, { timeout: 5000 });
     cy.get(tierCardSelector)
       .first()
@@ -97,7 +98,7 @@ describe('edit collective', () => {
     cy.get(tierCardSelector)
       .first()
       .find('[data-cy="contribute-btn"]')
-      .click({ force: true });
+      .click();
 
     // Ensure the new tiers are properly displayed on order form
     cy.contains('button', 'Next step', { timeout: 20000 }).click();

--- a/test/cypress/integration/25-host.apply.test.js
+++ b/test/cypress/integration/25-host.apply.test.js
@@ -2,7 +2,7 @@ describe('apply to host', () => {
   it('as a new collective', () => {
     cy.visit('/brusselstogetherasbl');
     cy.contains('We are fiscally hosting 2 Collectives');
-    cy.contains('[data-cy="host-apply-btn"]', 'Apply').click({ force: true });
+    cy.get('[data-cy="host-apply-btn"]:visible').click();
     cy.get('#email').type('testuser@opencollective.com');
     cy.wait(500);
     cy.getByDataCy('signin-btn').click();

--- a/test/cypress/integration/26-organization.create.test.js
+++ b/test/cypress/integration/26-organization.create.test.js
@@ -7,7 +7,7 @@ describe('create an organization', () => {
     cy.fillInputField('name', 'New org');
     cy.fillInputField('description', 'short description for new org');
     cy.fillInputField('website', 'https://newco.com');
-    cy.get('.tos input[name="tos"]').click({ force: true });
+    cy.get('.tos input[name="tos"]').click();
     cy.wait(500);
     cy.get('.actions button').click();
     cy.wait(1000);

--- a/test/cypress/integration/27-expenses.create.test.js
+++ b/test/cypress/integration/27-expenses.create.test.js
@@ -12,7 +12,7 @@ const uploadReceipt = (dropzoneElement = '.InputTypeDropzone input') => {
 describe('new expense when logged out', () => {
   it('requires to login to submit an expense', () => {
     cy.visit('/testcollective/expenses');
-    cy.containsInDataCy('submit-expense-btn', 'Submit Expense').click({ force: true });
+    cy.containsInDataCy('submit-expense-btn', 'Submit Expense').click();
     cy.get('.CreateExpenseForm').contains('Sign up or login to submit an expense');
     cy.get('#email').type('testuser+admin@opencollective.com');
     cy.get('[data-cy="signin-btn"]').click();

--- a/test/cypress/integration/29-host.dashboard.test.js
+++ b/test/cypress/integration/29-host.dashboard.test.js
@@ -5,7 +5,7 @@ describe('host dashboard', () => {
 
   it('mark pending application approved', () => {
     cy.wait(2000);
-    cy.contains('[data-cy="host-apply-btn"]', 'Apply').click({ force: true });
+    cy.get('[data-cy="host-apply-btn"]:visible').click();
     cy.wait(1000);
     cy.fillInputField('name', 'Cavies United');
     cy.fillInputField('description', 'We will rule the world with our cute squeaks');
@@ -20,8 +20,8 @@ describe('host dashboard', () => {
       cy.login({ redirect: '/brusselstogetherasbl/dashboard' });
       cy.get('[data-cy="host-dashboard-menu-bar"]')
         .contains('Pending applications')
-        .click({ force: true });
-      cy.get(`[data-cy="${CollectiveSlug}-approve"]`).click({ force: true });
+        .click();
+      cy.get(`[data-cy="${CollectiveSlug}-approve"]`).click();
       cy.get(`[data-cy="${CollectiveSlug}-approved"]`).should('have.attr', 'color', 'green.700');
     });
   });
@@ -41,14 +41,14 @@ describe('host dashboard', () => {
     cy.get('[data-cy="expense-paid"]').as('currentExpense');
     cy.get('[data-cy="expense-actions"]')
       .contains('button', 'Unapprove')
-      .click({ force: true });
-    cy.get('[data-cy="confirmation-modal-continue"]').click({ force: true });
+      .click();
+    cy.get('[data-cy="confirmation-modal-continue"]').click();
     cy.wait(500);
     cy.get('[data-cy="reject-expense-btn"]').within(() => {
-      cy.get('button').click({ force: true });
+      cy.get('button').click();
     });
     cy.get('[data-cy="approve-expense-btn"]').within(() => {
-      cy.get('button').click({ force: true });
+      cy.get('button').click();
     });
   });
 
@@ -57,7 +57,7 @@ describe('host dashboard', () => {
     cy.get('[data-cy="expense-approved"]').as('currentExpense');
     cy.get('[data-cy="expense-actions"]')
       .contains('button', 'Record as paid')
-      .click({ force: true });
+      .click();
     cy.get('@currentExpense').should('have.attr', 'data-cy', 'expense-paid');
   });
 
@@ -67,10 +67,10 @@ describe('host dashboard', () => {
     cy.get('[data-cy="expense-actions"]')
       .as('currentExpenseActions')
       .contains('button', 'Mark as unpaid')
-      .click({ force: true });
+      .click();
     cy.get('@currentExpenseActions')
       .contains('button', 'Continue')
-      .click({ force: true });
+      .click();
     cy.get('@currentExpense').should('have.attr', 'data-cy', 'expense-approved');
   });
 
@@ -79,8 +79,8 @@ describe('host dashboard', () => {
     cy.get('[data-cy="expense-rejected"]').as('currentExpense');
     cy.get('[data-cy="expense-actions"]')
       .contains('button', 'Delete')
-      .click({ force: true });
-    cy.get('[data-cy="confirmation-modal-continue"]').click({ force: true });
+      .click();
+    cy.get('[data-cy="confirmation-modal-continue"]').click();
     cy.get('[data-cy="errorMessage"]').should('not.exist');
   });
 });

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -3,6 +3,7 @@ import { defaultTestUserEmail } from './data';
 import { randomEmail, randomSlug } from './faker';
 import { getLoggedInUserQuery } from '../../../lib/graphql/queries';
 import { CreditCards } from '../../stripe-helpers';
+import { disableSmoothScroll } from './helpers';
 
 /**
  * Login with an exising account. If not provided in `params`, the email used for
@@ -60,7 +61,7 @@ Cypress.Commands.add('openExternalLink', url => {
     link.setAttribute('href', url);
     link.setAttribute('id', linkIdentifier);
     window.document.body.appendChild(link);
-    cy.get(`#${linkIdentifier}`).click({ force: true });
+    cy.get(`#${linkIdentifier}`).click();
   });
 });
 
@@ -302,6 +303,14 @@ Cypress.Commands.add('containsInDataCy', (query, content, params) => {
   } else {
     return cy.contains(`[data-cy="${query}"]`, content, params);
   }
+});
+
+/**
+ * Helper to disable smooth scroll on page to help prevent cypress from missing elements
+ * that may be hidden from view.
+ */
+Cypress.Commands.add('disableSmoothScroll', () => {
+  disableSmoothScroll();
 });
 
 // ---- Private ----


### PR DESCRIPTION
Resolve: https://github.com/opencollective/opencollective/issues/2816
Retrying from: #3383 

# Description

Adress undesirable cy.get('...').click({ force: true }) usage in the cypress tests. 

# Changes

Changes made include adding a new command making use of the helper `disableSmoothScroll()`, address invisible elements due to testing viewport width/breakpoints, modifying selectors for better specificity and removing the unnecessary usages.

| Adressed  |  Occurence | Reason for use  | Change made  |   
|---|---|---|---|
| <ul><li>- [x] </li></ul>  |https://github.com/opencollective/opencollective-frontend/blob/68416b9490e95f3e2784208ee3a20610b52589ca/test/cypress/integration/04-collective_v2.test.js#L64  | Button parent not visible because of breakpoint setup  | Adjusted cypress viewport width  |
| <ul><li>- [x] </li></ul>  |https://github.com/opencollective/opencollective-frontend/blob/68416b9490e95f3e2784208ee3a20610b52589ca/test/cypress/integration/04-collective_v2.test.js#L80 |  Button parent not visible because of breakpoint setup  | Adjusted cypress viewport width  |
| <ul><li>- [x] </li></ul>  |https://github.com/opencollective/opencollective-frontend/blob/70ec8367200436b9f013fb7b9417c9f19f3b42cd/test/cypress/integration/04-organization_v2.test.js#L15  | not apparent from first implementation in #2756. Test works properly without `force: true`  | removed `force: true `without other changes |
| <ul><li>- [x] </li></ul>  |https://github.com/opencollective/opencollective-frontend/blob/68416b9490e95f3e2784208ee3a20610b52589ca/test/cypress/integration/04-organization_v2.test.js#L26  | click target is detached from DOM before .click() is executed in cypress  | changed before() hook in https://github.com/opencollective/opencollective-frontend/blob/68416b9490e95f3e2784208ee3a20610b52589ca/test/cypress/integration/04-organization_v2.test.js#L6 to beforeEach() to improve on fragility of test caused by click target being detached from DOM more likely due to re-render/ lost reference to target  |
| <ul><li>- [x] </li></ul>|https://github.com/opencollective/opencollective-frontend/blob/68416b9490e95f3e2784208ee3a20610b52589ca/test/cypress/integration/05-user_v2.test.js#L7 | not apparent from first implementation in #2756. Test works properly without `force: true`  | removed `force: true `without other changes |
| <ul><li>- [x] </li></ul>  |https://github.com/opencollective/opencollective-frontend/blob/68416b9490e95f3e2784208ee3a20610b52589ca/test/cypress/integration/05-user_v2.test.js#L30  | not apparent from first implementation in #2756. Test works properly without `force: true`  | removed `force: true `without other changes |
| <ul><li>- [x] </li></ul>  |https://github.com/opencollective/opencollective-frontend/blob/68416b9490e95f3e2784208ee3a20610b52589ca/test/cypress/integration/05-user_v2.test.js#L35 | not apparent from first implementation in #2756. Test works properly without `force: true`  | removed `force: true `without other changes |
| <ul><li>- [x] </li></ul>  | https://github.com/opencollective/opencollective-frontend/blob/68416b9490e95f3e2784208ee3a20610b52589ca/test/cypress/integration/05-user_v2.test.js#L40  | not apparent from first implementation in #2756. Test works properly without `force: true`  | removed `force: true `without other changes |
| <ul><li>- [x] </li></ul>  | https://github.com/opencollective/opencollective-frontend/blob/68416b9490e95f3e2784208ee3a20610b52589ca/test/cypress/integration/05-user_v2.test.js#L50  |  not apparent from first implementation in #2756. Test works properly without `force: true`  | removed `force: true `without other changes |
| <ul><li>- [x] </li></ul>  |  https://github.com/opencollective/opencollective-frontend/blob/68416b9490e95f3e2784208ee3a20610b52589ca/test/cypress/integration/05-user_v2.test.js#L53 | not apparent from first implementation in #2756. Test works properly without `force: true`  | removed `force: true `without other changes |
| <ul><li>- [x] </li></ul>  | https://github.com/opencollective/opencollective-frontend/blob/68416b9490e95f3e2784208ee3a20610b52589ca/test/cypress/integration/05-user_v2.test.js#L58  | not apparent from first implementation in #2756. Test works properly without `force: true`  | removed `force: true `without other changes |
| <ul><li>- [x] </li></ul>  | https://github.com/opencollective/opencollective-frontend/blob/68416b9490e95f3e2784208ee3a20610b52589ca/test/cypress/integration/06-host_v2.test.js#L14  | Click timeout issue because of a scrolling mismatch/visibility from #2691, however tests are now running fine without `force:true` | removed force:true without other changes  |
| <ul><li>- [x] </li></ul>  | https://github.com/opencollective/opencollective-frontend/blob/68416b9490e95f3e2784208ee3a20610b52589ca/test/cypress/integration/21-collective.create.test.js#L15  | not apparent from first implementation in #654, test working properly without `force: true`   | removed force:true without other changes  |
| <ul><li>- [x] </li></ul>  |  https://github.com/opencollective/opencollective-frontend/blob/68416b9490e95f3e2784208ee3a20610b52589ca/test/cypress/integration/21-collective.create.test.js#L43 | Button parent not visible because of breakpoint setup  | increased specificity of selector in `.get()` with `:visible` |
| <ul><li>- [x] </li></ul>  | https://github.com/opencollective/opencollective-frontend/blob/68416b9490e95f3e2784208ee3a20610b52589ca/test/cypress/integration/21-collective.create.test.js#L48 | Button parent not visible because of breakpoint setup  | increased specificity of selector in `.get()` with `:visible` |
| <ul><li>- [x] </li></ul>  | https://github.com/opencollective/opencollective-frontend/blob/68416b9490e95f3e2784208ee3a20610b52589ca/test/cypress/integration/21-collective.create.test.js#L50  | not apparent from first implementation in #654, test working properly without `force: true`   | removed force:true without other changes  |
| <ul><li>- [x] </li></ul>  | https://github.com/opencollective/opencollective-frontend/blob/68416b9490e95f3e2784208ee3a20610b52589ca/test/cypress/integration/22-collective.edit.test.js#L100  | element not in view because of scroll behaviour  | included `disableSmoothScroll` command in test  |
| <ul><li>- [x] </li></ul>  |  https://github.com/opencollective/opencollective-frontend/blob/593b631ab3ab3fc738fbf3d075194012e2ac1d8b/test/cypress/integration/25-host.apply.test.js#L5| Button not clickable because of multiple subjects based on scroll position  | increased specificity of selector in `.get()` with `:visible` |
| <ul><li>- [x] </li></ul>  | https://github.com/opencollective/opencollective-frontend/blob/593b631ab3ab3fc738fbf3d075194012e2ac1d8b/test/cypress/integration/26-organization.create.test.js#L10  | not apparent as first implementation during bug fix #920 may have been unnecessary, test works properly without.  | removed `force:true` without other changes   |
| <ul><li>- [x] </li></ul>  | https://github.com/opencollective/opencollective-frontend/blob/593b631ab3ab3fc738fbf3d075194012e2ac1d8b/test/cypress/integration/27-expenses.create.test.js#L15  | not apparent as first implementation during  #2005 may have been unnecessary, test works properly without.  | removed `force:true` without other changes  |
| <ul><li>- [ ] </li></ul>  | https://github.com/opencollective/opencollective-frontend/blob/593b631ab3ab3fc738fbf3d075194012e2ac1d8b/test/cypress/integration/29-host.dashboard.test.js#L8 | Button not clickable because of multiple subjects based on scroll position  | increased specificity of selector in `.get()` with `:visible`, still tracking due to detached from DOM fragility in test runs |
| <ul><li>- [x] </li></ul>  | https://github.com/opencollective/opencollective-frontend/blob/593b631ab3ab3fc738fbf3d075194012e2ac1d8b/test/cypress/integration/29-host.dashboard.test.js#L23  | not apparent from first implementation in #2977 . Test works properly without force: true | removed `force:true` without other changes  |
| <ul><li>- [x] </li></ul>  | https://github.com/opencollective/opencollective-frontend/blob/593b631ab3ab3fc738fbf3d075194012e2ac1d8b/test/cypress/integration/29-host.dashboard.test.js#L24  | not apparent from first implementation in #2977 . Test works properly without force: true | removed `force:true` without other changes  |
| <ul><li>- [x] </li></ul>  | https://github.com/opencollective/opencollective-frontend/blob/593b631ab3ab3fc738fbf3d075194012e2ac1d8b/test/cypress/integration/29-host.dashboard.test.js#L44  | not apparent from first implementation in #2977 . Test works properly without force: true | removed `force:true` without other changes  |
| <ul><li>- [x] </li></ul>  | https://github.com/opencollective/opencollective-frontend/blob/593b631ab3ab3fc738fbf3d075194012e2ac1d8b/test/cypress/integration/29-host.dashboard.test.js#L45  | not apparent from first implementation in #2977 . Test works properly without force: true | removed `force:true` without other changes  |
| <ul><li>- [x] </li></ul>  |  https://github.com/opencollective/opencollective-frontend/blob/593b631ab3ab3fc738fbf3d075194012e2ac1d8b/test/cypress/integration/29-host.dashboard.test.js#L48 | not apparent from first implementation in #2977 . Test works properly without force: true | removed `force:true` without other changes  |
| <ul><li>- [x] </li></ul>  | https://github.com/opencollective/opencollective-frontend/blob/593b631ab3ab3fc738fbf3d075194012e2ac1d8b/test/cypress/integration/29-host.dashboard.test.js#L51  | not apparent from first implementation in #2977 . Test works properly without force: true | removed `force:true` without other changes  |
| <ul><li>- [x] </li></ul>  |  https://github.com/opencollective/opencollective-frontend/blob/593b631ab3ab3fc738fbf3d075194012e2ac1d8b/test/cypress/integration/29-host.dashboard.test.js#L60 | not apparent from first implementation in #2977 . Test works properly without force: true | removed `force:true` without other changes  |
| <ul><li>- [x] </li></ul>  | https://github.com/opencollective/opencollective-frontend/blob/593b631ab3ab3fc738fbf3d075194012e2ac1d8b/test/cypress/integration/29-host.dashboard.test.js#L70  | not apparent from first implementation in #2977 . Test works properly without force: true | removed `force:true` without other changes  |
| <ul><li>- [x] </li></ul>  | https://github.com/opencollective/opencollective-frontend/blob/593b631ab3ab3fc738fbf3d075194012e2ac1d8b/test/cypress/integration/29-host.dashboard.test.js#L73  | not apparent from first implementation in #2977 . Test works properly without force: true | removed `force:true` without other changes  |
| <ul><li>- [x] </li></ul>  | https://github.com/opencollective/opencollective-frontend/blob/593b631ab3ab3fc738fbf3d075194012e2ac1d8b/test/cypress/integration/29-host.dashboard.test.js#L82  | not apparent from first implementation in #2977 . Test works properly without force: true | removed `force:true` without other changes  |
| <ul><li>- [x] </li></ul>  | https://github.com/opencollective/opencollective-frontend/blob/593b631ab3ab3fc738fbf3d075194012e2ac1d8b/test/cypress/integration/29-host.dashboard.test.js#L83  | not apparent from first implementation in #2977 . Test works properly without force: true | removed `force:true` without other changes  |