### PR TITLE
CollectiveNavbar: Fix filters overlapping mobile menu 

### DIFF
--- a/components/CollectiveNavbar.js
+++ b/components/CollectiveNavbar.js
@@ -407,6 +407,8 @@ const CollectiveNavbar = ({
               flexDirection={['column', null, 'row']}
               height="100%"
               borderBottom={['1px solid #e6e8eb', 'none']}
+              backgroundColor="#fff"
+              zIndex={1}
             >
               {sections.map(section => (
                 <MenuLinkContainer


### PR DESCRIPTION

Fixes [#3010](https://github.com/opencollective/opencollective/issues/3010)

# Description
Fix mobile menu on the transactions page

# Screenshots
### Before
![before](https://user-images.githubusercontent.com/42748725/77951013-4af44b00-72c1-11ea-8cfb-51fdd18bbf06.jpeg)

### After
![after](https://user-images.githubusercontent.com/42748725/77951170-8bec5f80-72c1-11ea-8fde-2b6d878f1e11.jpeg)
