### PR TITLE
E2E: Fix issue on Stripe challenge

### DIFF
--- a/test/cypress/integration/12-contributionFlow.donate.test.js
+++ b/test/cypress/integration/12-contributionFlow.donate.test.js
@@ -160,8 +160,9 @@ describe('Contribution Flow: Donate', () => {
     // Rejecting the validation should produce an error
     cy.get(iframeSelector).then($3dSecureIframe => {
       const $challengeIframe = $3dSecureIframe.contents().find('body iframe#challengeFrame');
-      const cyChallenge = cy.wrap($challengeIframe.contents().find('body'));
-      cyChallenge.find('#test-source-fail-3ds').click();
+      const $acsIframe = $challengeIframe.contents().find('iframe[name="acsFrame"]');
+      const $finalContent = $acsIframe.contents().find('body');
+      $finalContent.find('#test-source-fail-3ds').click();
     });
     cy.contains(
       'We are unable to authenticate your payment method. Please choose a different payment method and try again.',
@@ -177,8 +178,9 @@ describe('Contribution Flow: Donate', () => {
     // Approving the validation should create the order
     cy.get(iframeSelector).then($3dSecureIframe => {
       const $challengeIframe = $3dSecureIframe.contents().find('body iframe#challengeFrame');
-      const cyChallenge = cy.wrap($challengeIframe.contents().find('body'));
-      cyChallenge.find('#test-source-authorize-3ds').click();
+      const $acsIframe = $challengeIframe.contents().find('iframe[name="acsFrame"]');
+      const $finalContent = $acsIframe.contents().find('body');
+      $finalContent.find('#test-source-authorize-3ds').click();
     });
 
     cy.contains("You're now a backer of APEX!", { timeout: 15000 });


### PR DESCRIPTION
It seems that Stripe recently updated their 3D secure popup, adding a new level of `iframe`. This broke our E2E tests, because of the way Cypress works with `iframe`s it's pretty sensitive to simple changes like that.