### PR TITLE
refactor: transform expense and conversation tags to lowercase

### DIFF
--- a/components/ContributorCard.js
+++ b/components/ContributorCard.js
@@ -111,7 +111,7 @@ const ContributorCard = ({ intl, width, height, contributor, currency, isLoggedU
             {truncate(contributor.name, { length: 16 })}
           </H5>
         </LinkContributor>
-        <StyledTag my={2} padding="5px" letterSpacing="0.05em" fontStyle="initial">
+        <StyledTag my={2} padding="5px" letterSpacing="0.05em" fontStyle="initial" textTransform="uppercase">
           {formatMemberRole(intl.formatMessage, getMainContributorRole(contributor))}
         </StyledTag>
         {contributor.totalAmountDonated > 0 && (

--- a/components/ReplyToMemberInvitationCard.js
+++ b/components/ReplyToMemberInvitationCard.js
@@ -90,7 +90,7 @@ const ReplyToMemberInvitationCard = ({ invitation, isSelected }) => {
         </Flex>
       </LinkCollective>
       <hr />
-      <StyledTag>{formatMemberRole(formatMessage, invitation.role)}</StyledTag>
+      <StyledTag textTransform="uppercase">{formatMemberRole(formatMessage, invitation.role)}</StyledTag>
       {rolesDetails[invitation.role] && (
         <P my={2} color="black.600">
           {formatMessage(rolesDetails[invitation.role])}

--- a/components/StyledCollectiveCard.js
+++ b/components/StyledCollectiveCard.js
@@ -41,7 +41,7 @@ const StyledCollectiveCard = ({ collective, children, ...props }) => {
               {collective.name}
             </P>
           </LinkCollective>
-          <StyledTag display="inline-block" my={2}>
+          <StyledTag display="inline-block" textTransform="uppercase" my={2}>
             <I18nCollectiveTags
               tags={getCollectiveMainTag(get(collective, 'host.id'), collective.tags, collective.type)}
             />

--- a/components/StyledInputTags.js
+++ b/components/StyledInputTags.js
@@ -142,7 +142,7 @@ const StyledInputTags = ({ suggestedTags, value, onChange, renderUpdatedTags, de
   const handleToggleInput = () => {
     isOpen ? handleClose() : setOpen(true);
   };
-  const addTag = tag => setTags(uniqBy([...tags, { label: tag.toUpperCase(), value: tag.toUpperCase() }], 'value'));
+  const addTag = tag => setTags(uniqBy([...tags, { label: tag.toLowerCase(), value: tag.toLowerCase() }], 'value'));
   const removeTag = (tag, update) => {
     const updatedTags = tags.filter(v => v.value !== tag);
     setTags(updatedTags);

--- a/components/StyledSelect.js
+++ b/components/StyledSelect.js
@@ -45,7 +45,7 @@ const MultiValue = ({ children, removeProps }) => {
   }
 
   return (
-    <StyledTag mr="8px" variant="rounded-right" closeButtonProps={removeProps}>
+    <StyledTag mr="8px" variant="rounded-right" textTransform="uppercase" closeButtonProps={removeProps}>
       {children}
     </StyledTag>
   );

--- a/components/StyledTag.js
+++ b/components/StyledTag.js
@@ -20,7 +20,7 @@ const defaultRoundedStyleProps = {
 
 const StyledTagBase = styled.div`
   text-align: center;
-  white-space: nowrap; 
+  white-space: nowrap;
 
   ${variant({
     prop: 'variant',
@@ -49,7 +49,7 @@ const StyledTagBase = styled.div`
   & > * {
     vertical-align: middle;
   }
-  
+
   ${background}
   ${color}
   ${space}
@@ -143,7 +143,6 @@ StyledTag.propTypes = {
 
 StyledTag.defaultProps = {
   variant: 'squared',
-  textTransform: 'uppercase',
   iconHeight: '2.5em',
   iconWidth: '2.5em',
   iconBackgroundColor: 'rgba(33, 33, 33, 1)',

--- a/components/StyledTextarea.js
+++ b/components/StyledTextarea.js
@@ -145,7 +145,7 @@ export default class StyledTextarea extends React.PureComponent {
       <Container position="relative">
         {textarea}
         <Container position="absolute" bottom="1.25em" right="1.5em">
-          <StyledTag>
+          <StyledTag textTransform="uppercase">
             <span>{value.length}</span>
             {props.maxLength && <span> / {props.maxLength}</span>}
           </StyledTag>

--- a/components/collective-page/hero/Hero.js
+++ b/components/collective-page/hero/Hero.js
@@ -163,7 +163,7 @@ const Hero = ({ collective, host, isAdmin, onPrimaryColorChange, callsToAction, 
           {!isEvent && (
             <Flex alignItems="center" flexWrap="wrap">
               {isCollective && (
-                <StyledTag mx={2} my={2} mb={2}>
+                <StyledTag textTransform="uppercase" mx={2} my={2} mb={2}>
                   <I18nCollectiveTags
                     tags={getCollectiveMainTag(get(collective, 'host.id'), collective.tags, collective.type)}
                   />

--- a/components/contribute-cards/Contribute.js
+++ b/components/contribute-cards/Contribute.js
@@ -155,7 +155,15 @@ const ContributeCard = ({
   return (
     <StyledContributeCard {...props}>
       <CoverImage image={image} isDisabled={disableCTA}>
-        <StyledTag position="absolute" bottom="8px" left="8px" background="white" color="black.700" fontWeight="600">
+        <StyledTag
+          position="absolute"
+          bottom="8px"
+          left="8px"
+          background="white"
+          color="black.700"
+          fontWeight="600"
+          textTransform="uppercase"
+        >
           {intl.formatMessage(I18nContributionType[type])}
         </StyledTag>
       </CoverImage>

--- a/components/edit-collective/sections/Members.js
+++ b/components/edit-collective/sections/Members.js
@@ -242,7 +242,7 @@ class Members extends React.Component {
               {isInvitation && (
                 <Flex alignItems="center" my={1}>
                   <StyledTooltip content={intl.formatMessage(this.messages.memberPendingDetails)}>
-                    <StyledTag display="block" type="info">
+                    <StyledTag textTransform="uppercase" display="block" type="info">
                       <FormattedMessage id="Pending" defaultMessage="Pending" />
                     </StyledTag>
                   </StyledTooltip>

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -204,7 +204,7 @@ const ExpenseFormBody = ({ formik, payoutProfiles, collective, autoFocusTitle, o
                 onChange={tags =>
                   formik.setFieldValue(
                     'tags',
-                    tags.map(t => t.value.toUpperCase()),
+                    tags.map(t => t.value.toLowerCase()),
                   )
                 }
                 value={values.tags}

--- a/components/expenses/ExpenseStatusTag.js
+++ b/components/expenses/ExpenseStatusTag.js
@@ -27,7 +27,13 @@ const getExpenseStatusMsgType = status => {
 const ExpenseStatusTag = ({ status, ...props }) => {
   const intl = useIntl();
   return (
-    <StyledTag type={getExpenseStatusMsgType(status)} fontWeight="600" letterSpacing="0.8px" {...props}>
+    <StyledTag
+      type={getExpenseStatusMsgType(status)}
+      fontWeight="600"
+      letterSpacing="0.8px"
+      textTransform="uppercase"
+      {...props}
+    >
       {i18nExpenseStatus(intl, status)}
     </StyledTag>
   );

--- a/test/cypress/integration/17-conversations.test.js
+++ b/test/cypress/integration/17-conversations.test.js
@@ -46,7 +46,7 @@ describe('Conversations', () => {
       cy.getByDataCy('styled-input-tags-open').click();
       cy.getByDataCy('styled-input-tags-input').type(`${sampleTag}{enter}{enter}`);
       cy.getByDataCy('InlineEditField-Btn-Save').click();
-      cy.contains(`${sampleTag}`.toUpperCase());
+      cy.contains(`${sampleTag}`.toLowerCase());
 
       // Add comment
       cy.get('[data-cy="comment-form"] [data-cy="RichTextEditor"] trix-editor').as('comment-editor');


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Related https://github.com/opencollective/opencollective-api/pull/3776
https://github.com/opencollective/opencollective/issues/3085

# Description
- [x] Ensure that StyledTagInput creates lowercase tags
- [x] In StyledTag, remove the default textTransform: uppercase (but add it where it's needed, like on expense status tag)
- [x] Update tests

# Screenshots
* Tag Input are in lowercase
![conversation tags in lowercase](https://user-images.githubusercontent.com/24629960/80289201-28f8b780-870b-11ea-9868-548854b82652.png)

* Conversation tags are lowercase
![conversation tags in lowercase](https://user-images.githubusercontent.com/24629960/80289204-29914e00-870b-11ea-873a-7d74ad9895ee.png)

* Expense Tags are lowercase
![Expense tags are lowercase](https://user-images.githubusercontent.com/24629960/80289228-4ded2a80-870b-11ea-81ff-3f4f59d7cc53.png)

