### PR TITLE
eslint: Fix & enforce lines-between-class-members

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,7 @@
   "rules": {
     "no-console": "warn",
     "require-atomic-updates": "warn",
+    "lines-between-class-members": ["error", "always", { "exceptAfterSingleLine": true }],
     "no-restricted-imports": [
       "error",
       {

--- a/components/DateTime.js
+++ b/components/DateTime.js
@@ -8,6 +8,7 @@ class DateTime extends React.Component {
     date: PropTypes.string.isRequired,
     timezone: PropTypes.string.isRequired,
   };
+
   render() {
     const props = this.props;
     const { date, timezone } = props;

--- a/components/WarnIfUnsavedChanges.js
+++ b/components/WarnIfUnsavedChanges.js
@@ -14,6 +14,7 @@ class WarnIfUnsavedChanges extends React.Component {
     children: PropTypes.node,
     intl: PropTypes.object,
   };
+
   componentDidMount() {
     window.addEventListener('beforeunload', this.beforeunload);
     Router.router.events.on('routeChangeStart', this.routeChangeStart);

--- a/components/expenses/DownloadInvoicesPopOver.js
+++ b/components/expenses/DownloadInvoicesPopOver.js
@@ -76,6 +76,7 @@ class Overlay extends React.Component {
       </div>
     );
   }
+
   renderYear(year) {
     const invoices = this.props.data.allInvoices.filter(i => Number(i.year) === Number(year));
     const invoicesByHost = groupBy(invoices, 'host.slug');

--- a/pages/new-collective-page.js
+++ b/pages/new-collective-page.js
@@ -99,6 +99,7 @@ class NewCollectivePage extends React.Component {
   componentDidMount() {
     this.setState({ smooth: true });
   }
+
   getPageMetaData(collective) {
     if (collective) {
       return {

--- a/pages/unsubscribeEmail.js
+++ b/pages/unsubscribeEmail.js
@@ -16,6 +16,7 @@ class UnsubscribeEmail extends React.Component {
   static getInitialProps({ query }) {
     return { email: query.email, slug: query.slug, type: query.type, token: query.token };
   }
+
   static propTypes = {
     /** Unsubscription email, given in URL */
     email: PropTypes.string.isRequired,
@@ -26,12 +27,14 @@ class UnsubscribeEmail extends React.Component {
     /** Unsubscription token, given in URL */
     token: PropTypes.string.isRequired,
   };
+
   constructor(props) {
     super(props);
     this.state = {
       state: 'unsubscribing',
     };
   }
+
   async componentDidMount() {
     let state, errorMessage, response;
     await fetch(
@@ -51,6 +54,7 @@ class UnsubscribeEmail extends React.Component {
       this.setState({ state: state, errorMessage: errorMessage });
     });
   }
+
   getIconColor(state) {
     if (state === 'success') {
       return '#00A34C';
@@ -58,6 +62,7 @@ class UnsubscribeEmail extends React.Component {
       return '#CC1836';
     }
   }
+
   render() {
     return (
       <Page title="Unsubscribe Email">

--- a/test/mocks/withMockRouter.js
+++ b/test/mocks/withMockRouter.js
@@ -19,6 +19,7 @@ export const withMockRouterContext = mockRouter => {
         router: Object.assign(mockedRouter, mockRouter),
       };
     }
+
     render() {
       return this.props.children;
     }


### PR DESCRIPTION
Following up on https://github.com/opencollective/eslint-config-opencollective/pull/16

This fixes all the entries that we have an enforces the rule in the frontend.