### PR TITLE
ButtonWidget: correct path to load image

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -105,7 +105,7 @@ module.exports = (server, app) => {
   server.get('/:collectiveSlug/:verb(contribute|donate)/button:size(|@2x).png', (req, res) => {
     const color = req.query.color === 'blue' ? 'blue' : 'white';
     res.sendFile(
-      path.join(__dirname, `../static/images/buttons/${req.params.verb}-button-${color}${req.params.size}.png`),
+      path.join(__dirname, `../public/static/images/buttons/${req.params.verb}-button-${color}${req.params.size}.png`),
     );
   });
 


### PR DESCRIPTION
Initially reported in https://opencollective.slack.com/archives/C6JTTA4SK/p1584530744062700
Seems to be a side effect of https://github.com/opencollective/opencollective-frontend/pull/3638