### PR TITLE
Fix empty bank form in Accept Financial Contributions

### DIFF
--- a/components/expenses/PayoutBankInformationForm.js
+++ b/components/expenses/PayoutBankInformationForm.js
@@ -209,6 +209,7 @@ RequiredFields.propTypes = {
 const availableCurrenciesQuery = gqlV2`
   query Host($slug: String) {
     host(slug: $slug) {
+      slug
       transferwise {
         availableCurrencies
       }
@@ -228,6 +229,7 @@ const PayoutBankInformationForm = ({ isNew, getFieldName, host, fixedCurrency })
   });
   const formik = useFormikContext();
   const { formatMessage } = useIntl();
+  host = data?.host || host;
 
   // Display spinner if loading
   if (loading) {


### PR DESCRIPTION
Small bug related to the available currencies pre-load capability of the component.
The idea was that you could either pass the currency array with the host property of the component or leaving it blank for the component to fetch when it loads.
This was broken due to the fact we were not considering the non-preloaded host.