### PR TITLE
fix(update): reduce max image size

### DIFF
--- a/components/collective-page/sections/Updates.js
+++ b/components/collective-page/sections/Updates.js
@@ -51,6 +51,12 @@ const PrivateUpdateMesgBox = styled(MessageBox)`
   align-items: center;
 `;
 
+const SummaryContent = styled(HTMLContent)`
+  img {
+    max-height: 250px;
+  }
+`;
+
 /**
  * Displays collective's updates.
  */
@@ -168,7 +174,7 @@ class SectionUpdates extends React.PureComponent {
                       </P>
                     </Link>
                     {update.userCanSeeUpdate ? (
-                      <HTMLContent content={update.summary} />
+                      <SummaryContent content={update.summary} />
                     ) : (
                       <PrivateUpdateMesgBox type="info" data-cy="mesgBox">
                         <FormattedMessage


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve [#2827](https://github.com/opencollective/opencollective/issues/2827)

# Description

added `max-height: 250px` for images.

<!--
  Provide a short summary of the changes as well as - if necessary - instructions on how this should be tested.
-->

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
