### PR TITLE
EditCollectivePage: Disabled default sections for legacy usage

### DIFF
--- a/components/edit-collective/sections/EditCollectivePage.js
+++ b/components/edit-collective/sections/EditCollectivePage.js
@@ -130,8 +130,9 @@ const loadSectionsForCollective = collective => {
   };
 
   if (collectiveSections) {
-    const sections = [...collectiveSections, ...defaultSections].map(transformLegacySection);
-    return uniqBy(sections, 'section');
+    const existingSections = collectiveSections.map(transformLegacySection);
+    const addedSections = defaultSections.map(section => ({ section, isEnabled: false }));
+    return uniqBy([...existingSections, ...addedSections], 'section');
   } else {
     return defaultSections.map(transformLegacySection);
   }


### PR DESCRIPTION
The code was enabling disabled sections for collectives that stored sections with the legacy format (an array of string).