### PR TITLE
New expense page: Activate link to download expense's invoices

### DIFF
--- a/components/expenses/Expense.js
+++ b/components/expenses/Expense.js
@@ -643,6 +643,7 @@ const editExpense = graphql(
     mutation editExpense($expense: ExpenseInputType!) {
       editExpense(expense: $expense) {
         id
+        idV2
         description
         amount
         attachment

--- a/components/expenses/ExpenseAdminActions.js
+++ b/components/expenses/ExpenseAdminActions.js
@@ -8,6 +8,8 @@ import styled from 'styled-components';
 
 import { fadeIn } from '../StyledKeyframes';
 import StyledRoundButton from '../StyledRoundButton';
+import ExpenseInvoiceDownloadHelper from './ExpenseInvoiceDownloadHelper';
+import expenseTypes from '../../lib/constants/expenseTypes';
 
 const ButtonLabel = styled.div`
   position: absolute;
@@ -34,16 +36,20 @@ const ButtonWithLabel = styled(StyledRoundButton)`
  * Admin buttons for the expense, displayed in a React fragment to let parent
  * in control of the layout.
  */
-const ExpenseAdminActions = ({ permissions }) => {
+const ExpenseAdminActions = ({ expense, collective, permissions, onError }) => {
   return (
     <React.Fragment>
-      {permissions?.canSeeInvoiceInfo && (
-        <ButtonWithLabel size={40} m={2}>
-          <IconDownload size={18} />
-          <ButtonLabel>
-            <FormattedMessage id="actions.download" defaultMessage="Download" />
-          </ButtonLabel>
-        </ButtonWithLabel>
+      {permissions?.canSeeInvoiceInfo && expense?.type === expenseTypes.INVOICE && (
+        <ExpenseInvoiceDownloadHelper expense={expense} collective={collective} onError={onError}>
+          {({ isLoading, downloadInvoice }) => (
+            <ButtonWithLabel size={40} m={2} loading={isLoading} onClick={downloadInvoice}>
+              <IconDownload size={18} />
+              <ButtonLabel>
+                <FormattedMessage id="actions.download" defaultMessage="Download" />
+              </ButtonLabel>
+            </ButtonWithLabel>
+          )}
+        </ExpenseInvoiceDownloadHelper>
       )}
       <ButtonWithLabel size={40} m={2}>
         <IconLink size={18} />
@@ -64,10 +70,17 @@ const ExpenseAdminActions = ({ permissions }) => {
 };
 
 ExpenseAdminActions.propTypes = {
+  expense: PropTypes.shape({
+    type: PropTypes.oneOf(Object.values(expenseTypes)),
+  }),
+  collective: PropTypes.object,
   permissions: PropTypes.shape({
     canEdit: PropTypes.bool,
     canDelete: PropTypes.bool,
+    canSeeInvoiceInfo: PropTypes.bool,
   }),
+  /** Called with an error if anything wrong happens */
+  onError: PropTypes.func,
 };
 
 export default ExpenseAdminActions;

--- a/components/expenses/ExpenseInvoiceDownloadHelper.js
+++ b/components/expenses/ExpenseInvoiceDownloadHelper.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { saveAs } from 'file-saver';
+
+import { fetchFromPDFService } from '../../lib/api';
+import { invoiceServiceURL, expenseInvoiceUrl } from '../../lib/url_helpers';
+import { getErrorFromPdfService } from '../../lib/errors';
+
+/**
+ * An helper to build components that download expense's invoice. Does not check the permissions.
+ */
+const ExpenseInvoiceDownloadHelper = ({ children, expense, collective, onError }) => {
+  const [isLoading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState(null);
+  const filename = `Expense-${expense.legacyId}-${collective?.slug}-invoice.pdf`;
+
+  return children({
+    error,
+    isLoading,
+    filename,
+    downloadInvoice: async () => {
+      if (isLoading) {
+        return false;
+      }
+
+      const invoiceUrl = expenseInvoiceUrl(expense.id);
+      const fetchParams = { format: 'blob', allowExternal: invoiceServiceURL };
+      setLoading(true);
+      try {
+        const file = await fetchFromPDFService(invoiceUrl, fetchParams);
+        return saveAs(file, filename);
+      } catch (e) {
+        const error = getErrorFromPdfService(e);
+        setError(error);
+        if (onError) {
+          onError(error);
+        }
+      } finally {
+        setLoading(false);
+      }
+    },
+  });
+};
+
+ExpenseInvoiceDownloadHelper.propTypes = {
+  /** Link content */
+  children: PropTypes.func.isRequired,
+  /** Expense */
+  expense: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    legacyId: PropTypes.number.isRequired,
+  }).isRequired,
+  /** Collective where the expense was posted */
+  collective: PropTypes.shape({
+    slug: PropTypes.string.isRequired,
+  }),
+  /** Called with an error if anything wrong happens */
+  onError: PropTypes.func,
+};
+
+export default ExpenseInvoiceDownloadHelper;

--- a/components/expenses/ExpenseSummary.js
+++ b/components/expenses/ExpenseSummary.js
@@ -185,7 +185,7 @@ const ExpenseSummary = ({ expense, host, isLoading, isLoadingLoggedInUser }) => 
           <div data-cy="expense-summary-attachments">
             {expense.attachments.map((attachment, idx) => (
               <React.Fragment key={attachment.id}>
-                <Flex justifyContent="space-between" my={24}>
+                <Flex justifyContent="space-between" alignItems="center" my={24}>
                   {expense.type === expenseTypes.RECEIPT ? (
                     <Flex>
                       {attachment.url ? (

--- a/components/expenses/ExpenseWithData.js
+++ b/components/expenses/ExpenseWithData.js
@@ -84,6 +84,7 @@ const getExpenseQuery = gql`
   query Expense($id: Int!) {
     Expense(id: $id) {
       id
+      idV2
       description
       status
       createdAt

--- a/components/expenses/ExpensesWithData.js
+++ b/components/expenses/ExpensesWithData.js
@@ -83,6 +83,7 @@ const getExpensesQuery = gql`
       includeHostedCollectives: $includeHostedCollectives
     ) {
       id
+      idV2
       description
       status
       createdAt

--- a/lib/api.js
+++ b/lib/api.js
@@ -244,6 +244,26 @@ export function get(path, options = {}) {
     return checkResponseStatus(response);
   });
 }
+/**
+ * Fetch a file from PDF service.
+ */
+export async function fetchFromPDFService(url) {
+  if (!url.startsWith(process.env.INVOICES_URL)) {
+    throw new Error('PDF service URL is not properly set');
+  }
+
+  return fetch(url, { method: 'get', headers: addAuthTokenToHeader() }).then(response => {
+    const { status } = response;
+    if (status >= 200 && status < 300) {
+      return response.blob();
+    } else {
+      return response.json().then(json => {
+        const error = new Error();
+        throw Object.assign(error, json);
+      });
+    }
+  });
+}
 
 export function getGithubRepos(token) {
   return fetch(`/api/github-repositories?access_token=${token}`).then(checkResponseStatus);

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -112,6 +112,21 @@ export const getErrorFromGraphqlException = exception => {
   }
 };
 
+/**
+ * From an XMLHttpRequest returned by the PDF service (invoice service), returns a standard error.
+ *
+ * @returns {OCError}
+ */
+export const getErrorFromPdfService = exception => {
+  // Invoice service is reached using an XMLHTTPRequest
+  if (exception instanceof TypeError && exception.message === 'Network request failed') {
+    return createError(ERROR.NETWORK);
+  }
+
+  // But if something wrong happens, it returns the error from GraphQL API
+  return getErrorFromGraphqlException(exception);
+};
+
 // ---- Internationalization (i18n) ----
 
 const msg = defineMessages({

--- a/lib/graphql/schema.graphql
+++ b/lib/graphql/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:3060/graphql
-# timestamp: Tue Mar 17 2020 09:00:45 GMT+0100 (Central European Standard Time)
+# timestamp: Tue Mar 17 2020 16:29:27 GMT+0100 (GMT+01:00)
 
 """
 Application model
@@ -1334,6 +1334,7 @@ This represents an Expense
 """
 type ExpenseType {
   id: Int
+  idV2: String
   amount: Int
   currency: String
   createdAt: DateString

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:3060/graphql/v2
-# timestamp: Tue Mar 17 2020 09:01:03 GMT+0100 (Central European Standard Time)
+# timestamp: Tue Mar 17 2020 16:30:00 GMT+0100 (GMT+01:00)
 
 """
 Account interface shared by all kind of accounts (Bot, Collective, Event, User, Organization)

--- a/lib/url_helpers.js
+++ b/lib/url_helpers.js
@@ -41,6 +41,10 @@ export const transactionInvoiceURL = transactionUUID => {
   return `${invoiceServiceURL}/transactions/${transactionUUID}/invoice.pdf`;
 };
 
+export const expenseInvoiceUrl = expenseId => {
+  return `${invoiceServiceURL}/expense/${expenseId}/invoice.pdf`;
+};
+
 /**
  * `POST` endpoint to generate printable gift cards.
  *


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2944
Require https://github.com/opencollective/opencollective-invoices/pull/281
Require https://github.com/opencollective/opencollective-invoices/pull/293
Require https://github.com/opencollective/opencollective-api/pull/3531

Add the link to:
- [x] New expense page
- [x] Legacy expense pages
- [x] Host dashboard

---

## New expense page

![Peek 10-03-2020 18-09](https://user-images.githubusercontent.com/1556356/76339388-48be5280-62fa-11ea-9199-b1b281f21bfa.gif)

## Legacy expense page(s) (+ host dashboard)

![Peek 17-03-2020 16-25](https://user-images.githubusercontent.com/1556356/76871932-0356d380-686c-11ea-8eef-5bdbc26c7fb7.gif)
