### PR TITLE
HeroBackground: Improve crop & resize behavior

### DIFF
--- a/components/collective-page/hero/Hero.js
+++ b/components/collective-page/hero/Hero.js
@@ -24,6 +24,7 @@ import { Flex } from '../../Grid';
 import I18nCollectiveTags from '../../I18nCollectiveTags';
 import Link from '../../Link';
 import LinkCollective from '../../LinkCollective';
+import LoadingPlaceholder from '../../LoadingPlaceholder';
 import MessageBox from '../../MessageBox';
 import StyledButton from '../../StyledButton';
 import StyledLink from '../../StyledLink';
@@ -31,16 +32,25 @@ import StyledRoundButton from '../../StyledRoundButton';
 import StyledTag from '../../StyledTag';
 import { H1, Span } from '../../Text';
 import UserCompany from '../../UserCompany';
-// Local imports
 import ContainerSectionContent from '../ContainerSectionContent';
 
 import CollectiveColorPicker from './CollectiveColorPicker';
 import HeroAvatar from './HeroAvatar';
-import HeroBackground from './HeroBackground';
+import HeroBackground, { BASE_HERO_HEIGHT, StyledHeroBackground } from './HeroBackground';
 import HeroTotalCollectiveContributionsWithData from './HeroTotalCollectiveContributionsWithData';
 
 // Dynamic imports
 const HeroEventDetails = dynamic(() => import('./HeroEventDetails'));
+
+const HeroBackgroundEdit = dynamic(() => import('./HeroBackgroundEdit'), {
+  loading() {
+    return (
+      <StyledHeroBackground>
+        <LoadingPlaceholder height={BASE_HERO_HEIGHT} />
+      </StyledHeroBackground>
+    );
+  },
+});
 
 const Translations = defineMessages({
   website: {
@@ -97,7 +107,12 @@ const Hero = ({ collective, host, isAdmin, onPrimaryColorChange, callsToAction, 
         </MessageBox>
       )}
       <Container position="relative" minHeight={325} zIndex={1000} data-cy="collective-hero">
-        <HeroBackground collective={collective} isEditing={isEditingCover} onEditCancel={() => editCover(false)} />
+        {isEditing ? (
+          <HeroBackgroundEdit collective={collective} onEditCancel={() => editCover(false)} />
+        ) : (
+          <HeroBackground collective={collective} />
+        )}
+
         {isAdmin && !isEditing && (
           // We don't have any mobile view for this one yet
           <Container

--- a/components/collective-page/hero/HeroBackground.js
+++ b/components/collective-page/hero/HeroBackground.js
@@ -1,38 +1,12 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
-import { Mutation } from '@apollo/react-components';
-import { Upload } from '@styled-icons/feather/Upload';
-import { get, has, set } from 'lodash';
-import dynamic from 'next/dynamic';
-import { FormattedMessage } from 'react-intl';
-import styled from 'styled-components';
-
-import { upload } from '../../../lib/api';
-
-import Container from '../../Container';
-import LoadingPlaceholder from '../../LoadingPlaceholder';
-import MessageBox from '../../MessageBox';
-import StyledButton from '../../StyledButton';
-import { Span } from '../../Text';
-// Local imports
-import { EditCollectiveBackgroundMutation } from '../graphql/mutations';
+import { get, has } from 'lodash';
+import styled, { css } from 'styled-components';
 
 import HeroBackgroundMask from '../images/HeroBackgroundMask.svg';
 
-const BASE_WIDTH = 1368;
-const BASE_HEIGHT = 325;
-
-// Dynamically import cropper component
-const EditBackgroundLoadingPlaceholder = () => <LoadingPlaceholder height={BASE_HEIGHT} />;
-const Cropper = dynamic(() => import(/* webpackChunkName: 'react-easy-crop' */ 'react-easy-crop'), {
-  loading: EditBackgroundLoadingPlaceholder,
-  ssr: false,
-});
-
-// Dynamically import dropzone component
-const Dropzone = dynamic(() => import(/* webpackChunkName: 'react-dropzone' */ 'react-dropzone'), {
-  ssr: false,
-});
+export const BASE_HERO_WIDTH = 1368;
+export const BASE_HERO_HEIGHT = 325;
 
 const generateBackground = theme => {
   const color = theme.colors.primary[300];
@@ -40,23 +14,42 @@ const generateBackground = theme => {
   return `${gradient}, ${color}`;
 };
 
-const StyledBackground = styled.div`
+const BackgroundImage = styled.img.attrs({ alt: '' })``;
+
+export const StyledHeroBackground = styled.div`
   position: absolute;
   right: 0;
   top: 0;
   height: 100%;
   width: 100%;
-  max-width: ${BASE_WIDTH}px; // Should match SVG's viewbox
+  max-width: ${BASE_HERO_WIDTH}px; // Should match SVG's viewbox
   z-index: ${props => (props.isEditing ? 0 : -1)};
+  overflow: hidden;
 
   img {
     margin: 0;
   }
 
-  .reactEasyCrop_Image {
-    max-width: none;
+  .reactEasyCrop_Image,
+  ${BackgroundImage} {
     max-height: none;
+    max-width: none;
   }
+
+  ${props =>
+    props.isAlignedRight &&
+    css`
+      .reactEasyCrop_Image,
+      ${BackgroundImage} {
+        top: 0;
+        right: 0;
+        min-height: 0;
+        min-width: 0;
+        left: unset;
+        bottom: unset;
+        position: absolute;
+      }
+    `}
 
   @supports (mask-size: cover) {
     background: ${props => generateBackground(props.theme)};
@@ -74,214 +67,43 @@ const StyledBackground = styled.div`
   }
 `;
 
-const ImageContainer = styled.div`
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  position: absolute;
-  overflow: hidden;
-`;
+export const DEFAULT_BACKGROUND_CROP = { x: 0, y: 0 };
 
-const BackgroundImage = styled.img.attrs({ alt: '' })`
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  min-height: 0;
-  min-width: 0;
-  max-height: none;
-  max-width: none;
-  position: absolute;
-  margin: auto;
-`;
+export const getCrop = collective => {
+  return get(collective.settings, 'collectivePage.background.crop') || DEFAULT_BACKGROUND_CROP;
+};
 
-const KEY_IMG_REMOVE = '__REMOVE__';
-const DEFAULT_CROP = { x: 0, y: 0 };
+export const getZoom = collective => {
+  return get(collective.settings, 'collectivePage.background.zoom') || 1;
+};
 
-const getCrop = collective => get(collective.settings, 'collectivePage.background.crop') || DEFAULT_CROP;
-const getZoom = collective => get(collective.settings, 'collectivePage.background.zoom') || 1;
+export const getAlignedRight = collective => {
+  return get(collective.settings, 'collectivePage.background.isAlignedRight');
+};
 
 /**
  * Wraps the logic to display the hero background. Fallsback on a white background if
  * css `mask` is not supported.
  */
-const HeroBackground = ({ collective, isEditing, onEditCancel }) => {
-  const [crop, onCropChange] = React.useState(getCrop(collective));
-  const [zoom, onZoomChange] = React.useState(getZoom(collective));
-  const [uploadedImage, setUploadedImage] = React.useState();
-  const [submitting, setSubmitting] = React.useState(false);
+const HeroBackground = ({ collective }) => {
+  const crop = getCrop(collective);
+  const zoom = getZoom(collective);
+  const isAlignedRight = getAlignedRight(collective);
   const hasBackgroundSettings = has(collective.settings, 'collectivePage.background');
 
-  return !isEditing ? (
-    <StyledBackground>
+  return (
+    <StyledHeroBackground isAlignedRight={isAlignedRight}>
       {collective.backgroundImageUrl && (
-        <ImageContainer>
-          <BackgroundImage
-            src={collective.backgroundImageUrl}
-            style={
-              hasBackgroundSettings
-                ? { transform: `translate(${crop.x}px, ${crop.y}px) scale(${zoom})` }
-                : { minWidth: '100%' }
-            }
-          />
-        </ImageContainer>
+        <BackgroundImage
+          src={collective.backgroundImageUrl}
+          style={
+            hasBackgroundSettings
+              ? { transform: `translate(${crop.x}px, ${crop.y}px) scale(${zoom})` }
+              : { minWidth: '100%' }
+          }
+        />
       )}
-    </StyledBackground>
-  ) : (
-    <Mutation mutation={EditCollectiveBackgroundMutation}>
-      {editBackground => (
-        <StyledBackground
-          data-cy="collective-background-image-styledBackground"
-          backgroundImage={collective.backgroundImageUrl}
-          isEditing
-        >
-          <Cropper
-            image={uploadedImage ? uploadedImage.preview : collective.backgroundImageUrl}
-            cropSize={{ width: BASE_WIDTH, height: BASE_HEIGHT }}
-            crop={crop}
-            zoom={zoom}
-            minZoom={0.25}
-            maxZoom={5}
-            zoomSpeed={0.5}
-            restrictPosition={false}
-            onCropChange={onCropChange}
-            onZoomChange={onZoomChange}
-            style={{
-              imageStyle: { minHeight: '0', minWidth: '0', maxHeight: 'none', maxWidth: 'none' },
-              containerStyle: { height: BASE_HEIGHT },
-            }}
-          />
-          <Container display={['none', 'flex']} position="absolute" right={25} top={25} zIndex={222}>
-            <Dropzone
-              onDrop={acceptedFiles => {
-                onZoomChange(1);
-                onCropChange(DEFAULT_CROP);
-                setUploadedImage(
-                  ...acceptedFiles.map(file =>
-                    Object.assign(file, {
-                      preview: URL.createObjectURL(file),
-                    }),
-                  ),
-                );
-              }}
-              multiple={false}
-              accept="image/jpeg, image/png"
-              style={{}}
-              disabled={submitting}
-            >
-              {({ isDragActive, isDragAccept, getRootProps, getInputProps }) => (
-                <div {...getRootProps()}>
-                  <input data-cy="heroBackgroundDropzone" {...getInputProps()} />
-                  <StyledButton minWidth={150} disabled={submitting} buttonSize="small">
-                    {!isDragActive && (
-                      <React.Fragment>
-                        <Span mr={2}>
-                          <Upload size="1em" />
-                        </Span>
-                        <FormattedMessage id="Upload" defaultMessage="Upload" />
-                      </React.Fragment>
-                    )}
-                    {isDragActive &&
-                      (isDragAccept ? (
-                        <FormattedMessage id="uploadImage.isDragActive" defaultMessage="Drop it like it's hot 🔥" />
-                      ) : (
-                        <FormattedMessage
-                          id="uploadImage.isDragReject"
-                          defaultMessage="🚫 This file type is not accepted"
-                        />
-                      ))}
-                  </StyledButton>
-                </div>
-              )}
-            </Dropzone>
-            {uploadedImage !== KEY_IMG_REMOVE && collective.backgroundImage && (
-              <StyledButton
-                minWidth={150}
-                ml={3}
-                disabled={submitting}
-                onClick={() => (uploadedImage ? setUploadedImage(null) : setUploadedImage(KEY_IMG_REMOVE))}
-                buttonSize="small"
-              >
-                <FormattedMessage id="Remove" defaultMessage="Remove" />
-              </StyledButton>
-            )}
-            <StyledButton
-              textTransform="capitalize"
-              minWidth={150}
-              disabled={submitting}
-              ml={3}
-              buttonSize="small"
-              onClick={() => {
-                const base = get(collective.settings, 'collectivePage.background');
-                onCropChange((base && base.crop) || DEFAULT_CROP);
-                onZoomChange((base && base.zoom) || 1);
-                setUploadedImage(null);
-                onEditCancel();
-              }}
-            >
-              <FormattedMessage id="form.cancel" defaultMessage="cancel" />
-            </StyledButton>
-            <StyledButton
-              data-cy="heroBackgroundDropzoneSave"
-              textTransform="capitalize"
-              buttonStyle="primary"
-              buttonSize="small"
-              ml={3}
-              minWidth={150}
-              loading={submitting}
-              onClick={async () => {
-                setSubmitting(true); // Need this because `upload` is not a graphql function
-
-                try {
-                  // We intentionally use the raw image URL rather than image service here
-                  // because the `backgroundImage` column is not supposed to store the
-                  // images service address
-                  let imgURL = collective.backgroundImage;
-
-                  // Upload image if changed or remove it
-                  if (uploadedImage === KEY_IMG_REMOVE) {
-                    imgURL = null;
-                  } else if (uploadedImage) {
-                    imgURL = await upload(uploadedImage);
-                  }
-
-                  // Update settings
-                  const result = await editBackground({
-                    variables: {
-                      id: collective.id,
-                      backgroundImage: imgURL,
-                      settings: set({ ...collective.settings }, 'collectivePage.background', { crop, zoom }),
-                    },
-                  });
-
-                  // Reset
-                  const base = get(result, 'data.editCollective.settings.collectivePage.background');
-                  onCropChange((base && base.crop) || DEFAULT_CROP);
-                  onZoomChange((base && base.zoom) || 1);
-                  setUploadedImage(null);
-
-                  // Close the form
-                  onEditCancel();
-                } finally {
-                  setSubmitting(false);
-                }
-              }}
-            >
-              <FormattedMessage id="save" defaultMessage="Save" />
-            </StyledButton>
-          </Container>
-          <Container zIndex={222} position="absolute" right={25} top={75}>
-            <MessageBox type="info" withIcon opacity={0.9} px={2} py={1}>
-              <FormattedMessage
-                id="HeroBackground.Instructions"
-                defaultMessage="Use your mouse wheel or pinch to change the zoom, drag and drop to adjust position."
-              />
-            </MessageBox>
-          </Container>
-        </StyledBackground>
-      )}
-    </Mutation>
+    </StyledHeroBackground>
   );
 };
 

--- a/components/collective-page/hero/HeroBackground.js
+++ b/components/collective-page/hero/HeroBackground.js
@@ -126,12 +126,6 @@ HeroBackground.propTypes = {
       }),
     }),
   }).isRequired,
-
-  /** Called when user click on cancel */
-  onEditCancel: PropTypes.func.isRequired,
-
-  /** Wether to show the cropper/uploader */
-  isEditing: PropTypes.bool,
 };
 
 /** @component */

--- a/components/collective-page/hero/HeroBackgroundEdit.js
+++ b/components/collective-page/hero/HeroBackgroundEdit.js
@@ -31,7 +31,7 @@ const KEY_IMG_REMOVE = '__REMOVE__';
  * Wraps the logic to display the hero background. Fallsback on a white background if
  * css `mask` is not supported.
  */
-const HeroBackground = ({ collective, onEditCancel }) => {
+const HeroBackgroundEdit = ({ collective, onEditCancel }) => {
   const [isSubmitting, setSubmitting] = React.useState(false);
   const [editBackground] = useMutation(EditCollectiveBackgroundMutation);
   const [mediaSize, setMediaSize] = React.useState();
@@ -201,7 +201,7 @@ const HeroBackground = ({ collective, onEditCancel }) => {
   );
 };
 
-HeroBackground.propTypes = {
+HeroBackgroundEdit.propTypes = {
   /** The collective to show the image for */
   collective: PropTypes.shape({
     id: PropTypes.number,
@@ -223,10 +223,7 @@ HeroBackground.propTypes = {
 
   /** Called when user click on cancel */
   onEditCancel: PropTypes.func.isRequired,
-
-  /** Wether to show the cropper/uploader */
-  isEditing: PropTypes.bool,
 };
 
 /** @component */
-export default HeroBackground;
+export default HeroBackgroundEdit;

--- a/components/collective-page/hero/HeroBackgroundEdit.js
+++ b/components/collective-page/hero/HeroBackgroundEdit.js
@@ -1,0 +1,232 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+import { useMutation } from '@apollo/react-hooks';
+import { Upload } from '@styled-icons/feather/Upload';
+import { get, set } from 'lodash';
+import Dropzone from 'react-dropzone';
+import Cropper from 'react-easy-crop';
+import { FormattedMessage } from 'react-intl';
+
+import { upload } from '../../../lib/api';
+
+import Container from '../../Container';
+import MessageBox from '../../MessageBox';
+import StyledButton from '../../StyledButton';
+import { Span } from '../../Text';
+import { EditCollectiveBackgroundMutation } from '../graphql/mutations';
+
+import {
+  BASE_HERO_HEIGHT,
+  BASE_HERO_WIDTH,
+  DEFAULT_BACKGROUND_CROP,
+  getAlignedRight,
+  getCrop,
+  getZoom,
+  StyledHeroBackground,
+} from './HeroBackground';
+
+const KEY_IMG_REMOVE = '__REMOVE__';
+
+/**
+ * Wraps the logic to display the hero background. Fallsback on a white background if
+ * css `mask` is not supported.
+ */
+const HeroBackground = ({ collective, onEditCancel }) => {
+  const [isSubmitting, setSubmitting] = React.useState(false);
+  const [editBackground] = useMutation(EditCollectiveBackgroundMutation);
+  const [mediaSize, setMediaSize] = React.useState();
+  const [crop, onCropChange] = React.useState(getCrop(collective));
+  const [zoom, onZoomChange] = React.useState(getZoom(collective));
+  const [isAlignedRight, setAlignedRight] = React.useState(getAlignedRight(collective));
+  const [uploadedImage, setUploadedImage] = React.useState();
+
+  return (
+    <StyledHeroBackground
+      data-cy="collective-background-image-styledBackground"
+      backgroundImage={collective.backgroundImageUrl}
+      isAlignedRight={isAlignedRight}
+      isEditing
+    >
+      <Cropper
+        image={uploadedImage ? uploadedImage.preview : collective.backgroundImageUrl}
+        cropSize={{ width: BASE_HERO_WIDTH, height: BASE_HERO_HEIGHT }}
+        crop={crop}
+        zoom={zoom}
+        minZoom={0.25}
+        maxZoom={5}
+        zoomSpeed={0.5}
+        restrictPosition={false}
+        onCropChange={onCropChange}
+        onZoomChange={onZoomChange}
+        onMediaLoaded={mediaSize => setMediaSize({ width: mediaSize.naturalWidth, height: mediaSize.naturalHeight })}
+        style={{
+          imageStyle: { minHeight: '0', minWidth: '0', maxHeight: 'none', maxWidth: 'none' },
+          containerStyle: { height: BASE_HERO_HEIGHT },
+        }}
+      />
+      <Container display={['none', 'flex']} position="absolute" right={25} top={25} zIndex={222}>
+        <Dropzone
+          onDrop={acceptedFiles => {
+            onZoomChange(1);
+            onCropChange(DEFAULT_BACKGROUND_CROP);
+            setAlignedRight(true);
+            setUploadedImage(
+              ...acceptedFiles.map(file =>
+                Object.assign(file, {
+                  preview: URL.createObjectURL(file),
+                }),
+              ),
+            );
+          }}
+          multiple={false}
+          accept="image/jpeg, image/png"
+          style={{}}
+          disabled={isSubmitting}
+        >
+          {({ isDragActive, isDragAccept, getRootProps, getInputProps }) => (
+            <div {...getRootProps()}>
+              <input data-cy="heroBackgroundDropzone" {...getInputProps()} />
+              <StyledButton minWidth={150} disabled={isSubmitting} buttonSize="small">
+                {!isDragActive && (
+                  <React.Fragment>
+                    <Span mr={2}>
+                      <Upload size="1em" />
+                    </Span>
+                    <FormattedMessage id="Upload" defaultMessage="Upload" />
+                  </React.Fragment>
+                )}
+                {isDragActive &&
+                  (isDragAccept ? (
+                    <FormattedMessage id="uploadImage.isDragActive" defaultMessage="Drop it like it's hot 🔥" />
+                  ) : (
+                    <FormattedMessage
+                      id="uploadImage.isDragReject"
+                      defaultMessage="🚫 This file type is not accepted"
+                    />
+                  ))}
+              </StyledButton>
+            </div>
+          )}
+        </Dropzone>
+        {uploadedImage !== KEY_IMG_REMOVE && collective.backgroundImage && (
+          <StyledButton
+            minWidth={150}
+            ml={3}
+            disabled={isSubmitting}
+            onClick={() => (uploadedImage ? setUploadedImage(null) : setUploadedImage(KEY_IMG_REMOVE))}
+            buttonSize="small"
+          >
+            <FormattedMessage id="Remove" defaultMessage="Remove" />
+          </StyledButton>
+        )}
+        <StyledButton
+          textTransform="capitalize"
+          minWidth={150}
+          disabled={isSubmitting}
+          ml={3}
+          buttonSize="small"
+          onClick={() => {
+            const base = get(collective.settings, 'collectivePage.background');
+            onCropChange((base && base.crop) || DEFAULT_BACKGROUND_CROP);
+            onZoomChange((base && base.zoom) || 1);
+            setUploadedImage(null);
+            onEditCancel();
+          }}
+        >
+          <FormattedMessage id="form.cancel" defaultMessage="cancel" />
+        </StyledButton>
+        <StyledButton
+          data-cy="heroBackgroundDropzoneSave"
+          textTransform="capitalize"
+          buttonStyle="primary"
+          buttonSize="small"
+          ml={3}
+          minWidth={150}
+          loading={isSubmitting}
+          onClick={async () => {
+            try {
+              setSubmitting(true);
+
+              // We intentionally use the raw image URL rather than image service here
+              // because the `backgroundImage` column is not supposed to store the
+              // images service address
+              let imgURL = collective.backgroundImage;
+
+              // Upload image if changed or remove it
+              if (uploadedImage === KEY_IMG_REMOVE) {
+                imgURL = null;
+              } else if (uploadedImage) {
+                imgURL = await upload(uploadedImage);
+              }
+
+              // Update settings
+              const result = await editBackground({
+                variables: {
+                  id: collective.id,
+                  backgroundImage: imgURL,
+                  settings: set({ ...collective.settings }, 'collectivePage.background', {
+                    crop,
+                    zoom,
+                    mediaSize,
+                    isAlignedRight,
+                  }),
+                },
+              });
+
+              // Reset
+              const base = get(result, 'data.editCollective.settings.collectivePage.background');
+              onCropChange((base && base.crop) || DEFAULT_BACKGROUND_CROP);
+              onZoomChange((base && base.zoom) || 1);
+              setUploadedImage(null);
+
+              // Close the form
+              onEditCancel();
+            } finally {
+              setSubmitting(false);
+            }
+          }}
+        >
+          <FormattedMessage id="save" defaultMessage="Save" />
+        </StyledButton>
+      </Container>
+      <Container zIndex={222} position="absolute" right={25} top={75}>
+        <MessageBox type="info" withIcon opacity={0.9} px={2} py={1}>
+          <FormattedMessage
+            id="HeroBackground.Instructions"
+            defaultMessage="Use your mouse wheel or pinch to change the zoom, drag and drop to adjust position."
+          />
+        </MessageBox>
+      </Container>
+    </StyledHeroBackground>
+  );
+};
+
+HeroBackground.propTypes = {
+  /** The collective to show the image for */
+  collective: PropTypes.shape({
+    id: PropTypes.number,
+    /** The background image */
+    backgroundImage: PropTypes.string,
+    backgroundImageUrl: PropTypes.string,
+    /** Collective settings */
+    settings: PropTypes.shape({
+      collectivePage: PropTypes.shape({
+        background: PropTypes.shape({
+          /** Used to display the background at the right position */
+          offset: PropTypes.shape({ y: PropTypes.number.isRequired }),
+          /** Only used for the editor */
+          crop: PropTypes.shape({ y: PropTypes.number.isRequired }),
+        }),
+      }),
+    }),
+  }).isRequired,
+
+  /** Called when user click on cancel */
+  onEditCancel: PropTypes.func.isRequired,
+
+  /** Wether to show the cropper/uploader */
+  isEditing: PropTypes.bool,
+};
+
+/** @component */
+export default HeroBackground;


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2471.

After trying multiple approaches, it appears that the best one is to align the images on the right:
- When image is dropped, it appears at the top right - which solves one of the most frustrating [issue](https://github.com/opencollective/opencollective/issues/2471) with this component: not seeing the image you just dropped.
- The fact that it's aligned on the right makes it way more responsive, because the right marker (that is not cropped or hidden) will keep its position regardless of the screen size

Unfortunately there's no way to migrate the old images, so the enhancement will only be for newly uploaded images. Old images will keep working as before.

I've also added a `mediaSize` object that will prepare the path for https://github.com/opencollective/opencollective/issues/2709, and refactored the component to have cleaner code and only one dynamic component.

![Peek 11-06-2020 14-35](https://user-images.githubusercontent.com/1556356/84387503-66e66800-abf3-11ea-90a9-56e1a3affd8f.gif)
