### PR TITLE
Expense flow minor enhancements

### DIFF
--- a/components/expenses/ExpandableExpensePolicies.js
+++ b/components/expenses/ExpandableExpensePolicies.js
@@ -4,7 +4,8 @@ import { Box } from '@rebass/grid';
 import { defineMessages, useIntl } from 'react-intl';
 import Markdown from 'react-markdown';
 import Collapse from '../Collapse';
-import { H5, P } from '../Text';
+import { H5 } from '../Text';
+import Container from '../Container';
 
 const msg = defineMessages({
   policies: {
@@ -26,14 +27,14 @@ const ExpandableExpensePolicies = ({ host, collective, ...props }) => {
     <Box {...props}>
       <Collapse title={<H5>{formatMessage(msg.policies)}</H5>}>
         {host && host.expensePolicy && (
-          <P fontSize="Caption" color="black.800" lineHeight="Paragraph" mb={2}>
+          <Container fontSize="Caption" color="black.800" lineHeight="Paragraph" mb={2}>
             <Markdown source={host.expensePolicy} />
-          </P>
+          </Container>
         )}
         {collective && collective.expensePolicy && (
-          <P fontSize="Caption" color="black.800" lineHeight="Paragraph">
+          <Container fontSize="Caption" color="black.800" lineHeight="Paragraph">
             <Markdown source={collective.expensePolicy} />
-          </P>
+          </Container>
         )}
       </Collapse>
     </Box>

--- a/components/expenses/ExpenseFormItems.js
+++ b/components/expenses/ExpenseFormItems.js
@@ -49,16 +49,30 @@ export default class ExpenseFormItems extends React.PureComponent {
   };
 
   componentDidMount() {
-    this.addDefaultItemIfEmpty();
-  }
-
-  componentDidUpdate() {
-    this.addDefaultItemIfEmpty();
-  }
-
-  addDefaultItemIfEmpty() {
     const { values } = this.props.form;
-    if (values.type === expenseTypes.INVOICE && isEmpty(values.items)) {
+    if (values.type === expenseTypes.INVOICE) {
+      this.addDefaultItem();
+    }
+  }
+
+  componentDidUpdate(oldProps) {
+    const { values, touched } = this.props.form;
+
+    if (oldProps.form.values.type !== values.type) {
+      if (values.type === expenseTypes.INVOICE) {
+        this.addDefaultItem();
+      } else if (!touched.items && values.items?.length === 1) {
+        const firstItem = values.items[0];
+        if (!firstItem.url && !firstItem.description && !firstItem.amount) {
+          this.props.remove(0);
+        }
+      }
+    }
+  }
+
+  addDefaultItem() {
+    const { values } = this.props.form;
+    if (isEmpty(values.items)) {
       this.props.push(newExpenseItem());
     }
   }

--- a/components/expenses/ExpenseItemForm.js
+++ b/components/expenses/ExpenseItemForm.js
@@ -138,7 +138,7 @@ const ExpenseItemForm = ({ attachment, errors, onRemove, currency, requireFile, 
               required
               label={formatMessage(msg.dateLabel)}
               labelFontSize="LeadCaption"
-              flex="1 1 50%"
+              flex={requireFile ? '1 1 44%' : '1 1 50%'}
               mt={3}
             >
               {inputProps => (
@@ -163,6 +163,7 @@ const ExpenseItemForm = ({ attachment, errors, onRemove, currency, requireFile, 
               labelFontSize="LeadCaption"
               inputType="number"
               flex="1 1 30%"
+              minWidth={150}
               maxWidth="100%"
               mt={3}
             >

--- a/pages/create-expense.js
+++ b/pages/create-expense.js
@@ -207,7 +207,7 @@ class CreateExpensePage extends React.Component {
                       <LoadingPlaceholder width="100%" height={400} />
                     ) : (
                       <Box>
-                        <CreateExpenseDismissibleIntro />
+                        <CreateExpenseDismissibleIntro collectiveName={collective.name} />
                         {step === STEPS.FORM && (
                           <ExpenseForm
                             collective={collective}

--- a/pages/create-expense.js
+++ b/pages/create-expense.js
@@ -256,7 +256,7 @@ class CreateExpensePage extends React.Component {
                       </Box>
                     )}
                   </Box>
-                  <Box minWidth={300} width={['100%', null, null, 300]} px={3} mt={3}>
+                  <Box minWidth={270} width={['100%', null, null, 275]} mt={70}>
                     <ExpenseInfoSidebar
                       isLoading={data.loading}
                       collective={collective}

--- a/pages/expense.js
+++ b/pages/expense.js
@@ -239,7 +239,7 @@ class ExpensePage extends React.Component {
       <Page collective={collective} {...this.getPageMetaData(expense)} withoutGlobalStyles>
         <CollectiveThemeProvider collective={collective}>
           <CollectiveNavbar collective={collective} isLoading={!collective} selected={Sections.BUDGET} />
-          <Flex flexWrap="wrap" my={4} data-cy="expense-page-content">
+          <Flex flexWrap="wrap" my={[4, 5]} data-cy="expense-page-content">
             <Container
               display={['none', null, null, 'flex']}
               justifyContent="flex-end"
@@ -259,15 +259,7 @@ class ExpensePage extends React.Component {
                 )}
               </Flex>
             </Container>
-            <Box
-              flex="1 1 650px"
-              minWidth={300}
-              maxWidth={750}
-              mr={[null, 2, 3, 4, 5]}
-              py={2}
-              px={3}
-              ref={this.expenseTopRef}
-            >
+            <Box flex="1 1 650px" minWidth={300} maxWidth={750} mr={[null, 2, 3, 4, 5]} px={2} ref={this.expenseTopRef}>
               <H1 fontSize="H4" lineHeight="H4" mb={24} py={2}>
                 <FormattedMessage id="Expense.summary" defaultMessage="Expense summary" />
               </H1>
@@ -385,7 +377,7 @@ class ExpensePage extends React.Component {
               </Flex>
             </Box>
             <Flex flex="1 1" justifyContent={['center', null, 'flex-start', 'flex-end']} pt={80}>
-              <Box minWidth={300} width={['100%', null, null, 300]} px={3}>
+              <Box minWidth={270} width={['100%', null, null, 275]} px={2}>
                 <ExpenseInfoSidebar
                   isLoading={data.loading}
                   collective={collective}


### PR DESCRIPTION
A bunch of enhancements for the expense flow:
- CreateExpenseDismissibleIntro: Add collectiveName missing prop
- ExpandableExpensePolicies: Fix DOM nesting issue
- ExpenseForm: Reset default item when switching to receipts
- ExpenseItemForm: Fix layout issue on Firefox
- ExpenseForm: Adjust layouts and sidebar position 