### PR TITLE
Show bank account details on legacy expense pages

### DIFF
--- a/components/expenses/ExpenseDetails.js
+++ b/components/expenses/ExpenseDetails.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { graphql } from '@apollo/react-hoc';
 import gql from 'graphql-tag';
 import { cloneDeep, get, omit, pick, set, uniq } from 'lodash';
-import { defineMessages, FormattedMessage, FormattedNumber, injectIntl } from 'react-intl';
+import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 
 import categories from '../../lib/constants/categories';
 import { formatCurrency, getCurrencySymbol } from '../../lib/currency-utils';
@@ -22,6 +22,8 @@ import StyledLink from '../StyledLink';
 import StyledSpinner from '../StyledSpinner';
 
 import ExpenseInvoiceDownloadHelper from './ExpenseInvoiceDownloadHelper';
+import PayoutMethodData from './PayoutMethodData';
+import PayoutMethodTypeWithIcon from './PayoutMethodTypeWithIcon';
 import TransactionDetails from './TransactionDetails';
 
 class ExpenseDetails extends React.Component {
@@ -256,7 +258,7 @@ class ExpenseDetails extends React.Component {
             }
           `}
         </style>
-        <Flex flexWrap="wrap" alignItems="flex-end">
+        <Flex flexWrap="wrap">
           {editMode && (
             <div className="row">
               <div className="col large">
@@ -318,13 +320,13 @@ class ExpenseDetails extends React.Component {
             </div>
           )}
 
-          <Box mt={2} mr={2}>
-            <label>
-              <FormattedMessage id="Fields.amount" defaultMessage="Amount" />
-            </label>
-            <div className="amountDetails">
-              <span className="amount">
-                {editMode && canEditAmount && (
+          {editMode && canEditAmount && (
+            <Box mt={2} mr={2}>
+              <label>
+                <FormattedMessage id="Fields.amount" defaultMessage="Amount" />
+              </label>
+              <div className="amountDetails">
+                <span className="amount">
                   <InputField
                     name="amount"
                     defaultValue={expense.amount}
@@ -333,37 +335,34 @@ class ExpenseDetails extends React.Component {
                     className="amountField"
                     onChange={amount => this.handleChange('amount', amount)}
                   />
-                )}
-                {!(editMode && canEditAmount) && (
-                  <FormattedNumber value={expense.amount / 100} currency={expense.currency} {...this.currencyStyle} />
-                )}
-              </span>
-            </div>
-          </Box>
-
-          <Box mt={2} mr={2}>
-            <label>
-              <FormattedMessage id="expense.payoutMethod" defaultMessage="payout method" />
-            </label>
-            {(!editMode || payoutMethod === 'banktransfer') && (
-              <div>
-                {capitalize(
-                  intl.formatMessage(this.messages[payoutMethod], {
-                    paypalEmail: paypalEmail || (canEditExpense ? 'missing' : 'hidden'),
-                  }),
-                )}
+                </span>
               </div>
-            )}
-            {editMode && payoutMethod !== 'banktransfer' && (
-              <InputField
-                name="payoutMethod"
-                type="select"
-                options={payoutMethodOptions}
-                defaultValue={payoutMethod}
-                onChange={payoutMethod => this.handleChange('payoutMethod', payoutMethod)}
-              />
-            )}
-          </Box>
+            </Box>
+          )}
+
+          {(!editMode || payoutMethod !== 'banktransfer') && (
+            <Box mt={2} mr={2}>
+              <label>
+                <FormattedMessage id="expense.payoutMethod" defaultMessage="payout method" />
+              </label>
+              {!editMode ? (
+                <div>
+                  <Box mb={2}>
+                    <PayoutMethodTypeWithIcon type={expense.PayoutMethod?.type} fontSize="12px" iconSize={14} />
+                  </Box>
+                  <PayoutMethodData payoutMethod={expense.PayoutMethod} showLabel={false} />
+                </div>
+              ) : (
+                <InputField
+                  name="payoutMethod"
+                  type="select"
+                  options={payoutMethodOptions}
+                  defaultValue={payoutMethod}
+                  onChange={payoutMethod => this.handleChange('payoutMethod', payoutMethod)}
+                />
+              )}
+            </Box>
+          )}
 
           {(expense.privateMessage || ((isAuthor || canEditExpense) && payoutMethod === 'other')) && (
             <div className="col large privateMessage">
@@ -491,6 +490,7 @@ const getExpenseQuery = gql`
       PayoutMethod {
         id
         type
+        data
       }
       type
       privateMessage

--- a/components/expenses/ExpenseWithData.js
+++ b/components/expenses/ExpenseWithData.js
@@ -101,6 +101,7 @@ const getExpenseQuery = gql`
       PayoutMethod {
         id
         type
+        data
       }
       privateMessage
       userTaxFormRequiredBeforePayment

--- a/components/expenses/ExpensesWithData.js
+++ b/components/expenses/ExpensesWithData.js
@@ -98,6 +98,7 @@ const getExpensesQuery = gql`
       PayoutMethod {
         id
         type
+        data
       }
       privateMessage
       userTaxFormRequiredBeforePayment

--- a/components/expenses/PayoutMethodData.js
+++ b/components/expenses/PayoutMethodData.js
@@ -26,7 +26,7 @@ const renderObject = object =>
  * @returns boolean: True if the payout method has displayable data
  */
 export const payoutMethodHasData = payoutMethod => {
-  switch (payoutMethod.type) {
+  switch (payoutMethod?.type) {
     case PayoutMethodType.PAYPAL:
       return Boolean(get(payoutMethod, 'data.email'));
     case PayoutMethodType.OTHER:
@@ -41,7 +41,7 @@ export const payoutMethodHasData = payoutMethod => {
 /**
  * Shows the data of the given payout method
  */
-const PayoutMethodData = ({ payoutMethod }) => {
+const PayoutMethodData = ({ payoutMethod, showLabel }) => {
   if (!payoutMethodHasData(payoutMethod)) {
     return null;
   }
@@ -50,37 +50,43 @@ const PayoutMethodData = ({ payoutMethod }) => {
     case PayoutMethodType.PAYPAL:
       return (
         <div>
-          <Container fontSize="11px" fontWeight="500" mb={2}>
-            <FormattedMessage id="User.EmailAddress" defaultMessage="Email address" />
-            &nbsp;&nbsp;
-            <PrivateInfoIcon color="#969BA3" />
-          </Container>
-          <P fontSize="11px" color="black.700">
+          {showLabel && (
+            <Container fontSize="11px" fontWeight="500" mb={2}>
+              <FormattedMessage id="User.EmailAddress" defaultMessage="Email address" />
+              &nbsp;&nbsp;
+              <PrivateInfoIcon color="#969BA3" />
+            </Container>
+          )}
+          <Container fontSize="11px" color="black.700">
             {payoutMethod.data.email}
-          </P>
+          </Container>
         </div>
       );
     case PayoutMethodType.OTHER:
       return (
         <div>
-          <Container fontSize="11px" fontWeight="500" mb={2}>
-            <FormattedMessage id="Details" defaultMessage="Details" />
-            &nbsp;&nbsp;
-            <PrivateInfoIcon color="#969BA3" />
-          </Container>
-          <P fontSize="11px" color="black.700">
+          {showLabel && (
+            <Container fontSize="11px" fontWeight="500" mb={2}>
+              <FormattedMessage id="Details" defaultMessage="Details" />
+              &nbsp;&nbsp;
+              <PrivateInfoIcon color="#969BA3" />
+            </Container>
+          )}
+          <Container fontSize="11px" color="black.700">
             {payoutMethod.data.content}
-          </P>
+          </Container>
         </div>
       );
     case PayoutMethodType.BANK_ACCOUNT:
       return (
         <div>
-          <Container fontSize="11px" fontWeight="500" mb={2}>
-            <FormattedMessage id="Details" defaultMessage="Details" />
-            &nbsp;&nbsp;
-            <PrivateInfoIcon color="#969BA3" />
-          </Container>
+          {showLabel && (
+            <Container fontSize="11px" fontWeight="500" mb={2}>
+              <FormattedMessage id="Details" defaultMessage="Details" />
+              &nbsp;&nbsp;
+              <PrivateInfoIcon color="#969BA3" />
+            </Container>
+          )}
           <Container fontSize="11px" color="black.700">
             <FormattedMessage
               id="BankInfo.Type"
@@ -97,11 +103,17 @@ const PayoutMethodData = ({ payoutMethod }) => {
 };
 
 PayoutMethodData.propTypes = {
+  /** If false, only the raw data will be displayed */
+  showLabel: PropTypes.bool,
   payoutMethod: PropTypes.shape({
     id: PropTypes.string,
     type: PropTypes.oneOf(Object.values(PayoutMethodType)),
     data: PropTypes.object,
   }),
+};
+
+PayoutMethodData.defaultProps = {
+  showLabel: true,
 };
 
 // @component

--- a/components/expenses/PayoutMethodTypeWithIcon.js
+++ b/components/expenses/PayoutMethodTypeWithIcon.js
@@ -13,13 +13,13 @@ import { Span } from '../Text';
 /**
  * Shows the data of the given payout method
  */
-const PayoutMethodTypeWithIcon = ({ type }) => {
+const PayoutMethodTypeWithIcon = ({ type, fontSize, iconSize }) => {
   switch (type) {
     case PayoutMethodType.PAYPAL:
       return (
         <Flex alignItems="center">
-          <PaypalIcon size={24} color="#192f86" />
-          <Span ml={2} fontWeight="bold" fontSize="13px" color="black.900">
+          <PaypalIcon size={iconSize} color="#192f86" />
+          <Span ml={2} fontWeight="bold" fontSize={fontSize} color="black.900">
             PayPal
           </Span>
         </Flex>
@@ -27,8 +27,8 @@ const PayoutMethodTypeWithIcon = ({ type }) => {
     case PayoutMethodType.OTHER:
       return (
         <Flex alignItems="center">
-          <OtherIcon size={24} color="#9D9FA3" />
-          <Span ml={2} fontWeight="bold" fontSize="13px" color="black.900">
+          <OtherIcon size={iconSize} color="#9D9FA3" />
+          <Span ml={2} fontWeight="bold" fontSize={fontSize} color="black.900">
             <FormattedMessage id="PayoutMethod.Type.Other" defaultMessage="Other" />
           </Span>
         </Flex>
@@ -36,8 +36,8 @@ const PayoutMethodTypeWithIcon = ({ type }) => {
     case PayoutMethodType.BANK_ACCOUNT:
       return (
         <Flex alignItems="center">
-          <BankIcon size={24} color="#9D9FA3" />
-          <Span ml={2} fontWeight="bold" fontSize="13px" color="black.900">
+          <BankIcon size={iconSize} color="#9D9FA3" />
+          <Span ml={2} fontWeight="bold" fontSize={fontSize} color="black.900">
             <FormattedMessage id="Bank account" defaultMessage="Bank account" />
           </Span>
         </Flex>
@@ -49,6 +49,13 @@ const PayoutMethodTypeWithIcon = ({ type }) => {
 
 PayoutMethodTypeWithIcon.propTypes = {
   type: PropTypes.oneOf(Object.values(PayoutMethodType)),
+  fontSize: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  iconSize: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};
+
+PayoutMethodTypeWithIcon.defaultProps = {
+  fontSize: '13px',
+  iconSize: 24,
 };
 
 // @component


### PR DESCRIPTION
The main goal of this PR is to display the bank account details on the legacy expense pages (more especially the host dashboard). I did that by re-using the two components from the new flow, `PayoutMethodTypeWithIcon` and `PayoutMethodData`. 

![image](https://user-images.githubusercontent.com/1556356/80479853-fa1f5300-894f-11ea-9138-68c87a9a4b0c.png)
