### PR TITLE
ExpensePage: Remove double fetch

### DIFF
--- a/pages/expense.js
+++ b/pages/expense.js
@@ -137,11 +137,6 @@ class ExpensePage extends React.Component {
   }
 
   componentDidMount() {
-    // LoggedInUser is not set during SSR, we refetch for permissions
-    if (this.props.LoggedInUser) {
-      this.refetchDataForUser();
-    }
-
     this.handlePolling();
     document.addEventListener('mousemove', this.handlePolling);
   }


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/3217

This check wasn't necessary, as the only way `LoggedInUser` can be set in `componentDidMount` is if we're in client side rendering and in such case the private data has already been fetched.