### PR TITLE
StyledButton: Keep height when loading

### DIFF
--- a/components/StyledButton.js
+++ b/components/StyledButton.js
@@ -76,7 +76,7 @@ const StyledButton = ({ loading, ...props }) =>
     <StyledButtonContent {...props} />
   ) : (
     <StyledButtonContent {...props} onClick={undefined}>
-      <StyledSpinner />
+      <StyledSpinner size="0.9em" />
     </StyledButtonContent>
   );
 


### PR DESCRIPTION
Button's height was slightly changing when loading because the SVG is a square, so when rotating it will actually be higher than it's base size (hi Pythagore :wave:).

Introduced in #3804 