### PR TITLE
COVID Banner fixes from Friday Demos

### DIFF
--- a/components/banners/CovidBanner.js
+++ b/components/banners/CovidBanner.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { Close as _Close } from '@styled-icons/material/Close';
 import { Box, Flex } from '@rebass/grid';
 import { FormattedMessage } from 'react-intl';
-import { useRouter } from 'next/router';
 
 import StyledLink from '../StyledLink';
 import DismissibleMessage from '../DismissibleMessage';
@@ -16,11 +15,17 @@ const SPONSORED_COLLECTIVE = 'SPONSORED_COLLECTIVE';
 
 const Wrapper = styled(Flex)`
   width: 100%;
-  position: -webkit-sticky;
-  position: sticky;
-  bottom: 0px;
-  z-index: 1000;
   margin-top: 5em;
+
+  ${props =>
+    props.docked
+      ? `position: relative;`
+      : `
+          position: -webkit-sticky;
+          position: sticky;
+          bottom: 0px;
+          z-index: 1000;
+        `}
 `;
 
 const Banner = styled(Container)`
@@ -130,7 +135,7 @@ const Desktop = styled.div`
 
 const Virus = styled.div`
   position: absolute;
-  bottom: 0px;
+  bottom: ${props => (props.variant === SPONSORED_COLLECTIVE ? '-20px' : '0px')};
   right: 10px;
   width: 80px;
   height: 80px;
@@ -151,13 +156,6 @@ const Virus = styled.div`
 `;
 
 const CovidBanner = props => {
-  const router = useRouter();
-  const dismissAndRedirect = e => {
-    e.preventDefault();
-    props.dismiss();
-    router.push('/create');
-  };
-
   const content =
     props.variant === SPONSORED_COLLECTIVE ? (
       <Box>
@@ -207,7 +205,7 @@ const CovidBanner = props => {
     );
 
   return (
-    <Wrapper>
+    <Wrapper docked={props.docked}>
       <Banner
         width={[300, 992]}
         border="1px solid #E6E8EB"
@@ -217,7 +215,7 @@ const CovidBanner = props => {
         pt={[24, 16]}
         pb={24}
       >
-        <Virus>
+        <Virus variant={props.variant}>
           <img src="/static/images/virus-1.png" width="54px" />
           <img src="/static/images/virus-2.png" width="38px" />
         </Virus>
@@ -225,26 +223,31 @@ const CovidBanner = props => {
           {content}
           {props.showLink && (
             <Flex alignItems="center" mt={[16, 0]}>
-              <Button buttonStyle="standard" onClick={dismissAndRedirect}>
+              <Button buttonStyle="standard" href="/create" onClick={() => props.dismiss?.()}>
                 <FormattedMessage id="banners.covid.button" defaultMessage="Create a COVID-19 Initiative" />
               </Button>
             </Flex>
           )}
         </Flex>
-        <Close onClick={props.dismiss} />
+        {!props.docked && <Close onClick={props.dismiss} />}
       </Banner>
     </Wrapper>
   );
 };
 
 CovidBanner.propTypes = {
-  showLink: PropTypes.bool,
   dismiss: PropTypes.func,
+  docked: PropTypes.bool,
+  showLink: PropTypes.bool,
   variant: PropTypes.oneOf([SPONSORED_COLLECTIVE]),
 };
 
 const WrappedBanner = props => (
-  <DismissibleMessage displayForLoggedOutUser={true} messageId={BANNER.COVID}>
+  <DismissibleMessage
+    displayForLoggedOutUser={true}
+    messageId={BANNER.COVID}
+    dismissedComponent={<CovidBanner {...props} docked />}
+  >
     {({ dismiss }) => <CovidBanner {...{ dismiss, ...props }} />}
   </DismissibleMessage>
 );

--- a/components/banners/CovidBanner.js
+++ b/components/banners/CovidBanner.js
@@ -6,7 +6,7 @@ import { Box, Flex } from '@rebass/grid';
 import { FormattedMessage } from 'react-intl';
 import { useRouter } from 'next/router';
 
-import StyledButton from '../StyledButton';
+import StyledLink from '../StyledLink';
 import DismissibleMessage from '../DismissibleMessage';
 import { BANNER } from '../../lib/constants/dismissable-help-message';
 
@@ -73,11 +73,16 @@ const Banner = styled(Container)`
   }
 `;
 
-const Button = styled(StyledButton)`
+const Button = styled(StyledLink)`
   width: 212px;
   font-size: 13px;
   color: #fff;
   z-index: 100;
+  line-height: 21px;
+  padding-bottom: 8px;
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-top: 8px;
 
   background: linear-gradient(180deg, #313233 0%, #141414 100%);
   &:hover {

--- a/components/banners/CovidBanner.js
+++ b/components/banners/CovidBanner.js
@@ -174,7 +174,7 @@ const CovidBanner = props => {
           <h2>
             <FormattedMessage
               id="banners.covid.sponsored.description"
-              defaultMessage="Create a COVID-19 a related collective, we'll waive our fees until the end of June."
+              defaultMessage="Create a COVID-19 related collective, we'll waive our fees until the end of June."
             />
           </h2>
         </Mobile>

--- a/components/create-collective/CollectiveCategoryPicker.js
+++ b/components/create-collective/CollectiveCategoryPicker.js
@@ -2,11 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Flex, Box } from '@rebass/grid';
 import styled from 'styled-components';
-import { Info } from '@styled-icons/material/Info';
 import { defineMessages, injectIntl } from 'react-intl';
 import themeGet from '@styled-system/theme-get';
 
-import { H1, P } from '../Text';
+import { H1 } from '../Text';
 import StyledButton from '../StyledButton';
 import Container from '../Container';
 import Link from '../Link';
@@ -34,10 +33,6 @@ const Image = styled.img`
     height: 208px;
     width: 208px;
   }
-`;
-
-const RedInfo = styled(Info)`
-  color: ${themeGet('colors.red.500')};
 `;
 
 class CollectiveCategoryPicker extends React.Component {
@@ -88,10 +83,6 @@ class CollectiveCategoryPicker extends React.Component {
           <H1 fontSize={['H5', 'H3']} lineHeight={['H5', 'H3']} fontWeight="bold" color="black.900" textAlign="center">
             {intl.formatMessage(this.messages.header)}
           </H1>
-          <P color="black.700" textAlign="center" mt={[2, 3]} fontSize={['Caption', 'Paragraph']}>
-            <RedInfo size={14} />
-            {intl.formatMessage(this.messages.waivefees)}
-          </P>
         </Box>
         <Flex flexDirection="column" justifyContent="center" alignItems="center" mb={[5, 6]}>
           <Box alignItems="center">

--- a/lang/en.json
+++ b/lang/en.json
@@ -60,7 +60,7 @@
   "Back": "Back",
   "banners.covid.button": "Create a COVID-19 Initiative",
   "banners.covid.description": "We are waiving our platform fees on COVID-19 related Collectives until the end of June.",
-  "banners.covid.sponsored.description": "Create a COVID-19 a related collective, we'll waive our fees until the end of June.",
+  "banners.covid.sponsored.description": "Create a COVID-19 related collective, we'll waive our fees until the end of June.",
   "banners.covid.title.desktop": "Let's work together to support each other. We are apart but not alone.",
   "banners.covid.title.mobile": "Let's support each other.",
   "banners.covid.title.sponsored.desktop": "To support this collective's mission we are waiving our platform fees until the end of June.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -60,7 +60,7 @@
   "Back": "Volver",
   "banners.covid.button": "Create a COVID-19 Initiative",
   "banners.covid.description": "We are waiving our platform fees on COVID-19 related Collectives until the end of June.",
-  "banners.covid.sponsored.description": "Create a COVID-19 a related collective, we'll waive our fees until the end of June.",
+  "banners.covid.sponsored.description": "Create a COVID-19 related collective, we'll waive our fees until the end of June.",
   "banners.covid.title.desktop": "Let's work together to support each other. We are apart but not alone.",
   "banners.covid.title.mobile": "Let's support each other.",
   "banners.covid.title.sponsored.desktop": "To support this collective's mission we are waiving our platform fees until the end of June.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -60,7 +60,7 @@
   "Back": "Retour",
   "banners.covid.button": "Create a COVID-19 Initiative",
   "banners.covid.description": "We are waiving our platform fees on COVID-19 related Collectives until the end of June.",
-  "banners.covid.sponsored.description": "Create a COVID-19 a related collective, we'll waive our fees until the end of June.",
+  "banners.covid.sponsored.description": "Create a COVID-19 related collective, we'll waive our fees until the end of June.",
   "banners.covid.title.desktop": "Let's work together to support each other. We are apart but not alone.",
   "banners.covid.title.mobile": "Let's support each other.",
   "banners.covid.title.sponsored.desktop": "To support this collective's mission we are waiving our platform fees until the end of June.",

--- a/lang/it.json
+++ b/lang/it.json
@@ -60,7 +60,7 @@
   "Back": "Back",
   "banners.covid.button": "Create a COVID-19 Initiative",
   "banners.covid.description": "We are waiving our platform fees on COVID-19 related Collectives until the end of June.",
-  "banners.covid.sponsored.description": "Create a COVID-19 a related collective, we'll waive our fees until the end of June.",
+  "banners.covid.sponsored.description": "Create a COVID-19 related collective, we'll waive our fees until the end of June.",
   "banners.covid.title.desktop": "Let's work together to support each other. We are apart but not alone.",
   "banners.covid.title.mobile": "Let's support each other.",
   "banners.covid.title.sponsored.desktop": "To support this collective's mission we are waiving our platform fees until the end of June.",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -60,7 +60,7 @@
   "Back": "Back",
   "banners.covid.button": "Create a COVID-19 Initiative",
   "banners.covid.description": "We are waiving our platform fees on COVID-19 related Collectives until the end of June.",
-  "banners.covid.sponsored.description": "Create a COVID-19 a related collective, we'll waive our fees until the end of June.",
+  "banners.covid.sponsored.description": "Create a COVID-19 related collective, we'll waive our fees until the end of June.",
   "banners.covid.title.desktop": "Let's work together to support each other. We are apart but not alone.",
   "banners.covid.title.mobile": "Let's support each other.",
   "banners.covid.title.sponsored.desktop": "To support this collective's mission we are waiving our platform fees until the end of June.",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -60,7 +60,7 @@
   "Back": "Terug",
   "banners.covid.button": "Create a COVID-19 Initiative",
   "banners.covid.description": "We are waiving our platform fees on COVID-19 related Collectives until the end of June.",
-  "banners.covid.sponsored.description": "Create a COVID-19 a related collective, we'll waive our fees until the end of June.",
+  "banners.covid.sponsored.description": "Create a COVID-19 related collective, we'll waive our fees until the end of June.",
   "banners.covid.title.desktop": "Let's work together to support each other. We are apart but not alone.",
   "banners.covid.title.mobile": "Let's support each other.",
   "banners.covid.title.sponsored.desktop": "To support this collective's mission we are waiving our platform fees until the end of June.",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -60,7 +60,7 @@
   "Back": "Back",
   "banners.covid.button": "Create a COVID-19 Initiative",
   "banners.covid.description": "We are waiving our platform fees on COVID-19 related Collectives until the end of June.",
-  "banners.covid.sponsored.description": "Create a COVID-19 a related collective, we'll waive our fees until the end of June.",
+  "banners.covid.sponsored.description": "Create a COVID-19 related collective, we'll waive our fees until the end of June.",
   "banners.covid.title.desktop": "Let's work together to support each other. We are apart but not alone.",
   "banners.covid.title.mobile": "Let's support each other.",
   "banners.covid.title.sponsored.desktop": "To support this collective's mission we are waiving our platform fees until the end of June.",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -60,7 +60,7 @@
   "Back": "Back",
   "banners.covid.button": "Create a COVID-19 Initiative",
   "banners.covid.description": "We are waiving our platform fees on COVID-19 related Collectives until the end of June.",
-  "banners.covid.sponsored.description": "Create a COVID-19 a related collective, we'll waive our fees until the end of June.",
+  "banners.covid.sponsored.description": "Create a COVID-19 related collective, we'll waive our fees until the end of June.",
   "banners.covid.title.desktop": "Let's work together to support each other. We are apart but not alone.",
   "banners.covid.title.mobile": "Let's support each other.",
   "banners.covid.title.sponsored.desktop": "To support this collective's mission we are waiving our platform fees until the end of June.",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -60,7 +60,7 @@
   "Back": "Back",
   "banners.covid.button": "Create a COVID-19 Initiative",
   "banners.covid.description": "We are waiving our platform fees on COVID-19 related Collectives until the end of June.",
-  "banners.covid.sponsored.description": "Create a COVID-19 a related collective, we'll waive our fees until the end of June.",
+  "banners.covid.sponsored.description": "Create a COVID-19 related collective, we'll waive our fees until the end of June.",
   "banners.covid.title.desktop": "Let's work together to support each other. We are apart but not alone.",
   "banners.covid.title.mobile": "Let's support each other.",
   "banners.covid.title.sponsored.desktop": "To support this collective's mission we are waiving our platform fees until the end of June.",

--- a/pages/index.js
+++ b/pages/index.js
@@ -37,7 +37,7 @@ const HomePage = () => {
       <WeAreOpenSection />
       <LearnMoreSection />
       <JoinUsSection />
-      <CovidBanner showLink={true} />
+      <CovidBanner showLink />
     </Page>
   );
 };

--- a/pages/new-collective-page.js
+++ b/pages/new-collective-page.js
@@ -201,7 +201,7 @@ class NewCollectivePage extends React.Component {
           variant={
             collective?.tags?.some(tag => tag == 'covid' || tag == 'covid-19') ? 'SPONSORED_COLLECTIVE' : undefined
           }
-          showLink={true}
+          showLink
         />
       </Page>
     );

--- a/pages/new-create-collective.js
+++ b/pages/new-create-collective.js
@@ -39,7 +39,7 @@ class CreateCollectivePage extends React.Component {
     return (
       <Page>
         <CreateCollective host={data.Collective} query={query} />
-        <CovidBanner showLink={false} />
+        <CovidBanner />
       </Page>
     );
   }


### PR DESCRIPTION
- Docks the banner after being dismissed.
- Removes the header message in the collective creation page.
- Fix a typo in the mobile message, thanks @Betree.