### PR TITLE
Add Some Bottom Padding to Separate the Pledge Button

### DIFF
--- a/pages/search.js
+++ b/pages/search.js
@@ -156,7 +156,7 @@ class SearchPage extends React.Component {
 
           {showCollectives && collectives.length !== 0 && (
             <Flex py={3} width={1} justifyContent="center" flexDirection="column" alignItems="center">
-              <P pt={3} borderTop="1px solid #E6E6E6">
+              <P pt={3} pb={3} borderTop="1px solid #E6E6E6">
                 <em>
                   <FormattedMessage
                     id="search.ifYouDontSee"


### PR DESCRIPTION
This adds some bottom padding to the "If you don't see the collective you're looking for:" text.

Resolve https://github.com/opencollective/opencollective/issues/3103

# Screenshots

<details>
<summary>Desktop</summary>

![image](https://user-images.githubusercontent.com/12435965/80763791-2b388880-8af4-11ea-8d7f-d53f2117d065.png)
</details>

<details>
<summary>Mobile</summary>

![image](https://user-images.githubusercontent.com/12435965/80763912-6aff7000-8af4-11ea-81cb-5f3d602ce7a4.png)
</details>