### PR TITLE
StyledDropzone: New behavior for replacing image

### DIFF
--- a/components/StyledDropzone.js
+++ b/components/StyledDropzone.js
@@ -4,7 +4,7 @@ import { Box } from '@rebass/grid';
 import { FormattedMessage } from 'react-intl';
 import { useDropzone } from 'react-dropzone';
 import styled, { css } from 'styled-components';
-import { isNil } from 'lodash';
+import { isNil, omit } from 'lodash';
 import { v4 as uuid } from 'uuid';
 
 import { Download as DownloadIcon } from '@styled-icons/feather/Download';
@@ -14,27 +14,33 @@ import { P } from './Text';
 import Container from './Container';
 import { getI18nLink } from './I18nFormatters';
 import StyledSpinner from './StyledSpinner';
+import UploadedFilePreview from './UploadedFilePreview';
 
 const Dropzone = styled(Container)`
   border: 1px dashed #c4c7cc;
   border-radius: 10px;
   text-align: center;
-  cursor: pointer;
   background: white;
   display: flex;
   justify-content: center;
   align-items: center;
   overflow: hidden;
 
-  &:hover:not(:disabled) {
-    background: #f9f9f9;
-    border-color: ${props => props.theme.colors.primary[300]};
-  }
+  ${props =>
+    props.onClick &&
+    css`
+      cursor: pointer;
 
-  &:focus {
-    outline: 0;
-    border-color: ${props => props.theme.colors.primary[500]};
-  }
+      &:hover:not(:disabled) {
+        background: #f9f9f9;
+        border-color: ${props => props.theme.colors.primary[300]};
+      }
+
+      &:focus {
+        outline: 0;
+        border-color: ${props => props.theme.colors.primary[500]};
+      }
+    `}
 
   ${props =>
     props.error &&
@@ -45,6 +51,27 @@ const Dropzone = styled(Container)`
   img {
     max-height: 100%;
     max-width: 100%;
+  }
+`;
+
+const ReplaceContainer = styled.div`
+  box-sizing: border-box;
+  background: rgba(49, 50, 51, 0.5);
+  color: #ffffff;
+  cursor: pointer;
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 24px;
+  padding: 8px;
+  margin-top: -24px;
+  font-size: 12px;
+  line-height: 1em;
+
+  &:hover {
+    background: rgba(49, 50, 51, 0.6);
   }
 `;
 
@@ -64,7 +91,6 @@ const getUploadProgress = uploadProgressList => {
 const StyledDropzone = ({
   onSuccess,
   onReject,
-  showDefaultMessage,
   children,
   isLoading,
   loadingProgress,
@@ -76,6 +102,7 @@ const StyledDropzone = ({
   minSize,
   maxSize,
   error,
+  value,
   isMulti,
   ...props
 }) => {
@@ -120,8 +147,15 @@ const StyledDropzone = ({
 
   minHeight = size || minHeight;
   const innerMinHeight = minHeight - 2; // -2 To account for the borders
+  const dropProps = getRootProps();
   return (
-    <Dropzone {...props} {...getRootProps()} minHeight={size || minHeight} size={size} error={error}>
+    <Dropzone
+      {...props}
+      {...(value ? omit(dropProps, ['onClick']) : dropProps)}
+      minHeight={size || minHeight}
+      size={size}
+      error={error}
+    >
       <input {...getInputProps()} />
       {isLoading || isUploading ? (
         <Container
@@ -145,9 +179,9 @@ const StyledDropzone = ({
           {isLoading && !isNil(loadingProgress) && <Container>{loadingProgress}%</Container>}
         </Container>
       ) : (
-        <Container my={3} maxHeight="100%" maxWidth="100%" position="relative">
+        <Container position="relative">
           {isDragActive ? (
-            <Container color="primary.500">
+            <Container color="primary.500" fontSize="Caption">
               <Box mb={2}>
                 <DownloadIcon size={20} />
               </Box>
@@ -159,7 +193,7 @@ const StyledDropzone = ({
             </Container>
           ) : (
             <React.Fragment>
-              {showDefaultMessage && (
+              {!value ? (
                 <P color="black.500" px={2} fontSize={fontSize}>
                   {isMulti ? (
                     <FormattedMessage
@@ -176,6 +210,13 @@ const StyledDropzone = ({
                     />
                   )}
                 </P>
+              ) : (
+                <React.Fragment>
+                  <UploadedFilePreview size={size} url={value} hasLink border="none" />
+                  <ReplaceContainer onClick={dropProps.onClick}>
+                    <FormattedMessage id="Image.Replace" defaultMessage="Replace" />
+                  </ReplaceContainer>
+                </React.Fragment>
               )}
               {children}
             </React.Fragment>
@@ -193,8 +234,6 @@ StyledDropzone.propTypes = {
   onReject: PropTypes.func,
   /** Content to show inside the dropzone. Defaults to message "Drag and drop one or..." */
   children: PropTypes.node,
-  /** Whether to show the default message. By default, the message will be displayed if there's no children */
-  showDefaultMessage: PropTypes.bool,
   /** Force loading state to be displayed */
   isLoading: PropTypes.bool,
   /** Use this to override the loading progress indicator */
@@ -219,6 +258,8 @@ StyledDropzone.propTypes = {
   error: PropTypes.any,
   /** required field */
   required: PropTypes.bool,
+  /** if set, the image will be displayed and a "replace" banner will be added */
+  value: PropTypes.string,
 };
 
 StyledDropzone.defaultProps = {
@@ -226,7 +267,6 @@ StyledDropzone.defaultProps = {
   mockImageGenerator: () => `https://loremflickr.com/120/120?lock=${uuid()}`,
   isMulti: true,
   fontSize: 'Paragraph',
-  showDefaultMessage: true,
 };
 
 export default StyledDropzone;

--- a/components/UploadedFilePreview.js
+++ b/components/UploadedFilePreview.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { max } from 'lodash';
 import { FileText } from '@styled-icons/feather/FileText';
 import { imagePreview } from '../lib/image-utils';
 import ExternalLink from './ExternalLink';
@@ -19,7 +20,7 @@ const ImageLink = styled(ExternalLink).attrs({ openInNewTab: true })`
 
 const MainContainer = styled(Container)`
   border-radius: 8px;
-  padding: 8px;
+  padding: 4px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -28,6 +29,7 @@ const MainContainer = styled(Container)`
     height: 100%;
     max-height: 100%;
     max-width: 100%;
+    border-radius: 8px;
   }
 `;
 
@@ -39,13 +41,14 @@ const UploadedFilePreview = ({ isPrivate, isLoading, url, size, alt, hasLink, ..
   let content = null;
 
   if (isLoading) {
-    content = <LoadingPlaceholder />;
+    content = <LoadingPlaceholder borderRadius={8} />;
   } else if (isPrivate) {
     content = <PrivateInfoIcon color="#dcdee0" size={size / 2} />;
   } else if (!url) {
     content = <FileText color="#dcdee0" size={size / 2} />;
   } else {
-    const img = <img src={imagePreview(url)} alt={alt} />;
+    const resizeWidth = Array.isArray(size) ? max(size) : size;
+    const img = <img src={imagePreview(url, null, { width: resizeWidth })} alt={alt} />;
     content = !hasLink ? img : <ImageLink href={url}>{img}</ImageLink>;
   }
 
@@ -61,7 +64,7 @@ UploadedFilePreview.propTypes = {
   isPrivate: PropTypes.bool,
   isLoading: PropTypes.bool,
   alt: PropTypes.string,
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array]),
   /** If true, a link to the original file will be added if possible */
   hasLink: PropTypes.bool,
 };
@@ -70,6 +73,7 @@ UploadedFilePreview.defaultProps = {
   size: 88,
   border: '1px solid #dcdee0',
   hasLink: true,
+  alt: 'Uploaded file preview',
 };
 
 export default UploadedFilePreview;

--- a/components/expenses/ExpenseFormItems.js
+++ b/components/expenses/ExpenseFormItems.js
@@ -96,7 +96,6 @@ export default class ExpenseFormItems extends React.PureComponent {
           {...attachmentDropzoneParams}
           data-cy="expense-multi-attachments-dropzone"
           onSuccess={files => filesListToItems(files).map(this.props.push)}
-          showDefaultMessage
           mockImageGenerator={index => `https://loremflickr.com/120/120/invoice?lock=${index}`}
           mb={3}
         >

--- a/components/expenses/ExpenseItemForm.js
+++ b/components/expenses/ExpenseItemForm.js
@@ -16,7 +16,6 @@ import { Span } from '../Text';
 import { attachmentDropzoneParams, attachmentRequiresFile } from './lib/attachments';
 import StyledDropzone from '../StyledDropzone';
 import StyledButton from '../StyledButton';
-import UploadedFilePreview from '../UploadedFilePreview';
 import StyledHr from '../StyledHr';
 
 export const msg = defineMessages({
@@ -106,13 +105,11 @@ const ExpenseItemForm = ({ attachment, errors, onRemove, currency, requireFile, 
                     isMulti={false}
                     error={meta.error}
                     onSuccess={url => form.setFieldValue(field.name, url)}
-                    showDefaultMessage={!hasValidUrl}
                     mockImageGenerator={() => `https://loremflickr.com/120/120/invoice?lock=${attachmentKey}`}
                     fontSize="LeadCaption"
                     size={[84, 112]}
-                  >
-                    {hasValidUrl && <UploadedFilePreview size={112} url={field.value} hasLink={false} border="none" />}
-                  </StyledDropzone>
+                    value={hasValidUrl && field.value}
+                  />
                 </StyledInputField>
               );
             }}

--- a/lang/en.json
+++ b/lang/en.json
@@ -957,6 +957,7 @@
   "hosts.description.findOutMoreLink": "Find out more about becoming an Open Collective Host.",
   "hosts.title": "Open Collective Hosts",
   "HostSince": "Host since",
+  "Image.Replace": "Replace",
   "input.tags.placeholder": "Add a new tag (then press \"enter\")",
   "InputTypeCountry.placeholder": "Please select your country",
   "Invitation.Accepted": "Accepted",

--- a/lang/es.json
+++ b/lang/es.json
@@ -957,6 +957,7 @@
   "hosts.description.findOutMoreLink": "Obtenga más información sobre cómo convertirse en un anfitrión colectivo abierto.",
   "hosts.title": "Host Colectivo Abierto",
   "HostSince": "Host since",
+  "Image.Replace": "Replace",
   "input.tags.placeholder": "Añade una nueva etiqueta(luego presiona \"enter\")",
   "InputTypeCountry.placeholder": "Por favor, selecciona tu ciudad",
   "Invitation.Accepted": "Accepted",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -957,6 +957,7 @@
   "hosts.description.findOutMoreLink": "Plus d'information sur comment devenir un hôte de collectifs ouverts.",
   "hosts.title": "Hôtes d'Open Collective",
   "HostSince": "Host since",
+  "Image.Replace": "Replace",
   "input.tags.placeholder": "Ajoutez un nouveau tag (et appuyez sur \"entrer\")",
   "InputTypeCountry.placeholder": "Veuillez sélectionner votre pays",
   "Invitation.Accepted": "Acceptée",

--- a/lang/it.json
+++ b/lang/it.json
@@ -957,6 +957,7 @@
   "hosts.description.findOutMoreLink": "Find out more about becoming an Open Collective Host.",
   "hosts.title": "Open Collective Hosts",
   "HostSince": "Host since",
+  "Image.Replace": "Replace",
   "input.tags.placeholder": "Add a new tag (then press \"enter\")",
   "InputTypeCountry.placeholder": "Please select your country",
   "Invitation.Accepted": "Accepted",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -957,6 +957,7 @@
   "hosts.description.findOutMoreLink": "Find out more about becoming an Open Collective Host.",
   "hosts.title": "Open Collective ホスト",
   "HostSince": "Host since",
+  "Image.Replace": "Replace",
   "input.tags.placeholder": "Add a new tag (then press \"enter\")",
   "InputTypeCountry.placeholder": "あなたの国を選んでください",
   "Invitation.Accepted": "許可済",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -957,6 +957,7 @@
   "hosts.description.findOutMoreLink": "Find out more about becoming an Open Collective Host.",
   "hosts.title": "Open Collective Hosts",
   "HostSince": "Host since",
+  "Image.Replace": "Replace",
   "input.tags.placeholder": "Add a new tag (then press \"enter\")",
   "InputTypeCountry.placeholder": "Please select your country",
   "Invitation.Accepted": "Accepted",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -957,6 +957,7 @@
   "hosts.description.findOutMoreLink": "Descubra mais sobre como se tornar um Organizador do Open Collective.",
   "hosts.title": "Organizadores do Open Collective",
   "HostSince": "Host since",
+  "Image.Replace": "Replace",
   "input.tags.placeholder": "Adicione uma nova tag (e aperte \"enter\")",
   "InputTypeCountry.placeholder": "Por favor selecione seu país",
   "Invitation.Accepted": "Aceito",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -957,6 +957,7 @@
   "hosts.description.findOutMoreLink": "Узнайте больше о том, как стать Представителем Open Collective.",
   "hosts.title": "Представители Open Collective",
   "HostSince": "Host since",
+  "Image.Replace": "Replace",
   "input.tags.placeholder": "Add a new tag (then press \"enter\")",
   "InputTypeCountry.placeholder": "Выберите страну",
   "Invitation.Accepted": "Accepted",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -957,6 +957,7 @@
   "hosts.description.findOutMoreLink": "Find out more about becoming an Open Collective Host.",
   "hosts.title": "Open Collective Hosts",
   "HostSince": "Host since",
+  "Image.Replace": "Replace",
   "input.tags.placeholder": "Add a new tag (then press \"enter\")",
   "InputTypeCountry.placeholder": "请选择你的国家",
   "Invitation.Accepted": "Accepted",

--- a/styleguide/examples/StyledDropzone.md
+++ b/styleguide/examples/StyledDropzone.md
@@ -10,24 +10,10 @@
 <StyledDropzone onSuccess={console.log}>Hello World</StyledDropzone>
 ```
 
-### Override default message
-
-```jsx
-<StyledDropzone onSuccess={console.log} showDefaultMessage={false}>
-  Hello World
-</StyledDropzone>
-```
-
 ## Custom size
 
 ```jsx
 <StyledDropzone onSuccess={console.log} size={150} />
-```
-
-```jsx
-<StyledDropzone onSuccess={console.log} size={60} showDefaultMessage={false}>
-  DnD
-</StyledDropzone>
 ```
 
 ## Loading state


### PR DESCRIPTION
Based on https://www.figma.com/file/ZQBMWhnGGtRWeIZknFW1eP/%5BOC.com%5D-Production-Ready-%E2%9C%85?node-id=2446%3A5316

- A click on the image opens the image
- Dropping a file on the box still works as expected
- You need to click on replace to open the file select menu

![Peek 20-04-2020 12-09](https://user-images.githubusercontent.com/1556356/79740361-d6309180-82ff-11ea-910f-082030196c26.gif)
