### PR TITLE
Add missing platform fee in budget section

### DIFF
--- a/components/BudgetItemsList.js
+++ b/components/BudgetItemsList.js
@@ -225,7 +225,7 @@ const DetailDescription = styled.p`
 `;
 
 const getItemInfo = (item, isInverted, isFeesOnTop) => {
-  const platformFee = isFeesOnTop ? undefined : item.transaction?.platformFeeInHostCurrency;
+  const platformFee = isFeesOnTop ? undefined : item.platformFeeInHostCurrency;
   switch (item.__typename) {
     case 'ExpenseType':
       return {


### PR DESCRIPTION
This bug was introduced in the patch I wrote for removing the platform fees when dealing with a fees-on-top case.