### PR TITLE
John Doe, not Jhon Doe

### DIFF
--- a/components/CreateProfile.js
+++ b/components/CreateProfile.js
@@ -265,7 +265,7 @@ const CreateProfile = ({
               required
             >
               {inputProps => (
-                <StyledInput {...inputProps} {...getFieldProps(inputProps.name)} placeholder="i.e Jhon Doe" />
+                <StyledInput {...inputProps} {...getFieldProps(inputProps.name)} placeholder="i.e John Doe" />
               )}
             </StyledInputField>
           </Box>


### PR DESCRIPTION
# Description

My fix changes the spelling of Jhon Doe in the create account page to John Doe. Though Jhon Doe is most likely a legitimate name, I believe the industry standard is John Doe. 

# Screenshots

![image](https://user-images.githubusercontent.com/20846869/83688440-69294080-a5bb-11ea-99cb-546a206f80d1.png)
