### PR TITLE
StyledButton: update sizes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ stage
 *.swp
 styleguide/index.html
 styleguide/build/
+styleguide/static/fonts
 .vimrc
 
 # VSCode & VSCode's extensions

--- a/components/StyledButton.js
+++ b/components/StyledButton.js
@@ -20,6 +20,8 @@ const StyledButtonContent = styled.button`
   outline: 0;
   border: 1px solid;
   border-radius: 100px;
+  letter-spacing: -0.4px;
+  font-weight: 500;
   
   &:disabled {
     cursor: not-allowed;

--- a/components/StyledLink.js
+++ b/components/StyledLink.js
@@ -27,6 +27,21 @@ const StyledLink = styled.a`
   ${textDecoration}
   ${whiteSpace}
 
+  ${props =>
+    props.buttonStyle &&
+    css`
+      outline: 0;
+      border: 1px solid;
+      border-style: solid;
+      border-width: 1px;
+      border-radius: 100px;
+      text-align: center;
+
+      &:disabled {
+        cursor: not-allowed;
+      }
+    `}
+
   ${buttonStyle}
   ${buttonSize}
 
@@ -43,19 +58,6 @@ const StyledLink = styled.a`
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;
-    `}
-
-  ${props =>
-    props.buttonStyle &&
-    css`
-      outline: 0;
-      border-style: solid;
-      border-width: 1px;
-      border-radius: 100px;
-
-      &:disabled {
-        cursor: not-allowed;
-      }
     `}
 `;
 

--- a/lib/theme/variants/button.js
+++ b/lib/theme/variants/button.js
@@ -9,33 +9,51 @@ export const buttonSize = variant({
   prop: 'buttonSize',
 });
 
-export const getButtonSizes = ({ fontSizes, space }) => {
+export const getButtonSizes = ({ fontSizes }) => {
   return {
+    xLarge: {
+      fontSize: 17,
+      lineHeight: toPx(18),
+      paddingBottom: 22,
+      paddingLeft: 48,
+      paddingRight: 48,
+      paddingTop: 22,
+    },
+
     large: {
       fontSize: toPx(fontSizes.LeadParagraph),
-      lineHeight: toPx(fontSizes.LeadParagraph + 2),
-      paddingBottom: toPx(space[3]),
-      paddingLeft: toPx(space[5]),
-      paddingRight: toPx(space[5]),
-      paddingTop: toPx(space[3]),
+      lineHeight: toPx(fontSizes.LeadParagraph + 1),
+      paddingBottom: 18,
+      paddingLeft: 40,
+      paddingRight: 40,
+      paddingTop: 18,
     },
 
     medium: {
       fontSize: toPx(fontSizes.Paragraph),
-      lineHeight: toPx(fontSizes.Paragraph + 7),
-      paddingBottom: toPx(space[2]),
-      paddingLeft: toPx(space[3]),
-      paddingRight: toPx(space[3]),
-      paddingTop: toPx(space[2]),
+      lineHeight: toPx(fontSizes.Paragraph + 3),
+      paddingBottom: 14,
+      paddingLeft: 24,
+      paddingRight: 24,
+      paddingTop: 14,
     },
 
     small: {
+      fontSize: toPx(fontSizes.LeadCaption),
+      lineHeight: toPx(fontSizes.LeadCaption + 3),
+      paddingBottom: 11,
+      paddingLeft: 20,
+      paddingRight: 20,
+      paddingTop: 11,
+    },
+
+    tiny: {
       fontSize: toPx(fontSizes.Caption),
-      lineHeight: toPx(fontSizes.Caption + 2),
-      paddingBottom: toPx(space[1]),
-      paddingLeft: toPx(space[2]),
-      paddingRight: toPx(space[2]),
-      paddingTop: toPx(space[1]),
+      lineHeight: toPx(fontSizes.Caption),
+      paddingBottom: 5,
+      paddingLeft: 14,
+      paddingRight: 14,
+      paddingTop: 5,
     },
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10837,13 +10837,13 @@
       "dependencies": {
         "colors": {
           "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "resolved": "http://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
           "dev": true
         },
         "commander": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
           "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
           "dev": true
         }
@@ -11397,7 +11397,7 @@
         },
         "node-fetch": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
           "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
           "dev": true
         },
@@ -26755,7 +26755,7 @@
       "dependencies": {
         "ast-types": {
           "version": "0.7.8",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
+          "resolved": "http://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
           "integrity": "sha1-kC0uDWDQcb3NRtwRXhgJ7RHBOKk=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -180,6 +180,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
     "codecov": "^3.6.5",
     "commitizen": "^4.0.3",
+    "copy-webpack-plugin": "^5.1.1",
     "cross-env": "^7.0.2",
     "css-loader": "^3.4.2",
     "cypress": "^4.2.0",

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -1,5 +1,7 @@
 const fs = require('fs');
 const path = require('path');
+// eslint-disable-next-line node/no-unpublished-require
+const CopyPlugin = require('copy-webpack-plugin');
 
 // eslint-disable-next-line  node/no-unpublished-require
 const { default: fileExistsCaseInsensitive } = require('react-styleguidist/lib/scripts/utils/findFileCaseInsensitive');
@@ -104,6 +106,7 @@ module.exports = {
     optimization: {
       minimize: false, // See https://github.com/terser/terser/issues/567
     },
+    plugins: [new CopyPlugin([{ from: 'public/static/fonts', to: 'static/fonts' }])],
     module: {
       rules: [
         {
@@ -117,6 +120,18 @@ module.exports = {
             loader: 'url-loader',
             options: {
               limit: 1000000,
+            },
+          },
+        },
+        {
+          test: /public\/.*\/images[\\/].*\.(jpg|gif|png|svg)$/,
+          use: {
+            loader: 'file-loader',
+            options: {
+              publicPath: '/_next/static/images/',
+              outputPath: 'static/images/',
+              name: '[name]-[hash].[ext]',
+              esModule: false,
             },
           },
         },

--- a/styleguide/examples/StyledButton.md
+++ b/styleguide/examples/StyledButton.md
@@ -1,3 +1,23 @@
+## Sizes
+
+```js padded
+<StyledButton buttonSize="xLarge">
+  Extra Large
+</StyledButton>
+<StyledButton buttonSize="large">
+  Large
+</StyledButton>
+<StyledButton buttonSize="medium">
+  Medium
+</StyledButton>
+<StyledButton buttonSize="small">
+  Small
+</StyledButton>
+<StyledButton buttonSize="tiny">
+  Tiny
+</StyledButton>
+```
+
 ## Styles
 
 ### Standard


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/2979
See https://oc-styleguide-pr-3804.onrender.com/#!/Atoms/StyledButton/StyledButton/1

- Update button sizes to match what's in [Figma](https://www.figma.com/file/N4Xbl652BhzOutXmzhcrLGch/%5BDS%5D-03-UI-Atoms?node-id=1625%3A334)
- Adds new `xLarge` and `tiny` sizes
- Make sure `StyledLink` are the same size as other buttons when rendered as such
- Copy fonts in styleguidist static folder

# Preview

![image](https://user-images.githubusercontent.com/1556356/77744260-a7354180-7019-11ea-9cf7-306d28c306cf.png)
