### PR TITLE
fix bug to create Collective with personal open source repo

### DIFF
--- a/components/create-collective/GithubRepositories.js
+++ b/components/create-collective/GithubRepositories.js
@@ -81,7 +81,24 @@ const GithubRepositories = ({ repositories, sendRepoInfo, intl, ...fieldProps })
           </Container>
         )}
 
-        <StyledRadioList {...fieldProps} options={repositories} keyGetter="name">
+        <StyledRadioList
+          {...fieldProps}
+          options={repositories}
+          onChange={({ value }) => {
+            if (value.owner.type === 'User') {
+              setState(state => ({
+                ...state,
+                disabled: false,
+                repoInfo: {
+                  ...state.repoInfo,
+                  handle: `${value.owner.login}/${value.name}`,
+                  repo: value.name,
+                },
+              }));
+            }
+          }}
+          keyGetter="name"
+        >
           {({ value, radio, checked }) => {
             return (
               <RepositoryEntryContainer px={[2, 4]} py={3}>


### PR DESCRIPTION
Addresses opencollective/opencollective#3015

The issue was that adding the repo info to the state was done in the `GithubRepositoryEntry` component (i.e. if you picked an organisation repo and it had the two more drop down buttons and you chose one of those to make a Collective for the repo or the whole org). 

It wasn't being done in the `GithubRepositories` entry for personal repos where you didn't have to select those secondary radio buttons.