### PR TITLE
Fix edit expense for disconnected TransferWise host

### DIFF
--- a/components/expenses/PayoutBankInformationForm.js
+++ b/components/expenses/PayoutBankInformationForm.js
@@ -232,6 +232,8 @@ const PayoutBankInformationForm = ({ isNew, getFieldName, host, fixedCurrency })
   // Display spinner if loading
   if (loading) {
     return <StyledSpinner />;
+  } else if (!host.transferwise?.availableCurrencies && !fixedCurrency) {
+    return null;
   }
 
   const availableCurrencies = host.transferwise?.availableCurrencies || data?.host?.transferwise?.availableCurrencies;


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/3195

I'm just leaving the form empty so the editor can choose between keeping this Payout Method and manually marking as paid or picking a new Payout Method without breaking the interface.