### PR TITLE
Expense: Increase number of comments fetched

### DIFF
--- a/components/expenses/graphql/fragments.js
+++ b/components/expenses/graphql/fragments.js
@@ -159,7 +159,7 @@ export const expensePageExpenseFieldsFragment = gqlV2`
       type
       data
     }
-    comments {
+    comments(limit: 300) {
       nodes {
         ...CommentFields
       }


### PR DESCRIPTION
Resolve https://opencollective.freshdesk.com/a/tickets/7014 and https://opencollective.freshdesk.com/a/tickets/7005

`CollectionArgs` has a default `limit` set to 10. This increases this limit to 300, which should be way enough - the most commented expense currently in the database has 41 comments.