### PR TITLE
Remove template string for Open Source Collective

### DIFF
--- a/components/create-collective/ConnectGithub.js
+++ b/components/create-collective/ConnectGithub.js
@@ -283,10 +283,7 @@ class ConnectGithub extends React.Component {
                     values={{
                       osclink: (
                         <ExternalLink href="https://opencollective.com/opensource" openInNewTab>
-                          <FormattedMessage
-                            id="OpenSourceCollective501c6"
-                            defaultMessage="Open Source Collective 501c6"
-                          />
+                          Open Source Collective 501c6
                         </ExternalLink>
                       ),
                       criterialink: (

--- a/lang/en.json
+++ b/lang/en.json
@@ -991,7 +991,6 @@
   "openSourceApply.GithubRepositories.title": "Pick a repository",
   "openSourceApply.guidelines": "guidelines",
   "openSourceApply.title": "For Open Source Projects",
-  "OpenSourceCollective501c6": "Open Source Collective 501c6",
   "OptionalFieldLabel": "{field} (optional)",
   "order.active": "active",
   "order.cancelled": "cancelled",

--- a/lang/es.json
+++ b/lang/es.json
@@ -991,7 +991,6 @@
   "openSourceApply.GithubRepositories.title": "Pick a repository",
   "openSourceApply.guidelines": "guidelines",
   "openSourceApply.title": "For Open Source Projects",
-  "OpenSourceCollective501c6": "Open Source Collective 501c6",
   "OptionalFieldLabel": "{field} (optional)",
   "order.active": "activo",
   "order.cancelled": "cancelado",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -991,7 +991,6 @@
   "openSourceApply.GithubRepositories.title": "Choisissez un dépôt",
   "openSourceApply.guidelines": "instructions",
   "openSourceApply.title": "Pour les projets open-source",
-  "OpenSourceCollective501c6": "Open Source Collective 501c6",
   "OptionalFieldLabel": "{field} (optionnel)",
   "order.active": "actif",
   "order.cancelled": "annulé",

--- a/lang/it.json
+++ b/lang/it.json
@@ -991,7 +991,6 @@
   "openSourceApply.GithubRepositories.title": "Pick a repository",
   "openSourceApply.guidelines": "guidelines",
   "openSourceApply.title": "For Open Source Projects",
-  "OpenSourceCollective501c6": "Open Source Collective 501c6",
   "OptionalFieldLabel": "{field} (optional)",
   "order.active": "active",
   "order.cancelled": "cancellato",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -991,7 +991,6 @@
   "openSourceApply.GithubRepositories.title": "リポジトリを選ぶ",
   "openSourceApply.guidelines": "ガイドライン",
   "openSourceApply.title": "オープンソースプロジェクトへ",
-  "OpenSourceCollective501c6": "Open Source Collective 501c6",
   "OptionalFieldLabel": "{field} (optional)",
   "order.active": "アクティブ",
   "order.cancelled": "キャンセル済み",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -991,7 +991,6 @@
   "openSourceApply.GithubRepositories.title": "Pick a repository",
   "openSourceApply.guidelines": "guidelines",
   "openSourceApply.title": "For Open Source Projects",
-  "OpenSourceCollective501c6": "Open Source Collective 501c6",
   "OptionalFieldLabel": "{field} (optional)",
   "order.active": "active",
   "order.cancelled": "cancelled",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -991,7 +991,6 @@
   "openSourceApply.GithubRepositories.title": "Selecione um repositório",
   "openSourceApply.guidelines": "orientações",
   "openSourceApply.title": "Para projetos de código aberto",
-  "OpenSourceCollective501c6": "Open Source Collective 501c6",
   "OptionalFieldLabel": "{field} (opcional)",
   "order.active": "ativo",
   "order.cancelled": "cancelado",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -991,7 +991,6 @@
   "openSourceApply.GithubRepositories.title": "Pick a repository",
   "openSourceApply.guidelines": "руководящие принципы",
   "openSourceApply.title": "For Open Source Projects",
-  "OpenSourceCollective501c6": "Open Source Collective 501c6",
   "OptionalFieldLabel": "{field} (optional)",
   "order.active": "активен",
   "order.cancelled": "отменён",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -991,7 +991,6 @@
   "openSourceApply.GithubRepositories.title": "Pick a repository",
   "openSourceApply.guidelines": "guidelines",
   "openSourceApply.title": "For Open Source Projects",
-  "OpenSourceCollective501c6": "Open Source Collective 501c6",
   "OptionalFieldLabel": "{field} (optional)",
   "order.active": "active",
   "order.cancelled": "cancelled",


### PR DESCRIPTION
Though I agree that it could be translated, it's the name of the collective so we don't really want people to translate it. Like a brand, you don't want people to translate "Microsoft Corporation" :wink:.