### PR TITLE
Remove FormattedHTMLMessage

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,18 @@
   "rules": {
     "no-console": "warn",
     "require-atomic-updates": "warn",
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "react-intl",
+            "importNames": ["FormattedHTMLMessage"],
+            "message": "FormattedHTMLMessage is not allowed, please rely on the standard FormattedMessage."
+          }
+        ]
+      }
+    ],
     // To lint multiple schemas each one needs a different tagName.
     // https://github.com/apollographql/eslint-plugin-graphql#additional-schemas-or-tags
     "graphql/template-strings": [

--- a/components/I18nFormatters.js
+++ b/components/I18nFormatters.js
@@ -2,4 +2,7 @@ import React from 'react';
 import StyledLink from './StyledLink';
 
 export const I18nBold = msg => <strong>{msg}</strong>;
+export const I18nItalic = msg => <i>{msg}</i>;
 export const getI18nLink = linkProps => msg => <StyledLink {...linkProps}>{msg}</StyledLink>;
+const I18nFormatters = { strong: I18nBold, i: I18nItalic };
+export default I18nFormatters;

--- a/components/pricing/tabs/HostOrganization.js
+++ b/components/pricing/tabs/HostOrganization.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Flex } from '@rebass/grid';
-import { FormattedMessage, FormattedHTMLMessage } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import Container from '../../Container';
 import StyledLink from '../../StyledLink';
@@ -8,6 +8,7 @@ import BackButton from '../BackButton';
 import PricingTable from '../PricingTable';
 import { H1, P, H3, Span } from '../../Text';
 import { Router } from '../../../server/pages';
+import I18nFormatters from '../../I18nFormatters';
 
 const headings = ['', 'starter', 'small', 'medium', 'large', 'network'];
 
@@ -16,7 +17,7 @@ const rows = [
     {
       type: 'component',
       render() {
-        return <FormattedHTMLMessage id="pricingTable.row.price" defaultMessage="Price" />;
+        return <FormattedMessage id="pricingTable.row.price" defaultMessage="Price" />;
       },
     },
     {
@@ -24,7 +25,7 @@ const rows = [
       render() {
         return (
           <Span fontSize={20} fontWeight="bold">
-            <FormattedHTMLMessage id="pricingTable.cell.free" defaultMessage="Free" />
+            <FormattedMessage id="pricingTable.cell.free" defaultMessage="Free" />
           </Span>
         );
       },
@@ -49,7 +50,7 @@ const rows = [
       render() {
         return (
           <Span fontSize={20} fontWeight="bold">
-            <FormattedHTMLMessage id="pricingTable.cell.talkToUs" defaultMessage="Talk to us" />
+            <FormattedMessage id="pricingTable.cell.talkToUs" defaultMessage="Talk to us" />
           </Span>
         );
       },
@@ -59,13 +60,13 @@ const rows = [
     {
       type: 'component',
       render() {
-        return <FormattedHTMLMessage id="pricingTable.row.collectives" defaultMessage="Collectives" />;
+        return <FormattedMessage id="pricingTable.row.collectives" defaultMessage="Collectives" />;
       },
     },
     {
       type: 'component',
       render() {
-        return <FormattedHTMLMessage id="pricingTable.cell.unlimited" defaultMessage="Unlimited" />;
+        return <FormattedMessage id="pricingTable.cell.unlimited" defaultMessage="Unlimited" />;
       },
     },
     {
@@ -90,7 +91,7 @@ const rows = [
       type: 'component',
       render() {
         return (
-          <FormattedHTMLMessage
+          <FormattedMessage
             id="pricingTable.row.directPayment"
             defaultMessage="Credit card payments direct to Collectives"
           />
@@ -122,9 +123,7 @@ const rows = [
     {
       type: 'component',
       render() {
-        return (
-          <FormattedHTMLMessage id="pricingTable.row.collectivePage" defaultMessage="All Collective page features" />
-        );
+        return <FormattedMessage id="pricingTable.row.collectivePage" defaultMessage="All Collective page features" />;
       },
     },
     { type: 'check' },
@@ -138,10 +137,7 @@ const rows = [
       type: 'component',
       render() {
         return (
-          <FormattedHTMLMessage
-            id="pricingTable.row.addFunds"
-            defaultMessage="Add funds received through other channels"
-          />
+          <FormattedMessage id="pricingTable.row.addFunds" defaultMessage="Add funds received through other channels" />
         );
       },
     },
@@ -155,9 +151,7 @@ const rows = [
     {
       type: 'component',
       render() {
-        return (
-          <FormattedHTMLMessage id="pricingTable.row.bankTransfer" defaultMessage="Enable bank transfer payments" />
-        );
+        return <FormattedMessage id="pricingTable.row.bankTransfer" defaultMessage="Enable bank transfer payments" />;
       },
     },
     { type: 'html', html: 'Up to <strong>$1,000</strong>' },
@@ -171,7 +165,7 @@ const rows = [
       type: 'component',
       render() {
         return (
-          <FormattedHTMLMessage
+          <FormattedMessage
             id="pricingTable.row.hostFeature"
             defaultMessage="Link for Collectives to discover and apply to your host"
           />
@@ -220,9 +214,10 @@ const HostOrganization = () => (
           <FormattedMessage id="pricing.tab.welcome" defaultMessage="Welcome!" />
         </H1>
         <P my={3} fontSize={['Paragraph']} lineHeight={['H5']} letterSpacing={['-0.012em']}>
-          <FormattedHTMLMessage
+          <FormattedMessage
             id="pricing.tab.hostOrganization.description"
             defaultMessage="You will be a <strong>Fiscal Host</strong> on our platform. That means you hold funds on behalf of Collectives. You decide which Collectives to accept and what if any fees to charge them."
+            values={I18nFormatters}
           />
         </P>
       </Box>
@@ -234,7 +229,7 @@ const HostOrganization = () => (
       <Box textAlign="center" my={3}>
         <P my={3} fontSize={['Paragraph']} lineHeight={['H5']} letterSpacing={['-0.012em']}>
           <StyledLink href={'/become-a-fiscal-host'}>
-            <FormattedHTMLMessage
+            <FormattedMessage
               id="pricing.fiscalHost.learnMore"
               defaultMessage="Learn more about becoming a Fiscal Host."
             />
@@ -254,33 +249,38 @@ const HostOrganization = () => (
           </H3>
           <Box as="ul" color="black.800" mt={3} px={3} fontSize="13px" lineHeight="21px" letterSpacing="-0.012em">
             <Box as="li" my={2}>
-              <FormattedHTMLMessage
+              <FormattedMessage
                 id="pricing.starterPlans.collective"
                 defaultMessage="Collective - a page to <strong>coordinate your community and budget.</strong>"
+                values={I18nFormatters}
               />
             </Box>
             <Box as="li" my={3}>
-              <FormattedHTMLMessage
+              <FormattedMessage
                 id="pricing.starterPlans.communication"
                 defaultMessage="Communication tools: <strong>post updates, start conversations,</strong> and <strong>a contact form</strong> for your group."
+                values={I18nFormatters}
               />
             </Box>
             <Box as="li" my={3}>
-              <FormattedHTMLMessage
+              <FormattedMessage
                 id="pricing.starterPlans.transparency"
                 defaultMessage="Show your budget and expenses <strong>transparently.</strong> "
+                values={I18nFormatters}
               />
             </Box>
             <Box as="li" my={3}>
-              <FormattedHTMLMessage
+              <FormattedMessage
                 id="pricing.starterPlans.fundraise"
                 defaultMessage="<strong>Fundraise</strong> through credit card payments (cost: 5% plus Stripe payment processor fees)."
+                values={I18nFormatters}
               />
             </Box>
             <Box as="li" my={3}>
-              <FormattedHTMLMessage
+              <FormattedMessage
                 id="pricing.starterPlans.addFunds"
                 defaultMessage="Manually <strong>add funds raised</strong> through other channels (e.g. bank transfers) to your transparent budget (free up to $1,000, then you’ll need to upgrade to a paid plan)."
+                values={I18nFormatters}
               />
             </Box>
           </Box>

--- a/components/pricing/tabs/SingleCollectiveWithBankAccount.js
+++ b/components/pricing/tabs/SingleCollectiveWithBankAccount.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Flex } from '@rebass/grid';
-import { FormattedMessage, FormattedHTMLMessage } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import { Router } from '../../../server/pages';
 import Container from '../../Container';
 import BackButton from '../BackButton';
 import { H1, P, H3, Span } from '../../Text';
 import PricingTable from '../PricingTable';
+import I18nFormatters from '../../I18nFormatters';
 
 const headings = ['', 'starter', 'singleCollective'];
 
@@ -16,7 +17,7 @@ const rows = [
     {
       type: 'component',
       render() {
-        return <FormattedHTMLMessage id="pricingTable.row.price" defaultMessage="Price" />;
+        return <FormattedMessage id="pricingTable.row.price" defaultMessage="Price" />;
       },
     },
     {
@@ -24,7 +25,7 @@ const rows = [
       render() {
         return (
           <Span className="price">
-            <FormattedHTMLMessage id="pricingTable.cell.free" defaultMessage="Free" />
+            <FormattedMessage id="pricingTable.cell.free" defaultMessage="Free" />
           </Span>
         );
       },
@@ -39,9 +40,7 @@ const rows = [
     {
       type: 'component',
       render() {
-        return (
-          <FormattedHTMLMessage id="pricingTable.row.fundraise" defaultMessage="Fundraise via credit card payments" />
-        );
+        return <FormattedMessage id="pricingTable.row.fundraise" defaultMessage="Fundraise via credit card payments" />;
       },
     },
     {
@@ -57,9 +56,7 @@ const rows = [
     {
       type: 'component',
       render() {
-        return (
-          <FormattedHTMLMessage id="pricingTable.row.collectivePage" defaultMessage="All Collective page features" />
-        );
+        return <FormattedMessage id="pricingTable.row.collectivePage" defaultMessage="All Collective page features" />;
       },
     },
     { type: 'check' },
@@ -70,10 +67,7 @@ const rows = [
       type: 'component',
       render() {
         return (
-          <FormattedHTMLMessage
-            id="pricingTable.row.addFunds"
-            defaultMessage="Add funds received through other channels"
-          />
+          <FormattedMessage id="pricingTable.row.addFunds" defaultMessage="Add funds received through other channels" />
         );
       },
     },
@@ -86,9 +80,7 @@ const rows = [
     {
       type: 'component',
       render() {
-        return (
-          <FormattedHTMLMessage id="pricingTable.row.bankTransfer" defaultMessage="Enable bank transfer payments" />
-        );
+        return <FormattedMessage id="pricingTable.row.bankTransfer" defaultMessage="Enable bank transfer payments" />;
       },
     },
     { type: 'html', html: 'Up to <strong>$1,000</strong>' },
@@ -123,9 +115,10 @@ const SingleCollectiveWithBankAccount = () => (
           <FormattedMessage id="pricing.tab.welcome" defaultMessage="Welcome!" />
         </H1>
         <P color="black.700" fontSize={['Paragraph']} lineHeight={['H5']} letterSpacing={['-0.012em']}>
-          <FormattedHTMLMessage
+          <FormattedMessage
             id="pricing.tab.description"
             defaultMessage="You will begin with the <strong>STARTER PLAN</strong>. This plan is <strong>FREE</strong> to set up!"
+            values={I18nFormatters}
           />
         </P>
       </Box>
@@ -152,33 +145,38 @@ const SingleCollectiveWithBankAccount = () => (
           </H3>
           <Box as="ul" color="black.800" mt={3} px={3} fontSize="13px" lineHeight="21px" letterSpacing="-0.012em">
             <Box as="li" my={2}>
-              <FormattedHTMLMessage
+              <FormattedMessage
                 id="pricing.starterPlans.collective"
                 defaultMessage="Collective - a page to <strong>coordinate your community and budget.</strong>"
+                values={I18nFormatters}
               />
             </Box>
             <Box as="li" my={3}>
-              <FormattedHTMLMessage
+              <FormattedMessage
                 id="pricing.starterPlans.communication"
                 defaultMessage="Communication tools: <strong>post updates, start conversations,</strong> and <strong>a contact form</strong> for your group."
+                values={I18nFormatters}
               />
             </Box>
             <Box as="li" my={3}>
-              <FormattedHTMLMessage
+              <FormattedMessage
                 id="pricing.starterPlans.transparency"
                 defaultMessage="Show your budget and expenses <strong>transparently.</strong> "
+                values={I18nFormatters}
               />
             </Box>
             <Box as="li" my={3}>
-              <FormattedHTMLMessage
+              <FormattedMessage
                 id="pricing.starterPlans.fundraise"
                 defaultMessage="<strong>Fundraise</strong> through credit card payments (cost: 5% plus Stripe payment processor fees)."
+                values={I18nFormatters}
               />
             </Box>
             <Box as="li" my={3}>
-              <FormattedHTMLMessage
+              <FormattedMessage
                 id="pricing.starterPlans.addFunds"
                 defaultMessage="Manually <strong>add funds raised</strong> through other channels (e.g. bank transfers) to your transparent budget (free up to $1,000, then you’ll need to upgrade to a paid plan)."
+                values={I18nFormatters}
               />
             </Box>
           </Box>

--- a/components/pricing/tabs/SingleCollectiveWithoutBankAccount.js
+++ b/components/pricing/tabs/SingleCollectiveWithoutBankAccount.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 import styled from 'styled-components';
 import { Box, Flex } from '@rebass/grid';
-import { FormattedMessage, FormattedHTMLMessage } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { graphql } from 'react-apollo';
 
 import Container from '../../Container';
@@ -15,6 +15,7 @@ import { Router } from '../../../server/pages';
 import StyledCollectiveCard from '../../StyledCollectiveCard';
 import StyledButton from '../../StyledButton';
 import Link from '../../Link';
+import I18nFormatters, { getI18nLink } from '../../I18nFormatters';
 
 const featuredHostsSlugs = ['opensource', 'wwcodeinc', 'paris', 'allforclimate'];
 
@@ -59,21 +60,24 @@ const SingleCollectiveWithoutBankAccount = ({ data }) => {
             <FormattedMessage id="pricing.tab.welcome" defaultMessage="Welcome!" />
           </H1>
           <P my={3} fontSize={['Paragraph']} lineHeight={['H5']} letterSpacing={['-0.012em']}>
-            <FormattedHTMLMessage
+            <FormattedMessage
               id="pricing.tab.joinHost"
               defaultMessage="If you don't have access to a bank account you can use, please <strong>join a Fiscal Host</strong>!"
+              values={I18nFormatters}
             />
           </P>
           <P my={3} fontSize={['Paragraph']} lineHeight={['H5']} letterSpacing={['-0.012em']}>
-            <FormattedHTMLMessage
+            <FormattedMessage
               id="pricing.fiscalHost.description"
               defaultMessage="A Fiscal Host is an <strong>organization who offers fund-holding as a service</strong>. They keep your money in their bank account and  <strong>handle things like accounting, taxes, admin, payments, and liability</strong>-so you don’t have to!"
+              values={I18nFormatters}
             />
           </P>
           <P my={3} fontSize={['Paragraph']} lineHeight={['H5']} letterSpacing={['-0.012em']}>
-            <FormattedHTMLMessage
+            <FormattedMessage
               id="pricing.fiscalHost.reasonToJoin"
               defaultMessage="If you join a Fiscal Host, <strong>you don’t need to go on an Open Collective paid plan</strong>, as your Collective is already included. Each Fiscal Host sets their own fees and acceptance criteria for Collectives. Open Collective keeps a 5% of the donations your raise via credit card payments (Stripe). All other payment methods such as PayPal and Bank transfers are included in your Host's plan."
+              values={I18nFormatters}
             />
           </P>
           <P my={3} fontSize={['Paragraph']} lineHeight={['H5']} letterSpacing={['-0.012em']}>
@@ -83,9 +87,10 @@ const SingleCollectiveWithoutBankAccount = ({ data }) => {
             />
           </P>
           <P my={3} fontSize={['Paragraph']} lineHeight={['H5']} letterSpacing={['-0.012em']}>
-            <FormattedHTMLMessage
+            <FormattedMessage
               id="pricing.fiscalHost.featured"
-              defaultMessage="Below are some of our most popular hosts or <a href='/hosts'>browse all of them</a>."
+              defaultMessage="Below are some of our most popular hosts or <hosts-link>browse all of them</hosts-link>."
+              values={{ 'hosts-link': getI18nLink({ as: Link, route: '/hosts' }) }}
             />
           </P>
         </Box>
@@ -164,7 +169,7 @@ const SingleCollectiveWithoutBankAccount = ({ data }) => {
         </HostsWrapper>
         <P my={3} fontSize={['Paragraph']} lineHeight={['H5']} letterSpacing={['-0.012em']}>
           <StyledLink href={'/hosts'}>
-            <FormattedHTMLMessage id="pricing.fiscalHost.more" defaultMessage="See more fiscal hosts" />
+            <FormattedMessage id="pricing.fiscalHost.more" defaultMessage="See more fiscal hosts" />
           </StyledLink>
         </P>
       </Container>

--- a/lang/en.json
+++ b/lang/en.json
@@ -1100,7 +1100,7 @@
   "pricing.back.btn": "Back",
   "pricing.fiscalHost.applyOpenSource": "If you are an open source project, you can apply to join  the Open Source Collective.",
   "pricing.fiscalHost.description": "A Fiscal Host is an <strong>organization who offers fund-holding as a service</strong>. They keep your money in their bank account and  <strong>handle things like accounting, taxes, admin, payments, and liability</strong>-so you don’t have to!",
-  "pricing.fiscalHost.featured": "Below are some of our most popular hosts or <a href='/hosts'>browse all of them</a>.",
+  "pricing.fiscalHost.featured": "Below are some of our most popular hosts or <hosts-link>browse all of them</hosts-link>.",
   "pricing.fiscalHost.learnMore": "Learn more about becoming a Fiscal Host.",
   "pricing.fiscalHost.more": "See more fiscal hosts",
   "pricing.fiscalHost.reasonToJoin": "If you join a Fiscal Host, <strong>you don’t need to go on an Open Collective paid plan</strong>, as your Collective is already included. Each Fiscal Host sets their own fees and acceptance criteria for Collectives. Open Collective keeps a 5% of the donations your raise via credit card payments (Stripe). All other payment methods such as PayPal and Bank transfers are included in your Host's plan.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1100,7 +1100,7 @@
   "pricing.back.btn": "Back",
   "pricing.fiscalHost.applyOpenSource": "If you are an open source project, you can apply to join  the Open Source Collective.",
   "pricing.fiscalHost.description": "A Fiscal Host is an <strong>organization who offers fund-holding as a service</strong>. They keep your money in their bank account and  <strong>handle things like accounting, taxes, admin, payments, and liability</strong>-so you don’t have to!",
-  "pricing.fiscalHost.featured": "Below are some of our most popular hosts or <a href='/hosts'>browse all of them</a>.",
+  "pricing.fiscalHost.featured": "Below are some of our most popular hosts or <hosts-link>browse all of them</hosts-link>.",
   "pricing.fiscalHost.learnMore": "Learn more about becoming a Fiscal Host.",
   "pricing.fiscalHost.more": "See more fiscal hosts",
   "pricing.fiscalHost.reasonToJoin": "If you join a Fiscal Host, <strong>you don’t need to go on an Open Collective paid plan</strong>, as your Collective is already included. Each Fiscal Host sets their own fees and acceptance criteria for Collectives. Open Collective keeps a 5% of the donations your raise via credit card payments (Stripe). All other payment methods such as PayPal and Bank transfers are included in your Host's plan.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1100,7 +1100,7 @@
   "pricing.back.btn": "Back",
   "pricing.fiscalHost.applyOpenSource": "If you are an open source project, you can apply to join  the Open Source Collective.",
   "pricing.fiscalHost.description": "A Fiscal Host is an <strong>organization who offers fund-holding as a service</strong>. They keep your money in their bank account and  <strong>handle things like accounting, taxes, admin, payments, and liability</strong>-so you don’t have to!",
-  "pricing.fiscalHost.featured": "Below are some of our most popular hosts or <a href='/hosts'>browse all of them</a>.",
+  "pricing.fiscalHost.featured": "Below are some of our most popular hosts or <hosts-link>browse all of them</hosts-link>.",
   "pricing.fiscalHost.learnMore": "Learn more about becoming a Fiscal Host.",
   "pricing.fiscalHost.more": "See more fiscal hosts",
   "pricing.fiscalHost.reasonToJoin": "If you join a Fiscal Host, <strong>you don’t need to go on an Open Collective paid plan</strong>, as your Collective is already included. Each Fiscal Host sets their own fees and acceptance criteria for Collectives. Open Collective keeps a 5% of the donations your raise via credit card payments (Stripe). All other payment methods such as PayPal and Bank transfers are included in your Host's plan.",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1100,7 +1100,7 @@
   "pricing.back.btn": "Back",
   "pricing.fiscalHost.applyOpenSource": "If you are an open source project, you can apply to join  the Open Source Collective.",
   "pricing.fiscalHost.description": "A Fiscal Host is an <strong>organization who offers fund-holding as a service</strong>. They keep your money in their bank account and  <strong>handle things like accounting, taxes, admin, payments, and liability</strong>-so you don’t have to!",
-  "pricing.fiscalHost.featured": "Below are some of our most popular hosts or <a href='/hosts'>browse all of them</a>.",
+  "pricing.fiscalHost.featured": "Below are some of our most popular hosts or <hosts-link>browse all of them</hosts-link>.",
   "pricing.fiscalHost.learnMore": "Learn more about becoming a Fiscal Host.",
   "pricing.fiscalHost.more": "See more fiscal hosts",
   "pricing.fiscalHost.reasonToJoin": "If you join a Fiscal Host, <strong>you don’t need to go on an Open Collective paid plan</strong>, as your Collective is already included. Each Fiscal Host sets their own fees and acceptance criteria for Collectives. Open Collective keeps a 5% of the donations your raise via credit card payments (Stripe). All other payment methods such as PayPal and Bank transfers are included in your Host's plan.",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1100,7 +1100,7 @@
   "pricing.back.btn": "Back",
   "pricing.fiscalHost.applyOpenSource": "If you are an open source project, you can apply to join  the Open Source Collective.",
   "pricing.fiscalHost.description": "A Fiscal Host is an <strong>organization who offers fund-holding as a service</strong>. They keep your money in their bank account and  <strong>handle things like accounting, taxes, admin, payments, and liability</strong>-so you don’t have to!",
-  "pricing.fiscalHost.featured": "Below are some of our most popular hosts or <a href='/hosts'>browse all of them</a>.",
+  "pricing.fiscalHost.featured": "Below are some of our most popular hosts or <hosts-link>browse all of them</hosts-link>.",
   "pricing.fiscalHost.learnMore": "Learn more about becoming a Fiscal Host.",
   "pricing.fiscalHost.more": "See more fiscal hosts",
   "pricing.fiscalHost.reasonToJoin": "If you join a Fiscal Host, <strong>you don’t need to go on an Open Collective paid plan</strong>, as your Collective is already included. Each Fiscal Host sets their own fees and acceptance criteria for Collectives. Open Collective keeps a 5% of the donations your raise via credit card payments (Stripe). All other payment methods such as PayPal and Bank transfers are included in your Host's plan.",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1100,7 +1100,7 @@
   "pricing.back.btn": "Back",
   "pricing.fiscalHost.applyOpenSource": "If you are an open source project, you can apply to join  the Open Source Collective.",
   "pricing.fiscalHost.description": "A Fiscal Host is an <strong>organization who offers fund-holding as a service</strong>. They keep your money in their bank account and  <strong>handle things like accounting, taxes, admin, payments, and liability</strong>-so you don’t have to!",
-  "pricing.fiscalHost.featured": "Below are some of our most popular hosts or <a href='/hosts'>browse all of them</a>.",
+  "pricing.fiscalHost.featured": "Below are some of our most popular hosts or <hosts-link>browse all of them</hosts-link>.",
   "pricing.fiscalHost.learnMore": "Learn more about becoming a Fiscal Host.",
   "pricing.fiscalHost.more": "See more fiscal hosts",
   "pricing.fiscalHost.reasonToJoin": "If you join a Fiscal Host, <strong>you don’t need to go on an Open Collective paid plan</strong>, as your Collective is already included. Each Fiscal Host sets their own fees and acceptance criteria for Collectives. Open Collective keeps a 5% of the donations your raise via credit card payments (Stripe). All other payment methods such as PayPal and Bank transfers are included in your Host's plan.",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1100,7 +1100,7 @@
   "pricing.back.btn": "Back",
   "pricing.fiscalHost.applyOpenSource": "If you are an open source project, you can apply to join  the Open Source Collective.",
   "pricing.fiscalHost.description": "A Fiscal Host is an <strong>organization who offers fund-holding as a service</strong>. They keep your money in their bank account and  <strong>handle things like accounting, taxes, admin, payments, and liability</strong>-so you don’t have to!",
-  "pricing.fiscalHost.featured": "Below are some of our most popular hosts or <a href='/hosts'>browse all of them</a>.",
+  "pricing.fiscalHost.featured": "Below are some of our most popular hosts or <hosts-link>browse all of them</hosts-link>.",
   "pricing.fiscalHost.learnMore": "Learn more about becoming a Fiscal Host.",
   "pricing.fiscalHost.more": "See more fiscal hosts",
   "pricing.fiscalHost.reasonToJoin": "If you join a Fiscal Host, <strong>you don’t need to go on an Open Collective paid plan</strong>, as your Collective is already included. Each Fiscal Host sets their own fees and acceptance criteria for Collectives. Open Collective keeps a 5% of the donations your raise via credit card payments (Stripe). All other payment methods such as PayPal and Bank transfers are included in your Host's plan.",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1100,7 +1100,7 @@
   "pricing.back.btn": "Back",
   "pricing.fiscalHost.applyOpenSource": "If you are an open source project, you can apply to join  the Open Source Collective.",
   "pricing.fiscalHost.description": "A Fiscal Host is an <strong>organization who offers fund-holding as a service</strong>. They keep your money in their bank account and  <strong>handle things like accounting, taxes, admin, payments, and liability</strong>-so you don’t have to!",
-  "pricing.fiscalHost.featured": "Below are some of our most popular hosts or <a href='/hosts'>browse all of them</a>.",
+  "pricing.fiscalHost.featured": "Below are some of our most popular hosts or <hosts-link>browse all of them</hosts-link>.",
   "pricing.fiscalHost.learnMore": "Learn more about becoming a Fiscal Host.",
   "pricing.fiscalHost.more": "See more fiscal hosts",
   "pricing.fiscalHost.reasonToJoin": "If you join a Fiscal Host, <strong>you don’t need to go on an Open Collective paid plan</strong>, as your Collective is already included. Each Fiscal Host sets their own fees and acceptance criteria for Collectives. Open Collective keeps a 5% of the donations your raise via credit card payments (Stripe). All other payment methods such as PayPal and Bank transfers are included in your Host's plan.",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1100,7 +1100,7 @@
   "pricing.back.btn": "Back",
   "pricing.fiscalHost.applyOpenSource": "If you are an open source project, you can apply to join  the Open Source Collective.",
   "pricing.fiscalHost.description": "A Fiscal Host is an <strong>organization who offers fund-holding as a service</strong>. They keep your money in their bank account and  <strong>handle things like accounting, taxes, admin, payments, and liability</strong>-so you don’t have to!",
-  "pricing.fiscalHost.featured": "Below are some of our most popular hosts or <a href='/hosts'>browse all of them</a>.",
+  "pricing.fiscalHost.featured": "Below are some of our most popular hosts or <hosts-link>browse all of them</hosts-link>.",
   "pricing.fiscalHost.learnMore": "Learn more about becoming a Fiscal Host.",
   "pricing.fiscalHost.more": "See more fiscal hosts",
   "pricing.fiscalHost.reasonToJoin": "If you join a Fiscal Host, <strong>you don’t need to go on an Open Collective paid plan</strong>, as your Collective is already included. Each Fiscal Host sets their own fees and acceptance criteria for Collectives. Open Collective keeps a 5% of the donations your raise via credit card payments (Stripe). All other payment methods such as PayPal and Bank transfers are included in your Host's plan.",


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2952

This PR removes the `FormattedHTMLMessage` component introduced in the pricing page. The component has been removed from the library in its latest version and it usage has always been discouraged:

> Note: This component is provided for apps that have legacy external strings which contain HTML, but is not recommended, use FormattedMessage instead, if you can.

The reason is that it introduces a very severe XSS issue, which affects us because we use Crowdin where anyone can contribute to the translations. Before this PR, anyone could have injected code in production by just translating a string with malicious content and a quick review could have easily missed it.

You can try it yourself with the following snippet:

```jsx
<FormattedHTMLMessage 
    id="test" 
    defaultMessage="<script>alert('XSS injection');</script>" 
/>
```

I've also added an ESLint rule to make sure we won't import it again in the future.

![image](https://user-images.githubusercontent.com/1556356/76244019-91620700-6239-11ea-96e6-523dc8283c54.png)
