### PR TITLE
fix button regression that wrapped whitespace on some buttons

### DIFF
--- a/components/create-collective/CreateCollectiveForm.js
+++ b/components/create-collective/CreateCollectiveForm.js
@@ -349,7 +349,7 @@ class CreateCollectiveForm extends React.Component {
                     <Flex justifyContent={['center', 'left']} mb={4}>
                       <StyledButton
                         fontSize="13px"
-                        width="148px"
+                        minWidth="148px"
                         minHeight="36px"
                         buttonStyle="primary"
                         type="submit"


### PR DESCRIPTION
Before

<img width="729" alt="Screenshot 2020-04-17 at 18 07 28" src="https://user-images.githubusercontent.com/37520401/79595219-58d60880-80d6-11ea-9a14-babf28ace417.png">

After

<img width="766" alt="Screenshot 2020-04-17 at 18 07 13" src="https://user-images.githubusercontent.com/37520401/79595211-5673ae80-80d6-11ea-8fce-e3fc900bcd78.png">

The whitespace css alone fixed the Create Collective regression but to follow best practice I changed width to minWidth anyways.