### PR TITLE
refactor: improve autolink to better match urls

### DIFF
--- a/components/RichTextEditor.js
+++ b/components/RichTextEditor.js
@@ -273,18 +273,79 @@ export default class RichTextEditor extends React.Component {
       const url = match[1];
       if (isURL(url)) {
         const position = match.index;
-        const range = [position, position + url.length];
+        const urlLength = this.autolinkDelimiter(url);
+        const range = [position, position + urlLength];
         const hrefAtRange = editor.getDocument().getCommonAttributesAtRange(range).href;
-        if (hrefAtRange !== url) {
+        const newURL = url.slice(0, urlLength);
+        if (hrefAtRange !== newURL) {
           this.updateInRange(editor, range, 0, () => {
             if (editor.canActivateAttribute('href')) {
-              editor.activateAttribute('href', url);
+              editor.activateAttribute('href', newURL);
             }
           });
         }
       }
     }
   }
+
+  /** A helper used by autolink to find where the url actually ends
+   * Credits:
+   * https://github.com/github/cmark-gfm/blob/36c1553d2a1f04dc1628e76b18490edeff78b8d0/extensions/autolink.c#L37
+   * https://github.com/vmg/redcarpet/blob/92a7b3ae2241b862e9bf45e0af3cf53ebdfb0afb/ext/redcarpet/autolink.c#L58
+   */
+  autolinkDelimiter = url => {
+    let lastCharacterPosition = url.length;
+
+    while (lastCharacterPosition > 0) {
+      const lastCharacterIndex = lastCharacterPosition - 1;
+      const closingPair = url[lastCharacterIndex];
+
+      let openingPair;
+      if (closingPair === ')') {
+        openingPair = '(';
+      } else if (closingPair === ']') {
+        openingPair = '[';
+      } else if (closingPair === '}') {
+        openingPair = '{';
+      } else if (closingPair === '"') {
+        openingPair = '"';
+      } else if (closingPair === "'") {
+        openingPair = "'";
+      }
+
+      // Ensure single punctuations marks at the end of the URL are not included as part of link
+      if ('?!.,:;*_~'.includes(url[lastCharacterIndex])) {
+        lastCharacterPosition--;
+      } else if (openingPair) {
+        let opening = 0,
+          closing = 0;
+
+        /** Check to ensure that when a URL is enclosed within pair punctuations,
+         * we do not include the closing punctuation as part of the link.
+         * We only want to accept a closing punctuation at the end of the link,
+         * if there is a corresponding opening punctuation within the URL.
+         */
+
+        for (let i = 0; i < lastCharacterPosition; i++) {
+          if (url[i] === openingPair) {
+            opening++;
+          } else if (url[i] === closingPair) {
+            closing++;
+          }
+        }
+
+        if (opening >= closing) {
+          break;
+        }
+
+        lastCharacterPosition--;
+      } else {
+        break;
+      }
+    }
+
+    return lastCharacterPosition;
+  };
 
   /** A trix helper that will apply func in range then restore base range when it's done */
   updateInRange(editor, range, offset = 0, updateFunc) {


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/2918

# Description

This PR improves the `autolink` in the RichTextEditor to better match urls by better identifying where the url actually ends. I couldn't find a way to improve this by changing the regex.

I was able to find code to help with this https://github.com/github/cmark-gfm/blob/36c1553d2a1f04dc1628e76b18490edeff78b8d0/extensions/autolink.c#L37
and
https://github.com/vmg/redcarpet/blob/92a7b3ae2241b862e9bf45e0af3cf53ebdfb0afb/ext/redcarpet/autolink.c#L58

# Screenshots

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
![Improve autolink](https://user-images.githubusercontent.com/24629960/76410879-0d0da200-6367-11ea-9e0d-3e2c4655250a.png)
