### PR TITLE
Expense: Remove transferwise-available-currencies

### DIFF
--- a/components/expenses/graphql/fragments.js
+++ b/components/expenses/graphql/fragments.js
@@ -60,9 +60,6 @@ const HostFieldsFragment = gqlV2`
       transferwisePayouts
       transferwisePayoutsLimit
     }
-    transferwise {
-      availableCurrencies
-    }
   }
 `;
 


### PR DESCRIPTION
As suggested by @kewitz, this field doesn't seems to be required here