### PR TITLE
updated links in OCUsers

### DIFF
--- a/components/home/sections/OCUsers.js
+++ b/components/home/sections/OCUsers.js
@@ -112,7 +112,7 @@ const User = ({ id, name, picture, type, collectivePath }) => {
             {intl.formatMessage(messages[`home.OCusers.${id}`])}
           </P>
         </Box>
-        <HomeStandardLink width="72px" href="/discover">
+        <HomeStandardLink width="72px" href="/discover" target="_blank" rel="noopener">
           <FormattedMessage id="home.more" defaultMessage="More" />
         </HomeStandardLink>
       </Container>

--- a/components/home/sections/OCUsers.js
+++ b/components/home/sections/OCUsers.js
@@ -112,7 +112,7 @@ const User = ({ id, name, picture, type, collectivePath }) => {
             {intl.formatMessage(messages[`home.OCusers.${id}`])}
           </P>
         </Box>
-        <HomeStandardLink width="72px" href="/discover" target="_blank" rel="noopener">
+        <HomeStandardLink width="72px" href={collectivePath} target="_blank" rel="noopener">
           <FormattedMessage id="home.more" defaultMessage="More" />
         </HomeStandardLink>
       </Container>


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Relates to opencollective/opencollective#2903

# Description

Updated the paths of the buttons and added  ` target='_blank'` to redirect in a new tab. `

