### PR TITLE
ExpenseFormAttachment: update uuid usage

### DIFF
--- a/components/expenses/ExpenseFormAttachments.js
+++ b/components/expenses/ExpenseFormAttachments.js
@@ -2,7 +2,7 @@ import { Box, Flex } from '@rebass/grid';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 import { isEmpty } from 'lodash';
 
 import Container from '../Container';


### PR DESCRIPTION
I opened the PR for the new expense flow before https://github.com/opencollective/opencollective-frontend/pull/3587 and missed the refactor that happened there before merging. This removes a warning in the create expense page.