### PR TITLE
Remove @rebass/grid dependency

### DIFF
--- a/components/AuthenticatedPage.js
+++ b/components/AuthenticatedPage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { Flex } from '@rebass/grid';
+import { Flex } from './Grid';
 
 import { withUser } from './UserProvider';
 import Page from './Page';

--- a/components/Avatar.js
+++ b/components/Avatar.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { color, border, space, layout } from 'styled-system';
 import themeGet from '@styled-system/theme-get';
-import { Flex } from '@rebass/grid';
+import { Flex } from './Grid';
 
 import { getCollectiveImage, getAvatarBorderRadius } from '../lib/image-utils';
 import { defaultImage, CollectiveType } from '../lib/constants/collectives';

--- a/components/BudgetItemsList.js
+++ b/components/BudgetItemsList.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, FormattedDate, injectIntl } from 'react-intl';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from './Grid';
 import gql from 'graphql-tag';
 import styled, { css } from 'styled-components';
 import { round, truncate } from 'lodash';

--- a/components/ButtonGroup.js
+++ b/components/ButtonGroup.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { borders, borderRadius } from 'styled-system';
-import { Flex } from '@rebass/grid';
+import { Flex } from './Grid';
 
 const computeBorderRadius = ({ index, itemCount }) => {
   if (index === 0) {

--- a/components/CollectiveCallsToAction.js
+++ b/components/CollectiveCallsToAction.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { Box } from '@rebass/grid';
+import { Box } from './Grid';
 import dynamic from 'next/dynamic';
 import { get } from 'lodash';
 

--- a/components/CollectiveContactForm.js
+++ b/components/CollectiveContactForm.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { Flex } from '@rebass/grid';
+import { Flex } from './Grid';
 import { useMutation } from '@apollo/react-hooks';
 import gql from 'graphql-tag';
 import { get } from 'lodash';

--- a/components/CollectiveNavbar.js
+++ b/components/CollectiveNavbar.js
@@ -4,7 +4,7 @@ import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import styled, { css } from 'styled-components';
 import themeGet from '@styled-system/theme-get';
 import { get } from 'lodash';
-import { Flex } from '@rebass/grid';
+import { Flex } from './Grid';
 
 import { Settings } from '@styled-icons/feather/Settings';
 import { ChevronDown } from '@styled-icons/boxicons-regular/ChevronDown';

--- a/components/CollectivePicker.js
+++ b/components/CollectivePicker.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { injectIntl, defineMessages } from 'react-intl';
 import { groupBy, sortBy, last, truncate, isEqual } from 'lodash';
 import memoizeOne from 'memoize-one';
-import { Flex } from '@rebass/grid';
+import { Flex } from './Grid';
 import { Manager, Reference, Popper } from 'react-popper';
 
 import { CollectiveType } from '../lib/constants/collectives';

--- a/components/CollectiveTypePicker.js
+++ b/components/CollectiveTypePicker.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { Box } from '@rebass/grid';
+import { Box } from './Grid';
 
 import { User } from '@styled-icons/feather/User';
 

--- a/components/CommentForm.js
+++ b/components/CommentForm.js
@@ -7,7 +7,7 @@ import Avatar from './Avatar';
 import Link from './Link';
 import MessageBox from './MessageBox';
 import RichTextEditor from './RichTextEditor';
-import { Box } from '@rebass/grid';
+import { Box } from './Grid';
 
 /**
  * Component to render for for **new** comments. Comment Edit form is created

--- a/components/ContributorCard.js
+++ b/components/ContributorCard.js
@@ -2,7 +2,7 @@ import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { truncate } from 'lodash';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from './Grid';
 import styled, { css } from 'styled-components';
 
 import formatMemberRole from '../lib/i18n-member-role';

--- a/components/CreateCollectiveMiniForm.js
+++ b/components/CreateCollectiveMiniForm.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl, defineMessages } from 'react-intl';
-import { Box } from '@rebass/grid';
+import { Box } from './Grid';
 import { get, pick, cloneDeep } from 'lodash';
 import { useMutation } from '@apollo/react-hooks';
 import gql from 'graphql-tag';

--- a/components/CreateProfile.js
+++ b/components/CreateProfile.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { pick } from 'lodash';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from './Grid';
 import { FormattedMessage, defineMessages, useIntl } from 'react-intl';
 
 import { Link } from '../server/pages';

--- a/components/CreateVirtualCardsForm.js
+++ b/components/CreateVirtualCardsForm.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import themeGet from '@styled-system/theme-get';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from './Grid';
 import { get, truncate } from 'lodash';
 import { graphql } from '@apollo/react-hoc';
 import moment from 'moment';

--- a/components/CreateVirtualCardsSuccess.js
+++ b/components/CreateVirtualCardsSuccess.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from './Grid';
 
 import { Clipboard } from '@styled-icons/feather/Clipboard';
 import { CheckCircle } from '@styled-icons/feather/CheckCircle';

--- a/components/EditPublicMessagePopup.js
+++ b/components/EditPublicMessagePopup.js
@@ -6,7 +6,7 @@ import { Times } from '@styled-icons/fa-solid/Times';
 import PropTypes from 'prop-types';
 import { FormattedMessage, defineMessages } from 'react-intl';
 import gql from 'graphql-tag';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from './Grid';
 
 import { Span } from './Text';
 import StyledButton from './StyledButton';

--- a/components/EditUpdateForm.js
+++ b/components/EditUpdateForm.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import dynamic from 'next/dynamic';
 import { FormattedMessage } from 'react-intl';
 import { pick, get } from 'lodash';
-import { Box } from '@rebass/grid';
+import { Box } from './Grid';
 
 import StyledInput from './StyledInput';
 import StyledInputField from './StyledInputField';

--- a/components/ErrorPage.js
+++ b/components/ErrorPage.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
-import { Flex } from '@rebass/grid';
+import { Flex } from './Grid';
 import { Router } from '../server/pages';
 
 import { Support } from '@styled-icons/boxicons-regular/Support';

--- a/components/EventDetails.js
+++ b/components/EventDetails.js
@@ -6,7 +6,7 @@ import { truncate, get } from 'lodash';
 import StyledCard from './StyledCard';
 import { FormattedMessage } from 'react-intl';
 import StyledLink from './StyledLink';
-import { Box } from '@rebass/grid';
+import { Box } from './Grid';
 import { Span } from './Text';
 import HTMLContent from './HTMLContent';
 

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from './Grid';
 import { FormattedMessage } from 'react-intl';
 import { Github } from '@styled-icons/fa-brands/Github';
 import { Blog } from '@styled-icons/icomoon/Blog';

--- a/components/GiftCard.js
+++ b/components/GiftCard.js
@@ -7,7 +7,7 @@ import Container from './Container';
 import { Span, P } from './Text';
 import Currency from './Currency';
 import Link from './Link';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from './Grid';
 import styled from 'styled-components';
 import { FormattedMessage, FormattedDate } from 'react-intl';
 import { width, height, fontSize } from 'styled-system';

--- a/components/GithubRepositoryEntry.js
+++ b/components/GithubRepositoryEntry.js
@@ -1,6 +1,6 @@
 import React, { Fragment, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Box } from '@rebass/grid';
+import { Box } from './Grid';
 import { pick } from 'lodash';
 import { Github } from '@styled-icons/fa-brands/Github';
 import { Star } from '@styled-icons/fa-solid/Star';

--- a/components/Grid.js
+++ b/components/Grid.js
@@ -1,0 +1,32 @@
+/**
+ * This file is a copy-paste from https://github.com/rebassjs/grid/blob/master/src/index.js.
+ * See https://github.com/opencollective/opencollective/issues/2929 for more info.
+ */
+
+import styled from 'styled-components';
+import { space, color, layout, flexbox, typography, compose } from 'styled-system';
+import propTypes from '@styled-system/prop-types';
+
+const boxProps = compose(space, color, layout, typography, flexbox);
+export const Box = styled('div')(
+  {
+    boxSizing: 'border-box',
+  },
+  boxProps,
+);
+
+Box.displayName = 'Box';
+
+Box.propTypes = {
+  ...propTypes.space,
+  ...propTypes.color,
+  ...propTypes.layout,
+  ...propTypes.typography,
+  ...propTypes.flexbox,
+};
+
+export const Flex = styled(Box)({
+  display: 'flex',
+});
+
+Flex.displayName = 'Flex';

--- a/components/Hide.js
+++ b/components/Hide.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { Box } from '@rebass/grid';
+import { Box } from './Grid';
 import { bottom, height, left, position, right, top } from 'styled-system';
 import PropTypes from 'prop-types';
 

--- a/components/IncognitoUserCollective.js
+++ b/components/IncognitoUserCollective.js
@@ -6,7 +6,7 @@ import Body from './Body';
 import Footer from './Footer';
 import { IncognitoAvatar } from './Avatar';
 import { defineMessages, injectIntl } from 'react-intl';
-import { Flex } from '@rebass/grid';
+import { Flex } from './Grid';
 
 class IncognitoUserCollective extends React.Component {
   static propTypes = {

--- a/components/InlineEditField.js
+++ b/components/InlineEditField.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from './Grid';
 import { Mutation } from '@apollo/react-components';
 import { get, pick } from 'lodash';
 import styled from 'styled-components';

--- a/components/Loading.js
+++ b/components/Loading.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import LoadingGrid from '../components/LoadingGrid';
-import { Flex } from '@rebass/grid';
+import { Flex } from './Grid';
 
 const Loading = props => {
   return (

--- a/components/Member.js
+++ b/components/Member.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import { defineMessages, injectIntl } from 'react-intl';
-import { Flex } from '@rebass/grid';
+import { Flex } from './Grid';
 
 import colors from '../lib/constants/colors';
 import { formatCurrency, formatDate, firstSentence, singular, capitalize } from '../lib/utils';

--- a/components/MemberCard.js
+++ b/components/MemberCard.js
@@ -6,7 +6,7 @@ import themeGet from '@styled-system/theme-get';
 import { FormattedMessage } from 'react-intl';
 import StyledCard from './StyledCard';
 import { H5, Span } from './Text';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from './Grid';
 import Avatar from './Avatar';
 import Link from './Link';
 import UserCompany from './UserCompany';

--- a/components/MemberInvitationsList.js
+++ b/components/MemberInvitationsList.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from './Grid';
 import { FormattedMessage } from 'react-intl';
 import ReplyToMemberInvitationCard from './ReplyToMemberInvitationCard';
 import MessageBox from './MessageBox';

--- a/components/NewCreditCardForm.js
+++ b/components/NewCreditCardForm.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Elements, CardElement, injectStripe } from 'react-stripe-elements';
-import { Flex } from '@rebass/grid';
+import { Flex } from './Grid';
 import { defineMessages, injectIntl } from 'react-intl';
 
 import { Span } from './Text';

--- a/components/NewsletterContainer.js
+++ b/components/NewsletterContainer.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { H5 } from './Text';
 import Container from './Container';
-import { Flex } from '@rebass/grid';
+import { Flex } from './Grid';
 import StyledInput, { SubmitInput } from '../components/StyledInput';
 
 class NewsletterContainer extends React.Component {

--- a/components/NotFound.js
+++ b/components/NotFound.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Flex } from '@rebass/grid';
+import { Flex } from './Grid';
 import { FormattedMessage } from 'react-intl';
 import Router from 'next/router';
 

--- a/components/OrderSuccessContributorCardWithData.js
+++ b/components/OrderSuccessContributorCardWithData.js
@@ -4,7 +4,7 @@ import { FormattedMessage, injectIntl } from 'react-intl';
 import { graphql } from '@apollo/react-hoc';
 import gql from 'graphql-tag';
 import { get } from 'lodash';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from './Grid';
 import styled from 'styled-components';
 import themeGet from '@styled-system/theme-get';
 

--- a/components/PageFeatureNotSupported.js
+++ b/components/PageFeatureNotSupported.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useIntl, defineMessages } from 'react-intl';
-import { Flex } from '@rebass/grid';
+import { Flex } from './Grid';
 import Page from './Page';
 import { H1, P } from './Text';
 

--- a/components/Pagination.js
+++ b/components/Pagination.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { withRouter } from 'next/router';
 import { FormattedMessage } from 'react-intl';
 
-import { Flex } from '@rebass/grid';
+import { Flex } from './Grid';
 import { TextInput } from './StyledInput';
 import StyledButton from './StyledButton';
 import Link from './Link';

--- a/components/PledgedCollectivePage.js
+++ b/components/PledgedCollectivePage.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { useQuery } from '@apollo/react-hooks';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from './Grid';
 import gql from 'graphql-tag';
 import { ExternalLinkAlt } from '@styled-icons/fa-solid/ExternalLinkAlt';
 

--- a/components/RedeemForm.js
+++ b/components/RedeemForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Flex } from '@rebass/grid';
+import { Flex } from './Grid';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import { P } from './Text';
 import InputField from './InputField';

--- a/components/RedeemSuccess.js
+++ b/components/RedeemSuccess.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from './Grid';
 import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 import { Check } from '@styled-icons/fa-solid/Check';

--- a/components/ReplyToMemberInvitationCard.js
+++ b/components/ReplyToMemberInvitationCard.js
@@ -1,4 +1,4 @@
-import { Flex } from '@rebass/grid';
+import { Flex } from './Grid';
 import gql from 'graphql-tag';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/components/SearchForm.js
+++ b/components/SearchForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from './Grid';
 import { fontSize } from 'styled-system';
 import styled from 'styled-components';
 

--- a/components/SectionTitle.js
+++ b/components/SectionTitle.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Box } from '@rebass/grid';
+import { Box } from './Grid';
 import { defineMessages, injectIntl } from 'react-intl';
 
 import Link from './Link';

--- a/components/SendMoneyToCollectiveBtn.js
+++ b/components/SendMoneyToCollectiveBtn.js
@@ -8,7 +8,7 @@ import { get, pick } from 'lodash';
 import { compose, formatCurrency } from '../lib/utils';
 
 import StyledButton from './StyledButton';
-import { Flex } from '@rebass/grid';
+import { Flex } from './Grid';
 
 class SendMoneyToCollectiveBtn extends React.Component {
   static propTypes = {

--- a/components/SignIn.js
+++ b/components/SignIn.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from './Grid';
 import Container from './Container';
 import StyledButton from './StyledButton';
 import StyledCard from './StyledCard';

--- a/components/SignInOrJoinFree.js
+++ b/components/SignInOrJoinFree.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from './Grid';
 import { FormattedMessage } from 'react-intl';
 import { pick } from 'lodash';
 

--- a/components/StepsProgress.js
+++ b/components/StepsProgress.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import styled, { css } from 'styled-components';
 import themeGet from '@styled-system/theme-get';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from './Grid';
 import { transparentize } from 'polished';
 import { Check } from '@styled-icons/fa-solid/Check';
 import withViewport, { VIEWPORTS } from '../lib/withViewport';

--- a/components/StyledCarousel.js
+++ b/components/StyledCarousel.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Swipeable } from 'react-swipeable';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from './Grid';
 import { throttle } from 'lodash';
 import { ArrowLeftCircle } from '@styled-icons/feather/ArrowLeftCircle';
 import { ArrowRightCircle } from '@styled-icons/feather/ArrowRightCircle';

--- a/components/StyledCollectiveCard.js
+++ b/components/StyledCollectiveCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Flex } from '@rebass/grid';
+import { Flex } from './Grid';
 import { get } from 'lodash';
 import { injectIntl } from 'react-intl';
 

--- a/components/StyledDropzone.js
+++ b/components/StyledDropzone.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box } from '@rebass/grid';
+import { Box } from './Grid';
 import { FormattedMessage } from 'react-intl';
 import { useDropzone } from 'react-dropzone';
 import styled, { css } from 'styled-components';

--- a/components/StyledFilters.js
+++ b/components/StyledFilters.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from './Grid';
 import StyledButton from './StyledButton';
 import { Span } from './Text';
 

--- a/components/StyledInputField.js
+++ b/components/StyledInputField.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from './Grid';
 import { FormattedMessage } from 'react-intl';
 import { P, Span } from './Text';
 

--- a/components/StyledMembershipCard.js
+++ b/components/StyledMembershipCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box } from '@rebass/grid';
+import { Box } from './Grid';
 import { FormattedMessage, FormattedDate, injectIntl } from 'react-intl';
 
 import roles from '../lib/constants/roles';

--- a/components/StyledRadioList.js
+++ b/components/StyledRadioList.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { find } from 'lodash';
 
-import { Box } from '@rebass/grid';
+import { Box } from './Grid';
 import Container from './Container';
 
 /**

--- a/components/StyledUpdate.js
+++ b/components/StyledUpdate.js
@@ -5,7 +5,7 @@ import { borders } from 'styled-system';
 import ReactTooltip from 'react-tooltip';
 import { graphql } from '@apollo/react-hoc';
 import gql from 'graphql-tag';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from './Grid';
 import { Lock } from '@styled-icons/fa-solid';
 import { get } from 'lodash';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';

--- a/components/TeamSection.js
+++ b/components/TeamSection.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
 import SectionTitle from './SectionTitle';
-import { Flex } from '@rebass/grid';
+import { Flex } from './Grid';
 import MemberCard from './MemberCard';
 
 class TeamSection extends React.Component {

--- a/components/TimezonePicker.js
+++ b/components/TimezonePicker.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import StyledSelect from './StyledSelect';
 import momentTimezone from 'moment-timezone';
-import { Box } from '@rebass/grid';
+import { Box } from './Grid';
 import { P } from './Text';
 
 class TimezonePicker extends React.Component {

--- a/components/TopBar.js
+++ b/components/TopBar.js
@@ -8,7 +8,7 @@ import { FormattedMessage } from 'react-intl';
 import { Link } from '../server/pages';
 
 import Hide from './Hide';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from './Grid';
 import styled from 'styled-components';
 
 import { rotateMixin } from '../lib/constants/animations';

--- a/components/TopBarProfileMenu.js
+++ b/components/TopBarProfileMenu.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import { get, uniqBy } from 'lodash';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from './Grid';
 import { ChevronDown } from '@styled-icons/boxicons-regular/ChevronDown';
 
 import { Settings } from '@styled-icons/feather/Settings';

--- a/components/UpdateBankDetailsForm.js
+++ b/components/UpdateBankDetailsForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from './Grid';
 import { defineMessages, injectIntl } from 'react-intl';
 import { get } from 'lodash';
 

--- a/components/VideoLinkerBox.js
+++ b/components/VideoLinkerBox.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { FormattedMessage } from 'react-intl';
 import themeGet from '@styled-system/theme-get';
-import { Box } from '@rebass/grid';
+import { Box } from './Grid';
 
 import { VideoPlus } from '@styled-icons/boxicons-regular/VideoPlus';
 import { ArrowUpCircle } from '@styled-icons/feather/ArrowUpCircle';

--- a/components/VirtualCardDetails.js
+++ b/components/VirtualCardDetails.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, FormattedDate } from 'react-intl';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from './Grid';
 import { get } from 'lodash';
 import moment from 'moment';
 import styled, { withTheme } from 'styled-components';

--- a/components/accept-financial-contributions/ApplyToHost.js
+++ b/components/accept-financial-contributions/ApplyToHost.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../Grid';
 import { defineMessages, injectIntl } from 'react-intl';
 import styled from 'styled-components';
 

--- a/components/accept-financial-contributions/ContributionCategoryPicker.js
+++ b/components/accept-financial-contributions/ContributionCategoryPicker.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../Grid';
 import styled from 'styled-components';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import { withRouter } from 'next/router';

--- a/components/accept-financial-contributions/HostCollectiveCard.js
+++ b/components/accept-financial-contributions/HostCollectiveCard.js
@@ -1,6 +1,6 @@
 import React, { useState, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../Grid';
 import { FormattedDate, useIntl, defineMessages, FormattedMessage } from 'react-intl';
 import { get } from 'lodash';
 import { useMutation } from '@apollo/react-hooks';

--- a/components/accept-financial-contributions/HostSuccessPage.js
+++ b/components/accept-financial-contributions/HostSuccessPage.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../Grid';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 import themeGet from '@styled-system/theme-get';

--- a/components/accept-financial-contributions/HostsContainer.js
+++ b/components/accept-financial-contributions/HostsContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../Grid';
 import styled from 'styled-components';
 import { graphql } from '@apollo/react-hoc';
 import { defineMessages, injectIntl } from 'react-intl';

--- a/components/banners/CovidBanner.js
+++ b/components/banners/CovidBanner.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Close as _Close } from '@styled-icons/material/Close';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../Grid';
 import { FormattedMessage } from 'react-intl';
 
 import StyledLink from '../StyledLink';

--- a/components/collective-page/TopContributors.js
+++ b/components/collective-page/TopContributors.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormattedMessage, FormattedDate } from 'react-intl';
 import PropTypes from 'prop-types';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../Grid';
 import styled from 'styled-components';
 import { truncate, size } from 'lodash';
 

--- a/components/collective-page/hero/CollectiveColorPicker.js
+++ b/components/collective-page/hero/CollectiveColorPicker.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Mutation } from '@apollo/react-components';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../../Grid';
 import { FormattedMessage } from 'react-intl';
 import { set } from 'lodash';
 import styled, { withTheme } from 'styled-components';

--- a/components/collective-page/hero/Hero.js
+++ b/components/collective-page/hero/Hero.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../../Grid';
 import styled from 'styled-components';
 import { get } from 'lodash';
 import dynamic from 'next/dynamic';

--- a/components/collective-page/hero/HeroTotalCollectiveContributionsWithData.js
+++ b/components/collective-page/hero/HeroTotalCollectiveContributionsWithData.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 import { useQuery } from '@apollo/react-hooks';
 import { get } from 'lodash';
-import { Box } from '@rebass/grid';
+import { Box } from '../../Grid';
 import { FormattedMessage } from 'react-intl';
 import { P } from '../../Text';
 import FormattedMoneyAmount from '../../FormattedMoneyAmount';

--- a/components/collective-page/sections/About.js
+++ b/components/collective-page/sections/About.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl, defineMessages } from 'react-intl';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../../Grid';
 import dynamic from 'next/dynamic';
 
 import { CollectiveType } from '../../../lib/constants/collectives';

--- a/components/collective-page/sections/Budget.js
+++ b/components/collective-page/sections/Budget.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl } from 'react-intl';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../../Grid';
 import { get, orderBy, isEmpty } from 'lodash';
 import gql from 'graphql-tag';
 import { Query } from '@apollo/react-components';

--- a/components/collective-page/sections/Contribute.js
+++ b/components/collective-page/sections/Contribute.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../../Grid';
 import memoizeOne from 'memoize-one';
 import { orderBy } from 'lodash';
 import styled from 'styled-components';

--- a/components/collective-page/sections/Contributions.js
+++ b/components/collective-page/sections/Contributions.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../../Grid';
 import gql from 'graphql-tag';
 import { graphql } from '@apollo/react-hoc';
 import memoizeOne from 'memoize-one';

--- a/components/collective-page/sections/Conversations.js
+++ b/components/collective-page/sections/Conversations.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../../Grid';
 import { isEmpty, get } from 'lodash';
 
 import { graphql } from '@apollo/react-hoc';

--- a/components/collective-page/sections/Location.js
+++ b/components/collective-page/sections/Location.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { Box } from '@rebass/grid';
+import { Box } from '../../Grid';
 
 import LocationComponent from '../../Location';
 import SectionTitle from '../SectionTitle';

--- a/components/collective-page/sections/SponsorsAndParticipants.js
+++ b/components/collective-page/sections/SponsorsAndParticipants.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 import { uniqBy, get } from 'lodash';
-import { Box } from '@rebass/grid';
+import { Box } from '../../Grid';
 
 import Responses from '../../Responses';
 import Sponsors from '../../Sponsors';

--- a/components/collective-page/sections/Tickets.js
+++ b/components/collective-page/sections/Tickets.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../../Grid';
 import memoizeOne from 'memoize-one';
 import { orderBy } from 'lodash';
 import styled from 'styled-components';

--- a/components/collective-page/sections/Transactions.js
+++ b/components/collective-page/sections/Transactions.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl, defineMessages } from 'react-intl';
-import { Box } from '@rebass/grid';
+import { Box } from '../../Grid';
 import { orderBy } from 'lodash';
 import gql from 'graphql-tag';
 import { graphql } from '@apollo/react-hoc';

--- a/components/collective-page/sections/Updates.js
+++ b/components/collective-page/sections/Updates.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl } from 'react-intl';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../../Grid';
 import styled from 'styled-components';
 import { get, isEmpty } from 'lodash';
 import gql from 'graphql-tag';

--- a/components/contribute-cards/Contribute.js
+++ b/components/contribute-cards/Contribute.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import styled, { css } from 'styled-components';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../Grid';
 
 import { ContributionTypes } from '../../lib/constants/contribution-types';
 

--- a/components/contribute-cards/ContributeEvent.js
+++ b/components/contribute-cards/ContributeEvent.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, FormattedDate } from 'react-intl';
 import { truncate } from 'lodash';
-import { Box } from '@rebass/grid';
+import { Box } from '../Grid';
 
 import { Calendar } from '@styled-icons/feather/Calendar';
 import { Clock } from '@styled-icons/feather/Clock';

--- a/components/contribute-cards/ContributeTier.js
+++ b/components/contribute-cards/ContributeTier.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl, defineMessages } from 'react-intl';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../Grid';
 import { truncate } from 'lodash';
 
 import { ContributionTypes } from '../../lib/constants/contribution-types';

--- a/components/contribute-cards/CreateNew.js
+++ b/components/contribute-cards/CreateNew.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../Grid';
 import styled from 'styled-components';
 
 import { CONTRIBUTE_CARD_WIDTH, CONTRIBUTE_CARD_BORDER_RADIUS } from './Contribute';

--- a/components/contribution-flow/ContributionFlowStepsProgress.js
+++ b/components/contribution-flow/ContributionFlowStepsProgress.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import StepsProgress from '../StepsProgress';
 import { FormattedMessage } from 'react-intl';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../Grid';
 import { Span } from '../Text';
 import { formatCurrency } from '../../lib/utils';
 

--- a/components/contribution-flow/Cover.js
+++ b/components/contribution-flow/Cover.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../Grid';
 
 import LinkCollective from '../LinkCollective';
 import Logo from '../Logo';

--- a/components/contribution-flow/StepBreakdown.js
+++ b/components/contribution-flow/StepBreakdown.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { FormattedMessage } from 'react-intl';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../Grid';
 import { get } from 'lodash';
 import { checkVATNumberFormat, getVatPercentage, getVatOriginCountry } from '@opencollective/taxes';
 

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, FormattedDate, defineMessages, injectIntl } from 'react-intl';
 import { get } from 'lodash';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../Grid';
 import memoizeOne from 'memoize-one';
 
 import Container from '../Container';

--- a/components/contribution-flow/StepPayment.js
+++ b/components/contribution-flow/StepPayment.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import themeGet from '@styled-system/theme-get';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../Grid';
 import { FormattedMessage, FormattedDate } from 'react-intl';
 import { uniqBy, get } from 'lodash';
 

--- a/components/contribution-flow/StepProfile.js
+++ b/components/contribution-flow/StepProfile.js
@@ -4,7 +4,7 @@ import { capitalize, omit, uniqBy, get, remove } from 'lodash';
 import styled from 'styled-components';
 import themeGet from '@styled-system/theme-get';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../Grid';
 
 import { Search } from '@styled-icons/octicons/Search';
 

--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -4,7 +4,7 @@ import { FormattedMessage, injectIntl, defineMessages } from 'react-intl';
 import { graphql } from '@apollo/react-hoc';
 import gql from 'graphql-tag';
 import { debounce, findIndex, get, pick, isNil } from 'lodash';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../Grid';
 import styled from 'styled-components';
 import { isURL } from 'validator';
 import { v4 as uuid } from 'uuid';

--- a/components/conversations/Comment.js
+++ b/components/conversations/Comment.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../Grid';
 import styled from 'styled-components';
 import { FormattedMessage } from 'react-intl';
 import { useMutation } from '@apollo/react-hooks';

--- a/components/conversations/ConversationsList.js
+++ b/components/conversations/ConversationsList.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../Grid';
 import { size } from 'lodash';
 
 import CommentIcon from '../icons/CommentIcon';

--- a/components/conversations/CreateConversationForm.js
+++ b/components/conversations/CreateConversationForm.js
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, defineMessages, useIntl } from 'react-intl';
 import { useFormik } from 'formik';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../Grid';
 import { useMutation } from '@apollo/react-hooks';
 
 import { gqlV2, API_V2_CONTEXT } from '../../lib/graphql/helpers';

--- a/components/conversations/FollowersAvatars.js
+++ b/components/conversations/FollowersAvatars.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box } from '@rebass/grid';
+import { Box } from '../Grid';
 
 import { withUser } from '../UserProvider';
 import Container from '../Container';

--- a/components/conversations/Thread.js
+++ b/components/conversations/Thread.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../Grid';
 import styled, { css, withTheme } from 'styled-components';
 
 import CommentIconLib from '../icons/CommentIcon';

--- a/components/conversations/ThreadActivity.js
+++ b/components/conversations/ThreadActivity.js
@@ -1,4 +1,4 @@
-import { Flex } from '@rebass/grid';
+import { Flex } from '../Grid';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';

--- a/components/create-collective/CollectiveCategoryPicker.js
+++ b/components/create-collective/CollectiveCategoryPicker.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../Grid';
 import styled from 'styled-components';
 import { defineMessages, injectIntl } from 'react-intl';
 import themeGet from '@styled-system/theme-get';

--- a/components/create-collective/ConnectGithub.js
+++ b/components/create-collective/ConnectGithub.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../Grid';
 import { URLSearchParams } from 'universal-url';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import themeGet from '@styled-system/theme-get';

--- a/components/create-collective/CreateCollectiveForm.js
+++ b/components/create-collective/CreateCollectiveForm.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Formik, Field, Form } from 'formik';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../Grid';
 import { assign, get } from 'lodash';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import themeGet from '@styled-system/theme-get';

--- a/components/create-collective/GithubRepositories.js
+++ b/components/create-collective/GithubRepositories.js
@@ -2,7 +2,7 @@ import React, { Fragment, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import themeGet from '@styled-system/theme-get';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../Grid';
 import { Search } from '@styled-icons/octicons/Search';
 import { FormattedMessage, injectIntl, defineMessages } from 'react-intl';
 

--- a/components/create-collective/GithubRepositoryEntry.js
+++ b/components/create-collective/GithubRepositoryEntry.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../Grid';
 import { Github } from '@styled-icons/fa-brands/Github';
 import { Star } from '@styled-icons/fa-solid/Star';
 

--- a/components/create-collective/index.js
+++ b/components/create-collective/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../Grid';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import { graphql } from '@apollo/react-hoc';
 import { get } from 'lodash';

--- a/components/discover/DiscoverCollectiveCard.js
+++ b/components/discover/DiscoverCollectiveCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box } from '@rebass/grid';
+import { Box } from '../Grid';
 import { FormattedMessage, injectIntl } from 'react-intl';
 
 import Container from '../Container';

--- a/components/discover/PledgedCollectiveCard.js
+++ b/components/discover/PledgedCollectiveCard.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
-import { Box } from '@rebass/grid';
+import { Box } from '../Grid';
 import themeGet from '@styled-system/theme-get';
 
 import Currency from '../Currency';

--- a/components/edit-collective/CreateHostForm.js
+++ b/components/edit-collective/CreateHostForm.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../Grid';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import { get, groupBy } from 'lodash';
 import { Button } from 'react-bootstrap';

--- a/components/edit-collective/CreateHostFormWithData.js
+++ b/components/edit-collective/CreateHostFormWithData.js
@@ -4,7 +4,7 @@ import { get } from 'lodash';
 import { graphql } from '@apollo/react-hoc';
 import gql from 'graphql-tag';
 
-import { Flex } from '@rebass/grid';
+import { Flex } from '../Grid';
 
 import { getErrorFromGraphqlException } from '../../lib/errors';
 import { compose } from '../../lib/utils';

--- a/components/edit-collective/EditPaymentMethod.js
+++ b/components/edit-collective/EditPaymentMethod.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Row } from 'react-bootstrap';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../Grid';
 
 import { Link } from '../../server/pages';
 import { getCurrencySymbol, capitalize } from '../../lib/utils';

--- a/components/edit-collective/EditUserEmailForm.js
+++ b/components/edit-collective/EditUserEmailForm.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { isEmail } from 'validator';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../Grid';
 import { isNil } from 'lodash';
 import { graphql } from '@apollo/react-hoc';
 import gql from 'graphql-tag';

--- a/components/edit-collective/Form.js
+++ b/components/edit-collective/Form.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { withRouter } from 'next/router';
 import { ArrowBack } from '@styled-icons/material/ArrowBack';
 import { get, set, find } from 'lodash';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../Grid';
 import { H3, H4, P } from '../Text';
 import { Button } from 'react-bootstrap';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';

--- a/components/edit-collective/Menu.js
+++ b/components/edit-collective/Menu.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl, defineMessages } from 'react-intl';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../Grid';
 import styled, { css } from 'styled-components';
 
 import { CollectiveType } from '../../lib/constants/collectives';

--- a/components/edit-collective/sections/CollectiveGoals.js
+++ b/components/edit-collective/sections/CollectiveGoals.js
@@ -4,7 +4,7 @@ import { get, sortBy } from 'lodash';
 import { v4 as uuid } from 'uuid';
 import { Form } from 'react-bootstrap';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../../Grid';
 import gql from 'graphql-tag';
 import { graphql } from '@apollo/react-hoc';
 

--- a/components/edit-collective/sections/Conversations.js
+++ b/components/edit-collective/sections/Conversations.js
@@ -1,4 +1,4 @@
-import { Flex } from '@rebass/grid';
+import { Flex } from '../../Grid';
 import { set, cloneDeep, pick } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/components/edit-collective/sections/Host.js
+++ b/components/edit-collective/sections/Host.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../../Grid';
 import { Radio } from '@material-ui/core';
 import { Button } from 'react-bootstrap';
 import { withRouter } from 'next/router';

--- a/components/edit-collective/sections/InvoicesReceipts.js
+++ b/components/edit-collective/sections/InvoicesReceipts.js
@@ -1,4 +1,4 @@
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../../Grid';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/components/edit-collective/sections/Members.js
+++ b/components/edit-collective/sections/Members.js
@@ -4,7 +4,7 @@ import { Form } from 'react-bootstrap';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import { get, update, omit } from 'lodash';
 import styled from 'styled-components';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../../Grid';
 import memoizeOne from 'memoize-one';
 import { graphql } from '@apollo/react-hoc';
 import gql from 'graphql-tag';

--- a/components/edit-collective/sections/PaymentMethods.js
+++ b/components/edit-collective/sections/PaymentMethods.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { graphql } from '@apollo/react-hoc';
 import { set, get, sortBy } from 'lodash';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../../Grid';
 import { Add } from '@styled-icons/material/Add';
 
 import { getErrorFromGraphqlException, isErrorType } from '../../../lib/errors';

--- a/components/edit-collective/sections/Tiers.js
+++ b/components/edit-collective/sections/Tiers.js
@@ -4,7 +4,7 @@ import { get } from 'lodash';
 import { Button, Form } from 'react-bootstrap';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import { v4 as uuid } from 'uuid';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../../Grid';
 import { getStandardVatRate, getVatOriginCountry } from '@opencollective/taxes';
 
 import { getCurrencySymbol, capitalize } from '../../../lib/utils';

--- a/components/edit-collective/sections/Updates.js
+++ b/components/edit-collective/sections/Updates.js
@@ -1,4 +1,4 @@
-import { Flex } from '@rebass/grid';
+import { Flex } from '../../Grid';
 import { set, cloneDeep, pick } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/components/edit-collective/sections/VirtualCards.js
+++ b/components/edit-collective/sections/VirtualCards.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl, defineMessages } from 'react-intl';
 import { graphql } from '@apollo/react-hoc';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../../Grid';
 import { get, last } from 'lodash';
 import { withRouter } from 'next/router';
 import gql from 'graphql-tag';

--- a/components/edit-collective/sections/Webhooks.js
+++ b/components/edit-collective/sections/Webhooks.js
@@ -7,7 +7,7 @@ import gql from 'graphql-tag';
 import { isURL } from 'validator';
 import { Close } from '@styled-icons/material/Close';
 import memoizeOne from 'memoize-one';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../../Grid';
 import { Add } from '@styled-icons/material/Add';
 
 import events from '../../../lib/constants/notificationEvents';

--- a/components/expenses/AmountCurrency.js
+++ b/components/expenses/AmountCurrency.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../Grid';
 
 import { Span } from '../Text';
 import Currency from '../Currency';

--- a/components/expenses/ExpandableExpensePolicies.js
+++ b/components/expenses/ExpandableExpensePolicies.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box } from '@rebass/grid';
+import { Box } from '../Grid';
 import { defineMessages, useIntl } from 'react-intl';
 import Markdown from 'react-markdown';
 import Collapse from '../Collapse';

--- a/components/expenses/Expense.js
+++ b/components/expenses/Expense.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import { graphql } from '@apollo/react-hoc';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../Grid';
 import { get } from 'lodash';
 
 import { capitalize, formatCurrency, compose } from '../../lib/utils';

--- a/components/expenses/ExpenseAttachedFiles.js
+++ b/components/expenses/ExpenseAttachedFiles.js
@@ -1,4 +1,4 @@
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../Grid';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedMessage } from 'react-intl';

--- a/components/expenses/ExpenseAttachedFilesForm.js
+++ b/components/expenses/ExpenseAttachedFilesForm.js
@@ -1,4 +1,4 @@
-import { Box } from '@rebass/grid';
+import { Box } from '../Grid';
 import { uniqBy } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/components/expenses/ExpenseDetails.js
+++ b/components/expenses/ExpenseDetails.js
@@ -13,7 +13,7 @@ import categories from '../../lib/constants/categories';
 import DefinedTerm, { Terms } from '../DefinedTerm';
 
 import TransactionDetails from './TransactionDetails';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../Grid';
 import ExpenseInvoiceDownloadHelper from './ExpenseInvoiceDownloadHelper';
 import StyledSpinner from '../StyledSpinner';
 import StyledButton from '../StyledButton';

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, defineMessages, useIntl } from 'react-intl';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../Grid';
 import { first, isEmpty, get, pick } from 'lodash';
 import { Formik, Form, Field, FieldArray, FastField } from 'formik';
 

--- a/components/expenses/ExpenseFormItems.js
+++ b/components/expenses/ExpenseFormItems.js
@@ -1,4 +1,4 @@
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../Grid';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedMessage } from 'react-intl';

--- a/components/expenses/ExpenseItemForm.js
+++ b/components/expenses/ExpenseItemForm.js
@@ -1,4 +1,4 @@
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../Grid';
 import { get, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/components/expenses/ExpenseSummary.js
+++ b/components/expenses/ExpenseSummary.js
@@ -1,4 +1,4 @@
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../Grid';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedMessage, useIntl, FormattedDate } from 'react-intl';

--- a/components/expenses/ExpenseTypeRadioSelect.js
+++ b/components/expenses/ExpenseTypeRadioSelect.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../Grid';
 import { defineMessages, useIntl } from 'react-intl';
 import styled from 'styled-components';
 

--- a/components/expenses/Expenses.js
+++ b/components/expenses/Expenses.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { ButtonGroup, Button } from 'react-bootstrap';
 import { FormattedMessage } from 'react-intl';
 import { get } from 'lodash';
-import { Box } from '@rebass/grid';
+import { Box } from '../Grid';
 
 import colors from '../../lib/constants/colors';
 

--- a/components/expenses/MobileCollectiveInfoStickyBar.js
+++ b/components/expenses/MobileCollectiveInfoStickyBar.js
@@ -1,4 +1,4 @@
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../Grid';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedMessage } from 'react-intl';

--- a/components/expenses/Order.js
+++ b/components/expenses/Order.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 import { graphql } from '@apollo/react-hoc';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../Grid';
 
 import colors from '../../lib/constants/colors';
 import { capitalize } from '../../lib/utils';

--- a/components/expenses/Orders.js
+++ b/components/expenses/Orders.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ButtonGroup, Button } from 'react-bootstrap';
 import { FormattedMessage } from 'react-intl';
-import { Box } from '@rebass/grid';
+import { Box } from '../Grid';
 
 import colors from '../../lib/constants/colors';
 

--- a/components/expenses/PayoutBankInformationForm.js
+++ b/components/expenses/PayoutBankInformationForm.js
@@ -1,5 +1,5 @@
 import { useQuery } from '@apollo/react-hooks';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../Grid';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/components/expenses/PayoutMethodForm.js
+++ b/components/expenses/PayoutMethodForm.js
@@ -1,4 +1,4 @@
-import { Box } from '@rebass/grid';
+import { Box } from '../Grid';
 import { Field } from 'formik';
 import { get, set } from 'lodash';
 import PropTypes from 'prop-types';

--- a/components/expenses/PayoutMethodTypeWithIcon.js
+++ b/components/expenses/PayoutMethodTypeWithIcon.js
@@ -1,4 +1,4 @@
-import { Flex } from '@rebass/grid';
+import { Flex } from '../Grid';
 import { Paypal as PaypalIcon } from '@styled-icons/fa-brands/Paypal';
 import { University as BankIcon } from '@styled-icons/fa-solid/University';
 import { ExchangeAlt as OtherIcon } from '@styled-icons/fa-solid/ExchangeAlt';

--- a/components/expenses/Transaction.js
+++ b/components/expenses/Transaction.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../Grid';
 import { FormattedMessage } from 'react-intl';
 
 import Link from '../Link';

--- a/components/expenses/Transactions.js
+++ b/components/expenses/Transactions.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ButtonGroup, Button } from 'react-bootstrap';
 import { FormattedMessage } from 'react-intl';
-import { Box } from '@rebass/grid';
+import { Box } from '../Grid';
 
 import colors from '../../lib/constants/colors';
 

--- a/components/faqs/CreateExpenseFAQ.js
+++ b/components/faqs/CreateExpenseFAQ.js
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import FAQ, { Entry, Title, Content } from './FAQ';
 import StyledLink from '../StyledLink';
 import ExternalLink from '../ExternalLink';
-import { Box } from '@rebass/grid';
+import { Box } from '../Grid';
 
 const CreateExpenseFAQ = ({ defaultOpen, ...props }) => (
   <FAQ {...props}>

--- a/components/faqs/FAQ.js
+++ b/components/faqs/FAQ.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import themeGet from '@styled-system/theme-get';
-import { Box } from '@rebass/grid';
+import { Box } from '../Grid';
 
 import { P } from '../Text';
 import Container from '../Container';

--- a/components/home/CollectiveStatsCard.js
+++ b/components/home/CollectiveStatsCard.js
@@ -7,7 +7,7 @@ import { defaultBackgroundImage } from '../../lib/constants/collectives';
 
 import { imagePreview, getCollectiveImage } from '../../lib/image-utils';
 
-import { Flex } from '@rebass/grid';
+import { Flex } from '../Grid';
 import Container from '../Container';
 import { P, Span } from '../Text';
 import { Link } from '../../server/pages';

--- a/components/home/Newsletter.js
+++ b/components/home/Newsletter.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Container from '../Container';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../Grid';
 import { FormattedMessage } from 'react-intl';
 import { Envelope } from '@styled-icons/fa-solid/Envelope';
 

--- a/components/home/sections/Features.js
+++ b/components/home/sections/Features.js
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
 import themeGet from '@styled-system/theme-get';
 import { FormattedMessage, useIntl, defineMessages } from 'react-intl';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../../Grid';
 
 import { Span, H4, P } from '../../Text';
 import Container from '../../Container';

--- a/components/home/sections/FiscalHost.js
+++ b/components/home/sections/FiscalHost.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../../Grid';
 import { FormattedMessage } from 'react-intl';
 
 import { Link as RouterLink } from '../../../server/pages';

--- a/components/home/sections/JoinUs.js
+++ b/components/home/sections/JoinUs.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { FormattedMessage } from 'react-intl';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../../Grid';
 import { ArrowRight } from '@styled-icons/feather/ArrowRight';
 
 import { H1, P } from '../../Text';

--- a/components/home/sections/LearnMore.js
+++ b/components/home/sections/LearnMore.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import styled from 'styled-components';
-import { Box } from '@rebass/grid';
+import { Box } from '../../Grid';
 import { FormattedMessage, useIntl, defineMessages } from 'react-intl';
 
 import { H3, P } from '../../Text';

--- a/components/home/sections/MakeCommunity.js
+++ b/components/home/sections/MakeCommunity.js
@@ -1,7 +1,7 @@
 import React, { useState, Fragment } from 'react';
 import styled from 'styled-components';
 import { FormattedMessage } from 'react-intl';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../../Grid';
 import { RightArrow } from '@styled-icons/boxicons-regular/RightArrow';
 
 import { P, Span, H1, H4 } from '../../Text';

--- a/components/home/sections/OCUsers.js
+++ b/components/home/sections/OCUsers.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../../Grid';
 import { FormattedMessage, defineMessages, useIntl } from 'react-intl';
 
 import { P } from '../../Text';

--- a/components/home/sections/WeAreOpen.js
+++ b/components/home/sections/WeAreOpen.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Box } from '@rebass/grid';
+import { Box } from '../../Grid';
 import { FormattedMessage, defineMessages, useIntl } from 'react-intl';
 
 import { P, H4 } from '../../Text';

--- a/components/home/sections/WhatCanYouDo.js
+++ b/components/home/sections/WhatCanYouDo.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import themeGet from '@styled-system/theme-get';
 import { display } from 'styled-system';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../../Grid';
 import { FormattedMessage } from 'react-intl';
 
 import { P, H3, H4 } from '../../Text';

--- a/components/host-dashboard/Dashboard.js
+++ b/components/host-dashboard/Dashboard.js
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from '@apollo/react-hoc';
 import gql from 'graphql-tag';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../Grid';
 import { FormattedMessage } from 'react-intl';
 
 import ExpensesWithData from '../expenses/ExpensesWithData';

--- a/components/host-dashboard/HostDashboardActionsBanner.js
+++ b/components/host-dashboard/HostDashboardActionsBanner.js
@@ -4,7 +4,7 @@ import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import { graphql } from '@apollo/react-hoc';
 import gql from 'graphql-tag';
 import { get, pick } from 'lodash';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../Grid';
 import styled from 'styled-components';
 
 import Container from '../Container';

--- a/components/host-dashboard/PendingApplications.js
+++ b/components/host-dashboard/PendingApplications.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { graphql } from '@apollo/react-hoc';
 import { Mutation } from '@apollo/react-components';
 import gql from 'graphql-tag';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../Grid';
 import { FormattedMessage } from 'react-intl';
 import { get } from 'lodash';
 

--- a/components/onboarding-modal/OnboardingContentBox.js
+++ b/components/onboarding-modal/OnboardingContentBox.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../Grid';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import { Github } from '@styled-icons/fa-brands/Github';
 import { Twitter } from '@styled-icons/fa-brands/Twitter';

--- a/components/onboarding-modal/OnboardingModal.js
+++ b/components/onboarding-modal/OnboardingModal.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../Grid';
 import { graphql } from '@apollo/react-hoc';
 import gql from 'graphql-tag';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';

--- a/components/onboarding-modal/OnboardingNavButtons.js
+++ b/components/onboarding-modal/OnboardingNavButtons.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../Grid';
 import { FormattedMessage } from 'react-intl';
 
 import StyledRoundButton from '../../components/StyledRoundButton';

--- a/components/onboarding-modal/OnboardingProfileCard.js
+++ b/components/onboarding-modal/OnboardingProfileCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../Grid';
 import styled from 'styled-components';
 import { FormattedMessage } from 'react-intl';
 

--- a/components/onboarding-modal/OnboardingStepsProgress.js
+++ b/components/onboarding-modal/OnboardingStepsProgress.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../Grid';
 import { FormattedMessage } from 'react-intl';
 
 import { Span } from '../Text';

--- a/components/pricing/PricingTable.js
+++ b/components/pricing/PricingTable.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import themeGet from '@styled-system/theme-get';
 import { defineMessages, useIntl, FormattedMessage } from 'react-intl';
 import { display } from 'styled-system';
-import { Box } from '@rebass/grid';
+import { Box } from '../Grid';
 import { Check } from '@styled-icons/fa-solid/Check';
 import { isObject } from 'lodash';
 

--- a/components/pricing/PricingTabs.js
+++ b/components/pricing/PricingTabs.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../Grid';
 
 import I18nFormatters from '../I18nFormatters';
 import StyledInputField from '../StyledInputField';

--- a/components/pricing/tabs/HostOrganization.js
+++ b/components/pricing/tabs/HostOrganization.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../../Grid';
 import { FormattedMessage } from 'react-intl';
 
 import Container from '../../Container';

--- a/components/pricing/tabs/SingleCollectiveWithBankAccount.js
+++ b/components/pricing/tabs/SingleCollectiveWithBankAccount.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../../Grid';
 import { FormattedMessage } from 'react-intl';
 
 import { Router } from '../../../server/pages';

--- a/components/pricing/tabs/SingleCollectiveWithoutBankAccount.js
+++ b/components/pricing/tabs/SingleCollectiveWithoutBankAccount.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 import styled from 'styled-components';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../../Grid';
 import { FormattedMessage } from 'react-intl';
 import { graphql } from '@apollo/react-hoc';
 

--- a/components/tier-page/ShareButtons.js
+++ b/components/tier-page/ShareButtons.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../Grid';
 import copy from 'copy-to-clipboard';
 
 // Styled-icons

--- a/components/tier-page/TierContributors.js
+++ b/components/tier-page/TierContributors.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
-import { Box } from '@rebass/grid';
+import { Box } from '../Grid';
 import memoizeOne from 'memoize-one';
 
 import { P, H2 } from '../Text';

--- a/components/tier-page/index.js
+++ b/components/tier-page/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../Grid';
 import styled from 'styled-components';
 import themeGet from '@styled-system/theme-get';
 import { withRouter } from 'next/router';

--- a/components/virtual-cards/CollectiveCard.js
+++ b/components/virtual-cards/CollectiveCard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../Grid';
 import { has } from 'lodash';
 
 import Container from '../Container';

--- a/package-lock.json
+++ b/package-lock.json
@@ -3358,15 +3358,6 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.3.3.tgz",
       "integrity": "sha512-yEvVC8RfhRPkD9TUn7cFcLcgoJePgZRAOR7T21rcRY5I8tpuhzeWfGa7We7tB14fe9R7wENdqUABcMdwD4SQLw=="
     },
-    "@rebass/grid": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@rebass/grid/-/grid-6.1.0.tgz",
-      "integrity": "sha512-0UbW75JgIB7b7moMYgl+rBsHAIt/Nt+/ntUrBqkdbalMuGH6q3qfLW5i79uE3rrY0iLlkcmY7w6mOo56FzCJsg==",
-      "requires": {
-        "@styled-system/prop-types": "^5.0.18",
-        "styled-system": "^5.0.18"
-      }
-    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -11017,13 +11008,13 @@
       "dependencies": {
         "colors": {
           "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "resolved": "http://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
           "dev": true
         },
         "commander": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
           "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
           "dev": true
         }
@@ -11577,7 +11568,7 @@
         },
         "node-fetch": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
           "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
           "dev": true
         },
@@ -12329,7 +12320,7 @@
     },
     "immutable": {
       "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+      "resolved": "http://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
       "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
     },
     "import-cwd": {
@@ -26745,7 +26736,7 @@
       "dependencies": {
         "ast-types": {
           "version": "0.7.8",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
+          "resolved": "http://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
           "integrity": "sha1-kC0uDWDQcb3NRtwRXhgJ7RHBOKk=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@material-ui/core": "4.9.11",
     "@opencollective/taxes": "2.4.0",
     "@popperjs/core": "2.3.3",
-    "@rebass/grid": "6.1.0",
     "@sentry/browser": "5.15.4",
     "@sentry/node": "5.15.4",
     "@styled-icons/boxicons-regular": "10.0.0",

--- a/pages/ExpenseInfoSidebar.js
+++ b/pages/ExpenseInfoSidebar.js
@@ -1,4 +1,4 @@
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../components/Grid';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedMessage } from 'react-intl';

--- a/pages/__test__/test-errors.js
+++ b/pages/__test__/test-errors.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Link from 'next/link';
 import { IgnorableError } from '../../lib/errors';
 import Page from '../../components/Page';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../../components/Grid';
 
 class TestErrorsPage extends React.Component {
   static getInitialProps({ query }) {

--- a/pages/action.js
+++ b/pages/action.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import { graphql } from '@apollo/react-hoc';
 import gql from 'graphql-tag';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../components/Grid';
 
 import { capitalize, compose } from '../lib/utils';
 import { getErrorFromGraphqlException } from '../lib/errors';

--- a/pages/applications.js
+++ b/pages/applications.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Query, Mutation } from '@apollo/react-components';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../components/Grid';
 import { get, update, cloneDeep } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 

--- a/pages/claimCollective.js
+++ b/pages/claimCollective.js
@@ -4,7 +4,7 @@ import { graphql } from '@apollo/react-hoc';
 import gql from 'graphql-tag';
 import fetch from 'node-fetch';
 import { get } from 'lodash';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../components/Grid';
 import { Github } from '@styled-icons/fa-brands/Github';
 import { URLSearchParams } from 'universal-url';
 

--- a/pages/completePledge.js
+++ b/pages/completePledge.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from '@apollo/react-hoc';
 import gql from 'graphql-tag';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../components/Grid';
 import { defineMessages, injectIntl } from 'react-intl';
 
 import Page from '../components/Page';

--- a/pages/confirmCollectiveDeletion.js
+++ b/pages/confirmCollectiveDeletion.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import themeGet from '@styled-system/theme-get';
 import { FormattedMessage } from 'react-intl';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../components/Grid';
 
 import Container from '../components/Container';
 import Page from '../components/Page';

--- a/pages/confirmEmail.js
+++ b/pages/confirmEmail.js
@@ -4,7 +4,7 @@ import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import { graphql } from '@apollo/react-hoc';
 import gql from 'graphql-tag';
-import { Box } from '@rebass/grid';
+import { Box } from '../components/Grid';
 
 import { Email } from '@styled-icons/material/Email';
 

--- a/pages/conversation.js
+++ b/pages/conversation.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql, withApollo } from '@apollo/react-hoc';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../components/Grid';
 import { get, isEmpty, cloneDeep, update, uniqBy } from 'lodash';
 
 import { Router } from '../server/pages';

--- a/pages/conversations.js
+++ b/pages/conversations.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from '@apollo/react-hoc';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../components/Grid';
 import { get } from 'lodash';
 import { withRouter } from 'next/router';
 import { FormattedMessage } from 'react-intl';

--- a/pages/create-conversation.js
+++ b/pages/create-conversation.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from '@apollo/react-hoc';
-import { Box } from '@rebass/grid';
+import { Box } from '../components/Grid';
 import { FormattedMessage } from 'react-intl';
 import { withRouter } from 'next/router';
 

--- a/pages/create-expense.js
+++ b/pages/create-expense.js
@@ -1,4 +1,4 @@
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../components/Grid';
 import { get } from 'lodash';
 import memoizeOne from 'memoize-one';
 import { withRouter } from 'next/router';

--- a/pages/createExpense.js
+++ b/pages/createExpense.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { graphql } from '@apollo/react-hoc';
 import gql from 'graphql-tag';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../components/Grid';
 
 import { compose } from '../lib/utils';
 

--- a/pages/createOrder.js
+++ b/pages/createOrder.js
@@ -4,7 +4,7 @@ import { injectIntl, defineMessages, FormattedMessage } from 'react-intl';
 import { graphql } from '@apollo/react-hoc';
 import gql from 'graphql-tag';
 import { get } from 'lodash';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../components/Grid';
 
 import { compose, parseToBoolean } from '../lib/utils';
 import { CollectiveType } from '../lib/constants/collectives';

--- a/pages/createPledge.js
+++ b/pages/createPledge.js
@@ -21,7 +21,7 @@ import Footer from '../components/Footer';
 import { H3, H4, H5, P } from '../components/Text';
 import StyledInput, { SubmitInput, TextInput } from '../components/StyledInput';
 import StyledInputGroup from '../components/StyledInputGroup';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../components/Grid';
 import Container from '../components/Container';
 import ButtonGroup from '../components/ButtonGroup';
 import Link from '../components/Link';

--- a/pages/createUpdate.js
+++ b/pages/createUpdate.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { FormattedMessage } from 'react-intl';
 import { graphql } from '@apollo/react-hoc';
 import gql from 'graphql-tag';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../components/Grid';
 import { ArrowBack } from '@styled-icons/boxicons-regular';
 
 import { compose } from '../lib/utils';

--- a/pages/discover.js
+++ b/pages/discover.js
@@ -5,7 +5,7 @@ import { Query } from '@apollo/react-components';
 import gql from 'graphql-tag';
 import { FormattedMessage, injectIntl, defineMessages } from 'react-intl';
 import { withRouter } from 'next/router';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../components/Grid';
 import styled from 'styled-components';
 import DiscoverCollectiveCard from '../components/discover/DiscoverCollectiveCard';
 import PledgedCollectiveCard from '../components/discover/PledgedCollectiveCard';

--- a/pages/editCollective.js
+++ b/pages/editCollective.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../components/Grid';
 import { get } from 'lodash';
 import { graphql } from '@apollo/react-hoc';
 

--- a/pages/expense-legacy.js
+++ b/pages/expense-legacy.js
@@ -9,7 +9,7 @@ import Header from '../components/Header';
 import Body from '../components/Body';
 import Footer from '../components/Footer';
 import CollectiveNavbar from '../components/CollectiveNavbar';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../components/Grid';
 import ExpenseNeedsTaxFormMessage from '../components/expenses/ExpenseNeedsTaxFormMessage';
 import ErrorPage from '../components/ErrorPage';
 import Link from '../components/Link';

--- a/pages/expense.js
+++ b/pages/expense.js
@@ -1,4 +1,4 @@
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../components/Grid';
 import { cloneDeep, uniqBy, update, get, sortBy } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';

--- a/pages/host.dashboard.js
+++ b/pages/host.dashboard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../components/Grid';
 import { omit } from 'lodash';
 
 import { Receipt as ReceiptIcon } from '@styled-icons/material/Receipt';

--- a/pages/openSourceApply.js
+++ b/pages/openSourceApply.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../components/Grid';
 import { URLSearchParams } from 'universal-url';
 
 import Page from '../components/Page';

--- a/pages/orderSuccess.js
+++ b/pages/orderSuccess.js
@@ -4,7 +4,7 @@ import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import { graphql } from '@apollo/react-hoc';
 import gql from 'graphql-tag';
 import { get } from 'lodash';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../components/Grid';
 import styled from 'styled-components';
 
 import { Facebook } from '@styled-icons/fa-brands/Facebook';

--- a/pages/redeem.js
+++ b/pages/redeem.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import sanitizeHtml from 'sanitize-html';
 import { graphql } from '@apollo/react-hoc';
 import { fontSize, maxWidth } from 'styled-system';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../components/Grid';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import { get } from 'lodash';
 

--- a/pages/redeemed.js
+++ b/pages/redeemed.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import sanitizeHtml from 'sanitize-html';
 import styled from 'styled-components';
 import gql from 'graphql-tag';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../components/Grid';
 import { fontSize, maxWidth } from 'styled-system';
 import { FormattedMessage } from 'react-intl';
 import { get } from 'lodash';

--- a/pages/search.js
+++ b/pages/search.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ControlLabel, FormControl, FormGroup } from 'react-bootstrap';
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from '../components/Grid';
 import { withRouter } from 'next/router';
 import styled from 'styled-components';
 

--- a/pages/signin.js
+++ b/pages/signin.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { Flex } from '@rebass/grid';
+import { Flex } from '../components/Grid';
 import { mapValues } from 'lodash';
 
 import { Router } from '../server/pages';

--- a/pages/signinLinkSent.js
+++ b/pages/signinLinkSent.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import themeGet from '@styled-system/theme-get';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../components/Grid';
 import { FormattedMessage } from 'react-intl';
 
 import { PaperPlane } from '@styled-icons/boxicons-regular/PaperPlane';

--- a/pages/unsubscribeEmail.js
+++ b/pages/unsubscribeEmail.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { Box } from '@rebass/grid';
+import { Box } from '../components/Grid';
 import { Email } from '@styled-icons/material/Email';
 import { getBaseApiUrl } from '../lib/utils';
 import Page from '../components/Page';

--- a/pages/updatePaymentMethod.js
+++ b/pages/updatePaymentMethod.js
@@ -4,7 +4,7 @@ import gql from 'graphql-tag';
 import styled from 'styled-components';
 import { graphql } from '@apollo/react-hoc';
 import { maxWidth } from 'styled-system';
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from '../components/Grid';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { get } from 'lodash';
 

--- a/styleguide/examples/Box.md
+++ b/styleguide/examples/Box.md
@@ -1,10 +1,8 @@
-[See `@rebass/grid` docs for more info](https://www.npmjs.com/package/@rebass/grid#box)
-
 Using fractions to set percentage width:
 
 ```js
 import styled from 'styled-components';
-import { Box } from '@rebass/grid';
+import { Box } from 'components/Grid';
 import { P } from 'components/Text';
 
 const Block = styled(Box)`
@@ -31,7 +29,7 @@ Using fixed pixel width:
 
 ```js
 import styled from 'styled-components';
-import { Box } from '@rebass/grid';
+import { Box } from 'components/Grid';
 import { P } from 'components/Text';
 const Block = styled(Box)`
   border: 1px solid black;
@@ -46,7 +44,7 @@ Using relative unit widths:
 
 ```js
 import styled from 'styled-components';
-import { Box } from '@rebass/grid';
+import { Box } from 'components/Grid';
 import { P } from 'components/Text';
 const Block = styled(Box)`
   border: 1px solid black;
@@ -61,7 +59,7 @@ Set responsive width using an array of values, works for padding and margin prop
 
 ```js
 import styled from 'styled-components';
-import { Box } from '@rebass/grid';
+import { Box } from 'components/Grid';
 import { P } from 'components/Text';
 const Block = styled(Box)`
   border: 1px solid black;

--- a/styleguide/examples/Flex.md
+++ b/styleguide/examples/Flex.md
@@ -1,9 +1,9 @@
-[See `@rebass/grid` docs for more info](https://www.npmjs.com/package/@rebass/grid#flex)
+[See `components/Grid` docs for more info](https://www.npmjs.com/package/components/Grid#flex)
 
 The `<Flex />` component extends the `<Box />` with `display: flex` on by default;
 
 ```js
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from 'components/Grid';
 import styled from 'styled-components';
 import { P } from 'components/Text';
 
@@ -24,7 +24,7 @@ const Block = styled(Box)`
 Use any of the flexbox style props: `alignItems`, `justifyContent`, `flexDirection`, `flexWrap`:
 
 ```js
-import { Flex, Box } from '@rebass/grid';
+import { Flex, Box } from 'components/Grid';
 import styled from 'styled-components';
 import { P } from 'components/Text';
 

--- a/styleguide/examples/StyledButton.md
+++ b/styleguide/examples/StyledButton.md
@@ -163,7 +163,7 @@
 ### Defaults to the `medium` button size
 
 ```jsx
-import { Flex } from '@rebass/grid';
+import { Flex } from 'components/Grid';
 const [buttonSize, setButtonSize] = React.useState('medium');
 <React.Fragment>
   <Flex mb={4} flexWrap="wrap" justifyContent="space-evenly">
@@ -229,7 +229,7 @@ const [buttonSize, setButtonSize] = React.useState('medium');
 Use the `asLink` prop. Works best with secondary button styles.
 
 ```jsx padded
-import { Flex } from '@rebass/grid';
+import { Flex } from 'components/Grid';
 <React.Fragment>
   <h4>Default</h4>
   <Flex justifyContent="space-evenly">

--- a/styleguide/examples/StyledRadioList.md
+++ b/styleguide/examples/StyledRadioList.md
@@ -24,7 +24,7 @@ Using a default value:
 Customize list style using child render function:
 
 ```js
-const { Box } = require('@rebass/grid');
+const { Box } = require('components/Grid');
 <StyledRadioList
   options={['one', 'two', 'three', 'four', 'five']}
   name="selected-list"
@@ -45,7 +45,7 @@ const { Box } = require('@rebass/grid');
 Advanced customization:
 
 ```js
-import { Box, Flex } from '@rebass/grid';
+import { Box, Flex } from 'components/Grid';
 import Container from 'components/Container';
 import StyledInputField from 'components/StyledInputField';
 import StyledCard from 'components/StyledCard';

--- a/styleguide/pages/Grid.md
+++ b/styleguide/pages/Grid.md
@@ -1,11 +1,9 @@
-For the layout of our pages and components, we use responsive grid system from [`@rebass/grid`](https://www.npmjs.com/package/@rebass/grid).
+For the layout of our pages and components, we use responsive grid system from [`../components/Grid`](https://www.npmjs.com/package/../components/Grid).
 
-> All @rebass/grid components use [styled-system](https://github.com/jxnblk/styled-system) for style props, which pick up values from a theme and allow for responsive styles to be passed as array values.
+> All ../components/Grid components use [styled-system](https://github.com/jxnblk/styled-system) for style props, which pick up values from a theme and allow for responsive styles to be passed as array values.
 
-The [margin and padding props](https://www.npmjs.com/package/@rebass/grid#margin-and-padding-props) used the default spacing values (in pixels) from `@rebass/grid`:
+The [margin and padding props](https://www.npmjs.com/package/../components/Grid#margin-and-padding-props) used the default spacing values (in pixels) from `../components/Grid`:
 
 ```md
 const spacing = [0, 4, 8, 16, 32, 64, 128, 256, 512];
 ```
-
-


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2929

We recently had more confusion about `@rebass/grid` because the package that we used is deprecated and the documentation on https://rebassjs.org/reflexbox/ doesn't match the component that we're using.

I imported the file in our codebase (https://github.com/opencollective/opencollective-frontend/pull/4005/files#diff-ad7c1cbc2fc6a3e54fb9f16e11045d42) and removed the dependency.