### PR TITLE
Fix React render max call-stack bug when set custom value = 0

### DIFF
--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -278,7 +278,8 @@ class CreateOrderPage extends React.Component {
 
     // sets the total amount & fee options correctly when we change the base amount (if fees on top is available)
     const hasProfileChanged = prevState.stepProfile?.id !== this.state.stepProfile?.id;
-    const hasAmountChanged = prevState.stepDetails?.amount !== this.state.stepDetails?.amount;
+    const hasAmountChanged =
+      this.state.stepDetails?.amount && prevState.stepDetails?.amount !== this.state.stepDetails?.amount;
     if ((hasProfileChanged || hasAmountChanged) && this.canHaveFeesOnTop()) {
       const platformFeeOptions = this.createplatformFeeOptions(this.state.stepDetails.amount);
       this.setState(state => ({
@@ -976,7 +977,8 @@ class CreateOrderPage extends React.Component {
                           id="platformFee.totalContribution"
                           values={{
                             amount: formatCurrency(
-                              get(this.state, 'stepDetails.amount') + get(this.state, 'stepDetails.platformFee.value'),
+                              get(this.state, 'stepDetails.amount') +
+                                get(this.state, 'stepDetails.platformFee.value') || 0, // Prevent displaying "Total contribution: €NaN"
                               this.getCurrency(),
                             ),
                             frequency: stepDetails.interval ? `per ${stepDetails.interval}` : '',


### PR DESCRIPTION
Setting the custom value to 0 would cause the component to continually `setState()` and `render()`, but this would happen only when `feesOnTop` was enabled.