### PR TITLE
Fix missing collective name in receipt's filename

### DIFF
--- a/components/BudgetItemsList.js
+++ b/components/BudgetItemsList.js
@@ -447,7 +447,7 @@ const BudgetItem = ({ item, isInverted, isCompact, canDownloadInvoice, intl }) =
               toCollectiveSlug={collective.slug}
             >
               {({ loading, download }) => (
-                <StyledButton buttonSize="small" loading={loading} onClick={download} minWidth={140} height={30}>
+                <StyledButton buttonSize="small" loading={loading} onClick={download} minWidth={140}>
                   <FormattedMessage id="DownloadInvoice" defaultMessage="Download invoice" />
                 </StyledButton>
               )}

--- a/components/BudgetItemsList.js
+++ b/components/BudgetItemsList.js
@@ -441,7 +441,11 @@ const BudgetItem = ({ item, isInverted, isCompact, canDownloadInvoice, intl }) =
             </div>
           )}
           {hasInvoiceBtn && (
-            <InvoiceDownloadLink type="transaction" transactionUuid={transaction.uuid}>
+            <InvoiceDownloadLink
+              type="transaction"
+              transactionUuid={transaction.uuid}
+              toCollectiveSlug={collective.slug}
+            >
               {({ loading, download }) => (
                 <StyledButton buttonSize="small" loading={loading} onClick={download} minWidth={140} height={30}>
                   <FormattedMessage id="DownloadInvoice" defaultMessage="Download invoice" />

--- a/components/expenses/InvoiceDownloadLink.js
+++ b/components/expenses/InvoiceDownloadLink.js
@@ -26,8 +26,6 @@ export default class InvoiceDownloadLink extends Component {
     dateTo: PropTypes.string,
     /** Invoice date to */
     invoice: PropTypes.object,
-    /** Invoice Recipient */
-    recipient: PropTypes.string,
     /** Transaction creation date */
     createdAt: PropTypes.string,
   };
@@ -45,10 +43,10 @@ export default class InvoiceDownloadLink extends Component {
   }
 
   getFilename() {
-    const { fromCollectiveSlug, toCollectiveSlug, dateFrom, dateTo, recipient, createdAt } = this.props;
+    const { fromCollectiveSlug, toCollectiveSlug, dateFrom, dateTo, createdAt } = this.props;
     if (this.props.type === 'transaction') {
       const createdAtString = toIsoDateStr(createdAt ? new Date(createdAt) : new Date());
-      return `${recipient}_${createdAtString}_${this.props.transactionUuid}.pdf`;
+      return `${toCollectiveSlug || 'transaction'}_${createdAtString}_${this.props.transactionUuid}.pdf`;
     } else {
       const fromString = toIsoDateStr(dateFrom ? new Date(dateFrom) : new Date());
       const toString = toIsoDateStr(dateTo ? new Date(dateTo) : new Date());

--- a/components/expenses/TransactionDetails.js
+++ b/components/expenses/TransactionDetails.js
@@ -276,7 +276,7 @@ class TransactionDetails extends React.Component {
                 <InvoiceDownloadLink
                   type="transaction"
                   transactionUuid={uuid}
-                  recipient={recipient.name}
+                  toCollectiveSlug={recipient.slug}
                   createdAt={createdAt}
                 >
                   {({ loading, download }) => (


### PR DESCRIPTION
Also fixed https://github.com/opencollective/opencollective/issues/3052

The `recipient` prop for `InvoiceDownloadLink`that was introduced in https://github.com/opencollective/opencollective-frontend/pull/3837 was not set on the other instances of the component. As a consequence, the other paths were generating receipt names like `undefined_2020-04-10_uuid`.

I've switched to the `toCollectiveSlug` prop, added a fallback and used the slug rather than the name because the first can contains characters that are not safe to display in the filename.
