### PR TITLE
feat(Create Collective Flow): Add COVID-19 category for related initiatives

### DIFF
--- a/components/create-collective/CollectiveCategoryPicker.js
+++ b/components/create-collective/CollectiveCategoryPicker.js
@@ -59,6 +59,7 @@ class CollectiveCategoryPicker extends React.Component {
         defaultMessage: 'For open source projects',
       },
       climate: { id: 'createCollective.category.climate', defaultMessage: 'For climate initiatives' },
+      covid: { id: 'createCollective.category.covid', defaultMessage: 'For COVID-19 initiatives' },
       header: { id: 'createCollective.header.create', defaultMessage: 'Create a Collective' },
       examples: { id: 'createCollective.examples', defaultMessage: 'See examples' },
     });
@@ -162,14 +163,14 @@ class CollectiveCategoryPicker extends React.Component {
                 <Flex flexDirection="column" justifyContent="center" alignItems="center">
                   <Image
                     src="/static/images/create-collective/climateIllustration.png"
-                    alt={intl.formatMessage(this.messages.climate)}
+                    alt={intl.formatMessage(this.messages.covid)}
                   />
                   <Link
                     route="create-collective"
                     params={{
                       hostCollectiveSlug: query.hostCollectiveSlug,
                       verb: query.verb,
-                      category: 'climate',
+                      category: 'covid-19',
                     }}
                   >
                     <StyledButton
@@ -180,13 +181,13 @@ class CollectiveCategoryPicker extends React.Component {
                       mb={3}
                       px={3}
                       onClick={() => {
-                        this.handleChange('category', 'climate');
+                        this.handleChange('category', 'covid-19');
                       }}
                     >
-                      {intl.formatMessage(this.messages.climate)}
+                      {intl.formatMessage(this.messages.covid)}
                     </StyledButton>
                   </Link>
-                  <ExamplesLink href="/discover?show=climate" openInNewTab>
+                  <ExamplesLink href="/discover?show=covid-19" openInNewTab>
                     {intl.formatMessage(this.messages.examples)}
                   </ExamplesLink>
                 </Flex>

--- a/components/create-collective/CollectiveCategoryPicker.js
+++ b/components/create-collective/CollectiveCategoryPicker.js
@@ -120,6 +120,44 @@ class CollectiveCategoryPicker extends React.Component {
                 borderTop={['1px solid #E6E8EB', 'none']}
                 alignItems="center"
                 width={[null, 280, 312]}
+              >
+                <Flex flexDirection="column" justifyContent="center" alignItems="center">
+                  <Image
+                    src="/static/images/create-collective/climateIllustration.png"
+                    alt={intl.formatMessage(this.messages.covid)}
+                  />
+                  <Link
+                    route="create-collective"
+                    params={{
+                      hostCollectiveSlug: query.hostCollectiveSlug,
+                      verb: query.verb,
+                      category: 'covid-19',
+                    }}
+                  >
+                    <StyledButton
+                      fontSize="13px"
+                      buttonStyle="primary"
+                      minHeight="36px"
+                      mt={[2, 3]}
+                      mb={3}
+                      px={3}
+                      onClick={() => {
+                        this.handleChange('category', 'covid-19');
+                      }}
+                    >
+                      {intl.formatMessage(this.messages.covid)}
+                    </StyledButton>
+                  </Link>
+                  <ExamplesLink href="/discover?show=covid-19" openInNewTab>
+                    {intl.formatMessage(this.messages.examples)}
+                  </ExamplesLink>
+                </Flex>
+              </Container>
+              <Container
+                borderLeft={['none', '1px solid #E6E8EB']}
+                borderTop={['1px solid #E6E8EB', 'none']}
+                alignItems="center"
+                width={[null, 280, 312]}
                 mb={[4, 0]}
               >
                 <Flex flexDirection="column" justifyContent="center" alignItems="center">
@@ -150,44 +188,6 @@ class CollectiveCategoryPicker extends React.Component {
                     </StyledButton>
                   </Link>
                   <ExamplesLink href="/discover?show=community" openInNewTab>
-                    {intl.formatMessage(this.messages.examples)}
-                  </ExamplesLink>
-                </Flex>
-              </Container>
-              <Container
-                borderLeft={['none', '1px solid #E6E8EB']}
-                borderTop={['1px solid #E6E8EB', 'none']}
-                alignItems="center"
-                width={[null, 280, 312]}
-              >
-                <Flex flexDirection="column" justifyContent="center" alignItems="center">
-                  <Image
-                    src="/static/images/create-collective/climateIllustration.png"
-                    alt={intl.formatMessage(this.messages.covid)}
-                  />
-                  <Link
-                    route="create-collective"
-                    params={{
-                      hostCollectiveSlug: query.hostCollectiveSlug,
-                      verb: query.verb,
-                      category: 'covid-19',
-                    }}
-                  >
-                    <StyledButton
-                      fontSize="13px"
-                      buttonStyle="primary"
-                      minHeight="36px"
-                      mt={[2, 3]}
-                      mb={3}
-                      px={3}
-                      onClick={() => {
-                        this.handleChange('category', 'covid-19');
-                      }}
-                    >
-                      {intl.formatMessage(this.messages.covid)}
-                    </StyledButton>
-                  </Link>
-                  <ExamplesLink href="/discover?show=covid-19" openInNewTab>
                     {intl.formatMessage(this.messages.examples)}
                   </ExamplesLink>
                 </Flex>

--- a/lang/en.json
+++ b/lang/en.json
@@ -428,6 +428,7 @@
   "createAccount.alreadyLoggedIn": "It seems like you're already signed in as \"{email}\". If you want to create a new account, please log out first.",
   "createCollective.category.climate": "For climate initiatives",
   "createCollective.category.community": "For any community",
+  "createCollective.category.covid": "For COVID-19 initiatives",
   "createCollective.category.newOpenSource": "For open source projects",
   "createCollective.examples": "See examples",
   "createCollective.form.descriptionLabel": "What does your collective do?",

--- a/lang/es.json
+++ b/lang/es.json
@@ -428,6 +428,7 @@
   "createAccount.alreadyLoggedIn": "Parece que ya ha iniciado sesión como \"{email}\". Si desea crear una nueva cuenta, cierre la sesión primero.",
   "createCollective.category.climate": "For climate initiatives",
   "createCollective.category.community": "For any community",
+  "createCollective.category.covid": "For COVID-19 initiatives",
   "createCollective.category.newOpenSource": "Para proyectos de código abierto",
   "createCollective.examples": "Ver ejemplos",
   "createCollective.form.descriptionLabel": "What does your collective do?",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -428,6 +428,7 @@
   "createAccount.alreadyLoggedIn": "Il semble que vous soyez déjà connecté en tant que « {email} ». Pour créer un nouveau compte, veuillez d'abord vous déconnecter.",
   "createCollective.category.climate": "Pour les initiatives en matière de climat",
   "createCollective.category.community": "Pour toutes les communautés",
+  "createCollective.category.covid": "For COVID-19 initiatives",
   "createCollective.category.newOpenSource": "Pour les projets open source",
   "createCollective.examples": "Voir les exemples",
   "createCollective.form.descriptionLabel": "Que fait votre collectif ?",

--- a/lang/it.json
+++ b/lang/it.json
@@ -428,6 +428,7 @@
   "createAccount.alreadyLoggedIn": "It seems like you're already signed in as \"{email}\". If you want to create a new account, please log out first.",
   "createCollective.category.climate": "For climate initiatives",
   "createCollective.category.community": "For any community",
+  "createCollective.category.covid": "For COVID-19 initiatives",
   "createCollective.category.newOpenSource": "For open source projects",
   "createCollective.examples": "See examples",
   "createCollective.form.descriptionLabel": "What does your collective do?",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -428,6 +428,7 @@
   "createAccount.alreadyLoggedIn": "It seems like you're already signed in as \"{email}\". If you want to create a new account, please log out first.",
   "createCollective.category.climate": "For climate initiatives",
   "createCollective.category.community": "For any community",
+  "createCollective.category.covid": "For COVID-19 initiatives",
   "createCollective.category.newOpenSource": "For open source projects",
   "createCollective.examples": "See examples",
   "createCollective.form.descriptionLabel": "What does your collective do?",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -428,6 +428,7 @@
   "createAccount.alreadyLoggedIn": "It seems like you're already signed in as \"{email}\". If you want to create a new account, please log out first.",
   "createCollective.category.climate": "For climate initiatives",
   "createCollective.category.community": "For any community",
+  "createCollective.category.covid": "For COVID-19 initiatives",
   "createCollective.category.newOpenSource": "For open source projects",
   "createCollective.examples": "See examples",
   "createCollective.form.descriptionLabel": "What does your collective do?",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -428,6 +428,7 @@
   "createAccount.alreadyLoggedIn": "Parece que você já está conectado com o email \"{email}\". Se você deseja criar uma nova conta, por favor faça o logout primeiro.",
   "createCollective.category.climate": "For climate initiatives",
   "createCollective.category.community": "For any community",
+  "createCollective.category.covid": "For COVID-19 initiatives",
   "createCollective.category.newOpenSource": "For open source projects",
   "createCollective.examples": "See examples",
   "createCollective.form.descriptionLabel": "What does your collective do?",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -428,6 +428,7 @@
   "createAccount.alreadyLoggedIn": "It seems like you're already signed in as \"{email}\". If you want to create a new account, please log out first.",
   "createCollective.category.climate": "For climate initiatives",
   "createCollective.category.community": "For any community",
+  "createCollective.category.covid": "For COVID-19 initiatives",
   "createCollective.category.newOpenSource": "For open source projects",
   "createCollective.examples": "See examples",
   "createCollective.form.descriptionLabel": "What does your collective do?",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -428,6 +428,7 @@
   "createAccount.alreadyLoggedIn": "It seems like you're already signed in as \"{email}\". If you want to create a new account, please log out first.",
   "createCollective.category.climate": "For climate initiatives",
   "createCollective.category.community": "For any community",
+  "createCollective.category.covid": "For COVID-19 initiatives",
   "createCollective.category.newOpenSource": "For open source projects",
   "createCollective.examples": "See examples",
   "createCollective.form.descriptionLabel": "What does your collective do?",

--- a/server/pages.js
+++ b/server/pages.js
@@ -78,7 +78,7 @@ const pages = routes()
 // New Create Collective Flow
 pages.add(
   'create-collective',
-  '/:hostCollectiveSlug?/:verb(apply|create)/:version(v2)?/:category(opensource|community|climate)?/:step(form)?',
+  '/:hostCollectiveSlug?/:verb(apply|create)/:version(v2)?/:category(opensource|community|climate|covid-19)?/:step(form)?',
   'new-create-collective',
 );
 // temporary onboarding modal page


### PR DESCRIPTION
Quick PR to change the third category of the Create Collective Picker to 'COVID-19' initiatives instead of 'climate' initiatives.