### PR TITLE
Expense: Mark any paid expense as unpaid

### DIFF
--- a/components/expenses/Expense.js
+++ b/components/expenses/Expense.js
@@ -240,11 +240,7 @@ class Expense extends React.Component {
     mode = mode || view;
 
     const canPay = LoggedInUser && LoggedInUser.canPayExpense(expense) && expense.status === 'APPROVED';
-    const canMarkExpenseAsUnpaid =
-      LoggedInUser &&
-      LoggedInUser.canPayExpense(expense) &&
-      expense.status === 'PAID' &&
-      expense.payoutMethod === 'other';
+    const canMarkExpenseAsUnpaid = LoggedInUser?.canPayExpense(expense) && expense.status === 'PAID';
 
     const canReject =
       LoggedInUser &&


### PR DESCRIPTION
Together with https://github.com/opencollective/opencollective-api/pull/4020, this PR solves https://github.com/opencollective/opencollective/issues/2773 by enabling the `Mark as unpaid` button for all paid expenses - regardless of the payout method.