### PR TITLE
Design system: improve responsiveness docs

### DIFF
--- a/components/ContributorsGrid.js
+++ b/components/ContributorsGrid.js
@@ -173,10 +173,10 @@ ContributorsGrid.propTypes = {
   /** Maximum number of rows for different viewports. Will fallback on `defaultNbRows` if not provided */
   maxNbRowsForViewports: PropTypes.shape({
     [VIEWPORTS.UNKNOWN]: PropTypes.number,
-    [VIEWPORTS.MOBILE]: PropTypes.number,
-    [VIEWPORTS.TABLET]: PropTypes.number,
-    [VIEWPORTS.DESKTOP]: PropTypes.number,
-    [VIEWPORTS.WIDESCREEN]: PropTypes.number,
+    [VIEWPORTS.XSMALL]: PropTypes.number,
+    [VIEWPORTS.SMALL]: PropTypes.number,
+    [VIEWPORTS.MEDIUM]: PropTypes.number,
+    [VIEWPORTS.LARGE]: PropTypes.number,
   }).isRequired,
 
   /** A callback to calculate left padding */
@@ -205,10 +205,10 @@ ContributorsGrid.defaultProps = {
   defaultNbRows: 1,
   maxNbRowsForViewports: {
     [VIEWPORTS.UNKNOWN]: 1,
-    [VIEWPORTS.MOBILE]: 1,
-    [VIEWPORTS.TABLET]: 2,
-    [VIEWPORTS.DESKTOP]: 3,
-    [VIEWPORTS.WIDESCREEN]: 3,
+    [VIEWPORTS.XSMALL]: 1,
+    [VIEWPORTS.SMALL]: 2,
+    [VIEWPORTS.MEDIUM]: 3,
+    [VIEWPORTS.LARGE]: 3,
   },
 };
 

--- a/components/StepsProgress.js
+++ b/components/StepsProgress.js
@@ -225,7 +225,7 @@ const StepsProgress = ({
 
   return (
     <StepsOuter className="steps-progress">
-      {viewport === VIEWPORTS.MOBILE ? (
+      {viewport === VIEWPORTS.XSMALL ? (
         <StepMobile>
           <StepsMobileLeft>
             <P color="black.900" fontWeight="600" fontSize="Paragraph">

--- a/components/onboarding-modal/OnboardingNavButtons.js
+++ b/components/onboarding-modal/OnboardingNavButtons.js
@@ -46,7 +46,7 @@ class OnboardingNavButtons extends React.Component {
       <Flex>
         {step === 2 ? (
           <Fragment>
-            {viewport === VIEWPORTS.MOBILE ? (
+            {viewport === VIEWPORTS.XSMALL ? (
               <StyledButton
                 type="button"
                 mx={1}
@@ -86,7 +86,7 @@ class OnboardingNavButtons extends React.Component {
           </Fragment>
         ) : (
           <Fragment>
-            {viewport === VIEWPORTS.MOBILE ? (
+            {viewport === VIEWPORTS.XSMALL ? (
               <StyledButton
                 type="button"
                 mx={1}
@@ -119,7 +119,7 @@ class OnboardingNavButtons extends React.Component {
                 ←
               </StyledRoundButton>
             )}
-            {viewport === VIEWPORTS.MOBILE ? (
+            {viewport === VIEWPORTS.XSMALL ? (
               <StyledButton
                 type="button"
                 mx={1}

--- a/components/pricing/index.js
+++ b/components/pricing/index.js
@@ -32,7 +32,7 @@ class Pricing extends Component {
   getActiveTab() {
     const { viewport, tab } = this.props;
     // Return a default tab for desktop
-    if (viewport !== VIEWPORTS.UNKNOWN && viewport !== VIEWPORTS.MOBILE && !tab) {
+    if (viewport !== VIEWPORTS.UNKNOWN && viewport !== VIEWPORTS.XSMALL && !tab) {
       return 'singleCollectiveWithAccount';
     }
     return tab;

--- a/lib/theme/breakpoints.js
+++ b/lib/theme/breakpoints.js
@@ -1,8 +1,8 @@
 const breakpoints = [
-  '40em', //  640px - mobile
-  '52em', //  832px - tablet
-  '64em', // 1024px - desktop
-  '88em', // 1408px - widescreen
+  '40em', //  640px - xsmall
+  '52em', //  832px - small
+  '64em', // 1024px - medium
+  '88em', // 1408px - large
 ];
 
 export default breakpoints;

--- a/lib/theme/helpers.js
+++ b/lib/theme/helpers.js
@@ -3,6 +3,13 @@ export function toPx(value) {
   return `${value}px`;
 }
 
+/**
+ * Convert a value in `em` to pixels
+ */
+export function emToPx(value) {
+  return parseFloat(value) * 16;
+}
+
 export function getTopToBottomGradient(startColor, endColor) {
   return `linear-gradient(180deg, ${startColor} 0%, ${endColor} 100%);`;
 }

--- a/lib/withViewport.js
+++ b/lib/withViewport.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import { debounce, findLastIndex, zipObject } from 'lodash';
+import { emToPx } from './theme/helpers';
+import breakpoints from './theme/breakpoints';
 
 /**
  * Defines all the breakpoints names as passed by `withViewport`
@@ -14,7 +16,7 @@ export const VIEWPORTS = {
 
 // Please keep the same length for these two arrays
 export const BREAKPOINTS_NAMES = [VIEWPORTS.XSMALL, VIEWPORTS.SMALL, VIEWPORTS.MEDIUM, VIEWPORTS.LARGE];
-export const BREAKPOINTS_WIDTHS = [640, 832, 1024, 1408];
+export const BREAKPOINTS_WIDTHS = BREAKPOINTS_NAMES.map((_, idx) => emToPx(breakpoints[idx]));
 export const BREAKPOINTS = zipObject(BREAKPOINTS_NAMES, BREAKPOINTS_WIDTHS);
 
 /**

--- a/lib/withViewport.js
+++ b/lib/withViewport.js
@@ -5,15 +5,15 @@ import { debounce, findLastIndex, zipObject } from 'lodash';
  * Defines all the breakpoints names as passed by `withViewport`
  */
 export const VIEWPORTS = {
-  MOBILE: 'MOBILE',
-  TABLET: 'TABLET',
-  DESKTOP: 'DESKTOP',
-  WIDESCREEN: 'WIDESCREEN',
+  XSMALL: 'XSMALL',
+  SMALL: 'SMALL',
+  MEDIUM: 'MEDIUM',
+  LARGE: 'LARGE',
   UNKNOWN: 'UNKNOWN',
 };
 
 // Please keep the same length for these two arrays
-export const BREAKPOINTS_NAMES = [VIEWPORTS.MOBILE, VIEWPORTS.TABLET, VIEWPORTS.DESKTOP, VIEWPORTS.WIDESCREEN];
+export const BREAKPOINTS_NAMES = [VIEWPORTS.XSMALL, VIEWPORTS.SMALL, VIEWPORTS.MEDIUM, VIEWPORTS.LARGE];
 export const BREAKPOINTS_WIDTHS = [640, 832, 1024, 1408];
 export const BREAKPOINTS = zipObject(BREAKPOINTS_NAMES, BREAKPOINTS_WIDTHS);
 
@@ -34,7 +34,7 @@ export const viewportIsAbove = (viewport, breakpointName) => {
  * @param {VIEWPORTS} viewport
  */
 export const isDesktopOrAbove = viewport => {
-  return BREAKPOINTS_NAMES.indexOf(viewport) >= BREAKPOINTS_NAMES.indexOf(VIEWPORTS.DESKTOP);
+  return BREAKPOINTS_NAMES.indexOf(viewport) >= BREAKPOINTS_NAMES.indexOf(VIEWPORTS.MEDIUM);
 };
 
 /** Returns the name of the viewport (see `BREAKPOINTS_NAMES`) */

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -34,29 +34,39 @@ module.exports = {
       content: 'styleguide/pages/index.md',
     },
     {
-      name: 'Typography',
-      content: 'styleguide/pages/typography.md',
-      components: 'components/Text.js',
+      name: 'Design system',
+      description: 'Defines the general rules & best practices for design',
+      sections: [
+        {
+          name: 'Responsiveness',
+          content: 'styleguide/pages/responsiveness.md',
+        },
+        {
+          name: 'Grid',
+          content: 'styleguide/pages/Grid.md',
+          sections: [
+            {
+              name: 'Box',
+              content: 'styleguide/examples/Box.md',
+            },
+            {
+              name: 'Flex',
+              content: 'styleguide/examples/Flex.md',
+            },
+          ],
+        },
+        {
+          name: 'Typography',
+          content: 'styleguide/pages/typography.md',
+          components: 'components/Text.js',
+        },
+      ],
     },
     {
       name: 'Atoms',
       components: 'components/Styled*.js',
       description: 'Base design atoms.',
       sectionDepth: 1,
-    },
-    {
-      name: 'Grid',
-      content: 'styleguide/pages/Grid.md',
-      sections: [
-        {
-          name: 'Box',
-          content: 'styleguide/examples/Box.md',
-        },
-        {
-          name: 'Flex',
-          content: 'styleguide/examples/Flex.md',
-        },
-      ],
     },
     {
       name: 'Master components',

--- a/styleguide/examples/ContributorsGrid.md
+++ b/styleguide/examples/ContributorsGrid.md
@@ -2,5 +2,5 @@ This example doesn't have auto-resize, please use a desktop screen to review thi
 
 ```jsx
 import { webpackContributors } from '../mocks/contributors';
-<ContributorsGrid contributors={webpackContributors} maxNbRowsForViewports={{ DESKTOP: 2, WIDESCREEN: 2 }} />;
+<ContributorsGrid contributors={webpackContributors} maxNbRowsForViewports={{ MEDIUM: 2, LARGE: 2 }} />;
 ```

--- a/styleguide/pages/responsiveness.md
+++ b/styleguide/pages/responsiveness.md
@@ -1,0 +1,89 @@
+#### Responsive props
+
+The main way to deal with responsiveness in our codebase is through
+the [responsive props or styled-system](https://styled-system.com/responsive-styles).
+
+We use the following breakpoints:
+
+```jsx
+import { getViewportFromWidth } from '../../lib/withViewport';
+import breakpoints from '../../lib/theme/breakpoints';
+import { emToPx } from '../../lib/theme/helpers';
+<table style={{ maxWidth: 350, width: '100%' }}>
+  <thead>
+    <th align="left">Name</th>
+    <th align="left">Value (em)</th>
+    <th align="left">Value (px)</th>
+  </thead>
+  <tbody>
+    {breakpoints.map(breakpoint => (
+      <tr key={breakpoint}>
+        <td>{getViewportFromWidth(emToPx(breakpoint))}</td>
+        <td>{breakpoint}</td>
+        <td>{emToPx(breakpoint)}px</td>
+      </tr>
+    ))}
+  </tbody>
+</table>;
+```
+
+Based on that, the following props will be applied:
+
+```jsx
+import { BREAKPOINTS_NAMES, BREAKPOINTS_WIDTHS } from '../../lib/withViewport';
+<pre>{`
+  <Box
+    height={[
+      10, // Default value
+      20, // Applied above ${BREAKPOINTS_NAMES[0]} (${BREAKPOINTS_WIDTHS[0]}px)
+      30, // Applied above ${BREAKPOINTS_NAMES[1]} (${BREAKPOINTS_WIDTHS[1]}px)
+      40, // Applied above ${BREAKPOINTS_NAMES[2]} (${BREAKPOINTS_WIDTHS[2]}px)
+      50, // Applied above ${BREAKPOINTS_NAMES[3]} (${BREAKPOINTS_WIDTHS[3]}px)
+    ]}
+  />
+`}</pre>;
+```
+
+Which will translate to the following CSS:
+
+```css
+.Box-hash {
+  height: 10px;
+}
+
+@media screen and (min-width: 40em) {
+  .Box-hash {
+    height: 20px;
+  }
+}
+
+@media screen and (min-width: 52em) {
+  .Box-hash {
+    height: 30px;
+  }
+}
+
+@media screen and (min-width: 64em) {
+  .Box-hash {
+    height: 40px;
+  }
+}
+
+@media screen and (min-width: 88em) {
+  .Box-hash {
+    height: 50px;
+  }
+}
+```
+
+### withViewport
+
+`withViewport` is a helper to handle responsiveness from JS. Its usage is strongly discouraged if an alternative exists with CSS because:
+
+- It's normally CSS responsibility to handle the responsiveness
+- CSS is more performant to handle that
+- We don't have any info on the screen resolution during SSR
+
+That being said there are legit use cases for it, for example when the layout for a component
+is completly different between mobile and desktop and cannot be reconciliated with flex and
+responsive props.

--- a/styleguide/pages/typography.md
+++ b/styleguide/pages/typography.md
@@ -1,6 +1,6 @@
 The main way to deal with typography is through the components in `components/Text.js`.
 
-# Typeface & fonts
+### Typeface & fonts
 
 🎨️ [Figma file](https://www.figma.com/file/jxJfC29te8i1C8qMReth95/%5BDS%5D-01-Typography?node-id=9%3A10)
 
@@ -22,7 +22,7 @@ import { P } from 'components/Text';
 </div>;
 ```
 
-# Type scale
+### Type scale
 
 You can configure the scale through `fontSize` and `lineHeight` props.
 


### PR DESCRIPTION
1. Rename the breakpoints to reduce the confusion between design's breakpoints and ours
2. Add some documentation for responsiveness: https://oc-styleguide-pr-3959.onrender.com/#/Design%20system?id=section-responsiveness

---

![image](https://user-images.githubusercontent.com/1556356/79444388-65296b00-7fdb-11ea-9dfb-5e818c9e781e.png)
