### PR TITLE
Fix StyledDropzone onDrop callback memoization

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,6 +29,7 @@
     "graphql/capitalized-type-name": ["error"],
     "graphql/no-deprecated-fields": ["warn"],
     "react-hooks/rules-of-hooks": ["error"],
+    "react-hooks/exhaustive-deps": ["warn"],
     "react/jsx-fragments": ["error", "element"],
     // We can be stricter with these rules
     // because we don't have any occurences anymore

--- a/components/StyledDropzone.js
+++ b/components/StyledDropzone.js
@@ -87,32 +87,35 @@ const StyledDropzone = ({
     minSize,
     maxSize,
     multiple: isMulti,
-    onDrop: React.useCallback(async (acceptedFiles, rejectedFiles) => {
-      setUploading(true);
-      const filesToUpload = isMulti ? acceptedFiles : [acceptedFiles[0]];
-      const files = await Promise.all(
-        filesToUpload.map((file, index) =>
-          uploadImageWithXHR(file, {
-            mockImage: mockImageGenerator && mockImageGenerator(index),
-            onProgress: progress => {
-              const newProgressList = [...uploadProgressList];
-              newProgressList.splice(index, 0, progress);
-              setUploadProgressList(newProgressList);
-            },
-          }),
-        ),
-      );
+    onDrop: React.useCallback(
+      async (acceptedFiles, rejectedFiles) => {
+        setUploading(true);
+        const filesToUpload = isMulti ? acceptedFiles : [acceptedFiles[0]];
+        const files = await Promise.all(
+          filesToUpload.map((file, index) =>
+            uploadImageWithXHR(file, {
+              mockImage: mockImageGenerator && mockImageGenerator(index),
+              onProgress: progress => {
+                const newProgressList = [...uploadProgressList];
+                newProgressList.splice(index, 0, progress);
+                setUploadProgressList(newProgressList);
+              },
+            }),
+          ),
+        );
 
-      setUploading(false);
+        setUploading(false);
 
-      if (onSuccess) {
-        await onSuccess(isMulti ? files : files[0]);
-      }
+        if (onSuccess) {
+          await onSuccess(isMulti ? files : files[0]);
+        }
 
-      if (onReject) {
-        onReject(isMulti ? rejectedFiles : rejectedFiles[0]);
-      }
-    }, []),
+        if (onReject) {
+          onReject(isMulti ? rejectedFiles : rejectedFiles[0]);
+        }
+      },
+      [isMulti, onSuccess, onReject, mockImageGenerator, uploadProgressList],
+    ),
   });
 
   minHeight = size || minHeight;

--- a/components/StyledDropzone.js
+++ b/components/StyledDropzone.js
@@ -14,7 +14,6 @@ import { P } from './Text';
 import Container from './Container';
 import { getI18nLink } from './I18nFormatters';
 import StyledSpinner from './StyledSpinner';
-import ContainerOverlay from './ContainerOverlay';
 
 const Dropzone = styled(Container)`
   border: 1px dashed #c4c7cc;
@@ -144,8 +143,8 @@ const StyledDropzone = ({
         </Container>
       ) : (
         <Container my={3} maxHeight="100%" maxWidth="100%" position="relative">
-          {isDragActive && (
-            <ContainerOverlay backgroundType="white" backgroundOpacity={1} color="primary.500">
+          {isDragActive ? (
+            <Container color="primary.500">
               <Box mb={2}>
                 <DownloadIcon size={20} />
               </Box>
@@ -154,27 +153,30 @@ const StyledDropzone = ({
                 defaultMessage="Drop {count,plural, one {file} other {files}} here"
                 values={{ count: isMulti ? 2 : 1 }}
               />
-            </ContainerOverlay>
-          )}
-          {showDefaultMessage && (
-            <P color="black.500" px={2} fontSize={fontSize}>
-              {isMulti ? (
-                <FormattedMessage
-                  id="DropZone.UploadBox"
-                  defaultMessage="Drag and drop one or multiple files or <i18n-link>click here to select</i18n-link>."
-                  values={{ 'i18n-link': getI18nLink() }}
-                />
-              ) : (
-                <FormattedMessage
-                  id="DragAndDropOrClickToUpload"
-                  defaultMessage="Drag & drop or <i18n-link>click to upload</i18n-link>"
-                  values={{ 'i18n-link': getI18nLink() }}
-                  tagName="span"
-                />
+            </Container>
+          ) : (
+            <React.Fragment>
+              {showDefaultMessage && (
+                <P color="black.500" px={2} fontSize={fontSize}>
+                  {isMulti ? (
+                    <FormattedMessage
+                      id="DropZone.UploadBox"
+                      defaultMessage="Drag and drop one or multiple files or <i18n-link>click here to select</i18n-link>."
+                      values={{ 'i18n-link': getI18nLink() }}
+                    />
+                  ) : (
+                    <FormattedMessage
+                      id="DragAndDropOrClickToUpload"
+                      defaultMessage="Drag & drop or <i18n-link>click to upload</i18n-link>"
+                      values={{ 'i18n-link': getI18nLink() }}
+                      tagName="span"
+                    />
+                  )}
+                </P>
               )}
-            </P>
+              {children}
+            </React.Fragment>
           )}
-          {children}
         </Container>
       )}
     </Dropzone>

--- a/components/expenses/ExpenseAttachedFiles.js
+++ b/components/expenses/ExpenseAttachedFiles.js
@@ -29,7 +29,7 @@ const ExpenseAttachedFiles = ({ files, onRemove }) => {
   return (
     <Flex flexWrap="wrap">
       {files.map((file, idx) => (
-        <Box key={file.id}>
+        <Box key={file.id || file.url}>
           <ImageLink href={file.url}>
             <img src={file.url} alt={`Attachment ${idx}`} />
           </ImageLink>
@@ -53,7 +53,7 @@ const ExpenseAttachedFiles = ({ files, onRemove }) => {
 ExpenseAttachedFiles.propTypes = {
   files: PropTypes.arrayOf(
     PropTypes.shape({
-      id: PropTypes.string.isRequired,
+      id: PropTypes.string,
       url: PropTypes.string.isRequired,
     }).isRequired,
   ).isRequired,

--- a/components/expenses/ExpenseAttachedFilesForm.js
+++ b/components/expenses/ExpenseAttachedFilesForm.js
@@ -24,6 +24,16 @@ const PrivateNoteLabel = () => {
 const ExpenseAttachedFilesForm = ({ onChange, disabled, defaultValue }) => {
   const [files, setFiles] = React.useState(uniqBy(defaultValue, 'url'));
 
+  const onSuccess = React.useCallback(
+    urls => {
+      const newFiles = urls.map(url => ({ url }));
+      const updatedFiles = uniqBy([...files, ...newFiles], 'url');
+      setFiles(updatedFiles);
+      onChange(updatedFiles);
+    },
+    [files],
+  );
+
   return (
     <StyledInputField
       name="attachedFiles"
@@ -52,12 +62,7 @@ const ExpenseAttachedFilesForm = ({ onChange, disabled, defaultValue }) => {
             {...attachmentDropzoneParams}
             isMulti
             disabled={disabled}
-            onSuccess={urls => {
-              const newFiles = urls.map(url => ({ url }));
-              const updatedFiles = uniqBy([...files, ...newFiles], 'url');
-              setFiles(updatedFiles);
-              onChange(updatedFiles);
-            }}
+            onSuccess={onSuccess}
           />
         </div>
       )}

--- a/styleguide/examples/expenses/ExpenseAttachedFilesForm.md
+++ b/styleguide/examples/expenses/ExpenseAttachedFilesForm.md
@@ -1,0 +1,3 @@
+```jsx
+<ExpenseAttachedFilesForm onChange={console.log} />
+```


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/3051

The `onDrop` callback was memoized with  `React.useCallback` but the update arguments were not passed, so the `onSuccess` callback was always given the initial `files` value.

I've added the `react-hooks/exhaustive-deps` eslint rule to avoid this mistake in the future.