### PR TITLE
fix(pricing): made hosts display correctly for mobile devices

### DIFF
--- a/components/pricing/tabs/SingleCollectiveWithoutBankAccount.js
+++ b/components/pricing/tabs/SingleCollectiveWithoutBankAccount.js
@@ -105,7 +105,7 @@ const SingleCollectiveWithoutBankAccount = ({ data }) => {
         >
           <FormattedMessage id="pricing.applyFiscalHost" defaultMessage="Apply to a fiscal host" />
         </H3>
-        <HostsWrapper width={1} justifyContent="center" py={4}>
+        <HostsWrapper width={1} justifyContent={['start', null, 'center']} py={4}>
           {hosts.map(collective => (
             <Box mx={2} key={collective.id}>
               <StyledCollectiveCard


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/3208

# Description

This PR fixes the bug by aligning the scroll items to the start of the page for mobile devices and leaving it centered for larger screen devices.

# Screenshots
Current             |  PR change
:-------------------------:|:-------------------------:
<img width="276" alt="Screen Shot 2020-06-09 at 5 47 30 PM" src="https://user-images.githubusercontent.com/12116352/84176514-6a55e400-aa79-11ea-931d-4e23c3d172b9.png"> |  <img width="281" alt="Screen Shot 2020-06-09 at 5 47 44 PM" src="https://user-images.githubusercontent.com/12116352/84176524-6fb32e80-aa79-11ea-9648-f82e893d5dcb.png">)

