### PR TITLE
fix(CollectiveColorPicker): paste whole color code when # included

### DIFF
--- a/components/collective-page/hero/CollectiveColorPicker.js
+++ b/components/collective-page/hero/CollectiveColorPicker.js
@@ -107,7 +107,7 @@ const CollectiveColorPicker = ({ collective, onChange, onClose, theme }) => {
                   px={2}
                   containerProps={{ ml: 2 }}
                   value={textValue}
-                  maxLength={6}
+                  maxLength={7}
                   disabled={loading}
                   onBlur={() => setShowError(true)}
                   error={


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/3178

# Description
allows pasting of whole color code when # is included.
<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots/GIF

![captured](https://user-images.githubusercontent.com/46647141/83319502-b4aaba00-a25c-11ea-9278-08a9971d95f5.gif)

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
