### PR TITLE
ExpenseSummary: improve loading and unauthenticated states

### DIFF
--- a/components/LocationAddress.js
+++ b/components/LocationAddress.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import LoadingPlaceholder from './LoadingPlaceholder';
+
+/**
+ * Displays a location object
+ */
+const LocationAddress = ({ location, isLoading }) => {
+  if (isLoading) {
+    return (
+      <div>
+        <LoadingPlaceholder height="1em" mb="0.5em" />
+        <LoadingPlaceholder height="1em" mb="0.5em" />
+        <LoadingPlaceholder height="1em" />
+      </div>
+    );
+  } else if (!location) {
+    return null;
+  }
+
+  return (
+    <React.Fragment>
+      {location.address}
+      {location.address && location.country && <br />}
+      {location.country}
+    </React.Fragment>
+  );
+};
+
+LocationAddress.propTypes = {
+  location: PropTypes.shape({
+    address: PropTypes.string,
+    country: PropTypes.string,
+  }),
+  isLoading: PropTypes.bool,
+};
+
+export default LocationAddress;

--- a/components/expenses/ExpenseSummary.js
+++ b/components/expenses/ExpenseSummary.js
@@ -237,7 +237,7 @@ const ExpenseSummary = ({
                 <PayoutMethodTypeWithIcon type={expense.payoutMethod?.type} />
               </Box>
               <div data-cy="expense-summary-payout-method-data">
-                <PayoutMethodData payoutMethod={expense.payoutMethod} isLoading={isLoadingLoggedInUser} />
+                <PayoutMethodData payoutMethod={expense.payoutMethod} isLoading={isLoading || isLoadingLoggedInUser} />
               </div>
               {expense.invoiceInfo && (
                 <Box mt={3} data-cy="expense-summary-invoice-info">

--- a/components/expenses/ExpenseSummary.js
+++ b/components/expenses/ExpenseSummary.js
@@ -14,6 +14,7 @@ import { Box, Flex } from '../Grid';
 import PrivateInfoIcon from '../icons/PrivateInfoIcon';
 import LinkCollective from '../LinkCollective';
 import LoadingPlaceholder from '../LoadingPlaceholder';
+import LocationAddress from '../LocationAddress';
 import StyledCard from '../StyledCard';
 import StyledHr from '../StyledHr';
 import StyledLink from '../StyledLink';
@@ -63,7 +64,15 @@ const PrivateInfoColumnHeader = styled(H4).attrs({
  * Last step of the create expense flow, shows the summary of the expense with
  * the ability to submit it.
  */
-const ExpenseSummary = ({ expense, collective, host, isLoading, permissions, showProcessActions }) => {
+const ExpenseSummary = ({
+  expense,
+  collective,
+  host,
+  isLoading,
+  isLoadingLoggedInUser,
+  permissions,
+  showProcessActions,
+}) => {
   const { payee, createdByAccount, payeeLocation } = expense || {};
   const isReceipt = expense?.type === expenseTypes.RECEIPT;
   const existsInAPI = expense && (expense.id || expense.legacyId);
@@ -138,7 +147,7 @@ const ExpenseSummary = ({ expense, collective, host, isLoading, permissions, sho
                     <Box mr={3}>
                       <UploadedFilePreview
                         url={attachment.url}
-                        isLoading={isLoading}
+                        isLoading={isLoading || isLoadingLoggedInUser}
                         isPrivate={!attachment.url && !isLoading}
                         size={48}
                       />
@@ -208,13 +217,9 @@ const ExpenseSummary = ({ expense, collective, host, isLoading, permissions, sho
                 </Span>
               </Flex>
             </LinkCollective>
-            {payeeLocation && (
-              <P whiteSpace="pre-wrap" fontSize="11px" lineHeight="16px" mt={2}>
-                {payeeLocation.address}
-                {payeeLocation.address && payeeLocation.country && <br />}
-                {payeeLocation.country}
-              </P>
-            )}
+            <P whiteSpace="pre-wrap" fontSize="11px" lineHeight="16px" mt={2}>
+              <LocationAddress location={payeeLocation} isLoading={isLoading || isLoadingLoggedInUser} />
+            </P>
             {payee.website && (
               <P mt={2} fontSize="11px">
                 <StyledLink href={payee.website} openInNewTab>
@@ -232,7 +237,7 @@ const ExpenseSummary = ({ expense, collective, host, isLoading, permissions, sho
                 <PayoutMethodTypeWithIcon type={expense.payoutMethod?.type} />
               </Box>
               <div data-cy="expense-summary-payout-method-data">
-                <PayoutMethodData payoutMethod={expense.payoutMethod} />
+                <PayoutMethodData payoutMethod={expense.payoutMethod} isLoading={isLoadingLoggedInUser} />
               </div>
               {expense.invoiceInfo && (
                 <Box mt={3} data-cy="expense-summary-invoice-info">

--- a/components/expenses/PayoutMethodData.js
+++ b/components/expenses/PayoutMethodData.js
@@ -7,6 +7,7 @@ import { PayoutMethodType } from '../../lib/constants/payout-method';
 
 import Container from '../Container';
 import PrivateInfoIcon from '../icons/PrivateInfoIcon';
+import LoadingPlaceholder from '../LoadingPlaceholder';
 import { P } from '../Text';
 
 const renderObject = object =>
@@ -38,11 +39,23 @@ export const payoutMethodHasData = payoutMethod => {
   }
 };
 
+const PRIVATE_DATA_PLACEHOLER = '********';
+
+const getPmData = (payoutMethod, field, isLoading) => {
+  if (isLoading) {
+    return <LoadingPlaceholder height={15} />;
+  } else {
+    return get(payoutMethod, `data.${field}`, PRIVATE_DATA_PLACEHOLER);
+  }
+};
+
 /**
  * Shows the data of the given payout method
  */
-const PayoutMethodData = ({ payoutMethod, showLabel }) => {
-  if (!payoutMethodHasData(payoutMethod)) {
+const PayoutMethodData = ({ payoutMethod, showLabel, isLoading }) => {
+  if (isLoading && !payoutMethod) {
+    return <LoadingPlaceholder height={24} mb={2} />;
+  } else if (!payoutMethod) {
     return null;
   }
 
@@ -58,7 +71,7 @@ const PayoutMethodData = ({ payoutMethod, showLabel }) => {
             </Container>
           )}
           <Container fontSize="11px" color="black.700">
-            {payoutMethod.data.email}
+            {getPmData(payoutMethod, 'email', isLoading)}
           </Container>
         </div>
       );
@@ -73,7 +86,7 @@ const PayoutMethodData = ({ payoutMethod, showLabel }) => {
             </Container>
           )}
           <Container fontSize="11px" color="black.700">
-            {payoutMethod.data.content}
+            {getPmData(payoutMethod, 'content', isLoading)}
           </Container>
         </div>
       );
@@ -87,14 +100,20 @@ const PayoutMethodData = ({ payoutMethod, showLabel }) => {
               <PrivateInfoIcon color="#969BA3" />
             </Container>
           )}
-          <Container fontSize="11px" color="black.700">
-            <FormattedMessage
-              id="BankInfo.Type"
-              defaultMessage="Type: {type}"
-              values={{ type: upperCase(payoutMethod.data.type) }}
-            />
-            {renderObject(payoutMethod.data.details)}
-          </Container>
+          {payoutMethod.data ? (
+            <Container fontSize="11px" color="black.700">
+              <FormattedMessage
+                id="BankInfo.Type"
+                defaultMessage="Type: {type}"
+                values={{ type: upperCase(payoutMethod.data.type) }}
+              />
+              {renderObject(payoutMethod.data.details)}
+            </Container>
+          ) : isLoading ? (
+            <LoadingPlaceholder height="1.5em" />
+          ) : (
+            PRIVATE_DATA_PLACEHOLER
+          )}
         </div>
       );
     default:
@@ -105,6 +124,7 @@ const PayoutMethodData = ({ payoutMethod, showLabel }) => {
 PayoutMethodData.propTypes = {
   /** If false, only the raw data will be displayed */
   showLabel: PropTypes.bool,
+  isLoading: PropTypes.bool,
   payoutMethod: PropTypes.shape({
     id: PropTypes.string,
     type: PropTypes.oneOf(Object.values(PayoutMethodType)),


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/3094

This PR changes the way we handle missing data in the summary to better cover unauthenticated and loading states. Here are the changes:

### Loading

Address and payout method data will now show a loading placeholder while loading or refetching the data (when user gets logged in) instead of the blank space.

![Peek 26-05-2020 12-58](https://user-images.githubusercontent.com/1556356/82892974-a86ae800-9f50-11ea-8a46-b147ba6e38da.gif)

### Unauthenticated

Rather than not displaying anything, we now display asterisks (`********`) for private data. The tooltip should make things explicit enough.

![Peek 26-05-2020 13-00](https://user-images.githubusercontent.com/1556356/82893217-f54ebe80-9f50-11ea-8266-d48664440f4f.gif)
