### PR TITLE
DismissibleMessage: Never render during SSR

### DIFF
--- a/components/DismissibleMessage.js
+++ b/components/DismissibleMessage.js
@@ -45,6 +45,7 @@ const DismissibleMessage = ({ LoggedInUser, messageId, displayForLoggedOutUser, 
 
   const loggedInAccount = data?.loggedInAccount;
   if (
+    typeof window === 'undefined' || // never render message during SSR
     isDismissedLocally ||
     (!loggedInAccount && !displayForLoggedOutUser) ||
     get(loggedInAccount, `settings.${settingsKey}`)


### PR DESCRIPTION
During SSR there's no way for us to know if a user has dismissed the message, because we don't have access to `localStorage` nor to `LoggedInUser`. As a consequence, the covid message was occasionally displayed when loading a new page then disappearing suddenly when the rehydration is completed.