### PR TITLE
ExpenseSummary: Support for null payout methods

### DIFF
--- a/components/expenses/ExpenseSummary.js
+++ b/components/expenses/ExpenseSummary.js
@@ -229,7 +229,7 @@ const ExpenseSummary = ({ expense, collective, host, isLoading, permissions, sho
             </PrivateInfoColumnHeader>
             <Container fontSize="Caption" color="black.600">
               <Box mb={3} data-cy="expense-summary-payout-method-type">
-                <PayoutMethodTypeWithIcon type={expense.payoutMethod.type} />
+                <PayoutMethodTypeWithIcon type={expense.payoutMethod?.type} />
               </Box>
               <div data-cy="expense-summary-payout-method-data">
                 <PayoutMethodData payoutMethod={expense.payoutMethod} />


### PR DESCRIPTION
Fix viewing old expenses with `null` payout method