### PR TITLE
ExpensePage: Admin actions label responsiveness

### DIFF
--- a/lib/hooks/useHover.js
+++ b/lib/hooks/useHover.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export const useHover = () => {
+  const [isHovered, set] = React.useState(false);
+  const elemProps = { onMouseEnter: () => set(true), onMouseLeave: () => set(false) };
+  return [isHovered, elemProps];
+};


### PR DESCRIPTION
Address an issue reported in https://opencollective.slack.com/archives/CNA7RE3SN/p1590487304003700 by using `react-popper` to position the label.

![image](https://user-images.githubusercontent.com/1556356/84137937-bf7c0080-aa4d-11ea-8e23-fffd8d845e29.png)
