### PR TITLE
Optimize discover query

### DIFF
--- a/pages/discover.js
+++ b/pages/discover.js
@@ -80,9 +80,6 @@ const DiscoverPageDataQuery = gql`
           }
         }
         isPledged
-        memberOf {
-          id
-        }
         parentCollective {
           id
           slug


### PR DESCRIPTION
This small snippet would fetch all memberships of the 40 collectives for nothing it seems.

I haven't found why that info would be useful in the discover context.