### PR TITLE
Refactor: refetchLoggedInUser

### DIFF
--- a/components/UserProvider.js
+++ b/components/UserProvider.js
@@ -98,10 +98,10 @@ class UserProvider extends React.Component {
    * [refetchQueries](https://www.apollographql.com/docs/react/api/react-apollo.html#graphql-mutation-options-refetchQueries)
    * if you really need to be up-to-date with server.
    */
-  refetchLoggedInUser = async ({ ignoreApolloCache = false } = {}) => {
+  refetchLoggedInUser = async () => {
     const { getLoggedInUser } = this.props;
     try {
-      const LoggedInUser = await getLoggedInUser({ ignoreLocalStorage: true, ignoreApolloCache });
+      const LoggedInUser = await getLoggedInUser({ ignoreLocalStorage: true });
       this.setState({
         errorLoggedInUser: null,
         loadingLoggedInUser: false,

--- a/components/UserProvider.js
+++ b/components/UserProvider.js
@@ -98,10 +98,10 @@ class UserProvider extends React.Component {
    * [refetchQueries](https://www.apollographql.com/docs/react/api/react-apollo.html#graphql-mutation-options-refetchQueries)
    * if you really need to be up-to-date with server.
    */
-  refetchLoggedInUser = async () => {
+  refetchLoggedInUser = async ({ ignoreApolloCache = false } = {}) => {
     const { getLoggedInUser } = this.props;
     try {
-      const LoggedInUser = await getLoggedInUser({ ignoreLocalStorage: true });
+      const LoggedInUser = await getLoggedInUser({ ignoreLocalStorage: true, ignoreApolloCache });
       this.setState({
         errorLoggedInUser: null,
         loadingLoggedInUser: false,

--- a/components/create-collective/index.js
+++ b/components/create-collective/index.js
@@ -13,7 +13,6 @@ import SignInOrJoinFree from '../SignInOrJoinFree';
 import MessageBox from '../MessageBox';
 import { withUser } from '../UserProvider';
 
-import { getLoggedInUserQuery } from '../../lib/graphql/queries';
 import { API_V2_CONTEXT, gqlV2 } from '../../lib/graphql/helpers';
 import { getErrorFromGraphqlException } from '../../lib/errors';
 import { parseToBoolean } from '../../lib/utils';
@@ -100,7 +99,7 @@ class CreateCollective extends Component {
         status: 'idle',
         result: { success: 'Collective created successfully' },
       });
-      await this.props.refetchLoggedInUser();
+      await this.props.refetchLoggedInUser({ ignoreApolloCache: true });
       // don't show banner if we show the modal and vice versa
       if (parseToBoolean(process.env.ONBOARDING_MODAL) === true) {
         Router.pushRoute('collective-with-onboarding', {
@@ -218,8 +217,6 @@ const addCreateCollectiveMutation = graphql(createCollectiveQuery, {
     createCollective: async ({ collective, host, automateApprovalWithGithub }) => {
       return await mutate({
         variables: { collective, host, automateApprovalWithGithub },
-        awaitRefetchQueries: true,
-        refetchQueries: [{ query: getLoggedInUserQuery }],
       });
     },
   }),

--- a/components/create-collective/index.js
+++ b/components/create-collective/index.js
@@ -99,7 +99,7 @@ class CreateCollective extends Component {
         status: 'idle',
         result: { success: 'Collective created successfully' },
       });
-      await this.props.refetchLoggedInUser({ ignoreApolloCache: true });
+      await this.props.refetchLoggedInUser();
       // don't show banner if we show the modal and vice versa
       if (parseToBoolean(process.env.ONBOARDING_MODAL) === true) {
         Router.pushRoute('collective-with-onboarding', {

--- a/components/edit-collective/actions/Delete.js
+++ b/components/edit-collective/actions/Delete.js
@@ -41,7 +41,7 @@ const DeleteCollective = ({ collective, deleteCollective, deleteUserCollective, 
         await deleteUserCollective(collective.id);
       } else {
         await deleteCollective(collective.id);
-        await props.refetchLoggedInUser();
+        await props.refetchLoggedInUser({ ignoreApolloCache: true });
       }
       await Router.pushRoute(`/deleteCollective/confirmed?type=${collective.type}`);
     } catch (err) {

--- a/components/edit-collective/actions/Delete.js
+++ b/components/edit-collective/actions/Delete.js
@@ -57,7 +57,7 @@ const DeleteCollective = ({ collective, ...props }) => {
         await deleteUserCollective();
       } else {
         await deleteCollective();
-        await props.refetchLoggedInUser({ ignoreApolloCache: true });
+        await props.refetchLoggedInUser();
       }
       await Router.pushRoute(`/deleteCollective/confirmed?type=${collective.type}`);
     } catch (err) {

--- a/components/onboarding-modal/OnboardingModal.js
+++ b/components/onboarding-modal/OnboardingModal.js
@@ -19,7 +19,6 @@ import StyledButton from '../../components/StyledButton';
 
 import { confettiFireworks } from '../../lib/confettis';
 import { getErrorFromGraphqlException } from '../../lib/errors';
-import { getLoggedInUserQuery } from '../../lib/graphql/queries';
 import { Router } from '../../server/pages';
 
 const StepsProgressBox = styled(Box)`
@@ -415,8 +414,6 @@ const addEditCoreContributorsMutation = graphql(editCoreContributorsMutation, {
     EditCollectiveMembers: async ({ collectiveId, members }) => {
       return await mutate({
         variables: { collectiveId, members },
-        awaitRefetchQueries: true,
-        refetchQueries: [{ query: getLoggedInUserQuery }],
       });
     },
   }),
@@ -439,8 +436,6 @@ const addEditCollectiveContactMutation = graphql(editCollectiveContactMutation, 
     EditCollectiveContact: async ({ collective }) => {
       return await mutate({
         variables: { collective },
-        awaitRefetchQueries: true,
-        refetchQueries: [{ query: getLoggedInUserQuery }],
       });
     },
   }),

--- a/lib/graphql/mutations.js
+++ b/lib/graphql/mutations.js
@@ -239,8 +239,6 @@ export const addDeleteCollectiveMutation = graphql(deleteCollectiveQuery, {
     deleteCollective: async id => {
       return await mutate({
         variables: { id },
-        awaitRefetchQueries: true,
-        refetchQueries: [{ query: getLoggedInUserQuery }],
       });
     },
   }),

--- a/lib/graphql/mutations.js
+++ b/lib/graphql/mutations.js
@@ -56,22 +56,6 @@ const editCollectiveQuery = gql`
 `;
 /* eslint-enable graphql/template-strings, graphql/no-deprecated-fields, graphql/capitalized-type-name, graphql/named-operations */
 
-const deleteCollectiveQuery = gql`
-  mutation deleteCollective($id: Int!) {
-    deleteCollective(id: $id) {
-      id
-    }
-  }
-`;
-
-const deleteUserCollectiveQuery = gql`
-  mutation deleteUserCollective($id: Int!) {
-    deleteUserCollective(id: $id) {
-      id
-    }
-  }
-`;
-
 const archiveCollectiveQuery = gql`
   mutation archiveCollective($id: Int!) {
     archiveCollective(id: $id) {
@@ -230,24 +214,6 @@ export const addEditCollectiveMutation = graphql(editCollectiveQuery, {
 
       CollectiveInputType.location = pick(collective.location, ['name', 'address', 'lat', 'long', 'country']);
       return await mutate({ variables: { collective: CollectiveInputType } });
-    },
-  }),
-});
-
-export const addDeleteCollectiveMutation = graphql(deleteCollectiveQuery, {
-  props: ({ mutate }) => ({
-    deleteCollective: async id => {
-      return await mutate({
-        variables: { id },
-      });
-    },
-  }),
-});
-
-export const addDeleteUserCollectiveMutation = graphql(deleteUserCollectiveQuery, {
-  props: ({ mutate }) => ({
-    deleteUserCollective: async id => {
-      return await mutate({ variables: { id } });
     },
   }),
 });

--- a/lib/withLoggedInUser.js
+++ b/lib/withLoggedInUser.js
@@ -49,8 +49,9 @@ export default WrappedComponent => {
       client: PropTypes.object,
     };
 
-    getLoggedInUserFromServer = () =>
-      this.props.client.query({ query: getLoggedInUserQuery }).then(result => {
+    getLoggedInUserFromServer = ({ ignoreApolloCache }) => {
+      const fetchPolicy = ignoreApolloCache ? 'network-only' : null;
+      return this.props.client.query({ query: getLoggedInUserQuery, fetchPolicy }).then(result => {
         if (result.data && result.data.LoggedInUser) {
           const user = result.data.LoggedInUser;
           storage.set('LoggedInUser', user, 1000 * 60 * 60);
@@ -66,6 +67,7 @@ export default WrappedComponent => {
           return null;
         }
       });
+    };
 
     /**
      * If `token` is passed in `options`, function it will throw if
@@ -73,7 +75,7 @@ export default WrappedComponent => {
      * but instead force refetch it from the server.
      */
     getLoggedInUser = async (options = {}) => {
-      const { ignoreLocalStorage = false, token = null } = options;
+      const { ignoreLocalStorage = false, ignoreApolloCache = false, token = null } = options;
 
       // only Client Side for now
       if (!process.browser || !window) {
@@ -117,7 +119,7 @@ export default WrappedComponent => {
       }
 
       // Synchronously
-      return this.getLoggedInUserFromServer();
+      return this.getLoggedInUserFromServer({ ignoreApolloCache });
     };
 
     render() {

--- a/lib/withLoggedInUser.js
+++ b/lib/withLoggedInUser.js
@@ -49,9 +49,8 @@ export default WrappedComponent => {
       client: PropTypes.object,
     };
 
-    getLoggedInUserFromServer = ({ ignoreApolloCache = false } = {}) => {
-      const fetchPolicy = ignoreApolloCache ? 'network-only' : null;
-      return this.props.client.query({ query: getLoggedInUserQuery, fetchPolicy }).then(result => {
+    getLoggedInUserFromServer = () => {
+      return this.props.client.query({ query: getLoggedInUserQuery, fetchPolicy: 'network-only' }).then(result => {
         if (result.data && result.data.LoggedInUser) {
           const user = result.data.LoggedInUser;
           storage.set('LoggedInUser', user, 1000 * 60 * 60);
@@ -75,7 +74,7 @@ export default WrappedComponent => {
      * but instead force refetch it from the server.
      */
     getLoggedInUser = async (options = {}) => {
-      const { ignoreLocalStorage = false, ignoreApolloCache = false, token = null } = options;
+      const { ignoreLocalStorage = false, token = null } = options;
 
       // only Client Side for now
       if (!process.browser || !window) {
@@ -119,7 +118,7 @@ export default WrappedComponent => {
       }
 
       // Synchronously
-      return this.getLoggedInUserFromServer({ ignoreApolloCache });
+      return this.getLoggedInUserFromServer();
     };
 
     render() {

--- a/lib/withLoggedInUser.js
+++ b/lib/withLoggedInUser.js
@@ -49,7 +49,7 @@ export default WrappedComponent => {
       client: PropTypes.object,
     };
 
-    getLoggedInUserFromServer = ({ ignoreApolloCache }) => {
+    getLoggedInUserFromServer = ({ ignoreApolloCache = false } = {}) => {
       const fetchPolicy = ignoreApolloCache ? 'network-only' : null;
       return this.props.client.query({ query: getLoggedInUserQuery, fetchPolicy }).then(result => {
         if (result.data && result.data.LoggedInUser) {

--- a/pages/redeem.js
+++ b/pages/redeem.js
@@ -21,7 +21,6 @@ import RedeemSuccess from '../components/RedeemSuccess';
 import { P, H1, H5 } from '../components/Text';
 import LinkCollective from '../components/LinkCollective';
 
-import { getLoggedInUserQuery } from '../lib/graphql/queries';
 import { isValidEmail } from '../lib/utils';
 import { getErrorFromGraphqlException } from '../lib/errors';
 
@@ -301,11 +300,7 @@ const redeemMutation = gql`
 const addMutation = graphql(redeemMutation, {
   props: ({ mutate }) => ({
     claimPaymentMethod: async (code, user) => {
-      // Claim payment method and refresh LoggedInUser Apollo cache so
-      // `client.query` will deliver new data for next call
-      return await mutate({
-        variables: { code, user },
-      });
+      return await mutate({ variables: { code, user } });
     },
   }),
 });

--- a/pages/redeem.js
+++ b/pages/redeem.js
@@ -112,9 +112,7 @@ class RedeemPage extends React.Component {
     try {
       if (this.props.LoggedInUser) {
         await this.props.claimPaymentMethod(code);
-
-        // Refresh LoggedInUser
-        this.props.refetchLoggedInUser();
+        await this.props.refetchLoggedInUser({ ignoreApolloCache: true });
         Router.pushRoute('redeemed', { code, collectiveSlug: this.props.collectiveSlug });
         return;
       } else {
@@ -307,8 +305,6 @@ const addMutation = graphql(redeemMutation, {
       // `client.query` will deliver new data for next call
       return await mutate({
         variables: { code, user },
-        awaitRefetchQueries: true,
-        refetchQueries: [{ query: getLoggedInUserQuery }],
       });
     },
   }),

--- a/pages/redeem.js
+++ b/pages/redeem.js
@@ -111,7 +111,7 @@ class RedeemPage extends React.Component {
     try {
       if (this.props.LoggedInUser) {
         await this.props.claimPaymentMethod(code);
-        await this.props.refetchLoggedInUser({ ignoreApolloCache: true });
+        await this.props.refetchLoggedInUser();
         Router.pushRoute('redeemed', { code, collectiveSlug: this.props.collectiveSlug });
         return;
       } else {


### PR DESCRIPTION
Update refetchLoggedInUser so that it can reload the data skipping Apollo cache. https://github.com/opencollective/opencollective-frontend/commit/114e3ee19ceb088809bc0f31214537366d4fd69f

The idea is that we should need to take care of updating `getLoggedInUserQuery`, we just use `refetchLoggedInUser` when we need it and that's all.

We may consider making that behavior (`ignoreApolloCache: true`) the default.

The second commit it just a follow up refactor. https://github.com/opencollective/opencollective-frontend/commit/328f7aad118372715034f77b12ca5191776d688b
