### PR TITLE
ContributionFlow/Cover: Use Avatar component

### DIFF
--- a/components/contribution-flow/Cover.js
+++ b/components/contribution-flow/Cover.js
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
+import Avatar from '../Avatar';
 import Container from '../Container';
 import { Flex } from '../Grid';
 import LinkCollective from '../LinkCollective';
-import Logo from '../Logo';
 import { H2, P } from '../Text';
 
 /**
@@ -16,7 +16,9 @@ const Cover = ({ collective, tier }) => {
     <Container pt={[4, 48]} mb={28}>
       <Flex alignItems="center" flexDirection="column" mx="auto" width="100%" maxWidth={320}>
         <LinkCollective collective={collective}>
-          <Logo collective={collective} className="logo" height="10rem" style={{ margin: '0 auto' }} />
+          <Flex justifyContent="center">
+            <Avatar collective={collective} radius="10rem" />
+          </Flex>
           <H2 as="h1" color="black.900" textAlign="center">
             {collective.name}
           </H2>


### PR DESCRIPTION
I ended up on this error while working on https://github.com/opencollective/opencollective-frontend/pull/4198. Switched the component to `Avatar` and used Flex to center the image.

![image](https://user-images.githubusercontent.com/1556356/81912833-6bf1d080-95cf-11ea-9e45-3a194e6c5589.png)
