### PR TITLE
chore: allow collective admins delete rejected expenses

### DIFF
--- a/components/expenses/Expense.js
+++ b/components/expenses/Expense.js
@@ -258,7 +258,9 @@ class Expense extends React.Component {
         expense.status === 'ERROR' ||
         (expense.status === 'REJECTED' && Date.now() - new Date(expense.updatedAt).getTime() < 60 * 1000 * 15)); // we can approve an expense for up to 10mn after rejecting it
 
-    const canDelete = LoggedInUser && LoggedInUser.canPayExpense(expense) && expense.status === 'REJECTED';
+    const isCollectiveAdmin = LoggedInUser && LoggedInUser.canEditCollective(collective);
+    const canDelete =
+      LoggedInUser && expense.status === 'REJECTED' && (isCollectiveAdmin || LoggedInUser.isHostAdmin(collective));
 
     return (
       <div className={`expense ${status} ${this.state.mode}View`} data-cy={`expense-${status}`}>


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/2951

# Description

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

This PR allows collective admins delete rejected expenses.

# Screenshots

![Collective Admin Delete Expense](https://user-images.githubusercontent.com/24629960/76057722-55ccf180-5f48-11ea-8a2d-8438d38d1946.png)


<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
