### PR TITLE
DismissibleMessage: Message flashing during SSR

### DIFF
--- a/components/DismissibleMessage.js
+++ b/components/DismissibleMessage.js
@@ -46,7 +46,7 @@ const DismissibleMessage = ({ LoggedInUser, messageId, displayForLoggedOutUser, 
   const loggedInAccount = data?.loggedInAccount || LoggedInUser?.collective;
   // Hide it if SSR or still loading user
   if (typeof window === 'undefined' || (!LoggedInUser && loading)) {
-    null;
+    return null;
   } else if (
     isDismissedLocally ||
     (!loggedInAccount && !displayForLoggedOutUser) ||


### PR DESCRIPTION
The message was flashing in the create expense flow, I realized we forgot the `return`