### PR TITLE
ExpenseFlow: Add more validations on payee location

### DIFF
--- a/components/StyledSelect.js
+++ b/components/StyledSelect.js
@@ -176,6 +176,8 @@ StyledSelect.propTypes = {
   hideDropdownIndicator: PropTypes.bool,
   /** If true, options list will not be displayed */
   hideMenu: PropTypes.bool,
+  /** Displayes a red border when truthy */
+  error: PropTypes.any,
   /** @ignore from injectIntl */
   intl: PropTypes.object,
   /** Default option */

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -153,6 +153,10 @@ const validate = expense => {
     }
   }
 
+  if (expense.type === expenseTypes.INVOICE) {
+    Object.assign(errors, requireFields(expense, ['payeeLocation.country', 'payeeLocation.address']));
+  }
+
   return errors;
 };
 
@@ -328,16 +332,18 @@ const ExpenseFormBody = ({
                               <StyledInputField
                                 name={field.name}
                                 label={formatMessage(msg.country)}
+                                error={formatFormErrorMessage(intl, errors.payeeLocation?.country)}
                                 required
                                 minWidth={250}
                                 mr={fieldsMarginRight}
                                 mt={3}
                               >
-                                {({ id }) => (
+                                {({ id, error }) => (
                                   <InputTypeCountry
                                     inputId={id}
                                     onChange={value => formik.setFieldValue(field.name, value)}
                                     value={field.value}
+                                    error={error}
                                   />
                                 )}
                               </StyledInputField>
@@ -348,6 +354,7 @@ const ExpenseFormBody = ({
                               <StyledInputField
                                 name={field.name}
                                 label={formatMessage(msg.address)}
+                                error={formatFormErrorMessage(intl, errors.payeeLocation?.address)}
                                 required
                                 minWidth={250}
                                 mr={fieldsMarginRight}

--- a/lib/form-utils.js
+++ b/lib/form-utils.js
@@ -1,6 +1,18 @@
-import { get } from 'lodash';
+import { get, set } from 'lodash';
 
 import { createError, ERROR, formatErrorMessage } from './errors';
+
+const isEmpty = value => {
+  if (!value) {
+    return true;
+  } else if (Array.isArray(value) && value.length === 0) {
+    return true;
+  } else if (typeof value === 'string' && !value.trim()) {
+    return true;
+  } else {
+    return false;
+  }
+};
 
 /**
  * Will return an object of errors for all fields defined in `requiredFields`
@@ -11,8 +23,8 @@ export const requireFields = (data, requiredFields, { stopOnFirstError = false }
 
   for (const field of requiredFields) {
     const value = get(data, field);
-    if (!value || (Array.isArray(value) && value.length === 0)) {
-      errors[field] = createError(ERROR.FORM_FIELD_REQUIRED);
+    if (isEmpty(value)) {
+      set(errors, field, createError(ERROR.FORM_FIELD_REQUIRED));
       if (stopOnFirstError) {
         return errors;
       }


### PR DESCRIPTION
This adds additional validations on payee's location, making sure that it's impossible to submit if address is an empty string. Also adds JS validations, so this will work even if native validations are disabled.