### PR TITLE
New conversation: save draft in local storage

### DIFF
--- a/components/StyledInputTags.js
+++ b/components/StyledInputTags.js
@@ -18,7 +18,7 @@ const getOptions = tags => {
   }
 };
 
-const StyledInputTags = ({ suggestedTags, defaultValue, ...props }) => {
+const StyledInputTags = ({ suggestedTags, value, defaultValue, ...props }) => {
   const { formatMessage } = useIntl();
   const options = getOptions(suggestedTags);
   return (
@@ -26,6 +26,7 @@ const StyledInputTags = ({ suggestedTags, defaultValue, ...props }) => {
       isMulti
       data-cy="styled-input-tags"
       options={options}
+      value={getOptions(value)}
       hideDropdownIndicator={!options}
       hideMenu={!options}
       placeholder={formatMessage(messages.placeholder)}
@@ -40,6 +41,7 @@ StyledInputTags.propTypes = {
   inputId: PropTypes.string,
   suggestedTags: PropTypes.arrayOf(PropTypes.string),
   defaultValue: PropTypes.arrayOf(PropTypes.string),
+  value: PropTypes.arrayOf(PropTypes.string),
 };
 
 export default React.memo(StyledInputTags);

--- a/components/conversations/CreateConversationForm.js
+++ b/components/conversations/CreateConversationForm.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, defineMessages, useIntl } from 'react-intl';
 import { useForm } from 'react-hook-form';
@@ -15,6 +15,7 @@ import LoadingPlaceholder from '../LoadingPlaceholder';
 import { P, H4 } from '../Text';
 import StyledInputTags from '../StyledInputTags';
 import CreateConversationFAQ from '../faqs/CreateConversationFAQ';
+import FormPersister from '../../lib/form-persister';
 
 const CreateConversationMutation = gqlV2`
   mutation CreateConversation($title: String!, $html: String!, $CollectiveId: String!, $tags: [String]) {
@@ -48,21 +49,50 @@ const messages = defineMessages({
  *
  * /!\ Can only be used with data from API V2.
  */
-const CreateConversationForm = ({ collectiveId, suggestedTags, onSuccess, disabled, loading }) => {
+const CreateConversationForm = ({ collective, LoggedInUser, suggestedTags, onSuccess, disabled, loading }) => {
   const { formatMessage } = useIntl();
   const [createConversation, { error: submitError }] = useMutation(CreateConversationMutation, mutationOptions);
-  const { register, handleSubmit, errors, formState, setValue } = useForm();
+  const { register, watch, handleSubmit, errors, formState, setValue } = useForm();
+
+  const [formPersister] = React.useState(new FormPersister());
+  const conversationText = watch('html', '');
+  const conversationTags = watch('tags', []);
+  const conversationTitle = watch('title', '');
+
+  const { id: collectiveId, slug: collectiveSlug } = collective;
 
   // Manually register custom fields
-  React.useEffect(() => {
+  useEffect(() => {
     register('html', { required: true });
     register('tags');
+    register('title');
   }, []);
+
+  useEffect(() => {
+    if (!loading && LoggedInUser && !conversationTitle && !conversationText && !conversationTags.length) {
+      const id = `conversation-${collectiveSlug}-${LoggedInUser.id}`;
+      formPersister.setFormId(id);
+    }
+
+    const formValues = formPersister.loadValues();
+    if (formValues && !conversationTitle && !conversationText && !conversationTags.length) {
+      setValue('title', formValues['title']);
+      setValue('html', formValues['html']);
+      setValue('tags', formValues['tags']);
+    }
+  }, [loading, LoggedInUser]);
+
+  useEffect(() => {
+    if (conversationTitle || conversationText || conversationTags.length || !formPersister.loadValues()) {
+      formPersister.saveValues({ html: conversationText, tags: conversationTags, title: conversationTitle });
+    }
+  }, [conversationTitle, conversationText, conversationTags]);
 
   return (
     <form
       onSubmit={handleSubmit(async values => {
         const response = await createConversation({ variables: { ...values, CollectiveId: collectiveId } });
+        formPersister.clearValues();
         return onSuccess(response.data.createConversation);
       })}
     >
@@ -83,6 +113,8 @@ const CreateConversationForm = ({ collectiveId, suggestedTags, onSuccess, disabl
               maxLength={255}
               px={0}
               py={0}
+              value={conversationTitle}
+              onChange={e => setValue('title', e.target.value)}
               placeholder={formatMessage(messages.titlePlaceholder)}
               ref={register({ required: true, minLength: 3, maxLength: 255 })}
             />
@@ -112,6 +144,7 @@ const CreateConversationForm = ({ collectiveId, suggestedTags, onSuccess, disabl
                 editorMinHeight={225}
                 inputName="html"
                 fontSize="13px"
+                defaultValue={conversationText}
                 onChange={e => setValue('html', e.target.value)}
                 error={errors.title}
               />
@@ -135,8 +168,9 @@ const CreateConversationForm = ({ collectiveId, suggestedTags, onSuccess, disabl
                 <StyledInputTags
                   maxWidth={300}
                   suggestedTags={suggestedTags}
+                  value={conversationTags}
                   onChange={options =>
-                    setValue('tags', options && options.length > 0 ? options.map(option => option.value) : null)
+                    setValue('tags', options && options.length > 0 ? options.map(option => option.value) : [])
                   }
                 />
               )}
@@ -171,8 +205,8 @@ const CreateConversationForm = ({ collectiveId, suggestedTags, onSuccess, disabl
 };
 
 CreateConversationForm.propTypes = {
-  /** ID of the collective where the conversation will be created */
-  collectiveId: PropTypes.string.isRequired,
+  /** the collective where the conversation will be created */
+  collective: PropTypes.object.isRequired,
   /** Called when the conversation gets successfully created. Return a promise if you want to keep the submitting state active. */
   onSuccess: PropTypes.func.isRequired,
   /** Will disable the form */
@@ -181,6 +215,8 @@ CreateConversationForm.propTypes = {
   loading: PropTypes.bool,
   /** Tags suggested for this new conversation */
   suggestedTags: PropTypes.arrayOf(PropTypes.string),
+  /** LoggedInUser */
+  LoggedInUser: PropTypes.object,
 };
 
 export default CreateConversationForm;

--- a/lib/form-persister.js
+++ b/lib/form-persister.js
@@ -1,0 +1,34 @@
+import { throttle } from 'lodash';
+
+import { removeFromLocalStorage, getFromLocalStorage, setLocalStorage } from './local-storage';
+
+export default class FormPersister {
+  constructor(formId = null, throttlePeriod = 1000) {
+    this.formId = formId;
+    this.saveValues = throttle(this.saveValues, throttlePeriod);
+  }
+
+  setFormId(formId) {
+    this.formId = `formState-${formId}`;
+  }
+
+  saveValues(values) {
+    if (this.formId) {
+      setLocalStorage(this.formId, JSON.stringify(values));
+    }
+  }
+
+  loadValues() {
+    if (this.formId) {
+      const itemFromStorage = getFromLocalStorage(this.formId);
+      return JSON.parse(itemFromStorage);
+    }
+    return null;
+  }
+
+  clearValues() {
+    if (this.formId) {
+      removeFromLocalStorage(this.formId);
+    }
+  }
+}

--- a/pages/create-conversation.js
+++ b/pages/create-conversation.js
@@ -112,7 +112,8 @@ class CreateConversationPage extends React.Component {
                   </StyledLink>
                   <Box mt={4}>
                     <CreateConversationForm
-                      collectiveId={collective.id}
+                      collective={collective}
+                      LoggedInUser={LoggedInUser}
                       loading={loadingLoggedInUser}
                       onSuccess={this.onCreateSuccess}
                       suggestedTags={this.getSuggestedTags(collective)}


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/2800

# Description
This PR automatically saves a draft of new conversations created by a user in local storage 

# Screenshots
![save-draft-in-local-storage](https://user-images.githubusercontent.com/24629960/76645133-b8b51e80-652e-11ea-9384-86a76d8e8390.gif)

