### PR TITLE
feat: display total recurring donations

### DIFF
--- a/components/DefinedTerm.js
+++ b/components/DefinedTerm.js
@@ -104,9 +104,16 @@ const UnderlinedTerm = styled.span`
  * Underlines the given word and show a tooltip with the definition when focused
  * or hovered. Both the term and the definition are translated.
  */
-const DefinedTerm = ({ intl, term, textTransform, fontSize, children, color }) => {
+const DefinedTerm = ({ intl, term, textTransform, fontSize, children, color, extraTooltipContent }) => {
   return (
-    <StyledTooltip content={() => intl.formatMessage(TranslatedDefinitions[term], TranslationParams[term])}>
+    <StyledTooltip
+      content={() => (
+        <React.Fragment>
+          {intl.formatMessage(TranslatedDefinitions[term], TranslationParams[term])}
+          {extraTooltipContent}
+        </React.Fragment>
+      )}
+    >
       {props => (
         <UnderlinedTerm {...props} textTransform={textTransform} color={color} borderColor={color} fontSize={fontSize}>
           {children || intl.formatMessage(TranslatedTerms[term])}
@@ -129,6 +136,8 @@ DefinedTerm.propTypes = {
   children: PropTypes.node,
   /** @ignore from injectIntl */
   intl: PropTypes.object.isRequired,
+  /** Extra content to include with term definition */
+  extraTooltipContent: PropTypes.node,
 };
 
 DefinedTerm.defaultProps = {

--- a/components/collective-page/graphql/queries.js
+++ b/components/collective-page/graphql/queries.js
@@ -9,7 +9,12 @@ import {
 import * as fragments from './fragments';
 
 export const getCollectivePageQuery = gql`
-  query getCollectivePageQuery($slug: String!, $nbContributorsPerContributeCard: Int) {
+  query getCollectivePageQuery(
+    $slug: String!
+    $nbContributorsPerContributeCard: Int
+    $startDateForTotalAmountReceived: DateString
+    $endDateForTotalAmountReceived: DateString
+  ) {
     Collective(slug: $slug, throwIfMissing: false) {
       id
       slug
@@ -43,6 +48,8 @@ export const getCollectivePageQuery = gql`
         balance
         yearlyBudget
         updates
+        activeRecurringContributions
+        totalAmountReceived(startDate: $startDateForTotalAmountReceived, endDate: $endDateForTotalAmountReceived)
         backers {
           id
           all

--- a/components/collective-page/sections/Budget.js
+++ b/components/collective-page/sections/Budget.js
@@ -47,6 +47,8 @@ const TransactionsAndExpensesQuery = gql`
  * abut the global budget of the collective.
  */
 const SectionBudget = ({ collective, stats }) => {
+  const monthlyRecurring =
+    (stats.activeRecurringContributions?.monthly || 0) + (stats.activeRecurringContributions?.yearly || 0) / 12;
   return (
     <ContainerSectionContent pt={[4, 5]} pb={3}>
       <SectionTitle>
@@ -143,7 +145,27 @@ const SectionBudget = ({ collective, stats }) => {
             </P>
           </Box>
           <Container data-cy="budgetSection-estimated-budget" flex="1" background="#F5F7FA" py={16} px={4}>
-            <DefinedTerm term={Terms.ESTIMATED_BUDGET} fontSize="Tiny" textTransform="uppercase" color="black.700" />
+            <DefinedTerm
+              term={Terms.ESTIMATED_BUDGET}
+              fontSize="Tiny"
+              textTransform="uppercase"
+              color="black.700"
+              extraTooltipContent={
+                <Box mt={2}>
+                  <FormattedMessage
+                    id="CollectivePage.SectionBudget.MonthlyRecurringAmount"
+                    defaultMessage="Monthly recurring: {amount}"
+                    values={{ amount: formatCurrency(monthlyRecurring, collective.currency) }}
+                  />
+                  <br />
+                  <FormattedMessage
+                    id="CollectivePage.SectionBudget.TotalAmountReceived"
+                    defaultMessage="Total received in the last 12 months: {amount}"
+                    values={{ amount: formatCurrency(stats?.totalAmountReceived || 0, collective.currency) }}
+                  />
+                </Box>
+              }
+            />
             <P fontSize="H5" mt={2}>
               <Span fontWeight="bold">~ {formatCurrency(stats.yearlyBudget, collective.currency)}</Span>{' '}
               <Span color="black.400">{collective.currency}</Span>
@@ -168,6 +190,8 @@ SectionBudget.propTypes = {
   stats: PropTypes.shape({
     balance: PropTypes.number.isRequired,
     yearlyBudget: PropTypes.number.isRequired,
+    activeRecurringContributions: PropTypes.object,
+    totalAmountReceived: PropTypes.number,
   }),
 
   /** @ignore from injectIntl */

--- a/lang/en.json
+++ b/lang/en.json
@@ -278,6 +278,8 @@
   "CollectivePage.SectionBudget.Annual.Definition": "Projected annual budget based on total financial contributions from the past 12 months.",
   "CollectivePage.SectionBudget.Balance": "Today’s balance",
   "CollectivePage.SectionBudget.Description": "See how money openly circulates through {collectiveName}. All contributions and all expenses are published in our transparent public ledger. Learn who is donating, how much, where is that money going, submit expenses, get reimbursed and more!",
+  "CollectivePage.SectionBudget.MonthlyRecurringAmount": "Monthly recurring: {amount}",
+  "CollectivePage.SectionBudget.TotalAmountReceived": "Total received in the last 12 months: {amount}",
   "CollectivePage.SectionBudget.ViewAll": "View all transactions",
   "CollectivePage.SectionBudget.ViewAllExpenses": "View all expenses",
   "CollectivePage.SectionContributions.Empty": "{collectiveName} seems to be hibernating in a cave in the North Pole ❄️☃️!",

--- a/lang/es.json
+++ b/lang/es.json
@@ -278,6 +278,8 @@
   "CollectivePage.SectionBudget.Annual.Definition": "Presupuesto anual proyectado basado en el total de contribuciones financieras de los últimos 12 meses.",
   "CollectivePage.SectionBudget.Balance": "Balance diario",
   "CollectivePage.SectionBudget.Description": "Vea cómo el dinero circula abiertamente a través de {collectiveName}. Todas las contribuciones y todos los gastos se publican en nuestro libro de contabilidad público transparente. ¡Aprenda quién está donando, cuánto dinero va a llegar, presentar gastos, reembolsar y mucho más!",
+  "CollectivePage.SectionBudget.MonthlyRecurringAmount": "Monthly recurring: {amount}",
+  "CollectivePage.SectionBudget.TotalAmountReceived": "Total received in the last 12 months: {amount}",
   "CollectivePage.SectionBudget.ViewAll": "Ver todas las transacciones",
   "CollectivePage.SectionBudget.ViewAllExpenses": "Ver todos los gastos",
   "CollectivePage.SectionContributions.Empty": "¡{collectiveName} parece estar hibernando en una cueva en el Polo Norte ❄️☃️!",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -278,6 +278,8 @@
   "CollectivePage.SectionBudget.Annual.Definition": "Budget annuel estimé à partir des contributions financières des 12 derniers mois.",
   "CollectivePage.SectionBudget.Balance": "Solde actuel",
   "CollectivePage.SectionBudget.Description": "Observez comment les fonds de {collectiveName} circulent librement. Tous les contributeurs et toutes les dépenses sont publiées sur notre registre transparent et ouvert. Voyez qui donne, combien, où part l'argent, ajoutez des dépenses, soyez remboursez et plus encore !",
+  "CollectivePage.SectionBudget.MonthlyRecurringAmount": "Monthly recurring: {amount}",
+  "CollectivePage.SectionBudget.TotalAmountReceived": "Total received in the last 12 months: {amount}",
   "CollectivePage.SectionBudget.ViewAll": "Voir toutes les transactions",
   "CollectivePage.SectionBudget.ViewAllExpenses": "Voir toutes les dépenses",
   "CollectivePage.SectionContributions.Empty": "{collectiveName} semble endormi·e dans une cave au pôle nord ❄️☃️ !",

--- a/lang/it.json
+++ b/lang/it.json
@@ -278,6 +278,8 @@
   "CollectivePage.SectionBudget.Annual.Definition": "Il bilancio annuale previsto si basa sul totale dei contributi finanziari degli ultimi 12 mesi.",
   "CollectivePage.SectionBudget.Balance": "Bilancio giornaliero",
   "CollectivePage.SectionBudget.Description": "Scopri come il denaro circola apertamente attraverso {collectiveName}. Tutti i contributi e tutte le spese sono pubblicati nel nostro registro pubblico trasparente. Scopri chi sta donando, quanto e dove vanno i soldi, invia le spese, ricevi i rimborsi e molto altro!",
+  "CollectivePage.SectionBudget.MonthlyRecurringAmount": "Monthly recurring: {amount}",
+  "CollectivePage.SectionBudget.TotalAmountReceived": "Total received in the last 12 months: {amount}",
   "CollectivePage.SectionBudget.ViewAll": "Vedi tutte le transazioni",
   "CollectivePage.SectionBudget.ViewAllExpenses": "Vedi tutte le spese",
   "CollectivePage.SectionContributions.Empty": "{collectiveName} sembra stia ibernando in una grotta nel Polo Nord <unk> flake:<unk> man!",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -278,6 +278,8 @@
   "CollectivePage.SectionBudget.Annual.Definition": "Projected annual budget based on total financial contributions from the past 12 months.",
   "CollectivePage.SectionBudget.Balance": "今日の残高",
   "CollectivePage.SectionBudget.Description": "See how money openly circulates through {collectiveName}. All contributions and all expenses are published in our transparent public ledger. Learn who is donating, how much, where is that money going, submit expenses, get reimbursed and more!",
+  "CollectivePage.SectionBudget.MonthlyRecurringAmount": "Monthly recurring: {amount}",
+  "CollectivePage.SectionBudget.TotalAmountReceived": "Total received in the last 12 months: {amount}",
   "CollectivePage.SectionBudget.ViewAll": "全ての取引を表示する",
   "CollectivePage.SectionBudget.ViewAllExpenses": "全ての経費申請を表示する",
   "CollectivePage.SectionContributions.Empty": "{collectiveName} seems to be hibernating in a cave in the North Pole ❄️☃️!",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -278,6 +278,8 @@
   "CollectivePage.SectionBudget.Annual.Definition": "Verwacht jaarlijks budget op basis van de totale financiële bijdragen van de afgelopen 12 maanden.",
   "CollectivePage.SectionBudget.Balance": "Vandaag's saldo",
   "CollectivePage.SectionBudget.Description": "Bekijk hoe geld openlijk circuleert doorheen {collectiveName}. Alle bijdragen en alle onkosten worden gepubliceerd in onze transparante publieke logboek. Ontdek wie er doneert, welk bedrag, waar gaat het geld naartoe, dien onkostennota's in, wordt vergoed en meer!",
+  "CollectivePage.SectionBudget.MonthlyRecurringAmount": "Monthly recurring: {amount}",
+  "CollectivePage.SectionBudget.TotalAmountReceived": "Total received in the last 12 months: {amount}",
   "CollectivePage.SectionBudget.ViewAll": "Bekijk alle transacties",
   "CollectivePage.SectionBudget.ViewAllExpenses": "Bekijk alle uitgaven",
   "CollectivePage.SectionContributions.Empty": "{collectiveName} lijkt een winterslaap te houden in een grot op de Noordpool ❄️☃️!",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -278,6 +278,8 @@
   "CollectivePage.SectionBudget.Annual.Definition": "Orçamento anual projetado com base no total de contribuições dos últimos 12 meses.",
   "CollectivePage.SectionBudget.Balance": "Balanço de hoje",
   "CollectivePage.SectionBudget.Description": "Veja como o dinheiro circula abertamente através de {collectiveName}. Todas as contribuições e todas as despesas são publicadas em nosso livro caixa transparente. Saiba quem está doando, quanto, para onde está indo esse dinheiro, envie despesas, seja reembolsado e muito mais!",
+  "CollectivePage.SectionBudget.MonthlyRecurringAmount": "Monthly recurring: {amount}",
+  "CollectivePage.SectionBudget.TotalAmountReceived": "Total received in the last 12 months: {amount}",
   "CollectivePage.SectionBudget.ViewAll": "Ver todas as transações",
   "CollectivePage.SectionBudget.ViewAllExpenses": "Ver todas as despesas",
   "CollectivePage.SectionContributions.Empty": "{collectiveName} aparentemente está hibernando em uma caverna no Pólo Norte ❄️☃️!",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -278,6 +278,8 @@
   "CollectivePage.SectionBudget.Annual.Definition": "Projected annual budget based on total financial contributions from the past 12 months.",
   "CollectivePage.SectionBudget.Balance": "Текущий баланс",
   "CollectivePage.SectionBudget.Description": "See how money openly circulates through {collectiveName}. All contributions and all expenses are published in our transparent public ledger. Learn who is donating, how much, where is that money going, submit expenses, get reimbursed and more!",
+  "CollectivePage.SectionBudget.MonthlyRecurringAmount": "Monthly recurring: {amount}",
+  "CollectivePage.SectionBudget.TotalAmountReceived": "Total received in the last 12 months: {amount}",
   "CollectivePage.SectionBudget.ViewAll": "Посмотреть все транзакции",
   "CollectivePage.SectionBudget.ViewAllExpenses": "Посмотреть все расходы",
   "CollectivePage.SectionContributions.Empty": "{collectiveName} кажется уснул в пещере на Северном полюсе❄️☃️!",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -278,6 +278,8 @@
   "CollectivePage.SectionBudget.Annual.Definition": "Projected annual budget based on total financial contributions from the past 12 months.",
   "CollectivePage.SectionBudget.Balance": "今日结余",
   "CollectivePage.SectionBudget.Description": "See how money openly circulates through {collectiveName}. All contributions and all expenses are published in our transparent public ledger. Learn who is donating, how much, where is that money going, submit expenses, get reimbursed and more!",
+  "CollectivePage.SectionBudget.MonthlyRecurringAmount": "Monthly recurring: {amount}",
+  "CollectivePage.SectionBudget.TotalAmountReceived": "Total received in the last 12 months: {amount}",
   "CollectivePage.SectionBudget.ViewAll": "浏览全部交易",
   "CollectivePage.SectionBudget.ViewAllExpenses": "View all expenses",
   "CollectivePage.SectionContributions.Empty": "{collectiveName} seems to be hibernating in a cave in the North Pole ❄️☃️!",

--- a/lib/date-utils.js
+++ b/lib/date-utils.js
@@ -30,3 +30,15 @@ export const toIsoDateStr = date => {
   const day = date.getUTCDate();
   return `${year}-${padStart(month.toString(), 2, '0')}-${padStart(day.toString(), 2, '0')}`;
 };
+
+/**
+ * For a given date, return the date 12 months before that date
+ * @param {Date} date
+ */
+export const date12MonthsAgo = date => {
+  const month = date.getUTCMonth();
+  const previousYear = date.getUTCFullYear() - 1;
+
+  const day = month === 2 ? Math.min(date.getUTCDate(), 28) : date.getUTCDate();
+  return new Date(previousYear, month, day);
+};

--- a/lib/graphql/schema.graphql
+++ b/lib/graphql/schema.graphql
@@ -704,10 +704,11 @@ type CollectiveStatsType {
   """
   Net amount received
   """
-  totalAmountReceived: Int
+  totalAmountReceived(startDate: DateString, endDate: DateString): Int
   yearlyBudget: Int
   topExpenses: JSON
   topFundingSources: JSON
+  activeRecurringContributions: JSON
 }
 
 """

--- a/pages/new-collective-page.js
+++ b/pages/new-collective-page.js
@@ -5,6 +5,7 @@ import { get } from 'lodash';
 import dynamic from 'next/dynamic';
 import { createGlobalStyle } from 'styled-components';
 
+import { date12MonthsAgo } from '../lib/date-utils';
 import { generateNotFoundError } from '../lib/errors';
 
 import CollectivePage from '../components/collective-page';
@@ -214,6 +215,8 @@ const getCollective = graphql(getCollectivePageQuery, {
     variables: {
       slug: props.slug,
       nbContributorsPerContributeCard: MAX_CONTRIBUTORS_PER_CONTRIBUTE_CARD,
+      endDateForTotalAmountReceived: new Date().toUTCString(),
+      startDateForTotalAmountReceived: date12MonthsAgo(new Date()).toUTCString(),
     },
   }),
 });


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolves https://github.com/opencollective/opencollective/issues/1585

# Description

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->
This PR adds a monthly recurring and total received to the estimated annual budget tooltip

# Screenshots

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
![estimate tooltip](https://user-images.githubusercontent.com/24629960/81014331-a9659980-8e2a-11ea-9c4c-b90673015a08.png)


* when no monthly recurring
![estimated tooltip when no monthly recurring](https://user-images.githubusercontent.com/24629960/81014392-c4380e00-8e2a-11ea-83d7-dccc32f588e6.png)

