### PR TITLE
Omit platformFees when using feesOnTop

### DIFF
--- a/components/collective-page/graphql/queries.js
+++ b/components/collective-page/graphql/queries.js
@@ -34,6 +34,7 @@ export const getCollectivePageQuery = gql`
       isHost
       isIncognito
       hostFeePercent
+      platformFeePercent
       image
       imageUrl(height: 256)
       canApply

--- a/components/collective-page/sections/Budget.js
+++ b/components/collective-page/sections/Budget.js
@@ -49,6 +49,7 @@ const TransactionsAndExpensesQuery = gql`
 const SectionBudget = ({ collective, stats }) => {
   const monthlyRecurring =
     (stats.activeRecurringContributions?.monthly || 0) + (stats.activeRecurringContributions?.yearly || 0) / 12;
+  const isFeesOnTop = collective.platformFeePercent === 0 && get(collective, 'host.settings.feesOnTop');
   return (
     <ContainerSectionContent pt={[4, 5]} pb={3}>
       <SectionTitle>
@@ -84,7 +85,7 @@ const SectionBudget = ({ collective, stats }) => {
             const budgetItems = orderBy(budgetItemsUnsorted, i => new Date(i.createdAt), ['desc']).slice(0, 3);
             return (
               <Container flex="10" mb={3} width="100%" maxWidth={800}>
-                <BudgetItemsList items={budgetItems} isCompact />
+                <BudgetItemsList items={budgetItems} isCompact isFeesOnTop={isFeesOnTop} />
                 <Flex flexWrap="wrap" justifyContent="space-between" mt={3}>
                   <Box flex="1 1" mx={[0, 2]}>
                     <Link route="transactions" params={{ collectiveSlug: collective.slug }}>
@@ -184,6 +185,7 @@ SectionBudget.propTypes = {
     name: PropTypes.string.isRequired,
     currency: PropTypes.string.isRequired,
     isArchived: PropTypes.bool,
+    platformFeePercent: PropTypes.number,
   }),
 
   /** Stats */

--- a/components/collective-page/sections/Transactions.js
+++ b/components/collective-page/sections/Transactions.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from '@apollo/react-hoc';
 import gql from 'graphql-tag';
-import { orderBy } from 'lodash';
+import { get, orderBy } from 'lodash';
 import memoizeOne from 'memoize-one';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 
@@ -47,6 +47,7 @@ class SectionTransactions extends React.Component {
       name: PropTypes.string.isRequired,
       slug: PropTypes.string.isRequired,
       currency: PropTypes.string.isRequired,
+      platformFeePercent: PropTypes.number,
     }).isRequired,
 
     /** Wether user is admin of `collective` */
@@ -137,6 +138,7 @@ class SectionTransactions extends React.Component {
     const { data, intl, collective, isAdmin, isRoot } = this.props;
     const { filter } = this.state;
     let showFilters = true;
+    const isFeesOnTop = collective.platformFeePercent === 0 && get(collective, 'host.settings.feesOnTop');
 
     if (!data || data.loading) {
       return <LoadingPlaceholder height={600} borderRadius={0} />;
@@ -181,7 +183,12 @@ class SectionTransactions extends React.Component {
         )}
 
         <ContainerSectionContent>
-          <BudgetItemsList items={budgetItems} canDownloadInvoice={isAdmin || isRoot} isInverted />
+          <BudgetItemsList
+            items={budgetItems}
+            canDownloadInvoice={isAdmin || isRoot}
+            isInverted
+            isFeesOnTop={isFeesOnTop}
+          />
           <Link route="transactions" params={{ collectiveSlug: collective.slug }}>
             <StyledButton mt={3} width="100%" buttonSize="small" fontSize="Paragraph">
               <FormattedMessage id="transactions.viewAll" defaultMessage="View All Transactions" /> →

--- a/components/expenses/Transaction.js
+++ b/components/expenses/Transaction.js
@@ -59,11 +59,13 @@ class Transaction extends React.Component {
       type: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
       slug: PropTypes.string,
+      platformFeePercent: PropTypes.number,
     }),
     subscription: PropTypes.shape({
       interval: PropTypes.oneOf(['month', 'year']),
     }),
     type: PropTypes.oneOf(['CREDIT', 'DEBIT']),
+    isFeesOnTop: PropTypes.bool, // whether or not this transaction refers to a refund
     isRefund: PropTypes.bool, // whether or not this transaction refers to a refund
     /** Choose between date (eg. 2018/12/09) or interval (eg. two months ago) */
     dateDisplayType: PropTypes.oneOf(['date', 'interval']),
@@ -126,6 +128,8 @@ class Transaction extends React.Component {
       paymentProcessorFeeInHostCurrency,
       dateDisplayType,
       expense,
+      isFeesOnTop,
+      platformFeeInHostCurrency,
     } = this.props;
 
     if (!fromCollective) {
@@ -133,7 +137,10 @@ class Transaction extends React.Component {
       return <div />;
     }
 
-    const amountToDisplay = ['ORGANIZATION', 'USER'].includes(collective.type) ? netAmountInCollectiveCurrency : amount;
+    let amountToDisplay = isFeesOnTop ? amount + platformFeeInHostCurrency : amount;
+    if (['ORGANIZATION', 'USER'].includes(collective.type)) {
+      amountToDisplay = netAmountInCollectiveCurrency;
+    }
 
     return (
       <Flex my={4}>

--- a/components/expenses/TransactionDetails.js
+++ b/components/expenses/TransactionDetails.js
@@ -47,6 +47,7 @@ class TransactionDetails extends React.Component {
     }),
     type: PropTypes.oneOf(['CREDIT', 'DEBIT']),
     isRefund: PropTypes.bool, // whether or not this transaction refers to a refund
+    isFeesOnTop: PropTypes.bool, // whether or not this transaction refers to a refund
     intl: PropTypes.object.isRequired,
     mode: PropTypes.string, // open or closed
     fromCollective: PropTypes.object,
@@ -110,10 +111,14 @@ class TransactionDetails extends React.Component {
       currency,
       hostCurrency,
       hostCurrencyFxRate,
+      isFeesOnTop,
+      platformFeeInHostCurrency,
     } = this.props;
 
-    const initialAmount = ['ORGANIZATION', 'USER'].includes(collective.type) ? -netAmountInCollectiveCurrency : amount;
-    let totalAmount = initialAmount;
+    const initialAmount = isFeesOnTop ? amount + platformFeeInHostCurrency : amount;
+    let totalAmount = ['ORGANIZATION', 'USER'].includes(collective.type)
+      ? -netAmountInCollectiveCurrency
+      : initialAmount;
     const amountDetails = [
       intl.formatNumber(initialAmount / 100, {
         currency: currency,
@@ -121,8 +126,8 @@ class TransactionDetails extends React.Component {
       }),
     ];
     if (hostCurrencyFxRate && hostCurrencyFxRate !== 1) {
-      const amountInHostCurrency = amount * hostCurrencyFxRate;
-      totalAmount = amount;
+      const amountInHostCurrency = initialAmount * hostCurrencyFxRate;
+      totalAmount = initialAmount;
       amountDetails.push(
         ` (${intl.formatNumber(amountInHostCurrency / 100, {
           currency: hostCurrency,
@@ -147,7 +152,11 @@ class TransactionDetails extends React.Component {
       });
     };
 
-    addFees(['taxAmount', 'hostFeeInHostCurrency', 'platformFeeInHostCurrency', 'paymentProcessorFeeInHostCurrency']);
+    addFees(
+      isFeesOnTop
+        ? ['taxAmount', 'hostFeeInHostCurrency', 'paymentProcessorFeeInHostCurrency']
+        : ['taxAmount', 'hostFeeInHostCurrency', 'platformFeeInHostCurrency', 'paymentProcessorFeeInHostCurrency'],
+    );
 
     let amountDetailsStr = amountDetails.length > 1 ? amountDetails.join(' ') : '';
 

--- a/components/expenses/Transactions.js
+++ b/components/expenses/Transactions.js
@@ -76,6 +76,8 @@ class Transactions extends React.Component {
     const isRoot = LoggedInUser && LoggedInUser.isRoot();
     const isHostAdmin = LoggedInUser && LoggedInUser.isHostAdmin(collective);
     const isCollectiveAdmin = LoggedInUser && LoggedInUser.canEditCollective(collective);
+    const isFeesOnTop = collective.platformFeePercent === 0 && collective.host?.settings?.feesOnTop;
+
     return (
       <div className="Transactions">
         <style jsx>
@@ -185,6 +187,7 @@ class Transactions extends React.Component {
               <Transaction
                 collective={collective}
                 {...transaction}
+                isFeesOnTop={isFeesOnTop}
                 isRefund={Boolean(transaction.refundTransaction)}
                 canRefund={this.canRefund(isRoot, isHostAdmin, isCollectiveAdmin)}
                 canDownloadInvoice={this.canDownloadInvoice(transaction, isRoot, isCollectiveAdmin)}

--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -646,6 +646,7 @@ const getCollectiveCoverQuery = gql`
       imageUrl
       isIncognito
       backgroundImage
+      platformFeePercent
       isHost
       isActive
       isArchived

--- a/lib/graphql/schema.graphql
+++ b/lib/graphql/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:3060/graphql
-# timestamp: Mon May 04 2020 16:05:00 GMT+0200 (GMT+02:00)
+# timestamp: Fri May 15 2020 15:52:28 GMT+0000 (Coordinated Universal Time)
 
 """
 Application model

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:3060/graphql/v2
-# timestamp: Wed May 06 2020 16:30:04 GMT+0200 (GMT+02:00)
+# timestamp: Fri May 15 2020 15:52:42 GMT+0000 (Coordinated Universal Time)
 
 """
 Account interface shared by all kind of accounts (Bot, Collective, Event, User, Organization)
@@ -2322,7 +2322,7 @@ type Expense {
   tags: [String]!
 
   """
-  Returns the list of legal documents required from the payee before the expense can be payed
+  Returns the list of legal documents required from the payee before the expense can be payed. Must be logged in.
   """
   requiredLegalDocuments: [LegalDocumentType]
 }


### PR DESCRIPTION
This is a patch to omit fees and fix the donation order value when the platform fee was charged as fees on top.
There's the right way to solve this and it involves separating the transactions.
As soon as we validate fees on top and decide to go that way, we should refactor the implementation and revert this commit.