### PR TITLE
PayExpenseModal: Pass action when paying manually

### DIFF
--- a/components/expenses/PayExpenseModal.js
+++ b/components/expenses/PayExpenseModal.js
@@ -44,7 +44,7 @@ const getPayoutLabel = (intl, type) => {
 const generatePayoutOptions = (intl, payoutMethodType, collective) => {
   const payoutMethodLabel = getPayoutLabel(intl, payoutMethodType);
   if (payoutMethodType === PayoutMethodType.OTHER) {
-    return [{ label: payoutMethodLabel, value: PayoutMethodType.OTHER }];
+    return [{ label: payoutMethodLabel, value: { forceManual: true, action: 'PAY' } }];
   } else {
     const defaultTypes = [
       {


### PR DESCRIPTION
Fix issue reported in https://opencollective.slack.com/archives/C6JTTA4SK/p1591346714136000
Introduced in https://github.com/opencollective/opencollective-frontend/pull/4272