### PR TITLE
Fix 'ready to pay', remove pagination

### DIFF
--- a/components/expenses/ExpensesWithData.js
+++ b/components/expenses/ExpensesWithData.js
@@ -145,9 +145,6 @@ const EXPENSES_PER_PAGE = 10;
 
 const getExpensesVariables = props => {
   const filters = { ...props.filters };
-  if (filters.status === 'READY') {
-    filters.status = 'APPROVED';
-  }
 
   const vars = {
     CollectiveId: props.collective.id,
@@ -161,6 +158,12 @@ const getExpensesVariables = props => {
   } else {
     vars.category = null;
   }
+
+  if (vars.status === 'READY') {
+    vars.status = 'APPROVED';
+    vars.limit = null;
+  }
+
   return vars;
 };
 


### PR DESCRIPTION
Spent some time on that this morning, this is the only solution I have.

This means it will be slow and load all APPROVED expenses. That's currently around 200 expenses for the Open Source Collective and is working without timeout.
