### PR TITLE
Fix New Expense tag UX

### DIFF
--- a/components/StyledInputTags.js
+++ b/components/StyledInputTags.js
@@ -240,19 +240,20 @@ const StyledInputTags = ({ suggestedTags, value, onChange, renderUpdatedTags, de
                             </AddTagButton>
                           </TagWrapper>
                         ))}
-                      {tags.map(tag => (
-                        <TagWrapper key={tag.value} px="16px" py="8px" autoFocus>
-                          <StyledTag variant="rounded-right">{tag.label}</StyledTag>
-                          <DeleteTagButton
-                            data-cy={`styled-input-tags-remove-${tag.value}`}
-                            onClick={() => {
-                              removeTag(tag.value);
-                            }}
-                          >
-                            <Times size="10px" />
-                          </DeleteTagButton>
-                        </TagWrapper>
-                      ))}
+                      {!renderUpdatedTags &&
+                        tags.map(tag => (
+                          <TagWrapper key={tag.value} px="16px" py="8px" autoFocus>
+                            <StyledTag variant="rounded-right">{tag.label}</StyledTag>
+                            <DeleteTagButton
+                              data-cy={`styled-input-tags-remove-${tag.value}`}
+                              onClick={() => {
+                                removeTag(tag.value);
+                              }}
+                            >
+                              <Times size="10px" />
+                            </DeleteTagButton>
+                          </TagWrapper>
+                        ))}
                     </Box>
                   )}
                 </StyledCard>

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -242,6 +242,7 @@ const ExpenseFormBody = ({
                     {i18nExpenseType(intl, values.type, values.legacyId)}
                   </StyledTag>
                   <StyledInputTags
+                    renderUpdatedTags
                     suggestedTags={expensesTags}
                     onChange={tags =>
                       formik.setFieldValue(


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/3057

Feedback:
> When adding tags, you get no visual feedback after pressing +. At first I thought it didn't work, but then I click off and the new tags were there. They should appear as you click them.

Actually there is. The tags are added to the dropdown and when you're finished with editing they'll appear as tags in the expense.
I've enabled the variant that updates existing tags live and this should fix it.
I also removed existing tags from the dropdown when we're editing tags live, it looks redundant.

Preview:
![Screen Recording 2020-05-06 at 16 30 49 mov](https://user-images.githubusercontent.com/2119706/81220697-21ad9580-8fb8-11ea-8cc7-b2a2fb76bf0f.gif)

