### PR TITLE
Typography minor enhancements

### DIFF
--- a/components/Text.js
+++ b/components/Text.js
@@ -28,7 +28,7 @@ export const P = styled.p.attrs(props => ({
 P.defaultProps = {
   fontSize: 'Paragraph',
   letterSpacing: '-0.4px',
-  lineHeight: 'Paragraph',
+  lineHeight: '1.1em',
 };
 
 export const Span = P.withComponent('span');

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -32,6 +32,11 @@ module.exports = {
       content: 'styleguide/pages/index.md',
     },
     {
+      name: 'Typography',
+      content: 'styleguide/pages/typography.md',
+      components: 'components/Text.js',
+    },
+    {
       name: 'Atoms',
       components: 'components/Styled*.js',
       description: 'Base design atoms.',
@@ -117,6 +122,19 @@ module.exports = {
             loader: 'url-loader',
             options: {
               limit: 1000000,
+            },
+          },
+        },
+        // Configuration for images
+        {
+          test: /public\/.*\/images[\\/].*\.(jpg|gif|png)$/,
+          use: {
+            loader: 'file-loader',
+            options: {
+              publicPath: '/_next/static/images/',
+              outputPath: 'static/images/',
+              name: '[name]-[hash].[ext]',
+              esModule: false,
             },
           },
         },

--- a/styleguide/pages/typography.md
+++ b/styleguide/pages/typography.md
@@ -1,0 +1,55 @@
+The main way to deal with typography is through the components in `components/Text.js`.
+
+# Typeface & fonts
+
+🎨️ [Figma file](https://www.figma.com/file/jxJfC29te8i1C8qMReth95/%5BDS%5D-01-Typography?node-id=9%3A10)
+
+The main font on Open Collective is [Inter](https://rsms.me/inter/). The colors can vary from `black.50` to `black.900` (the darkest).
+
+```jsx
+import { P } from 'components/Text';
+<div>
+  <P color="black.50">50: We are on a mission to help collaborative groups collect and spend money transparently.</P>
+  <P color="black.100">100: We are on a mission to help collaborative groups collect and spend money transparently.</P>
+  <P color="black.200">200: We are on a mission to help collaborative groups collect and spend money transparently.</P>
+  <P color="black.300">300: We are on a mission to help collaborative groups collect and spend money transparently.</P>
+  <P color="black.400">400: We are on a mission to help collaborative groups collect and spend money transparently.</P>
+  <P color="black.500">500: We are on a mission to help collaborative groups collect and spend money transparently.</P>
+  <P color="black.600">600: We are on a mission to help collaborative groups collect and spend money transparently.</P>
+  <P color="black.700">700: We are on a mission to help collaborative groups collect and spend money transparently.</P>
+  <P color="black.800">800: We are on a mission to help collaborative groups collect and spend money transparently.</P>
+  <P color="black.900">900: We are on a mission to help collaborative groups collect and spend money transparently.</P>
+</div>;
+```
+
+# Type scale
+
+You can configure the scale through `fontSize` and `lineHeight` props.
+
+```jsx
+import { P } from 'components/Text';
+<div>
+  <P fontSize="H1">H1: We are on a mission to help collaborative groups collect and spend money transparently.</P>
+  <P fontSize="H2">H2: We are on a mission to help collaborative groups collect and spend money transparently.</P>
+  <P fontSize="H3">H3: We are on a mission to help collaborative groups collect and spend money transparently.</P>
+  <P fontSize="H4">H4: We are on a mission to help collaborative groups collect and spend money transparently.</P>
+  <P fontSize="H5">H5: We are on a mission to help collaborative groups collect and spend money transparently.</P>
+  <P fontSize="H6">H6: We are on a mission to help collaborative groups collect and spend money transparently.</P>
+  <P fontSize="LeadParagraph">
+    LeadParagraph: We are on a mission to help collaborative groups collect and spend money transparently.
+  </P>
+  <P fontSize="Paragraph">
+    Paragraph: We are on a mission to help collaborative groups collect and spend money transparently.
+  </P>
+  <P fontSize="LeadCaption">
+    LeadCaption: We are on a mission to help collaborative groups collect and spend money transparently.
+  </P>
+  <P fontSize="Caption">
+    Caption: We are on a mission to help collaborative groups collect and spend money transparently.
+  </P>
+  <P fontSize="SmallCaption">
+    SmallCaption: We are on a mission to help collaborative groups collect and spend money transparently.
+  </P>
+  <P fontSize="Tiny">Tiny: We are on a mission to help collaborative groups collect and spend money transparently.</P>
+</div>;
+```


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/2979

This does not implement https://github.com/opencollective/opencollective/issues/2979 completely because the changes needed for the typography are quite massive: we need to rename all our font sizes. I don't want to invest more time doing that right now so I just added a styleguide page to at least start documenting what we have today.

I also set the default `lineHeight` to `1.1em` which fits 99% of the font sizes. It should free us from having to change it each time we set a different `fontSize`.