### PR TITLE
MemberInvitation: Center title

### DIFF
--- a/pages/member-invitations.js
+++ b/pages/member-invitations.js
@@ -61,7 +61,7 @@ class MemberInvitationsPage extends React.Component {
                   <Loading />
                 ) : (
                   <div>
-                    <H1 mb={5}>
+                    <H1 mb={5} textAlign="center">
                       <FormattedMessage id="MemberInvitations.title" defaultMessage="Pending invitations" />
                     </H1>
                     {!data || !data.memberInvitations || error ? (


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/3070

Text-align: center was recently removed from H1's default to improve consistency, which created this regression. I haven't tried to fix the other issues described in https://github.com/opencollective/opencollective/issues/3070 as I'm not sure what the expectation is.

![image](https://user-images.githubusercontent.com/1556356/79750980-20bb0980-8312-11ea-8af2-85f5d0f52256.png)
