### PR TITLE
Bug fixes for CCF

### DIFF
--- a/components/CollectivePickerAsync.js
+++ b/components/CollectivePickerAsync.js
@@ -79,7 +79,7 @@ const CollectivePickerAsync = ({ types, limit, hostCollectiveIds, preload, filte
   const [searchCollectives, { loading, data }] = useLazyQuery(searchQuery);
   const [term, setTerm] = React.useState(null);
   const { formatMessage } = useIntl();
-  const collectives = (data && data.search && data.search.collectives) || [];
+  const collectives = term === '' ? [] : (data && data.search && data.search.collectives) || [];
   const filteredCollectives = filterResults ? filterResults(collectives) : collectives;
   const placeholder = getPlaceholder(formatMessage, types);
 

--- a/components/CollectivePickerAsync.js
+++ b/components/CollectivePickerAsync.js
@@ -79,7 +79,7 @@ const CollectivePickerAsync = ({ types, limit, hostCollectiveIds, preload, filte
   const [searchCollectives, { loading, data }] = useLazyQuery(searchQuery);
   const [term, setTerm] = React.useState(null);
   const { formatMessage } = useIntl();
-  const collectives = term === '' ? [] : (data && data.search && data.search.collectives) || [];
+  const collectives = ((term || preload) && data?.search?.collectives) || [];
   const filteredCollectives = filterResults ? filterResults(collectives) : collectives;
   const placeholder = getPlaceholder(formatMessage, types);
 

--- a/components/StyledSelect.js
+++ b/components/StyledSelect.js
@@ -148,6 +148,10 @@ export const makeStyledSelect = SelectComponent => styled(SelectComponent).attrs
       dropdownIndicator: baseStyles => {
         return hideDropdownIndicator ? STYLES_DISPLAY_NONE : baseStyles;
       },
+      menuPortal: baseStyles => ({
+        ...baseStyles,
+        zIndex: 99999,
+      }),
     },
   }),
 )`

--- a/components/onboarding-modal/OnboardingContentBox.js
+++ b/components/onboarding-modal/OnboardingContentBox.js
@@ -133,9 +133,9 @@ class OnboardingContentBox extends React.Component {
 
             <Flex my={2} px={3} flexDirection="column" width="100%">
               <CollectivePickerAsync
+                menuPortalTarget={document.body}
                 creatable
                 collective={null}
-                preload={true}
                 types={['USER']}
                 onChange={option => {
                   // only assign admins if they are not in the list already

--- a/components/onboarding-modal/OnboardingModal.js
+++ b/components/onboarding-modal/OnboardingModal.js
@@ -248,17 +248,20 @@ class OnboardingModal extends React.Component {
   validateFormik = values => {
     const errors = {};
 
-    if (isURL(values.website) === false) {
+    if (values.website !== '' && isURL(values.website) === false) {
       errors.website = this.props.intl.formatMessage(this.messages['websiteError']);
     }
 
     // https://github.com/shinnn/github-username-regex
-    if (matches(values.githubHandle, /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i) === false) {
+    if (
+      values.githubHandle !== '' &&
+      matches(values.githubHandle, /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i) === false
+    ) {
       errors.githubHandle = this.props.intl.formatMessage(this.messages['githubError']);
     }
 
     // https://stackoverflow.com/questions/11361044/twitter-name-validation
-    if (matches(values.twitterHandle, /^[a-zA-Z0-9_]{1,15}$/) === false) {
+    if (values.twitterHandle !== '' && matches(values.twitterHandle, /^[a-zA-Z0-9_]{1,15}$/) === false) {
       errors.twitterHandle = this.props.intl.formatMessage(this.messages['twitterError']);
     }
 

--- a/components/onboarding-modal/OnboardingSkipButton.js
+++ b/components/onboarding-modal/OnboardingSkipButton.js
@@ -16,6 +16,7 @@ class OnboardingSkipButton extends React.Component {
 
     return (
       <StyledButton
+        type="button"
         width="fit-content"
         buttonStyle="primary"
         onClick={() => {


### PR DESCRIPTION
A few bug fixes for the modal:

**Firefox flickering bug**

Adding the `menuPortal` from `react-select` helps fix this. The rendering was likely being overloaded due to the menu trying to render itself _inside_ the modal instead of appearing over the top of and spilling outside of the modal. Portaling it out allows it to render outside the modal in the `document.body` and fixes the flickering. Thanks @Betree!

**Form not allowing empty values** 

Fields were not marked as required but the validation schema we used (checking if a URL matched a regex, for example) failed if the string was empty. So add exception for empty strings.

**Collective Picker preloading**

The reason I did `preload` was because, even though we added the new `collective` prop that cleared the search input after we select a new admin, when you went back to type in a new search, the old list of admins was still there.

<img width="657" alt="Screenshot 2020-04-01 at 14 22 44" src="https://user-images.githubusercontent.com/37520401/78142119-66c43200-7424-11ea-8507-bdfff3453221.png">
<img width="627" alt="Screenshot 2020-04-01 at 14 22 54" src="https://user-images.githubusercontent.com/37520401/78142126-69268c00-7424-11ea-8ea9-95ee676ae4db.png">

Adding the `preload` prop was an attempt to mitigate this by just preloading an empty string search '' each time. However this is still not intended behaviour. So digging deeper I realised that the drop down list was the same, even though we cleared the search term, because we were not clearing the search data. Have simply added a condition to the `collective` variable that says if we have a cleared search term `' '` then we want to set the `collectives` back to an empty array so there is nothing to display in the drop down.