### PR TITLE
StyledInputAmount: Cross-browser behavior + accessibility

### DIFF
--- a/components/CreateVirtualCardsForm.js
+++ b/components/CreateVirtualCardsForm.js
@@ -30,8 +30,8 @@ import { CollectiveType } from '../lib/constants/collectives';
 import { isPrepaid } from '../lib/constants/payment-methods';
 import StyledSelectCreatable from './StyledSelectCreatable';
 
-const MIN_AMOUNT = 5;
-const MAX_AMOUNT = 1000000;
+const MIN_AMOUNT = 500;
+const MAX_AMOUNT = 100000000;
 
 const messages = defineMessages({
   emailCustomMessage: {
@@ -228,9 +228,6 @@ class CreateVirtualCardsForm extends Component {
     } else if (fieldName === 'numberOfVirtualCards') {
       const intNumberOfVirtualCards = parseInt(value);
       value = !isNaN(intNumberOfVirtualCards) ? intNumberOfVirtualCards : 1;
-    } else if (fieldName === 'amount') {
-      const amount = parseFloat(value);
-      value = !isNaN(amount) ? amount : MIN_AMOUNT;
     }
 
     // Set value
@@ -264,7 +261,7 @@ class CreateVirtualCardsForm extends Component {
 
       this.setState({ submitting: true });
       const params = {
-        amount: Math.round(values.amount * 100),
+        amount: values.amount,
         PaymentMethodId: paymentMethod.id,
         expiryDate: values.expiryDate,
         batch: values.batch,
@@ -475,7 +472,7 @@ class CreateVirtualCardsForm extends Component {
               id="virtualcard-amount"
               currency={currency}
               prepend={currency}
-              onChange={e => this.onChange('amount', e.target.value)}
+              onChange={value => this.onChange('amount', value)}
               error={this.getError('amount')}
               value={values.amount}
               min={MIN_AMOUNT}

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -114,7 +114,6 @@ const StepDetails = ({
     Router.pushRoute(`/${collectiveSlug}/donate/details`);
   };
   interval = interval || 'oneTime';
-
   return (
     <Flex width={1} flexDirection={hasOptions ? 'column' : 'row'} flexWrap="wrap">
       <Flex mb={3}>
@@ -160,16 +159,17 @@ const StepDetails = ({
             }
             htmlFor="custom-amount"
             disabled={disabledAmount}
+            required
           >
             {fieldProps => (
               <StyledInputAmount
                 {...fieldProps}
                 type="number"
                 currency={currency}
-                min={minAmount / 100}
-                value={amount / 100}
+                min={minAmount}
+                value={amount}
                 width={1}
-                onChange={({ target }) => dispatchChange({ amount: Math.round(parseFloat(target.value) * 100) })}
+                onChange={amount => dispatchChange({ amount })}
                 containerProps={{ borderRadius: hasOptions ? '0 4px 4px 0' : 3, ml: '-1px' }}
                 prependProps={{ pl: 2, pr: 0, bg: 'white.full' }}
                 px="2px"

--- a/components/edit-collective/Form.js
+++ b/components/edit-collective/Form.js
@@ -405,7 +405,7 @@ class EditCollectiveForm extends React.Component {
               flexWrap="wrap"
             >
               <Link route="editCollective" params={{ slug: collective.slug, section: 'gift-cards' }}>
-                <StyledButton>
+                <StyledButton data-cy="back-to-giftcards-list">
                   <ArrowBack size="1em" />{' '}
                   <FormattedMessage id="virtualCards.returnToEdit" defaultMessage="Go back to gift cards list" />
                 </StyledButton>

--- a/components/edit-collective/sections/VirtualCards.js
+++ b/components/edit-collective/sections/VirtualCards.js
@@ -153,7 +153,7 @@ class VirtualCards extends React.Component {
         {data.loading ? (
           <Loading />
         ) : (
-          <div className="virtualcards-list">
+          <div data-cy="virtualcards-list">
             {paymentMethods.length === 0 && (
               <Flex justifyContent="center" mt="4em">
                 {this.renderNoVirtualCardMessage(onlyConfirmed)}

--- a/components/expenses/ExpenseItemForm.js
+++ b/components/expenses/ExpenseItemForm.js
@@ -49,6 +49,10 @@ export const msg = defineMessages({
 export const validateExpenseItem = (expense, item) => {
   const errors = requireFields(item, ['description', 'incurredAt', 'amount']);
 
+  if (isNaN(item.amount)) {
+    errors.amount = createError(ERROR.FORM_FIELD_PATTERN);
+  }
+
   if (!isEmpty(errors)) {
     return errors;
   }
@@ -58,7 +62,7 @@ export const validateExpenseItem = (expense, item) => {
     if (!item.url) {
       errors.url = createError(ERROR.FORM_FIELD_REQUIRED);
     } else if (!isURL(item.url)) {
-      errors.url = createError(ERROR.FORM_FIELD_BAD_PATTERN);
+      errors.url = createError(ERROR.FORM_FIELD_PATTERN);
     }
   }
 
@@ -139,7 +143,7 @@ const ExpenseItemForm = ({ attachment, errors, onRemove, currency, requireFile, 
               mt={3}
             >
               {inputProps => (
-                <Field as={StyledInput} maxHeight={39} {...inputProps}>
+                <Field maxHeight={39} {...inputProps}>
                   {({ field }) => (
                     <StyledInput
                       {...inputProps}
@@ -165,16 +169,20 @@ const ExpenseItemForm = ({ attachment, errors, onRemove, currency, requireFile, 
               mt={3}
             >
               {inputProps => (
-                <Field
-                  as={StyledInputAmount}
-                  {...inputProps}
-                  currency={currency}
-                  currencyDisplay="CODE"
-                  min="0.01"
-                  maxWidth="100%"
-                  placeholder="0.00"
-                  parseNumbers
-                />
+                <Field as={StyledInputAmount} name={inputProps.name}>
+                  {({ field, form: { setFieldValue } }) => (
+                    <StyledInputAmount
+                      {...field}
+                      {...inputProps}
+                      currency={currency}
+                      currencyDisplay="CODE"
+                      min={1}
+                      maxWidth="100%"
+                      placeholder="0.00"
+                      onChange={(value, e) => setFieldValue(e.target.name, value)}
+                    />
+                  )}
+                </Field>
               )}
             </StyledInputField>
           </Flex>

--- a/components/expenses/ExpenseItemsTotalAmount.js
+++ b/components/expenses/ExpenseItemsTotalAmount.js
@@ -8,9 +8,10 @@ import { Span } from '../Text';
  */
 const ExpenseItemsTotalAmount = ({ items, currency }) => {
   const totalAmount = items.reduce((amount, attachment) => amount + (attachment.amount || 0), 0);
+  const isValid = items.every(item => item.amount);
   return (
     <Span color="black.500" fontSize="LeadParagraph" letterSpacing={0} data-cy="expense-items-total-amount">
-      <FormattedMoneyAmount amount={totalAmount} precision={2} currency={currency} />
+      {isValid ? <FormattedMoneyAmount amount={totalAmount} precision={2} currency={currency} /> : '--.--'}
     </Span>
   );
 };

--- a/styleguide/examples/StyledInputAmount.md
+++ b/styleguide/examples/StyledInputAmount.md
@@ -1,18 +1,49 @@
 With currency set to `EUR`:
 
 ```js
-<StyledInputAmount currency="EUR" />
+const [value, setValue] = React.useState(0);
+const [isValid, setIsValid] = React.useState(true);
+<div>
+  <StyledInputAmount
+    currency="EUR"
+    onChange={(value, e) => {
+      setValue(value);
+      setIsValid(e.target.checkValidity());
+    }}
+  />
+  <p>
+    Value: {new String(value)}
+    <br />
+    Is Valid: {isValid ? 'Yes' : 'No'}
+  </p>
+</div>;
 ```
 
 With min amount to `$10`:
 
 ```js
-<StyledInputAmount currency="USD" min="10" />
+<StyledInputAmount currency="USD" min="10" onChange={value => console.log(value)} />
 ```
 
-## With `parseNumbers`
+### Controlled
 
 ```js
-const [value, setValue] = React.useState('');
-<StyledInputAmount currency="USD" min="10" parseNumbers value={value} onChange={e => setValue(e.target.value)} />;
+const [value, setValue] = React.useState(0);
+const [isValid, setIsValid] = React.useState(true);
+<div>
+  <StyledInputAmount
+    currency="EUR"
+    value={value}
+    required
+    onChange={(value, e) => {
+      setValue(value);
+      setIsValid(e.target.checkValidity());
+    }}
+  />
+  <p>
+    Value: {new String(value)}
+    <br />
+    Is Valid: {isValid ? 'Yes' : 'No'}
+  </p>
+</div>;
 ```

--- a/test/cypress/integration/09-virtualcards-admin.test.js
+++ b/test/cypress/integration/09-virtualcards-admin.test.js
@@ -10,7 +10,7 @@ describe('Virtual cards admin', () => {
 
   it('start with empty gift cards list', () => {
     cy.login({ redirect: `/${collectiveSlug}/edit/gift-cards` });
-    cy.get('.virtualcards-list').contains('Create your first gift card!');
+    cy.getByDataCy('virtualcards-list').contains('Create your first gift card!');
   });
 
   it('create gift card codes', () => {
@@ -69,10 +69,12 @@ describe('Virtual cards admin', () => {
     cy.get(multiEmailSelector).type(
       '{selectall} test1@opencollective.com test2@opencollective.com test3@opencollective.com',
     );
-    cy.get('#virtualcard-amount').type('12');
+    cy.get('#virtualcard-amount').type('{selectall}').type('12');
     checkSubmit(true, 'Create 3 gift cards');
     cy.getByDataCy('submit-new-virtualcards').click();
     cy.contains('Your 3 gift cards have been sent!');
+    cy.getByDataCy('back-to-giftcards-list').click();
+    cy.getByDataCy('virtualcards-list').contains('$12.00 sent to test3@opencollective.com');
   });
 });
 

--- a/test/cypress/integration/27-expenses.create.test.js
+++ b/test/cypress/integration/27-expenses.create.test.js
@@ -65,7 +65,7 @@ describe('New expense flow', () => {
       cy.get('input[name="items[0].amount"]').type('{selectall}183');
       cy.getByDataCy('expense-summary-btn').should('be.disabled');
       cy.get('input:invalid').should('have.length', 2); // Missing attachment desctiption+amount
-      cy.getByDataCy('expense-items-total-amount').should('contain', '$183.00 USD');
+      cy.getByDataCy('expense-items-total-amount').should('contain', '--.--'); // amount for second item is missing
 
       // Select Payout Method
       cy.getByDataCy('payout-method-select').click();

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -391,7 +391,7 @@ function fillStripeInput(params) {
         return;
       }
 
-      return cy.wrap(body).find(`input:eq(${index})`).type(`{selectall}${value}`);
+      return cy.wrap(body).find(`input:eq(${index})`).type(`{selectall}${value}`, { force: true });
     };
 
     fillInput(1, creditCardNumber);


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/3066

A re-work of the `StyledInputAmount`, inspired by https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/ and various posts from the Internet. It should fix the behavior on Firefox and other browsers.

General ideas:
- Don't try to do any magic if the number is not formatted properly, let users fill the input as they want  (display the raw value) and return `NaN`.

![image](https://user-images.githubusercontent.com/1556356/80212101-2e84cd80-8637-11ea-82bf-377a70dcc179.png)

- Browsers have different ways to handle `,`. If the result of `parseFloat` is not consistent for such numbers, we mark them as invalid. On Chrome this plays nicely because `parseFloat('0,3') === '0.3'` in concerned locales. For other browsers, it will show a validation error saying that the format is incorrect.
- Don't hack the `event`, return an `amount` param instead
- All amounts in input/output are now in cents
- Can still be used controlled or uncontrolled
- In the expense flow, if one of the items amount is invalid, show a placeholder rather than a misleading total:
![image](https://user-images.githubusercontent.com/1556356/80213156-0ac28700-8639-11ea-87cd-7d0f8cf41885.png)
