### PR TITLE
Wait Until user Loads Before Showing Expense Form

### DIFF
--- a/pages/create-expense.js
+++ b/pages/create-expense.js
@@ -98,14 +98,14 @@ class CreateExpensePage extends React.Component {
   }
 
   componentDidMount() {
-    // Reftech data if user is logged in
+    // Re-fetch data if user is logged in
     if (this.props.LoggedInUser) {
       this.props.data.refetch();
     }
   }
 
   componentDidUpdate(oldProps, oldState) {
-    // Reftech data if user is logged in
+    // Re-fetch data if user is logged in
     if (!oldProps.LoggedInUser && this.props.LoggedInUser) {
       this.props.data.refetch();
     }
@@ -203,7 +203,7 @@ class CreateExpensePage extends React.Component {
                         <FormattedMessage id="Expense.summary" defaultMessage="Expense summary" />
                       )}
                     </H1>
-                    {data.loading ? (
+                    {data.loading || loadingLoggedInUser ? (
                       <LoadingPlaceholder width="100%" height={400} />
                     ) : (
                       <Box>


### PR DESCRIPTION
Fixes https://github.com/opencollective/opencollective/issues/3045

This fix is to wait until the user loads before showing the expense form.

![Peek 2020-04-20 11-40](https://user-images.githubusercontent.com/12435965/79787395-c616b300-82fb-11ea-8552-419dc1c44df3.gif)

