### PR TITLE
Show collective balance & host on new expense pages

### DIFF
--- a/components/Text.js
+++ b/components/Text.js
@@ -33,13 +33,15 @@ P.defaultProps = {
 
 export const Span = P.withComponent('span');
 
-export const Label = P.withComponent('label');
-
 Span.defaultProps = {
   ...P.defaultProps,
   fontSize: 'inherit',
   lineHeight: 'inherit',
 };
+
+export const Label = P.withComponent('label');
+
+export const Strong = P.withComponent('strong');
 
 export const H1 = P.withComponent('h1');
 

--- a/pages/create-expense.js
+++ b/pages/create-expense.js
@@ -27,13 +27,14 @@ import SignInOrJoinFree from '../components/SignInOrJoinFree';
 import StyledButton from '../components/StyledButton';
 import StyledInputTags from '../components/StyledInputTags';
 import StyledLink from '../components/StyledLink';
-import { H1, H5 } from '../components/Text';
+import { H1, H5, P, Strong } from '../components/Text';
 import { withUser } from '../components/UserProvider';
 import hasFeature, { FEATURES } from '../lib/allowed-features';
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
 import expenseTypes from '../lib/constants/expenseTypes';
 import { Router } from '../server/pages';
 import ExpenseNotesForm from '../components/expenses/ExpenseNotesForm';
+import LinkCollective from '../components/LinkCollective';
 
 const STEPS = { FORM: 'FORM', SUMMARY: 'summary' };
 
@@ -279,6 +280,18 @@ class CreateExpensePage extends React.Component {
                         />
                       )}
                     </Container>
+                    {host && (
+                      <P fontSize="SmallCaption" color="black.600" mt={2}>
+                        <FormattedMessage
+                          id="withColon"
+                          defaultMessage="{item}:"
+                          values={{ item: <FormattedMessage id="Fiscalhost" defaultMessage="Fiscal Host" /> }}
+                        />{' '}
+                        <LinkCollective collective={host}>
+                          <Strong color="black.600">{host.name}</Strong>
+                        </LinkCollective>
+                      </P>
+                    )}
                     <Box mt={50}>
                       <H5 mb={3}>
                         <FormattedMessage id="Tags" defaultMessage="Tags" />

--- a/pages/expense.js
+++ b/pages/expense.js
@@ -27,10 +27,13 @@ import ExpandableExpensePolicies from '../components/expenses/ExpandableExpenseP
 import CreateExpenseFAQ from '../components/faqs/CreateExpenseFAQ';
 import Container from '../components/Container';
 import { withUser } from '../components/UserProvider';
-import { H5, Span, P } from '../components/Text';
+import { H5, Span, P, Strong } from '../components/Text';
 import PrivateInfoIcon from '../components/icons/PrivateInfoIcon';
 import StyledHr from '../components/StyledHr';
 import MessageBox from '../components/MessageBox';
+import LoadingPlaceholder from '../components/LoadingPlaceholder';
+import FormattedMoneyAmount from '../components/FormattedMoneyAmount';
+import LinkCollective from '../components/LinkCollective';
 
 const messages = defineMessages({
   title: {
@@ -321,6 +324,32 @@ class ExpensePage extends React.Component {
             </Box>
             <Flex flex="1 1" justifyContent={['center', null, 'flex-start', 'flex-end']} pt={[1, 2, 5]}>
               <Box minWidth={300} width={['100%', null, null, 300]} px={3}>
+                <H5 mb={3}>
+                  <FormattedMessage id="CollectiveBalance" defaultMessage="Collective balance" />
+                </H5>
+                <Container borderLeft="1px solid" borderColor="green.600" pl={3} fontSize="H5" color="black.500">
+                  {data.loading ? (
+                    <LoadingPlaceholder height={28} width={75} />
+                  ) : (
+                    <FormattedMoneyAmount
+                      currency={collective.currency}
+                      amount={collective.balance}
+                      amountStyles={{ color: 'black.800' }}
+                    />
+                  )}
+                </Container>
+                {host && (
+                  <P fontSize="SmallCaption" color="black.600" mt={2}>
+                    <FormattedMessage
+                      id="withColon"
+                      defaultMessage="{item}:"
+                      values={{ item: <FormattedMessage id="Fiscalhost" defaultMessage="Fiscal Host" /> }}
+                    />{' '}
+                    <LinkCollective collective={host}>
+                      <Strong color="black.600">{host.name}</Strong>
+                    </LinkCollective>
+                  </P>
+                )}
                 <ExpandableExpensePolicies host={host} collective={collective} mt={50} />
                 <Box mt={50}>
                   <CreateExpenseFAQ


### PR DESCRIPTION
# Description

See https://www.figma.com/file/ZQBMWhnGGtRWeIZknFW1eP/%5BOC.com%5D-Production-Ready-%E2%9C%85?node-id=292%3A9739

# Screenshots

![image](https://user-images.githubusercontent.com/1556356/77084960-eb17bd80-69ff-11ea-9a18-967e74d7facc.png)


![image](https://user-images.githubusercontent.com/1556356/77084924-e18e5580-69ff-11ea-889d-dc6608ca95f7.png)

