### PR TITLE
fix(Create Collective Flow): Fix onboarding modal Formik submit bug

### DIFF
--- a/components/onboarding-modal/OnboardingModal.js
+++ b/components/onboarding-modal/OnboardingModal.js
@@ -355,6 +355,7 @@ class OnboardingModal extends React.Component {
                   this.submitCollectiveInfo(values);
                 }}
                 validate={this.validateFormik}
+                validateOnBlur={true}
               >
                 {({ values, handleSubmit, errors, touched }) => (
                   <FormWithStyles>

--- a/components/onboarding-modal/OnboardingNavButtons.js
+++ b/components/onboarding-modal/OnboardingNavButtons.js
@@ -48,6 +48,7 @@ class OnboardingNavButtons extends React.Component {
           <Fragment>
             {viewport === VIEWPORTS.MOBILE ? (
               <StyledButton
+                type="button"
                 mx={1}
                 buttonStyle="primary"
                 disabled={this.getStepParams(step, 'disabled')}
@@ -63,6 +64,7 @@ class OnboardingNavButtons extends React.Component {
               </StyledButton>
             ) : (
               <StyledRoundButton
+                type="button"
                 mx={1}
                 size={48}
                 disabled={this.getStepParams(step, 'disabled')}
@@ -78,7 +80,7 @@ class OnboardingNavButtons extends React.Component {
               </StyledRoundButton>
             )}
 
-            <StyledButton buttonStyle="primary" onClick={handleSubmit} loading={loading}>
+            <StyledButton buttonStyle="primary" onClick={() => handleSubmit} loading={loading}>
               <FormattedMessage id="Finish" defaultMessage="Finish" />
             </StyledButton>
           </Fragment>
@@ -86,6 +88,7 @@ class OnboardingNavButtons extends React.Component {
           <Fragment>
             {viewport === VIEWPORTS.MOBILE ? (
               <StyledButton
+                type="button"
                 mx={1}
                 buttonStyle="primary"
                 disabled={this.getStepParams(step, 'disabled')}
@@ -101,6 +104,7 @@ class OnboardingNavButtons extends React.Component {
               </StyledButton>
             ) : (
               <StyledRoundButton
+                type="button"
                 mx={1}
                 size={48}
                 disabled={this.getStepParams(step, 'disabled')}
@@ -117,6 +121,7 @@ class OnboardingNavButtons extends React.Component {
             )}
             {viewport === VIEWPORTS.MOBILE ? (
               <StyledButton
+                type="button"
                 mx={1}
                 buttonStyle="primary"
                 onClick={() => {
@@ -131,6 +136,7 @@ class OnboardingNavButtons extends React.Component {
               </StyledButton>
             ) : (
               <StyledRoundButton
+                type="button"
                 mx={1}
                 size={48}
                 onClick={() => {


### PR DESCRIPTION
I didn't understand why Formik was acting like all the fields were touched when you got to the Contacts screen for the first time.

Then I noticed that it was trying to submit every time you pushed a <- or -> button to navigate between screens.

Because the foot was now wrapped in a Formik, every button in the footer became a 'submit' button. So when you tried to navigate, it 'touched' and validated all the fields.

When Formik has a hammer, every button looks like a nail.