### PR TITLE
Expense form: improve behavior

### DIFF
--- a/components/expenses/CreateExpenseFormLegacy.js
+++ b/components/expenses/CreateExpenseFormLegacy.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import Markdown from 'react-markdown';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import { get, omit } from 'lodash';
-import { titleCase } from 'title-case';
 
 import { getCurrencySymbol } from '../../lib/utils';
 import categories from '../../lib/constants/categories';
@@ -74,14 +73,18 @@ class CreateExpenseForm extends React.Component {
         id: 'expense.error.expenseTypeMissing',
         defaultMessage: 'Please pick the type of this expense',
       },
+      expenseTypeReceipt: {
+        id: 'Expense.Type.Receipt',
+        defaultMessage: 'Receipt',
+      },
+      expenseTypeInvoice: {
+        id: 'Expense.Type.Invoice',
+        defaultMessage: 'Invoice',
+      },
     });
 
     this.categoriesOptions = categories(props.collective.slug).map(category => {
       return { [category]: category };
-    });
-
-    this.expenseTypes = Object.entries(expenseTypes).map(([key, value]) => {
-      return { [key]: titleCase(value) };
     });
 
     this.state = {
@@ -234,10 +237,15 @@ class CreateExpenseForm extends React.Component {
   }
 
   renderForm() {
-    const { LoggedInUser, collective } = this.props;
+    const { LoggedInUser, collective, intl } = this.props;
     const { expense } = this.state;
 
     const payoutMethodOptions = this.getOptions();
+    const expenseTypesOptions = [
+      { [expenseTypes.DEFAULT]: '' },
+      { [expenseTypes.RECEIPT]: intl.formatMessage(this.messages.expenseTypeReceipt) },
+      { [expenseTypes.INVOICE]: intl.formatMessage(this.messages.expenseTypeInvoice) },
+    ];
 
     return (
       <div className={`CreateExpenseForm ${this.props.mode}`}>
@@ -499,7 +507,7 @@ class CreateExpenseForm extends React.Component {
                 <span className="expenseType">
                   <InputField
                     type="select"
-                    options={this.expenseTypes}
+                    options={expenseTypesOptions}
                     defaultValue={expenseTypes.DEFAULT}
                     name="type"
                     className="expenseField"

--- a/components/expenses/ExpenseDetails.js
+++ b/components/expenses/ExpenseDetails.js
@@ -11,7 +11,6 @@ import { imagePreview } from '../../lib/image-utils';
 import InputField from '../../components/InputField';
 import categories from '../../lib/constants/categories';
 import DefinedTerm, { Terms } from '../DefinedTerm';
-import { titleCase } from 'title-case';
 
 import TransactionDetails from './TransactionDetails';
 import { Box, Flex } from '@rebass/grid';
@@ -58,6 +57,14 @@ class ExpenseDetails extends React.Component {
       banktransfer: {
         id: 'expense.payoutMethod.banktransfer',
         defaultMessage: 'Bank Transfer',
+      },
+      expenseTypeReceipt: {
+        id: 'Expense.Type.Receipt',
+        defaultMessage: 'Receipt',
+      },
+      expenseTypeInvoice: {
+        id: 'Expense.Type.Invoice',
+        defaultMessage: 'Invoice',
       },
     });
 
@@ -142,9 +149,11 @@ class ExpenseDetails extends React.Component {
     if (this.state.expense['type'] === 'RECEIPT' || this.state.expense['type'] === 'INVOICE') {
       delete expenseTypes['DEFAULT'];
     }
-    const expenseTypesOptions = Object.entries(expenseTypes).map(([key, value]) => {
-      return { [key]: titleCase(value) };
-    });
+    const expenseTypesOptions = [
+      { [expenseTypes.DEFAULT]: '' },
+      { [expenseTypes.RECEIPT]: intl.formatMessage(this.messages.expenseTypeReceipt) },
+      { [expenseTypes.INVOICE]: intl.formatMessage(this.messages.expenseTypeInvoice) },
+    ];
     const attachmentsWithFiles = expense.attachments?.filter(attachment => Boolean(attachment.url)) || [];
     const canDownloadAttachments = isAuthor || LoggedInUser?.canEditCollective(expense.collective);
 

--- a/components/expenses/ExpenseWithData.js
+++ b/components/expenses/ExpenseWithData.js
@@ -102,6 +102,12 @@ const getExpenseQuery = gql`
       privateMessage
       userTaxFormRequiredBeforePayment
       attachment
+      attachments {
+        id
+        url
+        description
+        amount
+      }
       collective {
         id
         slug


### PR DESCRIPTION
Fix two issues:
- Remove the `UNCLASSIFIED` type from legacy create expense form
- Missing attachment on expense page (introduced in https://github.com/opencollective/opencollective-frontend/pull/3681, wasn't deployed)