### PR TITLE
Add E2e test for members invitations

### DIFF
--- a/components/ReplyToMemberInvitationCard.js
+++ b/components/ReplyToMemberInvitationCard.js
@@ -16,6 +16,7 @@ import StyledButton from './StyledButton';
 import StyledCard from './StyledCard';
 import StyledTag from './StyledTag';
 import { H3, P } from './Text';
+import { withUser } from './UserProvider';
 
 const rolesDetails = defineMessages({
   [roles.ADMIN]: {
@@ -64,16 +65,17 @@ const replyToInvitationMutation = gql`
  * A card with actions for users to accept or decline an invitation to join the members
  * of a collective.
  */
-const ReplyToMemberInvitationCard = ({ invitation, isSelected }) => {
+const ReplyToMemberInvitationCard = ({ invitation, isSelected, refetchLoggedInUser }) => {
   const { formatMessage } = useIntl();
   const [accepted, setAccepted] = React.useState();
   const [sendReplyToInvitation, { loading, error, data }] = useMutation(replyToInvitationMutation);
   const isDisabled = loading;
   const hasReplied = data && typeof data.replyToMemberInvitation !== 'undefined';
 
-  const buildReplyToInvitation = accept => () => {
+  const buildReplyToInvitation = accept => async () => {
     setAccepted(accept);
-    sendReplyToInvitation({ variables: { id: invitation.id, accept } });
+    await sendReplyToInvitation({ variables: { id: invitation.id, accept } });
+    await refetchLoggedInUser();
   };
 
   return (
@@ -83,6 +85,7 @@ const ReplyToMemberInvitationCard = ({ invitation, isSelected }) => {
       width="100%"
       maxWidth={400}
       borderColor={isSelected ? 'primary.300' : undefined}
+      data-cy="member-invitation-card"
     >
       <LinkCollective collective={invitation.collective}>
         <Flex flexDirection="column" alignItems="center">
@@ -118,6 +121,7 @@ const ReplyToMemberInvitationCard = ({ invitation, isSelected }) => {
               disabled={isDisabled}
               loading={loading && accepted === false}
               onClick={buildReplyToInvitation(false)}
+              data-cy="member-invitation-decline-btn"
             >
               {formatMessage(messages.decline)}
             </StyledButton>
@@ -128,6 +132,7 @@ const ReplyToMemberInvitationCard = ({ invitation, isSelected }) => {
               disabled={isDisabled}
               loading={loading && accepted === true}
               onClick={buildReplyToInvitation(true)}
+              data-cy="member-invitation-accept-btn"
             >
               {formatMessage(messages.accept)}
             </StyledButton>
@@ -147,6 +152,8 @@ ReplyToMemberInvitationCard.propTypes = {
       name: PropTypes.string,
     }),
   }),
+  /** @ignore form withUser */
+  refetchLoggedInUser: PropTypes.func,
 };
 
-export default ReplyToMemberInvitationCard;
+export default withUser(ReplyToMemberInvitationCard);

--- a/components/edit-collective/sections/Members.js
+++ b/components/edit-collective/sections/Members.js
@@ -221,7 +221,7 @@ class Members extends React.Component {
     const memberKey = member.id ? `member-${member.id}` : `collective-${collectiveId}`;
 
     return (
-      <Container key={`member-${index}-${memberKey}`} mt={4} pb={4} borderBottom={BORDER}>
+      <Container key={`member-${index}-${memberKey}`} mt={4} pb={4} borderBottom={BORDER} data-cy={`member-${index}`}>
         <ResetGlobalStyles>
           <Flex mt={2} flexWrap="wrap">
             <div className="col-sm-2" />
@@ -237,10 +237,11 @@ class Members extends React.Component {
                   isDisabled={Boolean(memberCollective)}
                   types={[CollectiveType.USER]}
                   filterResults={collectives => collectives.filter(c => !membersCollectiveIds.includes(c.id))}
+                  data-cy="member-collective-picker"
                 />
               </Box>
               {isInvitation && (
-                <Flex alignItems="center" my={1}>
+                <Flex alignItems="center" my={1} data-cy="member-pending-tag">
                   <StyledTooltip content={intl.formatMessage(this.messages.memberPendingDetails)}>
                     <StyledTag display="block" type="info">
                       <FormattedMessage id="Pending" defaultMessage="Pending" />
@@ -310,7 +311,7 @@ class Members extends React.Component {
             {members.map(this.renderMember)}
           </div>
           <Container textAlign="center" py={4} mb={4} borderBottom={BORDER}>
-            <StyledButton onClick={() => this.addMember()}>
+            <StyledButton onClick={() => this.addMember()} data-cy="add-member-btn">
               + {intl.formatMessage(this.messages.addMember)}
             </StyledButton>
           </Container>
@@ -332,6 +333,7 @@ class Members extends React.Component {
               disabled={(isSubmitted && !isTouched) || !isValid}
               mx={2}
               minWidth={200}
+              data-cy="save-members-btn"
             >
               {isSubmitted && !isTouched ? (
                 <FormattedMessage id="saved" defaultMessage="Saved" />


### PR DESCRIPTION
To implement https://github.com/opencollective/opencollective-frontend/pull/4084 I had to remove the test that covered the collective picker > "create new" path, which is a little sad because this path is note covered by other tests. I copied the code and extended it a bit to test the member edit/invite flow.