### PR TITLE
feat(Event): move event balance to parent

### DIFF
--- a/components/SendMoneyToCollectiveBtn.js
+++ b/components/SendMoneyToCollectiveBtn.js
@@ -37,16 +37,11 @@ class SendMoneyToCollectiveBtn extends React.Component {
   }
 
   async onClick() {
-    const {
-      currency,
-      amount,
-      fromCollective,
-      toCollective,
-      description,
-      data: {
-        Collective: { paymentMethods },
-      },
-    } = this.props;
+    const { currency, amount, fromCollective, toCollective, description, data, LoggedInUser } = this.props;
+    if (!LoggedInUser || !LoggedInUser.canEditCollective(fromCollective) || !get(data, 'Collective')) {
+      return;
+    }
+    const paymentMethods = get(data, 'Collective.paymentMethods');
     if (!paymentMethods || paymentMethods.length === 0) {
       const error = "We couldn't find a payment method to make this transaction";
       this.setState({ error });
@@ -123,6 +118,9 @@ const addPaymentMethods = graphql(addPaymentMethodsQuery, {
         slug: get(props, 'fromCollective.slug'),
       },
     };
+  },
+  skip: props => {
+    return !props.LoggedInUser;
   },
 });
 

--- a/components/SendMoneyToCollectiveBtn.js
+++ b/components/SendMoneyToCollectiveBtn.js
@@ -7,7 +7,8 @@ import { get, pick } from 'lodash';
 
 import { compose, formatCurrency } from '../lib/utils';
 
-import SmallButton from './SmallButton';
+import StyledButton from './StyledButton';
+import { Flex } from '@rebass/grid';
 
 class SendMoneyToCollectiveBtn extends React.Component {
   static propTypes = {
@@ -80,19 +81,21 @@ class SendMoneyToCollectiveBtn extends React.Component {
             }
           `}
         </style>
-        <SmallButton className="approve" onClick={this.props.confirmTransfer || this.onClick}>
-          {this.state.loading && <FormattedMessage id="form.processing" defaultMessage="processing" />}
-          {!this.state.loading && (
-            <FormattedMessage
-              id="SendMoneyToCollective.btn"
-              defaultMessage="Send {amount} to {collective}"
-              values={{
-                amount: formatCurrency(amount, currency),
-                collective: toCollective.name,
-              }}
-            />
-          )}
-        </SmallButton>
+        <Flex justifyContent="center" mb={1}>
+          <StyledButton onClick={this.props.confirmTransfer || this.onClick}>
+            {this.state.loading && <FormattedMessage id="form.processing" defaultMessage="processing" />}
+            {!this.state.loading && (
+              <FormattedMessage
+                id="SendMoneyToCollective.btn"
+                defaultMessage="Send {amount} to {collective}"
+                values={{
+                  amount: formatCurrency(amount, currency),
+                  collective: toCollective.name,
+                }}
+              />
+            )}
+          </StyledButton>
+        </Flex>
         {this.state.error && <div className="error">{this.state.error}</div>}
       </div>
     );

--- a/components/collective-page/CollectiveNotificationBar.js
+++ b/components/collective-page/CollectiveNotificationBar.js
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 import { injectIntl, defineMessages } from 'react-intl';
 import NotificationBar from '../NotificationBar';
 import { CollectiveType } from '../../lib/constants/collectives';
+import SendMoneyToCollectiveBtn from '../SendMoneyToCollectiveBtn';
+import { moneyCanMoveFromEvent } from '../../lib/events';
+import { get } from 'lodash';
 
 const messages = defineMessages({
   // Created
@@ -47,9 +50,22 @@ const messages = defineMessages({
     id: 'collective.pending.description',
     defaultMessage: 'This collective is pending approval from the host ({host}).',
   },
+  'event.over.sendMoneyToParent.title': {
+    id: 'event.over.sendMoneyToParent.title',
+    defaultMessage: 'Event is over and still has a positive balance',
+  },
+  'event.over.sendMoneyToParent.description': {
+    id: 'event.over.sendMoneyToParent.description',
+    defaultMessage:
+      'If you still have expenses related to this event, please file them. Otherwise consider moving the money to your collective {collective}',
+  },
+  'event.over.sendMoneyToParent.transaction.description': {
+    id: 'event.over.sendMoneyToParent.transaction.description',
+    defaultMessage: 'Balance of {event}',
+  },
 });
 
-const getNotification = (intl, status, collective, host) => {
+const getNotification = (intl, status, collective, host, LoggedInUser) => {
   if (status === 'collectiveCreated') {
     switch (collective.type) {
       case CollectiveType.ORGANIZATION:
@@ -81,6 +97,24 @@ const getNotification = (intl, status, collective, host) => {
       description: intl.formatMessage(messages.approvalPendingDescription, { host: collective.host.name }),
       status: 'collectivePending',
     };
+  } else if (get(collective, 'type') === CollectiveType.EVENT && moneyCanMoveFromEvent(collective)) {
+    return {
+      title: intl.formatMessage(messages['event.over.sendMoneyToParent.title']),
+      description: intl.formatMessage(messages['event.over.sendMoneyToParent.description']),
+      actions: [
+        <SendMoneyToCollectiveBtn
+          key="SendMoneyToCollectiveBtn"
+          fromCollective={collective}
+          toCollective={collective.parentCollective}
+          LoggedInUser={LoggedInUser}
+          description={intl.formatMessage(messages['event.over.sendMoneyToParent.transaction.description'], {
+            event: collective.name,
+          })}
+          amount={collective.stats.balance}
+          currency={collective.currency}
+        />,
+      ],
+    };
   }
 };
 
@@ -91,7 +125,12 @@ const CollectiveNotificationBar = ({ intl, status, collective, host }) => {
   const notification = getNotification(intl, status, collective, host);
 
   return !notification ? null : (
-    <NotificationBar status={notification.status} title={notification.title} description={notification.description} />
+    <NotificationBar
+      status={status}
+      title={notification.title}
+      description={notification.description}
+      actions={notification.actions}
+    />
   );
 };
 
@@ -107,9 +146,11 @@ CollectiveNotificationBar.propTypes = {
     name: PropTypes.string,
   }),
   /** A special status to show the notification bar (collective created, archived...etc) */
-  status: PropTypes.oneOf(['collectiveCreated', 'collectiveArchived']),
+  status: PropTypes.oneOf(['collectiveCreated', 'collectiveArchived', 'eventConcludedWithBalance']),
   /** @ignore from injectIntl */
   intl: PropTypes.object,
+  /** from withUser */
+  LoggedInUser: PropTypes.object,
 };
 
 export default injectIntl(CollectiveNotificationBar);

--- a/components/collective-page/CollectiveNotificationBar.js
+++ b/components/collective-page/CollectiveNotificationBar.js
@@ -151,7 +151,7 @@ CollectiveNotificationBar.propTypes = {
     name: PropTypes.string,
   }),
   /** A special status to show the notification bar (collective created, archived...etc) */
-  status: PropTypes.oneOf(['collectiveCreated', 'collectiveArchived', 'eventConcludedWithBalance']),
+  status: PropTypes.oneOf(['collectiveCreated', 'collectiveArchived']),
   /** @ignore from injectIntl */
   intl: PropTypes.object,
   /** from withUser */

--- a/components/collective-page/CollectiveNotificationBar.js
+++ b/components/collective-page/CollectiveNotificationBar.js
@@ -98,9 +98,14 @@ const getNotification = (intl, status, collective, host, LoggedInUser) => {
       status: 'collectivePending',
     };
   } else if (get(collective, 'type') === CollectiveType.EVENT && moneyCanMoveFromEvent(collective)) {
+    if (!LoggedInUser || !LoggedInUser.canEditCollective(collective)) {
+      return;
+    }
     return {
       title: intl.formatMessage(messages['event.over.sendMoneyToParent.title']),
-      description: intl.formatMessage(messages['event.over.sendMoneyToParent.description']),
+      description: intl.formatMessage(messages['event.over.sendMoneyToParent.description'], {
+        collective: collective.parentCollective.name,
+      }),
       actions: [
         <SendMoneyToCollectiveBtn
           key="SendMoneyToCollectiveBtn"
@@ -121,8 +126,8 @@ const getNotification = (intl, status, collective, host, LoggedInUser) => {
 /**
  * Adds a notification bar for the collective.
  */
-const CollectiveNotificationBar = ({ intl, status, collective, host }) => {
-  const notification = getNotification(intl, status, collective, host);
+const CollectiveNotificationBar = ({ intl, status, collective, host, LoggedInUser }) => {
+  const notification = getNotification(intl, status, collective, host, LoggedInUser);
 
   return !notification ? null : (
     <NotificationBar

--- a/pages/new-collective-page.js
+++ b/pages/new-collective-page.js
@@ -141,7 +141,12 @@ class NewCollectivePage extends React.Component {
           </Container>
         ) : (
           <React.Fragment>
-            <CollectiveNotificationBar collective={collective} host={collective.host} status={status} />
+            <CollectiveNotificationBar
+              collective={collective}
+              host={collective.host}
+              status={status}
+              LoggedInUser={LoggedInUser}
+            />
             <CollectiveThemeProvider collective={collective}>
               {({ onPrimaryColorChange }) => (
                 <CollectivePage
@@ -160,7 +165,6 @@ class NewCollectivePage extends React.Component {
                   LoggedInUser={LoggedInUser}
                   isAdmin={Boolean(LoggedInUser && LoggedInUser.canEditCollective(collective))}
                   isRoot={Boolean(LoggedInUser && LoggedInUser.isRoot())}
-                  status={status}
                   onPrimaryColorChange={onPrimaryColorChange}
                 />
               )}


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve [#2792](https://github.com/opencollective/opencollective/issues/2792)

# Description
* add notification for event page.
* add button to move event balance when event is over.
<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots

- After purchasing tickets and `event` is over
<img width="1439" alt="Screenshot 2020-03-02 at 11 30 41" src="https://user-images.githubusercontent.com/29008971/75668422-99d6a280-5c79-11ea-9971-ce4b34703d0d.png">

- Moved Balance to Parent.
<img width="404" alt="Screenshot 2020-03-02 at 11 30 57" src="https://user-images.githubusercontent.com/29008971/75668454-a4913780-5c79-11ea-9768-283858686b28.png">

- Parents Balance.
<img width="1272" alt="Screenshot 2020-03-02 at 11 31 17" src="https://user-images.githubusercontent.com/29008971/75668468-a8bd5500-5c79-11ea-8b84-b2c8c5311fc4.png">
<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
