### PR TITLE
feat: improve download Receipts popover

### DIFF
--- a/components/expenses/DownloadInvoicesPopOver.js
+++ b/components/expenses/DownloadInvoicesPopOver.js
@@ -139,7 +139,7 @@ class Overlay extends React.Component {
 
     if (data.loading) {
       return (
-        <Popover id="downloadInvoicesPopover" title="Download invoices" {...forwardedProps}>
+        <Popover id="downloadInvoicesPopover" title="Download Receipts" {...forwardedProps}>
           <div>
             <FormattedMessage id="loading" defaultMessage="loading" />
             ...
@@ -149,10 +149,13 @@ class Overlay extends React.Component {
     }
     const invoices = data.allInvoices;
     const years = uniq(invoices.map(i => i.year));
-    const months = uniq(invoices.filter(i => Number(i.year) === Number(this.state.year)).map(i => i.month));
+    const months = []; //uniq(invoices.filter(i => Number(i.year) === Number(this.state.year)).map(i => i.month));
+    const none = <FormattedMessage id="renderNone" defaultMessage="None" />;
+    const renderMonths = months.length > 0 ? months.map(this.renderMonth) : none;
+    const renderyears = years.length > 0 ? years.map(this.renderYear) : none;
 
     return (
-      <Popover id="downloadInvoicesPopover" title="Download invoices" {...forwardedProps}>
+      <Popover id="downloadInvoicesPopover" title="Download Receipts" {...forwardedProps}>
         <ul className="nav nav-tabs">
           <li
             role="presentation"
@@ -178,7 +181,7 @@ class Overlay extends React.Component {
             defaultValue={this.state.year}
           />
         )}
-        <div>{this.state.isDisplayYearly ? years.map(this.renderYear) : months.map(this.renderMonth)}</div>
+        <div>{this.state.isDisplayYearly ? renderyears : renderMonths}</div>
       </Popover>
     );
   }

--- a/components/expenses/DownloadInvoicesPopOver.js
+++ b/components/expenses/DownloadInvoicesPopOver.js
@@ -149,7 +149,7 @@ class Overlay extends React.Component {
     }
     const invoices = data.allInvoices;
     const years = uniq(invoices.map(i => i.year));
-    const months = []; //uniq(invoices.filter(i => Number(i.year) === Number(this.state.year)).map(i => i.month));
+    const months = uniq(invoices.filter(i => Number(i.year) === Number(this.state.year)).map(i => i.month));
     const none = <FormattedMessage id="Receipts.None" defaultMessage="None" />;
     const renderMonths = months.length > 0 ? months.map(this.renderMonth) : none;
     const renderyears = years.length > 0 ? years.map(this.renderYear) : none;

--- a/components/expenses/DownloadInvoicesPopOver.js
+++ b/components/expenses/DownloadInvoicesPopOver.js
@@ -150,7 +150,7 @@ class Overlay extends React.Component {
     const invoices = data.allInvoices;
     const years = uniq(invoices.map(i => i.year));
     const months = []; //uniq(invoices.filter(i => Number(i.year) === Number(this.state.year)).map(i => i.month));
-    const none = <FormattedMessage id="renderNone" defaultMessage="None" />;
+    const none = <FormattedMessage id="Receipts.None" defaultMessage="None" />;
     const renderMonths = months.length > 0 ? months.map(this.renderMonth) : none;
     const renderyears = years.length > 0 ? years.map(this.renderYear) : none;
 

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1256,6 +1256,7 @@
   "profile.incognito.description": "Keep my contribution private (see FAQ for more info)",
   "profilemenu.memberships.tooltip.balance": "Saldo {balance}",
   "profilemenu.memberships.tooltip.pendingExpenses": "{n} pending expenses",
+  "Receipts.None": "None",
   "RecurringContributions.customAmount": "Custom amount",
   "RecurringContributions.minAmount": "Min. amount: {minAmount}",
   "RecurringContributions.none": "No recurring contributions to see here! 👀",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1256,6 +1256,7 @@
   "profile.incognito.description": "Zachovejte můj příspěvek soukromý (viz FAQ pro více informací)",
   "profilemenu.memberships.tooltip.balance": "Balance {balance}",
   "profilemenu.memberships.tooltip.pendingExpenses": "{n} pending expenses",
+  "Receipts.None": "None",
   "RecurringContributions.customAmount": "Custom amount",
   "RecurringContributions.minAmount": "Min. amount: {minAmount}",
   "RecurringContributions.none": "No recurring contributions to see here! 👀",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1256,6 +1256,7 @@
   "profile.incognito.description": "Hallte meine Spenden privat (siehe FAQ für weitere Infos)",
   "profilemenu.memberships.tooltip.balance": "Guthaben {balance}",
   "profilemenu.memberships.tooltip.pendingExpenses": "{n} pending expenses",
+  "Receipts.None": "None",
   "RecurringContributions.customAmount": "Custom amount",
   "RecurringContributions.minAmount": "Min. amount: {minAmount}",
   "RecurringContributions.none": "No recurring contributions to see here! 👀",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1256,6 +1256,7 @@
   "profile.incognito.description": "Keep my contribution private (see FAQ for more info)",
   "profilemenu.memberships.tooltip.balance": "Balance {balance}",
   "profilemenu.memberships.tooltip.pendingExpenses": "{n} pending expenses",
+  "Receipts.None": "None",
   "RecurringContributions.customAmount": "Custom amount",
   "RecurringContributions.minAmount": "Min. amount: {minAmount}",
   "RecurringContributions.none": "No recurring contributions to see here! 👀",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1256,6 +1256,7 @@
   "profile.incognito.description": "Keep my contribution private (see FAQ for more info)",
   "profilemenu.memberships.tooltip.balance": "Balance: {balance}",
   "profilemenu.memberships.tooltip.pendingExpenses": "{n} gastos pendientes",
+  "Receipts.None": "None",
   "RecurringContributions.customAmount": "Custom amount",
   "RecurringContributions.minAmount": "Min. amount: {minAmount}",
   "RecurringContributions.none": "No recurring contributions to see here! 👀",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1256,6 +1256,7 @@
   "profile.incognito.description": "Garder cette contribution privée (voir la FAQ pour + d'infos)",
   "profilemenu.memberships.tooltip.balance": "Solde {balance}",
   "profilemenu.memberships.tooltip.pendingExpenses": "{n} dépenses en attente",
+  "Receipts.None": "None",
   "RecurringContributions.customAmount": "Montant personnalisé",
   "RecurringContributions.minAmount": "Montant minimum : {minAmount}",
   "RecurringContributions.none": "No recurring contributions to see here! 👀",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1256,6 +1256,7 @@
   "profile.incognito.description": "Keep my contribution private (see FAQ for more info)",
   "profilemenu.memberships.tooltip.balance": "Bilancio {balance}",
   "profilemenu.memberships.tooltip.pendingExpenses": "{n} pending expenses",
+  "Receipts.None": "None",
   "RecurringContributions.customAmount": "Custom amount",
   "RecurringContributions.minAmount": "Min. amount: {minAmount}",
   "RecurringContributions.none": "No recurring contributions to see here! 👀",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1256,6 +1256,7 @@
   "profile.incognito.description": "Keep my contribution private (see FAQ for more info)",
   "profilemenu.memberships.tooltip.balance": "残高 {balance}",
   "profilemenu.memberships.tooltip.pendingExpenses": "{n} 件の請求が保留中",
+  "Receipts.None": "None",
   "RecurringContributions.customAmount": "Custom amount",
   "RecurringContributions.minAmount": "Min. amount: {minAmount}",
   "RecurringContributions.none": "No recurring contributions to see here! 👀",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1256,6 +1256,7 @@
   "profile.incognito.description": "Keep my contribution private (see FAQ for more info)",
   "profilemenu.memberships.tooltip.balance": "Balance {balance}",
   "profilemenu.memberships.tooltip.pendingExpenses": "{n} pending expenses",
+  "Receipts.None": "None",
   "RecurringContributions.customAmount": "Custom amount",
   "RecurringContributions.minAmount": "Min. amount: {minAmount}",
   "RecurringContributions.none": "No recurring contributions to see here! 👀",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1256,6 +1256,7 @@
   "profile.incognito.description": "Keep my contribution private (see FAQ for more info)",
   "profilemenu.memberships.tooltip.balance": "Balance {balance}",
   "profilemenu.memberships.tooltip.pendingExpenses": "{n} pending expenses",
+  "Receipts.None": "None",
   "RecurringContributions.customAmount": "Custom amount",
   "RecurringContributions.minAmount": "Min. amount: {minAmount}",
   "RecurringContributions.none": "No recurring contributions to see here! 👀",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1256,6 +1256,7 @@
   "profile.incognito.description": "Manter minha contribuição anônima (veja a FAQ para mais informações)",
   "profilemenu.memberships.tooltip.balance": "Saldo {balance}",
   "profilemenu.memberships.tooltip.pendingExpenses": "{n} despesas pendentes",
+  "Receipts.None": "None",
   "RecurringContributions.customAmount": "Custom amount",
   "RecurringContributions.minAmount": "Min. amount: {minAmount}",
   "RecurringContributions.none": "No recurring contributions to see here! 👀",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1256,6 +1256,7 @@
   "profile.incognito.description": "Keep my contribution private (see FAQ for more info)",
   "profilemenu.memberships.tooltip.balance": "Остаток {balance}",
   "profilemenu.memberships.tooltip.pendingExpenses": "{n} pending expenses",
+  "Receipts.None": "None",
   "RecurringContributions.customAmount": "Custom amount",
   "RecurringContributions.minAmount": "Min. amount: {minAmount}",
   "RecurringContributions.none": "No recurring contributions to see here! 👀",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1256,6 +1256,7 @@
   "profile.incognito.description": "Keep my contribution private (see FAQ for more info)",
   "profilemenu.memberships.tooltip.balance": "Balance {balance}",
   "profilemenu.memberships.tooltip.pendingExpenses": "{n} pending expenses",
+  "Receipts.None": "None",
   "RecurringContributions.customAmount": "Custom amount",
   "RecurringContributions.minAmount": "Min. amount: {minAmount}",
   "RecurringContributions.none": "No recurring contributions to see here! 👀",


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/3168

# Description
-  Use consistent name i.e, `Download Receipts`
-  Show `None` if no monthly or yearly receipts.

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots
![Screenshot at 2020-06-05 20-32-21](https://user-images.githubusercontent.com/46647141/83892026-b0563380-a76b-11ea-9567-d8dfbb2144f4.png)

![Screenshot at 2020-06-05 20-30-58](https://user-images.githubusercontent.com/46647141/83892040-b5b37e00-a76b-11ea-9677-5914233f9083.png)

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
