### PR TITLE
fix Admin can see Updates section when Updates is disabled

### DIFF
--- a/components/CollectiveNavbar.js
+++ b/components/CollectiveNavbar.js
@@ -285,6 +285,10 @@ export const getSectionsForCollective = (collective, isAdmin) => {
     toRemove.add(Sections.CONVERSATIONS);
   }
 
+  if (!hasFeature(collective, FEATURES.UPDATES)) {
+    toRemove.add(Sections.UPDATES);
+  }
+
   // Some sections are hidden for non-admins (usually when there's no data)
   if (!isAdmin) {
     const { updates, transactions, balance } = collective.stats || {};


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/3177

# Description

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->
Resolve https://github.com/opencollective/opencollective/issues/3177
# Screenshots

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
