### PR TITLE
Center name on success page contributor's card

### DIFF
--- a/components/OrderSuccessContributorCardWithData.js
+++ b/components/OrderSuccessContributorCardWithData.js
@@ -142,11 +142,13 @@ class OrderSuccessContributorCardWithData extends React.Component {
           <Container
             display="flex"
             mt={2}
+            px={2}
             justifyContent="center"
             fontSize="Paragraph"
             fontWeight="bold"
             lineHeight="Caption"
             color="black.900"
+            textAlign="center"
           >
             <LinkCollective collective={fromCollective}>{fromCollective.name}</LinkCollective>
           </Container>


### PR DESCRIPTION
Fix a display issue with long names on the order success page.

**Before**

![localhost_3000_babel_donate_success_OrderId=49455 (2)](https://user-images.githubusercontent.com/1556356/80504639-a7f02900-8973-11ea-92db-b6b9db5a01a1.png)

**After**

![localhost_3000_babel_donate_success_OrderId=49455](https://user-images.githubusercontent.com/1556356/80503646-73c83880-8972-11ea-906b-ecb40cbb8fe1.png)
