### PR TITLE
Update on deprecated fields

### DIFF
--- a/components/CommentsWithData.js
+++ b/components/CommentsWithData.js
@@ -45,7 +45,7 @@ class CommentsWithData extends React.Component {
 
     const CommentInputType = {
       ...comment,
-      ExpenseId: expense.id,
+      expense: { legacyId: expense.id },
     };
 
     const res = await this.props.createComment(CommentInputType);

--- a/components/host-dashboard/Dashboard.js
+++ b/components/host-dashboard/Dashboard.js
@@ -212,7 +212,7 @@ const getDataQuery = gql`
       name
       isHost
       currency
-      paymentMethods(includeOrganizationCollectivePaymentMethod: true) {
+      paymentMethods(includeHostCollectivePaymentMethod: true) {
         id
         uuid
         service

--- a/lib/graphql/schema.graphql
+++ b/lib/graphql/schema.graphql
@@ -703,9 +703,12 @@ Input type for CommentType
 """
 input CommentAttributesInputType {
   id: Int
+
+  """
+  Deprecated since 2020-03-18: Please use html.
+  """
   markdown: String
   html: String
-  UpdateId: Int
 }
 
 """

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -390,13 +390,15 @@ type CommentCollection implements Collection {
 }
 
 input CommentCreateInput {
+  """
+  Thr HTML content of your comment
+  """
   html: String
 
   """
   If your comment is linked to an expense, set it here
   """
   expense: ExpenseReferenceInput
-  ExpenseId: Int
   ConversationId: String
 }
 

--- a/pages/contribute.js
+++ b/pages/contribute.js
@@ -110,11 +110,14 @@ class TiersPage extends React.Component {
                         </ContributeCardContainer>
                       ))}
 
-                      {collective.childCollectives.map(childCollective => (
-                        <ContributeCardContainer key={childCollective.id}>
-                          <ContributeCollective collective={childCollective} />
-                        </ContributeCardContainer>
-                      ))}
+                      {collective.subCollectives.map(member => {
+                        const childCollective = member.collective;
+                        return (
+                          <ContributeCardContainer key={member.id}>
+                            <ContributeCollective collective={childCollective} />
+                          </ContributeCardContainer>
+                        );
+                      })}
 
                       {collective.events.map(event => (
                         <ContributeCardContainer key={`event-${event.id}`}>
@@ -220,15 +223,17 @@ const addTiersData = graphql(
             type
           }
         }
-        events(includePastEvents: true) {
+        events(includePastEvents: true, includeInactive: true) {
           id
           slug
           name
           description
           image
+          isActive
           startsAt
           endsAt
-          contributors(limit: $nbContributorsPerContributeCard) {
+          backgroundImageUrl(height: 208)
+          contributors(limit: $nbContributorsPerContributeCard, roles: [BACKER, ATTENDEE]) {
             id
             image
             collectiveSlug
@@ -245,28 +250,31 @@ const addTiersData = graphql(
             }
           }
         }
-        childCollectives {
+        subCollectives: members(role: "SUB_COLLECTIVE") {
           id
-          slug
-          name
-          type
-          description
-          backgroundImageUrl(height: 208)
-          stats {
+          collective: member {
             id
-            backers {
-              id
-              all
-              users
-              organizations
-            }
-          }
-          contributors(limit: $nbContributorsPerContributeCard) {
-            id
-            image
-            collectiveSlug
+            slug
             name
             type
+            description
+            backgroundImageUrl(height: 208)
+            stats {
+              id
+              backers {
+                id
+                all
+                users
+                organizations
+              }
+            }
+            contributors(limit: $nbContributorsPerContributeCard) {
+              id
+              image
+              collectiveSlug
+              name
+              type
+            }
           }
         }
       }


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-api/pull/3539 (for `includeHostCollectivePaymentMethod`)

Remove some deprecated fields from frontend and adapt contribute page for new subcollective system (follow up on #3289).