### PR TITLE
Add attached files on legacy expense pages

### DIFF
--- a/components/expenses/Expense.js
+++ b/components/expenses/Expense.js
@@ -659,6 +659,10 @@ const editExpense = graphql(
           description
           amount
         }
+        attachedFiles {
+          id
+          url
+        }
         category
         type
         privateMessage

--- a/components/expenses/ExpenseDetails.js
+++ b/components/expenses/ExpenseDetails.js
@@ -19,6 +19,7 @@ import StyledSpinner from '../StyledSpinner';
 import StyledButton from '../StyledButton';
 import MessageBox from '../MessageBox';
 import { formatErrorMessage } from '../../lib/errors';
+import ExternalLink from '../ExternalLink';
 
 class ExpenseDetails extends React.Component {
   static propTypes = {
@@ -65,6 +66,10 @@ class ExpenseDetails extends React.Component {
       expenseTypeInvoice: {
         id: 'Expense.Type.Invoice',
         defaultMessage: 'Invoice',
+      },
+      attachedFile: {
+        id: 'Expense.OpenAttachedFile',
+        defaultMessage: 'Open attached file in a new window',
       },
     });
 
@@ -414,16 +419,32 @@ class ExpenseDetails extends React.Component {
                     />
                   )}
                   {!editMode && attachment.url && (
-                    <a
+                    <ExternalLink
                       href={attachment.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
+                      openInNewTab
                       title={this.getAttachmentTitle(expense, attachment)}
                     >
                       <img src={this.getAttachmentPreview(attachment.url)} />
-                    </a>
+                    </ExternalLink>
                   )}
                   {!editMode && !attachment.url && <img src={this.getAttachmentPreview(attachment.url)} />}
+                </div>
+              </div>
+            ))}
+            {((!editMode && expense.attachedFiles) || []).map(attachment => (
+              <div key={attachment.id}>
+                <div className="frame">
+                  {attachment.url ? (
+                    <ExternalLink
+                      href={attachment.url}
+                      openInNewTab
+                      title={intl.formatMessage(this.messages.attachedFile)}
+                    >
+                      <img src={this.getAttachmentPreview(attachment.url)} />
+                    </ExternalLink>
+                  ) : (
+                    <img src={this.getAttachmentPreview(attachment.url)} />
+                  )}
                 </div>
               </div>
             ))}
@@ -462,6 +483,10 @@ const getExpenseQuery = gql`
         url
         description
         amount
+      }
+      attachedFiles {
+        id
+        url
       }
       payoutMethod
       PayoutMethod {

--- a/components/expenses/ExpenseWithData.js
+++ b/components/expenses/ExpenseWithData.js
@@ -110,6 +110,10 @@ const getExpenseQuery = gql`
         description
         amount
       }
+      attachedFiles {
+        id
+        url
+      }
       collective {
         id
         slug

--- a/components/expenses/ExpensesWithData.js
+++ b/components/expenses/ExpensesWithData.js
@@ -107,6 +107,10 @@ const getExpensesQuery = gql`
         description
         amount
       }
+      attachedFiles {
+        id
+        url
+      }
       collective {
         id
         slug

--- a/lang/en.json
+++ b/lang/en.json
@@ -709,6 +709,7 @@
   "expense.markAsUnpaid.btn": "Mark as unpaid",
   "expense.notes": "Notes",
   "Expense.NotFound": "This expense doesn't exist",
+  "Expense.OpenAttachedFile": "Open attached file in a new window",
   "expense.paid": "paid",
   "expense.pay.btn": "Pay with {paymentMethod}",
   "expense.pay.error.insufficientBalance": "Insufficient balance",

--- a/lang/es.json
+++ b/lang/es.json
@@ -709,6 +709,7 @@
   "expense.markAsUnpaid.btn": "Mark as unpaid",
   "expense.notes": "Notes",
   "Expense.NotFound": "This expense doesn't exist",
+  "Expense.OpenAttachedFile": "Open attached file in a new window",
   "expense.paid": "pagado",
   "expense.pay.btn": "Pagar con {paymentMethod}",
   "expense.pay.error.insufficientBalance": "Saldo insuficiente",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -709,6 +709,7 @@
   "expense.markAsUnpaid.btn": "Marquer comme impayé",
   "expense.notes": "Notes",
   "Expense.NotFound": "Cette dépense n'existe pas",
+  "Expense.OpenAttachedFile": "Open attached file in a new window",
   "expense.paid": "payé",
   "expense.pay.btn": "Payer avec {paymentMethod}",
   "expense.pay.error.insufficientBalance": "Solde insuffisant",

--- a/lang/it.json
+++ b/lang/it.json
@@ -709,6 +709,7 @@
   "expense.markAsUnpaid.btn": "Contrassegna come non pagato",
   "expense.notes": "Notes",
   "Expense.NotFound": "Questa spesa non esiste",
+  "Expense.OpenAttachedFile": "Open attached file in a new window",
   "expense.paid": "pagato",
   "expense.pay.btn": "Pay with {paymentMethod}",
   "expense.pay.error.insufficientBalance": "Credito insufficiente",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -709,6 +709,7 @@
   "expense.markAsUnpaid.btn": "未支払いにする",
   "expense.notes": "Notes",
   "Expense.NotFound": "This expense doesn't exist",
+  "Expense.OpenAttachedFile": "Open attached file in a new window",
   "expense.paid": "支払い済み",
   "expense.pay.btn": "Pay with {paymentMethod}",
   "expense.pay.error.insufficientBalance": "残高不足",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -709,6 +709,7 @@
   "expense.markAsUnpaid.btn": "Mark as unpaid",
   "expense.notes": "Notes",
   "Expense.NotFound": "This expense doesn't exist",
+  "Expense.OpenAttachedFile": "Open attached file in a new window",
   "expense.paid": "paid",
   "expense.pay.btn": "Pay with {paymentMethod}",
   "expense.pay.error.insufficientBalance": "Insufficient balance",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -709,6 +709,7 @@
   "expense.markAsUnpaid.btn": "Marcar como não pago",
   "expense.notes": "Notas",
   "Expense.NotFound": "Esta despesa não existe",
+  "Expense.OpenAttachedFile": "Open attached file in a new window",
   "expense.paid": "pago",
   "expense.pay.btn": "Pague com {paymentMethod}",
   "expense.pay.error.insufficientBalance": "Saldo insuficiente",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -709,6 +709,7 @@
   "expense.markAsUnpaid.btn": "Mark as unpaid",
   "expense.notes": "Notes",
   "Expense.NotFound": "This expense doesn't exist",
+  "Expense.OpenAttachedFile": "Open attached file in a new window",
   "expense.paid": "оплачено",
   "expense.pay.btn": "Pay with {paymentMethod}",
   "expense.pay.error.insufficientBalance": "Недостаточный остаток",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -709,6 +709,7 @@
   "expense.markAsUnpaid.btn": "Mark as unpaid",
   "expense.notes": "Notes",
   "Expense.NotFound": "This expense doesn't exist",
+  "Expense.OpenAttachedFile": "Open attached file in a new window",
   "expense.paid": "paid",
   "expense.pay.btn": "Pay with {paymentMethod}",
   "expense.pay.error.insufficientBalance": "Insufficient balance",


### PR DESCRIPTION
Most importantly, adds them on the host dashboard. They appears as regular attached files, except they can't be edited.

![image](https://user-images.githubusercontent.com/1556356/80119367-e360b100-8589-11ea-80ee-6f1d18c76bb1.png)
