### PR TITLE
CommentForm: Improve styles for sign in overlay

### DIFF
--- a/components/SignIn.js
+++ b/components/SignIn.js
@@ -22,8 +22,12 @@ export default class SignIn extends React.Component {
     onSecondaryAction: PropTypes.oneOfType([PropTypes.func, PropTypes.string]).isRequired,
     /** When set to true, will show a spinner in Sign In button and will disable all actions */
     loading: PropTypes.bool,
+    /** To display a box shadow below the card */
+    withShadow: PropTypes.bool,
     /** Set this to true to display the unknown email message */
     unknownEmail: PropTypes.bool,
+    /** Label, defaults to "Sign in using your email address:" */
+    label: PropTypes.node,
     /** Set the value of email input */
     email: PropTypes.string.isRequired,
     /** handles changes in the email input */
@@ -48,13 +52,13 @@ export default class SignIn extends React.Component {
   }
 
   render() {
-    const { onSubmit, loading, unknownEmail, email, onEmailChange } = this.props;
+    const { onSubmit, loading, unknownEmail, email, onEmailChange, withShadow, label } = this.props;
     const { error, showError } = this.state;
     return (
-      <StyledCard maxWidth={480} width={1}>
+      <StyledCard maxWidth={480} width={1} boxShadow={withShadow ? '0px 9px 14px 1px #dedede' : undefined}>
         <Box py={4} px={[3, 4]}>
           <H5 as="label" fontWeight="bold" htmlFor="email" mb={3} textAlign="left" display="block">
-            <FormattedMessage id="signin.usingEmail" defaultMessage="Sign in using your email address:" />
+            {label || <FormattedMessage id="signin.usingEmail" defaultMessage="Sign in using your email address:" />}
           </H5>
           <Flex
             as="form"

--- a/components/SignInOrJoinFree.js
+++ b/components/SignInOrJoinFree.js
@@ -39,6 +39,10 @@ class SignInOrJoinFree extends React.Component {
     createPersonalProfileLabel: PropTypes.node,
     /** A label to use instead of the default `Create Organization profile` */
     createOrganizationProfileLabel: PropTypes.node,
+    /** To display a box shadow below the card */
+    withShadow: PropTypes.bool,
+    /** Label for signIn, defaults to "Sign in using your email address:" */
+    signInLabel: PropTypes.node,
   };
 
   state = {
@@ -136,6 +140,8 @@ class SignInOrJoinFree extends React.Component {
             onSubmit={this.signIn}
             loading={submitting}
             unknownEmail={unknownEmailError}
+            withShadow={this.props.withShadow}
+            label={this.props.signInLabel}
           />
         ) : (
           <Flex flexDirection="column" width={1} alignItems="center">

--- a/components/conversations/CommentForm.js
+++ b/components/conversations/CommentForm.js
@@ -36,6 +36,10 @@ const messages = defineMessages({
     id: 'CommentForm.PostReply',
     defaultMessage: 'Post reply',
   },
+  signInLabel: {
+    id: 'CommentForm.SignIn',
+    defaultMessage: 'Please sign in to comment:',
+  },
 });
 
 const getRedirectUrl = (router, id) => {
@@ -100,8 +104,12 @@ const CommentForm = ({
   return (
     <Container id={id} position="relative">
       {!loadingLoggedInUser && !LoggedInUser && (
-        <ContainerOverlay>
-          <SignInOrJoinFree routes={{ join: getRedirectUrl(router, id) }} />
+        <ContainerOverlay background="rgba(255, 255, 255, 0.75)">
+          <SignInOrJoinFree
+            routes={{ join: getRedirectUrl(router, id) }}
+            signInLabel={formatMessage(messages.signInLabel)}
+            withShadow
+          />
         </ContainerOverlay>
       )}
       <form onSubmit={handleSubmit(submit)} data-cy="comment-form">

--- a/lang/en.json
+++ b/lang/en.json
@@ -269,6 +269,7 @@
   "Comment.PostedOn": "Posted on {createdAt, date, long}",
   "CommentForm.placeholder": "Type in your message...",
   "CommentForm.PostReply": "Post reply",
+  "CommentForm.SignIn": "Please sign in to comment:",
   "comments.count": "{n, plural, one {# comment} other {# comments}}",
   "completePledge.MissingOrder": "This pledge doesn't exist or has already been completed.",
   "completePledge.Title": "Complete your pledge",

--- a/lang/es.json
+++ b/lang/es.json
@@ -269,6 +269,7 @@
   "Comment.PostedOn": "Publicado el {createdAt, date, long}",
   "CommentForm.placeholder": "Escribe tu mensaje...",
   "CommentForm.PostReply": "Responder",
+  "CommentForm.SignIn": "Please sign in to comment:",
   "comments.count": "{n, plural, one {# comment} other {# comments}}",
   "completePledge.MissingOrder": "This pledge doesn't exist or has already been completed.",
   "completePledge.Title": "Completa tu promesa de donación",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -269,6 +269,7 @@
   "Comment.PostedOn": "Posté le {createdAt, date, long}",
   "CommentForm.placeholder": "Tapez votre message...",
   "CommentForm.PostReply": "Poster en réponse",
+  "CommentForm.SignIn": "Please sign in to comment:",
   "comments.count": "{n, plural, one {# commentaire} other {# commentaires}}",
   "completePledge.MissingOrder": "Cette promesse de don n'existe pas ou a déjà été remplie.",
   "completePledge.Title": "Compléter votre promesse de don",

--- a/lang/it.json
+++ b/lang/it.json
@@ -269,6 +269,7 @@
   "Comment.PostedOn": "Posted on {createdAt, date, long}",
   "CommentForm.placeholder": "Type in your message...",
   "CommentForm.PostReply": "Post reply",
+  "CommentForm.SignIn": "Please sign in to comment:",
   "comments.count": "{n, plural, one {# comment} other {# comments}}",
   "completePledge.MissingOrder": "This pledge doesn't exist or has already been completed.",
   "completePledge.Title": "Complete your pledge",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -269,6 +269,7 @@
   "Comment.PostedOn": "Posted on {createdAt, date, long}",
   "CommentForm.placeholder": "Type in your message...",
   "CommentForm.PostReply": "返信を投稿",
+  "CommentForm.SignIn": "Please sign in to comment:",
   "comments.count": "{n, plural, one {# comment} other {# comments}}",
   "completePledge.MissingOrder": "This pledge doesn't exist or has already been completed.",
   "completePledge.Title": "Complete your pledge",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -269,6 +269,7 @@
   "Comment.PostedOn": "Geplaatst op {createdAt, date, long}",
   "CommentForm.placeholder": "Typ hier je bericht...",
   "CommentForm.PostReply": "Plaats een reactie",
+  "CommentForm.SignIn": "Please sign in to comment:",
   "comments.count": "{n, plural, one {# reactie} other {# reacties}}",
   "completePledge.MissingOrder": "Deze belofte bestaat niet of is al voltooid.",
   "completePledge.Title": "Voltooi je belofte",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -269,6 +269,7 @@
   "Comment.PostedOn": "Postado em {createdAt, date, long}",
   "CommentForm.placeholder": "Escreva sua mensagem...",
   "CommentForm.PostReply": "Enviar resposta",
+  "CommentForm.SignIn": "Please sign in to comment:",
   "comments.count": "{n, plural, one {# comentário} other {# comentários}}",
   "completePledge.MissingOrder": "Esta promessa não existe ou já foi completada.",
   "completePledge.Title": "Complete sua promessa",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -269,6 +269,7 @@
   "Comment.PostedOn": "Опубликовано {createdAt, date, long}",
   "CommentForm.placeholder": "Введите ваше сообщение...",
   "CommentForm.PostReply": "Опубликовать ответ",
+  "CommentForm.SignIn": "Please sign in to comment:",
   "comments.count": "{n, plural, one {# комментарий} few {# комментария} many {# комментариев} other {# комментариев}}",
   "completePledge.MissingOrder": "Обязательство не существует или уже было завершено.",
   "completePledge.Title": "Выполнить свое обязательство",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -269,6 +269,7 @@
   "Comment.PostedOn": "Posted on {createdAt, date, long}",
   "CommentForm.placeholder": "Type in your message...",
   "CommentForm.PostReply": "Post reply",
+  "CommentForm.SignIn": "Please sign in to comment:",
   "comments.count": "{n, plural, one {# comment} other {# comments}}",
   "completePledge.MissingOrder": "This pledge doesn't exist or has already been completed.",
   "completePledge.Title": "Complete your pledge",


### PR DESCRIPTION
Based on a suggestion from @kewitz 

- Use a white overlay
- Add a shadow on sign in
- Change label to `Please sign in to comment:`

### Before

![localhost_3000_opensource_expenses_2395_v2 (7)](https://user-images.githubusercontent.com/1556356/77160463-a8a9bb80-6aa7-11ea-8cc5-99c33e8242d6.png)

### After

![localhost_3000_opensource_expenses_2395_v2 (8)](https://user-images.githubusercontent.com/1556356/77160466-a9dae880-6aa7-11ea-9b8f-759ba12bf885.png)
