### PR TITLE
Optimization: only load admin collectives

### DIFF
--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -126,7 +126,7 @@ export const getLoggedInUserQuery = gql`
           service
         }
       }
-      memberOf {
+      memberOf(roles: ["ADMIN"]) {
         id
         role
         collective {


### PR DESCRIPTION
This should help load (and compute) less data in the loggedInUser query.