### PR TITLE
fix(events): no tickets tab if no tickets have been created

### DIFF
--- a/components/CollectiveNavbar.js
+++ b/components/CollectiveNavbar.js
@@ -296,7 +296,7 @@ export const getSectionsForCollective = (collective, isAdmin) => {
 
   if (collective.type === CollectiveType.EVENT) {
     // Should not see tickets section if you can't order them
-    if ((!collective.isApproved && !isAdmin) || !canOrderTicketsFromEvent(collective)) {
+    if ((!collective.isApproved && !isAdmin) || (!canOrderTicketsFromEvent(collective) && !isAdmin)) {
       toRemove.add(Sections.TICKETS);
     }
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -1,11 +1,15 @@
-import { get } from 'lodash';
+import { get, some } from 'lodash';
 
 /**
- * Check if the given event is over. Ideally we would just rely on the date, but
- * as there can be timezones differences we add an additional security by keeping
- * tickets up to 24h after the event is over.
+ * Check if any tickets were created or if a given event is over. Ideally we would
+ * just rely on the date, but as there can be timezones differences we add an
+ * additional security by keeping tickets up to 24h after the event is over.
  */
 export const canOrderTicketsFromEvent = event => {
+  if (!some(event.tiers, { type: 'TICKET' })) {
+    return false;
+  }
+
   if (!event.endsAt) {
     return true;
   }


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/2955

# Description
This PR fixes the bug where a ticket tab is present on an approved event for non-admin users when no tickets have been created.

# Screenshots
#### No Tickets available
![no tickets currently available](https://user-images.githubusercontent.com/24629960/76686492-32faa700-65f2-11ea-9474-5c69e743fbb9.png)

#### No Ticket tab for non-admin user
![view as non signed user](https://user-images.githubusercontent.com/24629960/76686477-15c5d880-65f2-11ea-826b-039f02f38d09.png)

![view as non-admin user](https://user-images.githubusercontent.com/24629960/76686596-06935a80-65f3-11ea-9211-15a6ea04d63d.png)

#### Ticket Tab still present for Event Admin
![admin view](https://user-images.githubusercontent.com/24629960/76686480-18283280-65f2-11ea-8d49-b29f5ad95a53.png)

