### PR TITLE
ExpenseSummary: Show item file for INVOICE

### DIFF
--- a/components/expenses/ExpenseSummary.js
+++ b/components/expenses/ExpenseSummary.js
@@ -134,7 +134,7 @@ const ExpenseSummary = ({ expense, collective, host, isLoading, permissions, sho
             <React.Fragment key={attachment.id}>
               <Flex justifyContent="space-between" alignItems="center" my={24}>
                 <Flex>
-                  {isReceipt && (
+                  {(isReceipt || attachment.url) && (
                     <Box mr={3}>
                       <UploadedFilePreview
                         url={attachment.url}


### PR DESCRIPTION
Addresses an issue mentioned in https://github.com/opencollective/opencollective/issues/3145#issuecomment-633434665 that made legacy expense items appear without files.