### PR TITLE
PayExpenseModal: Hide fees message if not manual

### DIFF
--- a/components/expenses/PayExpenseModal.js
+++ b/components/expenses/PayExpenseModal.js
@@ -113,12 +113,14 @@ const PayExpenseModal = ({ onClose, onSubmit, expense, collective, error }) => {
         <H4 fontSize="20px" fontWeight="bold" mb={3}>
           <FormattedMessage id="Expense.PayoutAndFees" defaultMessage="Payout method and fees" />
         </H4>
-        <P fontSize="13px" lineHeight="19px" mb={3}>
-          <FormattedMessage
-            id="Expense.PayoutAndFeesDetails"
-            defaultMessage="Please add the corresponding fees according to the payout option selected."
-          />
-        </P>
+        {formik.values.forceManual && (
+          <P fontSize="13px" lineHeight="19px" mb={3}>
+            <FormattedMessage
+              id="Expense.PayoutAndFeesDetails"
+              defaultMessage="Please add the corresponding fees according to the payout option selected."
+            />
+          </P>
+        )}
         <StyledInputField
           htmlFor="payExpenseModalPayoutMethod"
           label={<FormattedMessage id="ExpenseForm.PayoutOptionLabel" defaultMessage="Payout method" />}


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/3187

![Peek 03-06-2020 17-27](https://user-images.githubusercontent.com/1556356/83656257-9c6dce80-a5bf-11ea-8397-65ef91d5ffa6.gif)
