### PR TITLE
CollectivePage: Fix regression on NavBar an unify CTAs sizes

### DIFF
--- a/components/CollectiveNavbar.js
+++ b/components/CollectiveNavbar.js
@@ -42,7 +42,7 @@ const MenuLink = styled.a`
   letter-spacing: -0.2px;
   text-decoration: none;
   white-space: nowrap;
-  padding: 8px 16px 16px;
+  padding: 12px 16px 16px;
 
   &:focus {
     color: ${themeGet('colors.primary.700')};

--- a/components/collective-page/sections/Budget.js
+++ b/components/collective-page/sections/Budget.js
@@ -93,6 +93,7 @@ const SectionBudget = ({ collective, stats }) => {
                         my={2}
                         minWidth={290}
                         width="100%"
+                        fontSize="Paragraph"
                         py="10px"
                       >
                         <FormattedMessage
@@ -110,6 +111,7 @@ const SectionBudget = ({ collective, stats }) => {
                         my={2}
                         minWidth={290}
                         width="100%"
+                        fontSize="Paragraph"
                         py="10px"
                       >
                         <FormattedMessage

--- a/components/collective-page/sections/Updates.js
+++ b/components/collective-page/sections/Updates.js
@@ -229,7 +229,14 @@ class SectionUpdates extends React.PureComponent {
         )}
         {updates.length > 0 && (
           <Link route="updates" params={{ collectiveSlug: collective.slug }}>
-            <StyledButton data-cy="view-all-updates-btn" buttonSize="large" mt={4} width={1} p="10px">
+            <StyledButton
+              data-cy="view-all-updates-btn"
+              buttonSize="large"
+              mt={4}
+              width={1}
+              p="10px"
+              fontSize="Paragraph"
+            >
               <FormattedMessage id="CollectivePage.SectionUpdates.ViewAll" defaultMessage="View all updates" /> →
             </StyledButton>
           </Link>


### PR DESCRIPTION
Fix a small regression introduced in #3804. Because of the changes for the button sizes, the hero had an empty space at the bottom.

Also unified the font sizes for all section's `View all ...`

![image](https://user-images.githubusercontent.com/1556356/77895594-4efb7b00-7277-11ea-8c8e-b776ce502c72.png)
