### PR TITLE
OnboardingContentBox: Remove withViewport

### DIFF
--- a/components/onboarding-modal/OnboardingContentBox.js
+++ b/components/onboarding-modal/OnboardingContentBox.js
@@ -15,8 +15,6 @@ import CollectivePickerAsync from '../../components/CollectivePickerAsync';
 import OnboardingProfileCard from './OnboardingProfileCard';
 import OnboardingSkipButton from './OnboardingSkipButton';
 
-import withViewport, { VIEWPORTS } from '../../lib/withViewport';
-
 class OnboardingContentBox extends React.Component {
   static propTypes = {
     slug: PropTypes.string,
@@ -26,7 +24,6 @@ class OnboardingContentBox extends React.Component {
     updateAdmins: PropTypes.func,
     addContact: PropTypes.func,
     intl: PropTypes.object.isRequired,
-    viewport: PropTypes.string,
     values: PropTypes.object,
     errors: PropTypes.object,
     touched: PropTypes.object,
@@ -65,7 +62,7 @@ class OnboardingContentBox extends React.Component {
   };
 
   render() {
-    const { slug, step, collective, updateAdmins, intl, LoggedInUser, viewport, values, errors, touched } = this.props;
+    const { slug, step, collective, updateAdmins, intl, LoggedInUser, values, errors, touched } = this.props;
     const { admins } = this.state;
 
     return (
@@ -88,11 +85,9 @@ class OnboardingContentBox extends React.Component {
               />
               &nbsp;🎉
             </H1>
-            {viewport === VIEWPORTS.MOBILE && (
-              <Fragment>
-                <OnboardingSkipButton slug={slug} />
-              </Fragment>
-            )}
+            <Box display={['block', null, 'none']}>
+              <OnboardingSkipButton slug={slug} />
+            </Box>
           </Flex>
         )}
         {step === 1 && (
@@ -241,4 +236,4 @@ class OnboardingContentBox extends React.Component {
   }
 }
 
-export default withViewport(injectIntl(OnboardingContentBox));
+export default injectIntl(OnboardingContentBox);


### PR DESCRIPTION
As recently documented in https://github.com/opencollective/opencollective-frontend/pull/3959, using `withViewport` is strongly discouraged if an alternative exists with CSS because:
- It's normally CSS responsibility to handle the responsiveness
- CSS is more performant to handle that
- We don't have any info on the screen resolution during SSR

This PR is just a small demo to show how to conditionally hide elements with responsive props.

An alternative is to use the `Hide` component:
```jsx
<Hide md lg>
  <OnboardingSkipButton slug={slug} />
</Hide>
```