### PR TITLE
StyledTag: use own variant and fix colors

### DIFF
--- a/components/StyledTag.js
+++ b/components/StyledTag.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { background, border, color, space, typography, layout, position } from 'styled-system';
+import { background, border, color, space, typography, layout, position, variant } from 'styled-system';
 
 import { Times } from '@styled-icons/fa-solid/Times';
 
 import { textTransform } from '../lib/styled-system-custom-properties';
-import { messageType } from '../lib/theme/variants/message';
 import { Span } from './Text';
 
 const StyledTagBase = styled.div`
@@ -32,7 +31,40 @@ const StyledTagBase = styled.div`
   ${position}
   ${textTransform}
 
-  ${messageType}
+  ${variant({
+    prop: 'type',
+    variants: {
+      white: {
+        backgroundColor: 'white.full',
+        borderColor: 'black.200',
+      },
+      dark: {
+        backgroundColor: 'black.800',
+        borderColor: 'black.900',
+        color: 'white.full',
+      },
+      info: {
+        backgroundColor: 'blue.100',
+        borderColor: 'blue.400',
+        color: 'blue.600',
+      },
+      success: {
+        backgroundColor: 'green.100',
+        borderColor: 'green.500',
+        color: 'green.700',
+      },
+      warning: {
+        backgroundColor: 'yellow.200',
+        borderColor: 'yellow.500',
+        color: 'yellow.800',
+      },
+      error: {
+        backgroundColor: 'red.100',
+        borderColor: 'red.500',
+        color: 'red.500',
+      },
+    },
+  })}
 `;
 
 const CloseButton = styled.button`

--- a/components/expenses/ExpenseStatusTag.js
+++ b/components/expenses/ExpenseStatusTag.js
@@ -27,7 +27,7 @@ const getExpenseStatusMsgType = status => {
 const ExpenseStatusTag = ({ status, ...props }) => {
   const intl = useIntl();
   return (
-    <StyledTag type={getExpenseStatusMsgType(status)} {...props}>
+    <StyledTag type={getExpenseStatusMsgType(status)} fontWeight="600" letterSpacing="0.8px" {...props}>
       {i18nExpenseStatus(intl, status)}
     </StyledTag>
   );


### PR DESCRIPTION
I just noticed that there was a deviation for `StyledTag` in [Figma](https://www.figma.com/file/N4Xbl652BhzOutXmzhcrLGch/%5BDS%5D-03-UI-Atoms?node-id=2402%3A567) from the `messageType` that we previously used.

I've added its own variant to `StyledTag`, using the new recommended API from `styled-system`.