### PR TITLE
New expense form: auto-save draft in local storage

### DIFF
--- a/components/expenses/ExpenseTypeRadioSelect.js
+++ b/components/expenses/ExpenseTypeRadioSelect.js
@@ -73,11 +73,11 @@ const ExpenseTypeOptionContainer = styled.label`
   }
 `;
 
-const ExpenseTypeOption = ({ name, type, defaultChecked }) => {
+const ExpenseTypeOption = ({ name, type, isChecked }) => {
   const { formatMessage } = useIntl();
   return (
     <ExpenseTypeOptionContainer data-cy={`radio-expense-type-${type}`}>
-      <input type="radio" name={name} value={type} defaultChecked={defaultChecked} />
+      <input type="radio" name={name} value={type} checked={isChecked} />
       <Box mr={3} size={64}>
         <StaticTypeIllustration expenseType={type} />
         <TypeIllustration src={type === expenseTypes.RECEIPT ? receiptIllustration : invoiceIllustration} />
@@ -97,7 +97,7 @@ const ExpenseTypeOption = ({ name, type, defaultChecked }) => {
 ExpenseTypeOption.propTypes = {
   name: PropTypes.string.isRequired,
   type: PropTypes.oneOf(Object.values(expenseTypes)).isRequired,
-  defaultChecked: PropTypes.bool,
+  isChecked: PropTypes.bool,
 };
 
 const Fieldset = styled.fieldset`
@@ -118,8 +118,8 @@ const ExpenseTypeRadioSelect = ({ name, onChange, value }) => {
     <StyledCard>
       <Fieldset onChange={onChange}>
         <Flex flexWrap="wrap" overflow="hidden">
-          <ExpenseTypeOption name={name} type={expenseTypes.RECEIPT} defaultChecked={value === expenseTypes.RECEIPT} />
-          <ExpenseTypeOption name={name} type={expenseTypes.INVOICE} defaultChecked={value === expenseTypes.INVOICE} />
+          <ExpenseTypeOption name={name} type={expenseTypes.RECEIPT} isChecked={value === expenseTypes.RECEIPT} />
+          <ExpenseTypeOption name={name} type={expenseTypes.INVOICE} isChecked={value === expenseTypes.INVOICE} />
         </Flex>
       </Fieldset>
     </StyledCard>

--- a/lib/form-persister.js
+++ b/lib/form-persister.js
@@ -21,7 +21,9 @@ export default class FormPersister {
   loadValues() {
     if (this.formId) {
       const itemFromStorage = getFromLocalStorage(this.formId);
-      return JSON.parse(itemFromStorage);
+      if (itemFromStorage) {
+        return JSON.parse(itemFromStorage);
+      }
     }
     return null;
   }

--- a/pages/create-expense.js
+++ b/pages/create-expense.js
@@ -8,6 +8,7 @@ import { graphql } from '@apollo/react-hoc';
 import { FormattedMessage } from 'react-intl';
 
 import expenseTypes from '../lib/constants/expenseTypes';
+import FormPersister from '../lib/form-persister';
 import { getErrorFromGraphqlException, generateNotFoundError } from '../lib/errors';
 import CollectiveNavbar from '../components/CollectiveNavbar';
 import CollectiveThemeProvider from '../components/CollectiveThemeProvider';
@@ -94,6 +95,7 @@ class CreateExpensePage extends React.Component {
       expense: null,
       tags: null,
       isSubmitting: false,
+      formPersister: new FormPersister(),
     };
   }
 
@@ -137,6 +139,7 @@ class CreateExpensePage extends React.Component {
         expense: { ...prepareExpenseForSubmit(expense), tags: tags },
       });
 
+      this.state.formPersister.clearValues();
       const legacyExpenseId = result.data.createExpense.legacyId;
       Router.pushRoute(`/${this.props.collectiveSlug}/expenses/${legacyExpenseId}/v2`);
     } catch (e) {
@@ -212,6 +215,8 @@ class CreateExpensePage extends React.Component {
                           <ExpenseForm
                             collective={collective}
                             loading={loadingLoggedInUser}
+                            loggedInAccountId={loggedInAccount?.id}
+                            formPersister={this.state.formPersister}
                             onSubmit={this.onFormSubmit}
                             expense={this.state.expense}
                             payoutProfiles={this.getPayoutProfiles(loggedInAccount)}


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/2922

# Description
This PR automatically saves a draft of an expense form created by a user in local storage 

# Screenshots

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
![save draft expense form](https://user-images.githubusercontent.com/24629960/78314868-4cc04780-7529-11ea-83e8-fbf78ab4dbda.gif)

