### PR TITLE
Only display relevant connectedAccounts

### DIFF
--- a/components/edit-collective/EditConnectedAccounts.js
+++ b/components/edit-collective/EditConnectedAccounts.js
@@ -5,11 +5,12 @@ import { capitalize } from '../../lib/utils';
 import EditConnectedAccount from '../EditConnectedAccount';
 
 const EditConnectedAccounts = props => {
-  const services = ['twitter'];
   const connectedAccountsByService = groupBy(props.connectedAccounts, 'service');
 
-  if (props.collective.type === 'USER') {
-    services.push('github');
+  const services = [];
+
+  if (props.collective.type === 'COLLECTIVE' || props.collective.isHost) {
+    services.push('twitter');
   }
 
   return (

--- a/components/edit-collective/MenuEditCollective.js
+++ b/components/edit-collective/MenuEditCollective.js
@@ -158,11 +158,8 @@ const sectionsDisplayConditions = {
   [EDIT_COLLECTIVE_SECTIONS.TIERS]: isOneOfTypes(CollectiveType.COLLECTIVE, CollectiveType.EVENT),
   [EDIT_COLLECTIVE_SECTIONS.VIRTUAL_CARDS]: isType(CollectiveType.ORGANIZATION),
   [EDIT_COLLECTIVE_SECTIONS.TICKETS]: isType(CollectiveType.EVENT),
-  [EDIT_COLLECTIVE_SECTIONS.CONNECTED_ACCOUNTS]: isOneOfTypes(
-    CollectiveType.COLLECTIVE,
-    CollectiveType.ORGANIZATION,
-    CollectiveType.USER,
-  ),
+  [EDIT_COLLECTIVE_SECTIONS.CONNECTED_ACCOUNTS]: collective =>
+    collective.isHost || collective.type == CollectiveType.COLLECTIVE,
   [EDIT_COLLECTIVE_SECTIONS.WEBHOOKS]: isOneOfTypes(
     CollectiveType.COLLECTIVE,
     CollectiveType.ORGANIZATION,


### PR DESCRIPTION
That is Twitter for Collectives. Twitter, Stripe & Transferwise for Hosts. Stripe & Transferwise will be moved out in a separated PR.