### PR TITLE
StyledDropzone: Truncate upload progress

### DIFF
--- a/components/StyledDropzone.js
+++ b/components/StyledDropzone.js
@@ -55,7 +55,7 @@ const getUploadProgress = uploadProgressList => {
     return 0;
   } else {
     const totalUploadProgress = uploadProgressList.reduce((total, current) => total + current, 0);
-    return totalUploadProgress / uploadProgressList.length;
+    return Math.trunc(totalUploadProgress / uploadProgressList.length);
   }
 };
 


### PR DESCRIPTION
Before this PR strange progress values (ie. `74.777777777777%`) could be displayed. This PR truncates any decimals from the number.