### PR TITLE
Collective/Contribute: Show subcollectives & events when inactive

### DIFF
--- a/components/CollectiveNavbar.js
+++ b/components/CollectiveNavbar.js
@@ -266,9 +266,12 @@ export const getSectionsForCollective = (collective, isAdmin) => {
   const sections = getDefaultSections(collective);
   const toRemove = new Set();
   collective = collective || {};
+  const isEvent = collective.type === CollectiveType.EVENT;
 
   // Can't contribute anymore if the collective is archived or has no host
-  if (!collective.isApproved && !isAdmin) {
+  const hasContribute = collective.isApproved;
+  const hasOtherWaysToContribute = !isEvent && (collective.events?.length > 0 || collective.subCollectives?.length > 0);
+  if (!hasContribute && !hasOtherWaysToContribute && !isAdmin) {
     toRemove.add(Sections.CONTRIBUTE);
   }
 
@@ -299,7 +302,8 @@ export const getSectionsForCollective = (collective, isAdmin) => {
       toRemove.add(Sections.UPDATES);
     }
   }
-  if (collective.type === CollectiveType.EVENT) {
+
+  if (isEvent) {
     // Should not see tickets section if you can't order them
     if ((!collective.isApproved && !isAdmin) || (!canOrderTicketsFromEvent(collective) && !isAdmin)) {
       toRemove.add(Sections.TICKETS);

--- a/components/collective-page/sections/Contribute.js
+++ b/components/collective-page/sections/Contribute.js
@@ -159,14 +159,14 @@ class SectionContribute extends React.PureComponent {
     1. admin + no host = Contribute Section and 'Start accepting financial contributions' ✅
     2a. admin + host = normal Contribute section ✅
     2b. not admin + Collective active = normal Contribute section ???
-    3. not admin + Collective not active = display nothing ✅
+    3. not admin + Collective not active + no subcollectives/events = display nothing ✅
     */
 
     const createContributionTierRoute = isEvent
       ? `/${collective.parentCollective.slug}/events/${collective.slug}/edit#tiers`
       : `/${collective.slug}/edit/tiers`;
 
-    if (!isAdmin && !isActive) {
+    if (!hasContribute && !hasOtherWaysToContribute) {
       return null;
     }
 


### PR DESCRIPTION
Follow up on https://github.com/opencollective/opencollective-frontend/pull/3631/files#r389736018. As mentioned in there, the change hides events and subcollectives for inactive collectives and this caused troubles for https://opencollective.com/permaculture-collaborative-laboratory-colab.

@sbinlondon do you see any regressions that this may induce?