### PR TITLE
updated 'more' button paths.

### DIFF
--- a/components/home/sections/Features.js
+++ b/components/home/sections/Features.js
@@ -203,7 +203,7 @@ const FeatureDescription = ({ intl, id, learnMoreLink, ...props }) => (
     >
       {intl.formatMessage(messages[`home.feature.${id}.description`])}{' '}
       {learnMoreLink && (
-        <LearnMoreLink href={learnMoreLink}>
+        <LearnMoreLink href={learnMoreLink} target="_blank">
           <FormattedMessage id="home.feature.learnmore" defaultMessage="Learn more..." />
         </LearnMoreLink>
       )}

--- a/components/home/sections/Features.js
+++ b/components/home/sections/Features.js
@@ -11,6 +11,7 @@ import SectionTitle from '../SectionTitle';
 import SectionSubtitle from '../SectionSubtitle';
 import Illustration from '../HomeIllustration';
 import StyledCarousel from '../../StyledCarousel';
+import ExternalLink from '../../ExternalLink';
 
 const SelectFeatureButton = styled.button`
   width: 100%;
@@ -68,9 +69,8 @@ const Title = styled(Span)`
   }
 `;
 
-const LearnMoreLink = styled.a`
+const LearnMoreLink = styled(ExternalLink)`
   color: #dc5f7d;
-
   &:hover {
     color: #dc5f7d;
   }
@@ -203,7 +203,7 @@ const FeatureDescription = ({ intl, id, learnMoreLink, ...props }) => (
     >
       {intl.formatMessage(messages[`home.feature.${id}.description`])}{' '}
       {learnMoreLink && (
-        <LearnMoreLink href={learnMoreLink} target="_blank">
+        <LearnMoreLink href={learnMoreLink} openInNewTab>
           <FormattedMessage id="home.feature.learnmore" defaultMessage="Learn more..." />
         </LearnMoreLink>
       )}

--- a/components/home/sections/OCUsers.js
+++ b/components/home/sections/OCUsers.js
@@ -48,6 +48,7 @@ const users = [
     type: 'Open Source Projects',
     description: '',
     collectivePath: '/babel',
+    learnMorePath: '/discover?show=open%20source',
     picture: '/static/images/home/oc-users-babel.png',
   },
   {
@@ -56,6 +57,7 @@ const users = [
     type: 'Meetups',
     description: 'We will never lock you in. Everything we do is open source (MIT License)',
     collectivePath: '/wwcodeatl',
+    learnMorePath: '/wwcodeinc',
     picture: '/static/images/home/oc-users-womenwhocode.png',
   },
   {
@@ -64,11 +66,12 @@ const users = [
     type: 'Movements',
     description: 'We will never lock you in. Everything we do is open source (MIT License)',
     collectivePath: '/xr-belgium',
+    learnMorePath: '/search?q=rebellion',
     picture: '/static/images/home/oc-users-extinctionrebllion.png',
   },
 ];
 
-const User = ({ id, name, picture, type, collectivePath }) => {
+const User = ({ id, name, picture, type, collectivePath, learnMorePath }) => {
   const intl = useIntl();
 
   return (
@@ -112,7 +115,7 @@ const User = ({ id, name, picture, type, collectivePath }) => {
             {intl.formatMessage(messages[`home.OCusers.${id}`])}
           </P>
         </Box>
-        <HomeStandardLink width="72px" href={collectivePath}>
+        <HomeStandardLink width="72px" href={learnMorePath}>
           <FormattedMessage id="home.more" defaultMessage="More" />
         </HomeStandardLink>
       </Container>
@@ -126,6 +129,7 @@ User.propTypes = {
   picture: PropTypes.string,
   type: PropTypes.string,
   collectivePath: PropTypes.string,
+  learnMorePath: PropTypes.string,
 };
 
 const OCUsers = () => {
@@ -142,7 +146,7 @@ const OCUsers = () => {
           />
         </SectionSubTitle>
         <Box mt={5}>
-          <HomeStandardLink fontSize="14px" lineHeight="18px" href="/discover">
+          <HomeStandardLink fontSize="14px" lineHeight="18px" href="https://blog.opencollective.com/tag/case-studies/">
             <FormattedMessage id="home.discover" defaultMessage="Discover more" />
           </HomeStandardLink>
         </Box>

--- a/components/home/sections/OCUsers.js
+++ b/components/home/sections/OCUsers.js
@@ -112,7 +112,7 @@ const User = ({ id, name, picture, type, collectivePath }) => {
             {intl.formatMessage(messages[`home.OCusers.${id}`])}
           </P>
         </Box>
-        <HomeStandardLink width="72px" href="/discover">
+        <HomeStandardLink width="72px" href={collectivePath}>
           <FormattedMessage id="home.more" defaultMessage="More" />
         </HomeStandardLink>
       </Container>


### PR DESCRIPTION

Relates to opencollective/opencollective#2903

# Description

Updated the paths of the buttons in OCUsers.
Added target='_blank' to 'learn more' buttons for redirecting in a new tab. `


