### PR TITLE
Enhance SignIn/Signup switch styles for some pages

### DIFF
--- a/components/CreateProfile.js
+++ b/components/CreateProfile.js
@@ -6,7 +6,7 @@ import { FormattedMessage, defineMessages, useIntl } from 'react-intl';
 
 import { Link } from '../server/pages';
 import Container from './Container';
-import { P } from './Text';
+import { P, Span } from './Text';
 import StyledButton from './StyledButton';
 import StyledCard from './StyledCard';
 import StyledInputField from './StyledInputField';
@@ -364,13 +364,15 @@ const CreateProfile = ({
       )}
 
       <Container alignItems="center" bg="black.50" display="flex" justifyContent="center" px={4} py={3}>
-        <P color="black.700" mr={2}>
+        <Span color="black.700" mr={1} fontSize="Paragraph">
           <FormattedMessage id="CreateProfile.AlreadyHaveAnAccount" defaultMessage="Already have an account?" />
-        </P>
-        <SecondaryAction onSecondaryAction={onSecondaryAction} loading={submitting}>
-          <FormattedMessage id="signIn" defaultMessage="Sign In" />
-          &nbsp;→
-        </SecondaryAction>
+        </Span>{' '}
+        <Span fontSize="Paragraph">
+          <SecondaryAction onSecondaryAction={onSecondaryAction} loading={submitting}>
+            <FormattedMessage id="signIn" defaultMessage="Sign In" />
+            &nbsp;→
+          </SecondaryAction>
+        </Span>
       </Container>
     </StyledCard>
   );

--- a/components/SignIn.js
+++ b/components/SignIn.js
@@ -6,7 +6,7 @@ import Container from './Container';
 import StyledButton from './StyledButton';
 import StyledCard from './StyledCard';
 import StyledInput from './StyledInput';
-import { H5, P, Span } from './Text';
+import { H5, Span } from './Text';
 import { FormattedMessage } from 'react-intl';
 import StyledLink from './StyledLink';
 import { Link } from '../server/pages';
@@ -123,10 +123,12 @@ export default class SignIn extends React.Component {
         </Box>
 
         <Container alignItems="center" bg="black.50" px={[3, 4]} py={3} display="flex" justifyContent="center">
-          <P color="black.700" mr={2}>
+          <Span color="black.700" mr={1} fontSize="Paragraph">
             <FormattedMessage id="signin.noAccount" defaultMessage="Don't have an account?" />
-          </P>
-          {this.renderSecondaryAction(<FormattedMessage id="signin.joinFree" defaultMessage="Join Free" />)}
+          </Span>{' '}
+          <Span fontSize="Paragraph">
+            {this.renderSecondaryAction(<FormattedMessage id="signin.joinFree" defaultMessage="Join Free" />)}
+          </Span>
         </Container>
       </StyledCard>
     );


### PR DESCRIPTION
On some pages like `/create` the signin/signup was off (look at the footer) because of global styles:

![localhost_3000_create (1)](https://user-images.githubusercontent.com/1556356/75046892-30f76980-54c6-11ea-878f-eb24f49d2c92.png)

Changed to:

![localhost_3000_create](https://user-images.githubusercontent.com/1556356/75046903-33f25a00-54c6-11ea-8386-ce53830267f1.png)
