### PR TITLE
test: Fix E2E tests related to host filters

### DIFF
--- a/test/cypress/integration/05-user_v2.test.js
+++ b/test/cypress/integration/05-user_v2.test.js
@@ -63,11 +63,7 @@ describe('New users profiles', () => {
     });
 
     it('Show transactions with all info and links', () => {
-      cy.get('[data-cy~="transactions"]')
-        .first()
-        .get('[data-cy=transaction-details] > a')
-        .should('have.attr', 'href', '/brusselstogether')
-        .contains('BrusselsTogether');
+      cy.get('[data-cy~="transactions"]:first a[href="/brusselstogether"]').should('exist');
       cy.get('[data-cy~="transactions"]')
         .first()
         .get('[data-cy=transaction-description]')

--- a/test/cypress/integration/06-host_v2.test.js
+++ b/test/cypress/integration/06-host_v2.test.js
@@ -9,9 +9,7 @@ describe('New host page', () => {
   describe('Contributions section', () => {
     // The rest of the contributions section is already tested in `05-user_v2.test.js`
     it('Show fiscally hosted collectives', () => {
-      cy.get('[data-cy~="filter-button"]')
-        .contains('Fiscal Host')
-        .click();
+      cy.contains('[data-cy~="filter-button"]', 'Hosted Collectives').click();
       cy.contains('[data-cy=Contributions]', 'Open Source Collective');
       cy.contains('[data-cy=Contributions]', 'APEX');
       cy.contains('[data-cy=Contributions]', 'tipbox');


### PR DESCRIPTION
06-host test broken in https://github.com/opencollective/opencollective-frontend/pull/3690
05-user_v2 test broken in https://github.com/opencollective/opencollective-frontend/pull/3659

We missed it because E2e test are not run on fork's PRs.