### PR TITLE
Revert "Expense: Remove transferwise-available-currencies"

### DIFF
--- a/components/expenses/graphql/fragments.js
+++ b/components/expenses/graphql/fragments.js
@@ -60,6 +60,9 @@ const HostFieldsFragment = gqlV2`
       transferwisePayouts
       transferwisePayoutsLimit
     }
+    transferwise {
+      availableCurrencies
+    }
   }
 `;
 


### PR DESCRIPTION
Reverts opencollective/opencollective-frontend#4202
Regression towards https://github.com/opencollective/opencollective-frontend/commit/9c9f5200f791ba0b864863640c9136637d18ca3f#diff-1aec823a3eea65cd9d2fe92a5dc5ebd5
Also, the costs for this is not that high since we're caching that information in the backend.