### PR TITLE
CollectivePicker: Support for nesting in forms

### DIFF
--- a/components/CollectivePicker.js
+++ b/components/CollectivePicker.js
@@ -288,7 +288,9 @@ class CollectivePicker extends React.PureComponent {
                       type={createFormCollectiveType}
                       onCancel={this.setCreateFormCollectiveType}
                       onSuccess={collective => {
-                        onChange({ label: collective.name, value: collective });
+                        if (onChange) {
+                          onChange({ label: collective.name, value: collective });
+                        }
                         this.setState(state => ({
                           menuIsOpen: false,
                           createFormCollectiveType: null,

--- a/styleguide/examples/CollectivePicker.md
+++ b/styleguide/examples/CollectivePicker.md
@@ -60,3 +60,24 @@ const [loading, setLoading] = React.useState(false);
   }}
 />;
 ```
+
+## Nested form
+
+When put inside a form, the collective picker should **never** submit its parent.
+
+```jsx
+const [isParentSubmitted, setParentSubmitted] = React.useState(false);
+<form
+  onSubmit={e => {
+    e.preventDefault();
+    console.log(e);
+    setParentSubmitted(true);
+  }}
+>
+  <p>
+    Is submitted: <strong>{isParentSubmitted ? 'Yes' : 'No'}</strong>
+  </p>
+  <CollectivePicker creatable />
+  <button style={{ marginTop: 400 }}>Submit</button>
+</form>;
+```


### PR DESCRIPTION
The issue was actually fixed by moving away from react-hook-form to formik (https://github.com/opencollective/opencollective-frontend/pull/3778). Still committing my styleguide example as it could help to test regressions in the future. 