### PR TITLE
Add Support for Expense Tag Suggestions

### DIFF
--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -159,7 +159,15 @@ const validate = expense => {
 // Margin x between inline fields, not displayed on mobile
 const fieldsMarginRight = [2, 3, 4];
 
-const ExpenseFormBody = ({ formik, payoutProfiles, collective, autoFocusTitle, onCancel, formPersister }) => {
+const ExpenseFormBody = ({
+  formik,
+  payoutProfiles,
+  collective,
+  autoFocusTitle,
+  onCancel,
+  formPersister,
+  expensesTags,
+}) => {
   const intl = useIntl();
   const { formatMessage } = intl;
   const { values, handleChange, errors, setValues, dirty } = formik;
@@ -231,6 +239,7 @@ const ExpenseFormBody = ({ formik, payoutProfiles, collective, autoFocusTitle, o
                     {i18nExpenseType(intl, values.type, values.legacyId)}
                   </StyledTag>
                   <StyledInputTags
+                    suggestedTags={expensesTags}
                     onChange={tags =>
                       formik.setFieldValue(
                         'tags',
@@ -484,6 +493,7 @@ ExpenseFormBody.propTypes = {
   autoFocusTitle: PropTypes.bool,
   onCancel: PropTypes.func,
   formPersister: PropTypes.object,
+  expensesTags: PropTypes.arrayOf(PropTypes.string),
   collective: PropTypes.shape({
     slug: PropTypes.string.isRequired,
     host: PropTypes.shape({
@@ -506,6 +516,7 @@ const ExpenseForm = ({
   onCancel,
   validateOnChange,
   formPersister,
+  expensesTags,
 }) => {
   const [hasValidate, setValidate] = React.useState(validateOnChange);
 
@@ -533,6 +544,7 @@ const ExpenseForm = ({
           autoFocusTitle={autoFocusTitle}
           onCancel={onCancel}
           formPersister={formPersister}
+          expensesTags={expensesTags}
         />
       )}
     </Formik>
@@ -546,6 +558,7 @@ ExpenseForm.propTypes = {
   onCancel: PropTypes.func,
   /** To save draft of form values */
   formPersister: PropTypes.object,
+  expensesTags: PropTypes.arrayOf(PropTypes.string),
   collective: PropTypes.shape({
     currency: PropTypes.string.isRequired,
     slug: PropTypes.string.isRequired,

--- a/components/expenses/graphql/fragments.js
+++ b/components/expenses/graphql/fragments.js
@@ -123,6 +123,11 @@ export const expensePageExpenseFieldsFragment = gqlV2`
       twitterHandle
       currency
       expensePolicy
+      expensesTags {
+        id
+        tag
+      }
+
       ... on Collective {
         id
         isApproved

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -104,6 +104,11 @@ interface Account {
   transferwise: TransferWise
 
   """
+  Returns expense tags for collective sorted by popularity
+  """
+  expensesTags(limit: Int = 30): [TagStat]
+
+  """
   The list of payout methods that this collective can use to get paid
   """
   payoutMethods: [PayoutMethod]
@@ -364,6 +369,11 @@ type Bot implements Account {
   transferwise: TransferWise
 
   """
+  Returns expense tags for collective sorted by popularity
+  """
+  expensesTags(limit: Int = 30): [TagStat]
+
+  """
   The list of payout methods that this collective can use to get paid
   """
   payoutMethods: [PayoutMethod]
@@ -487,6 +497,11 @@ type Collective implements Account {
   """
   conversationsTags(limit: Int = 30): [TagStat]
   transferwise: TransferWise
+
+  """
+  Returns expense tags for collective sorted by popularity
+  """
+  expensesTags(limit: Int = 30): [TagStat]
 
   """
   The list of payout methods that this collective can use to get paid
@@ -2155,6 +2170,11 @@ type Event implements Account {
   transferwise: TransferWise
 
   """
+  Returns expense tags for collective sorted by popularity
+  """
+  expensesTags(limit: Int = 30): [TagStat]
+
+  """
   The list of payout methods that this collective can use to get paid
   """
   payoutMethods: [PayoutMethod]
@@ -2728,6 +2748,11 @@ type Host implements Account {
   transferwise: TransferWise
 
   """
+  Returns expense tags for collective sorted by popularity
+  """
+  expensesTags(limit: Int = 30): [TagStat]
+
+  """
   The list of payout methods that this collective can use to get paid
   """
   payoutMethods: [PayoutMethod]
@@ -2910,6 +2935,11 @@ type Individual implements Account {
   """
   conversationsTags(limit: Int = 30): [TagStat]
   transferwise: TransferWise
+
+  """
+  Returns expense tags for collective sorted by popularity
+  """
+  expensesTags(limit: Int = 30): [TagStat]
 
   """
   The list of payout methods that this collective can use to get paid
@@ -3405,6 +3435,11 @@ type Organization implements Account {
   """
   conversationsTags(limit: Int = 30): [TagStat]
   transferwise: TransferWise
+
+  """
+  Returns expense tags for collective sorted by popularity
+  """
+  expensesTags(limit: Int = 30): [TagStat]
 
   """
   The list of payout methods that this collective can use to get paid

--- a/pages/create-expense.js
+++ b/pages/create-expense.js
@@ -69,6 +69,7 @@ class CreateExpensePage extends React.Component {
         type: PropTypes.string.isRequired,
         twitterHandle: PropTypes.string,
         imageUrl: PropTypes.string,
+        expensesTags: PropTypes.arrayOf(PropTypes.string),
       }),
       loggedInAccount: PropTypes.shape({
         adminMemberships: PropTypes.shape({
@@ -185,6 +186,11 @@ class CreateExpensePage extends React.Component {
     this.setState({ tags });
   };
 
+  getSuggestedTags(collective) {
+    const tagsStats = (collective && collective.expensesTags) || null;
+    return tagsStats && tagsStats.map(({ tag }) => tag);
+  }
+
   getPayoutProfiles = memoizeOne(loggedInAccount => {
     if (!loggedInAccount) {
       return [];
@@ -242,6 +248,7 @@ class CreateExpensePage extends React.Component {
                           loading={loadingLoggedInUser}
                           onSubmit={this.onFormSubmit}
                           expense={this.state.expense}
+                          expensesTags={this.getSuggestedTags(collective)}
                           payoutProfiles={this.getPayoutProfiles(loggedInAccount)}
                           formPersister={this.state.formPersister}
                           autoFocusTitle
@@ -335,6 +342,11 @@ const getData = graphql(
         twitterHandle
         currency
         expensePolicy
+        expensesTags {
+          id
+          tag
+        }
+
         ... on Collective {
           id
           isApproved

--- a/pages/expense.js
+++ b/pages/expense.js
@@ -109,6 +109,12 @@ class ExpensePage extends React.Component {
     mutate: PropTypes.func.isRequired,
     /** from injectIntl */
     intl: PropTypes.object,
+    expensesTags: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.string,
+        tag: PropTypes.string,
+      }),
+    ),
   };
 
   constructor(props) {
@@ -188,6 +194,11 @@ class ExpensePage extends React.Component {
     const variables = { collectiveSlug, legacyExpenseId };
     const data = cloneDeep(client.readQuery({ query, variables }));
     return [data, query, variables];
+  }
+
+  getSuggestedTags(collective) {
+    const tagsStats = (collective && collective.expensesTags) || null;
+    return tagsStats && tagsStats.map(({ tag }) => tag);
   }
 
   onCommentAdded = comment => {
@@ -369,6 +380,7 @@ class ExpensePage extends React.Component {
                   collective={collective}
                   loading={loadingLoggedInUser}
                   expense={editedExpense}
+                  expensesTags={this.getSuggestedTags(collective)}
                   payoutProfiles={this.getPayoutProfiles(loggedInAccount)}
                   onCancel={() => this.setState({ status: PAGE_STATUS.VIEW, editedExpense: null })}
                   validateOnChange


### PR DESCRIPTION
This adds support for expense tag suggestions for the frontend layer.

Resolve https://github.com/opencollective/opencollective/issues/3088

### Screenshots

<details>
  <summary>Expense Tags</summary>

![image](https://user-images.githubusercontent.com/12435965/80661412-76469300-8a43-11ea-98b0-0a448a013531.png)

![image](https://user-images.githubusercontent.com/12435965/80661438-89596300-8a43-11ea-94b8-aa95a77b6c7d.png)
</details>