### PR TITLE
fix: CSS import in dev

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -64,12 +64,6 @@ const nextConfig = {
         },
       },
       {
-        test: /static[\\/].*\.(css)$/,
-        use: {
-          loader: 'raw-loader',
-        },
-      },
-      {
         test: /static[\\/].*\.(jpg|gif|png|svg)$/,
         use: {
           loader: 'file-loader',


### PR DESCRIPTION
`app.css` was not imported in dev, resulting in small inconsistencies in styles. After investigating I found out that removing this special handling fixed the issue and it doesn't seems to affect the statics pages.