### PR TITLE
chore: replace collectivecover with new navbar on event expenses page

### DIFF
--- a/pages/createExpense.js
+++ b/pages/createExpense.js
@@ -12,7 +12,7 @@ import CreateExpenseForm from '../components/expenses/CreateExpenseForm';
 
 import ErrorPage from '../components/ErrorPage';
 import Button from '../components/Button';
-import CollectiveCover from '../components/CollectiveCover';
+import CollectiveNavbar from '../components/CollectiveNavbar';
 import Header from '../components/Header';
 import Body from '../components/Body';
 import Footer from '../components/Footer';
@@ -69,18 +69,13 @@ class CreateExpensePage extends React.Component {
     }
 
     const collective = data.Collective;
+    const canEdit = LoggedInUser && LoggedInUser.canEditCollective(collective);
     return (
       <div className="ExpensesPage">
         <Header collective={collective} LoggedInUser={LoggedInUser} />
 
         <Body>
-          <CollectiveCover
-            key={collective.slug}
-            collective={collective}
-            href={`/${collective.slug}`}
-            LoggedInUser={LoggedInUser}
-            displayContributeLink={collective.isActive && collective.host ? true : false}
-          />
+          <CollectiveNavbar collective={collective} isAdmin={canEdit} showEdit />
 
           <Flex flexDirection={['column', null, 'row']}>
             <Box width={[1, null, 3 / 4]}>

--- a/pages/expense.js
+++ b/pages/expense.js
@@ -8,7 +8,7 @@ import { ssrNotFoundError } from '../lib/nextjs_utils';
 import Header from '../components/Header';
 import Body from '../components/Body';
 import Footer from '../components/Footer';
-import CollectiveCover from '../components/CollectiveCover';
+import CollectiveNavbar from '../components/CollectiveNavbar';
 import { Box, Flex } from '@rebass/grid';
 import ExpenseNeedsTaxFormMessage from '../components/expenses/ExpenseNeedsTaxFormMessage';
 import ErrorPage, { generateError } from '../components/ErrorPage';
@@ -76,16 +76,16 @@ class ExpensePage extends React.Component {
 
     const collective = data.Collective;
     const successMessage = this.getSuccessMessage();
+    const canEdit = LoggedInUser && LoggedInUser.canEditCollective(collective);
     return (
       <div className="ExpensePage">
         <Header collective={collective} LoggedInUser={LoggedInUser} />
 
         <Body>
-          <CollectiveCover
-            key={collective.slug}
+          <CollectiveNavbar
             collective={collective}
-            LoggedInUser={LoggedInUser}
-            displayContributeLink={collective.isActive && collective.host ? true : false}
+            isAdmin={canEdit}
+            showEdit
             callsToAction={{ hasSubmitExpense: !collective.isArchived }}
           />
 

--- a/pages/expenses.js
+++ b/pages/expenses.js
@@ -8,7 +8,7 @@ import ExpensesStatsWithData from '../components/expenses/ExpensesStatsWithData'
 import Header from '../components/Header';
 import Body from '../components/Body';
 import Footer from '../components/Footer';
-import CollectiveCover from '../components/CollectiveCover';
+import CollectiveNavbar from '../components/CollectiveNavbar';
 import ErrorPage, { generateError } from '../components/ErrorPage';
 import SectionTitle from '../components/SectionTitle';
 
@@ -46,6 +46,7 @@ class ExpensesPage extends React.Component {
     }
 
     const collective = data.Collective;
+    const canEdit = LoggedInUser && LoggedInUser.canEditCollective(collective);
 
     let action, subtitle, filter;
     if (this.props.value) {
@@ -105,11 +106,10 @@ class ExpensesPage extends React.Component {
         <Header collective={collective} LoggedInUser={LoggedInUser} />
 
         <Body>
-          <CollectiveCover
-            key={collective.slug}
+          <CollectiveNavbar
             collective={collective}
-            LoggedInUser={LoggedInUser}
-            displayContributeLink={collective.isActive && collective.host ? true : false}
+            isAdmin={canEdit}
+            showEdit
             callsToAction={{ hasContact: collective.canContact, hasSubmitExpense: !collective.isArchived }}
           />
 


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/2826

# Description
This PR replaces `CollectiveCover` with the new `CollectiveNavbar` on event expense pages related pages.

# Screenshots
* All Expenses
![all expenses](https://user-images.githubusercontent.com/24629960/75206919-74134000-5745-11ea-9b45-cc457e023588.png)

* Create expense
![create expense](https://user-images.githubusercontent.com/24629960/75206920-74abd680-5745-11ea-999a-153a3fc20b4f.png)

* View of specific expense
![view expenses by id](https://user-images.githubusercontent.com/24629960/75206921-74abd680-5745-11ea-9c46-26822042633c.png)

