### PR TITLE
Disable polling in BudgetSection

### DIFF
--- a/components/collective-page/sections/Budget.js
+++ b/components/collective-page/sections/Budget.js
@@ -63,7 +63,7 @@ const SectionBudget = ({ collective, stats }) => {
         />
       </P>
       <Flex flexDirection={['column-reverse', null, 'row']} justifyContent="space-between" alignItems="flex-start">
-        <Query query={TransactionsAndExpensesQuery} variables={{ slug: collective.slug }} pollInterval={60000}>
+        <Query query={TransactionsAndExpensesQuery} variables={{ slug: collective.slug }}>
           {({ data }) => {
             const expenses = get(data, 'Collective.expenses');
             const transactions = get(data, 'Collective.transactions');


### PR DESCRIPTION
This is having a huge impact in number of queries to the API for not much gain in user experience.