### PR TITLE
StyledButtonSet: Fix a regression on size

### DIFF
--- a/components/StyledButtonSet.js
+++ b/components/StyledButtonSet.js
@@ -67,6 +67,7 @@ const StyledButtonSet = ({
         className={item === selected ? 'selected' : undefined}
         disabled={disabled}
         type="button"
+        py="8px"
         {...buttonProps}
         {...(buttonPropsBuilder ? buttonPropsBuilder({ item }) : {})}
       >

--- a/components/StyledInputGroup.js
+++ b/components/StyledInputGroup.js
@@ -69,7 +69,7 @@ const getBorderColor = ({ error, focused, success }) => {
     return 'green.300';
   }
 
-  return 'black.300';
+  return 'black.400';
 };
 
 /**


### PR DESCRIPTION
Fix a regression introduced in #3804. 
Also unified the border color for the custom input.

**Before**

![image](https://user-images.githubusercontent.com/1556356/77773780-5db11a80-704a-11ea-9f42-afef21c724ba.png)

**After**

![image](https://user-images.githubusercontent.com/1556356/77773690-42dea600-704a-11ea-888e-b40cf92b84fe.png)

