### PR TITLE
Remove malformed entry in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,3 @@ styleguide/static/fonts
 
 # Git time manager
 .gtm
-
- build/config.gypi:


### PR DESCRIPTION
Introduced in: https://github.com/opencollective/opencollective-frontend/commit/521cbee3203ae2f495cd561e3d38ed09fa1fe0b6

`build` should already be ignored.
