### PR TITLE
add extra info field to invoice

### DIFF
--- a/components/StyledInput.js
+++ b/components/StyledInput.js
@@ -38,6 +38,7 @@ const StyledInput = styled.input`
   box-sizing: border-box;
   outline: none;
   background-color: ${themeGet('colors.white.full')};
+  display:block;
 
   ${props => {
     if (props.withOutline) {

--- a/components/edit-collective/EditHostInvoice.js
+++ b/components/edit-collective/EditHostInvoice.js
@@ -12,15 +12,23 @@ import Container from '../Container';
 import MessageBox from '../MessageBox';
 import StyledButton from '../StyledButton';
 import StyledInput from '../StyledInput';
+import StyledTextarea from '../StyledTextarea';
 import { H3, P } from '../Text';
 import { updateSettingsMutation } from './mutations';
 
 const EditHostInvoice = ({ collective }) => {
+  // For invoice Title
   const defaultValue = get(collective.settings, 'invoiceTitle');
   const [setSettings, { loading, error, data }] = useMutation(updateSettingsMutation);
   const [value, setValue] = React.useState(defaultValue);
   const isTouched = value !== defaultValue;
   const isSaved = get(data, 'editCollective.settings.invoiceTitle') === value;
+
+  // For invoice extra info
+  const defaultInfo = get(collective.settings, 'extraInfo');
+  const [info, setInfo] = React.useState(defaultInfo);
+  const isSelected = info !== defaultInfo;
+  const isSave = get(data, 'editCollective.settings.extraInfo') === info;
 
   return (
     <Container>
@@ -43,19 +51,32 @@ const EditHostInvoice = ({ collective }) => {
           {getErrorFromGraphqlException(setValue).message}
         </MessageBox>
       )}
-      <Flex flexWrap="wrap">
+      <Flex flexWrap="wrap" flexDirection="column">
         <StyledInput
           placeholder="Payment Receipt"
           defaultValue={value}
           onChange={e => setValue(e.target.value)}
           width="100%"
           maxWidth={300}
+          my={3}
+        />
+
+        <StyledTextarea
+          placeholder="Add any other text to appear on payment receipts, such as your organization's tax ID number, info about tax deductibility of contributions, or a custom thank you message."
+          defaultValue={info}
+          onChange={e => setInfo(e.target.value)}
+          width="100%"
+          height="150px"
+          maxWidth={300}
           my={2}
         />
+
+        {/* <textarea placeholder="Add any other text to appear on payment receipts, such as your organization's tax ID number, info about tax deductibility of contributions, or a custom thank you message."defaultInfo={info} onChange={e => setInfo(e.target.value)}> </textarea> */}
+
         <StyledButton
           buttonStyle="primary"
-          mx={2}
           my={2}
+          maxWidth={300}
           minWidth={200}
           loading={loading}
           maxLength={255}
@@ -64,12 +85,12 @@ const EditHostInvoice = ({ collective }) => {
             setSettings({
               variables: {
                 id: collective.id,
-                settings: { ...collective.settings, invoiceTitle: value },
+                settings: { ...collective.settings, invoiceTitle: value, extraInfo: info },
               },
             })
           }
         >
-          {isSaved ? (
+          {isSaved && isSave ? (
             <FormattedMessage id="saved" defaultMessage="Saved" />
           ) : (
             <FormattedMessage id="save" defaultMessage="Save" />
@@ -78,6 +99,7 @@ const EditHostInvoice = ({ collective }) => {
       </Flex>
       <Box mt={3} maxWidth={400}>
         <img src={imgInvoiceTitlePreview} alt="" />
+        {console.log(collective.settings)}
       </Box>
     </Container>
   );


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve      #2907
@znarf  
# Description
Add free text field under Invoices & Receipts setting for hosts
<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
  added a text area for extra info under invoices & receipts also made the input fields to be on top of one another (image below)
-->

# Screenshots

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
![image](https://user-images.githubusercontent.com/44481619/75106405-14942380-55d1-11ea-98b1-9acf3495b9f1.png)
<img width="1336" alt="Screenshot 5780-05-28 at 12 13 54 AM" src="https://user-images.githubusercontent.com/44481619/75106484-14485800-55d2-11ea-934c-f55575a1c875.png">


-->
