### PR TITLE
Make expense comments private

### DIFF
--- a/components/CommentsWithData.js
+++ b/components/CommentsWithData.js
@@ -124,7 +124,7 @@ class CommentsWithData extends React.Component {
             <P ml={3} fontSize="Paragraph" lineHeight="Paragraph">
               <FormattedMessage
                 id="expense.privateCommentsWarning"
-                defaultMessage="The comments for this expense are private, you need to be authenticated as a host/collective admin or as an owner to see them."
+                defaultMessage="Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them."
               />
             </P>
           </Flex>

--- a/components/expenses/ExpenseWithData.js
+++ b/components/expenses/ExpenseWithData.js
@@ -19,6 +19,7 @@ class ExpenseWithData extends React.Component {
     filter: PropTypes.object, // { category, recipient }
     defaultAction: PropTypes.string, // "new" to open the new expense form by default
     LoggedInUser: PropTypes.object,
+    loadingLoggedInUser: PropTypes.bool,
     allowPayAction: PropTypes.bool,
     lockPayAction: PropTypes.func,
     unlockPayAction: PropTypes.func,
@@ -75,7 +76,12 @@ class ExpenseWithData extends React.Component {
 
         {view === 'details' && (
           <div className="comments">
-            <CommentsWithData expense={expense} collective={collective} LoggedInUser={LoggedInUser} />
+            <CommentsWithData
+              expense={expense}
+              collective={collective}
+              LoggedInUser={LoggedInUser}
+              loadingLoggedInUser={this.props.loadingLoggedInUser}
+            />
           </div>
         )}
       </div>

--- a/components/expenses/graphql/fragments.js
+++ b/components/expenses/graphql/fragments.js
@@ -190,6 +190,7 @@ export const expensePageExpenseFieldsFragment = gqlV2`
       canReject
       canPay
       canMarkAsUnpaid
+      canComment
     }
     activities {
       id

--- a/components/icons/PrivateInfoIcon.js
+++ b/components/icons/PrivateInfoIcon.js
@@ -15,15 +15,21 @@ const msg = defineMessages({
 /**
  * A lock icon with a tooltip indicating that this info is private
  */
-const PrivateInfoIcon = ({ children, size, tooltipProps, ...props }) => {
+const PrivateInfoIcon = ({ children, size, tooltipProps, withoutTooltip, ...props }) => {
   const { formatMessage } = useIntl();
+  const icon = <Lock size={size} {...props} />;
+
+  if (withoutTooltip) {
+    return icon;
+  }
+
   return (
     <StyledTooltip
       childrenContainer="span"
       content={() => children || formatMessage(msg.defaultContent)}
       {...tooltipProps}
     >
-      <Lock size={size} {...props} />
+      {icon}
     </StyledTooltip>
   );
 };
@@ -33,6 +39,7 @@ PrivateInfoIcon.propTypes = {
   children: PropTypes.node,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   tooltipProps: PropTypes.object,
+  withoutTooltip: PropTypes.bool,
 };
 
 PrivateInfoIcon.defaultProps = {

--- a/lang/en.json
+++ b/lang/en.json
@@ -758,6 +758,7 @@
   "expense.pending": "pending",
   "expense.platformFeeInCollectiveCurrency": "platform fee",
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
+  "expense.privateCommentsWarning": "The comments for this expense are private, you need to be authenticated as a host/collective admin or as an owner to see them.",
   "expense.privateMessage": "Private instructions",
   "expense.privateMessage.description": "Private instructions for the host to reimburse your expense",
   "expense.privateNote": "private note",

--- a/lang/en.json
+++ b/lang/en.json
@@ -758,7 +758,7 @@
   "expense.pending": "pending",
   "expense.platformFeeInCollectiveCurrency": "platform fee",
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
-  "expense.privateCommentsWarning": "The comments for this expense are private, you need to be authenticated as a host/collective admin or as an owner to see them.",
+  "expense.privateCommentsWarning": "Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them.",
   "expense.privateMessage": "Private instructions",
   "expense.privateMessage.description": "Private instructions for the host to reimburse your expense",
   "expense.privateNote": "private note",

--- a/lang/es.json
+++ b/lang/es.json
@@ -758,7 +758,7 @@
   "expense.pending": "pendiente",
   "expense.platformFeeInCollectiveCurrency": "comisión de la plataforma",
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
-  "expense.privateCommentsWarning": "The comments for this expense are private, you need to be authenticated as a host/collective admin or as an owner to see them.",
+  "expense.privateCommentsWarning": "Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them.",
   "expense.privateMessage": "Instrucciones privadas",
   "expense.privateMessage.description": "Instrucciones privadas para que el anfitrión reembolse sus gastos",
   "expense.privateNote": "nota privada",

--- a/lang/es.json
+++ b/lang/es.json
@@ -758,6 +758,7 @@
   "expense.pending": "pendiente",
   "expense.platformFeeInCollectiveCurrency": "comisión de la plataforma",
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
+  "expense.privateCommentsWarning": "The comments for this expense are private, you need to be authenticated as a host/collective admin or as an owner to see them.",
   "expense.privateMessage": "Instrucciones privadas",
   "expense.privateMessage.description": "Instrucciones privadas para que el anfitrión reembolse sus gastos",
   "expense.privateNote": "nota privada",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -758,6 +758,7 @@
   "expense.pending": "en attente",
   "expense.platformFeeInCollectiveCurrency": "commission de la plateforme",
   "Expense.PrivacyWarning": "Ce champ est public. N'ajoutez pas d'informations personnelles telles que des noms ou adresses.",
+  "expense.privateCommentsWarning": "The comments for this expense are private, you need to be authenticated as a host/collective admin or as an owner to see them.",
   "expense.privateMessage": "Instructions privées",
   "expense.privateMessage.description": "Les instructions privées sont uniquement visible pour les administrateurs du compte en banque de votre collectif",
   "expense.privateNote": "note privée",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -758,7 +758,7 @@
   "expense.pending": "en attente",
   "expense.platformFeeInCollectiveCurrency": "commission de la plateforme",
   "Expense.PrivacyWarning": "Ce champ est public. N'ajoutez pas d'informations personnelles telles que des noms ou adresses.",
-  "expense.privateCommentsWarning": "The comments for this expense are private, you need to be authenticated as a host/collective admin or as an owner to see them.",
+  "expense.privateCommentsWarning": "Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them.",
   "expense.privateMessage": "Instructions privées",
   "expense.privateMessage.description": "Les instructions privées sont uniquement visible pour les administrateurs du compte en banque de votre collectif",
   "expense.privateNote": "note privée",

--- a/lang/it.json
+++ b/lang/it.json
@@ -758,7 +758,7 @@
   "expense.pending": "in attesa",
   "expense.platformFeeInCollectiveCurrency": "compensi piattaforma",
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
-  "expense.privateCommentsWarning": "The comments for this expense are private, you need to be authenticated as a host/collective admin or as an owner to see them.",
+  "expense.privateCommentsWarning": "Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them.",
   "expense.privateMessage": "Istruzioni private",
   "expense.privateMessage.description": "Istruzioni private per l'host per rimborsare le tue spese",
   "expense.privateNote": "nota privata",

--- a/lang/it.json
+++ b/lang/it.json
@@ -758,6 +758,7 @@
   "expense.pending": "in attesa",
   "expense.platformFeeInCollectiveCurrency": "compensi piattaforma",
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
+  "expense.privateCommentsWarning": "The comments for this expense are private, you need to be authenticated as a host/collective admin or as an owner to see them.",
   "expense.privateMessage": "Istruzioni private",
   "expense.privateMessage.description": "Istruzioni private per l'host per rimborsare le tue spese",
   "expense.privateNote": "nota privata",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -758,7 +758,7 @@
   "expense.pending": "保留中",
   "expense.platformFeeInCollectiveCurrency": "プラットフォーム手数料",
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
-  "expense.privateCommentsWarning": "The comments for this expense are private, you need to be authenticated as a host/collective admin or as an owner to see them.",
+  "expense.privateCommentsWarning": "Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them.",
   "expense.privateMessage": "私的な指示",
   "expense.privateMessage.description": "ホストが請求を払い戻すための私的な指示",
   "expense.privateNote": "プライベートノート",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -758,6 +758,7 @@
   "expense.pending": "保留中",
   "expense.platformFeeInCollectiveCurrency": "プラットフォーム手数料",
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
+  "expense.privateCommentsWarning": "The comments for this expense are private, you need to be authenticated as a host/collective admin or as an owner to see them.",
   "expense.privateMessage": "私的な指示",
   "expense.privateMessage.description": "ホストが請求を払い戻すための私的な指示",
   "expense.privateNote": "プライベートノート",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -758,6 +758,7 @@
   "expense.pending": "pending",
   "expense.platformFeeInCollectiveCurrency": "platform fee",
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
+  "expense.privateCommentsWarning": "The comments for this expense are private, you need to be authenticated as a host/collective admin or as an owner to see them.",
   "expense.privateMessage": "Private instructions",
   "expense.privateMessage.description": "Private instructions for the host to reimburse your expense",
   "expense.privateNote": "private note",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -758,7 +758,7 @@
   "expense.pending": "pending",
   "expense.platformFeeInCollectiveCurrency": "platform fee",
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
-  "expense.privateCommentsWarning": "The comments for this expense are private, you need to be authenticated as a host/collective admin or as an owner to see them.",
+  "expense.privateCommentsWarning": "Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them.",
   "expense.privateMessage": "Private instructions",
   "expense.privateMessage.description": "Private instructions for the host to reimburse your expense",
   "expense.privateNote": "private note",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -758,7 +758,7 @@
   "expense.pending": "pendente",
   "expense.platformFeeInCollectiveCurrency": "taxa da plataforma",
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
-  "expense.privateCommentsWarning": "The comments for this expense are private, you need to be authenticated as a host/collective admin or as an owner to see them.",
+  "expense.privateCommentsWarning": "Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them.",
   "expense.privateMessage": "Instruções privadas",
   "expense.privateMessage.description": "Instruções privadas para o organizador reembolsar sua despesa",
   "expense.privateNote": "nota privada",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -758,6 +758,7 @@
   "expense.pending": "pendente",
   "expense.platformFeeInCollectiveCurrency": "taxa da plataforma",
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
+  "expense.privateCommentsWarning": "The comments for this expense are private, you need to be authenticated as a host/collective admin or as an owner to see them.",
   "expense.privateMessage": "Instruções privadas",
   "expense.privateMessage.description": "Instruções privadas para o organizador reembolsar sua despesa",
   "expense.privateNote": "nota privada",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -758,6 +758,7 @@
   "expense.pending": "ожидает",
   "expense.platformFeeInCollectiveCurrency": "комиссия платформы",
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
+  "expense.privateCommentsWarning": "The comments for this expense are private, you need to be authenticated as a host/collective admin or as an owner to see them.",
   "expense.privateMessage": "Личные инструкции",
   "expense.privateMessage.description": "Личные инструкции для представителя для возмещения ваших расходов",
   "expense.privateNote": "личная заметка",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -758,7 +758,7 @@
   "expense.pending": "ожидает",
   "expense.platformFeeInCollectiveCurrency": "комиссия платформы",
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
-  "expense.privateCommentsWarning": "The comments for this expense are private, you need to be authenticated as a host/collective admin or as an owner to see them.",
+  "expense.privateCommentsWarning": "Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them.",
   "expense.privateMessage": "Личные инструкции",
   "expense.privateMessage.description": "Личные инструкции для представителя для возмещения ваших расходов",
   "expense.privateNote": "личная заметка",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -758,6 +758,7 @@
   "expense.pending": "pending",
   "expense.platformFeeInCollectiveCurrency": "platform fee",
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
+  "expense.privateCommentsWarning": "The comments for this expense are private, you need to be authenticated as a host/collective admin or as an owner to see them.",
   "expense.privateMessage": "Private instructions",
   "expense.privateMessage.description": "Private instructions for the host to reimburse your expense",
   "expense.privateNote": "private note",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -758,7 +758,7 @@
   "expense.pending": "pending",
   "expense.platformFeeInCollectiveCurrency": "platform fee",
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
-  "expense.privateCommentsWarning": "The comments for this expense are private, you need to be authenticated as a host/collective admin or as an owner to see them.",
+  "expense.privateCommentsWarning": "Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them.",
   "expense.privateMessage": "Private instructions",
   "expense.privateMessage.description": "Private instructions for the host to reimburse your expense",
   "expense.privateNote": "private note",

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -2334,6 +2334,10 @@ type Expense {
   The state of the expense (pending, approved, paid, rejected...etc)
   """
   status: ExpenseStatus!
+
+  """
+  Returns the list of comments for this expense, or `null` if user is not allowed to see them
+  """
   comments(
     """
     The number of results to fetch (default 10, max 1000)
@@ -2345,7 +2349,7 @@ type Expense {
     """
     offset: Int = 0
     orderBy: ChronologicalOrderInput = { field: CREATED_AT, direction: ASC }
-  ): CommentCollection!
+  ): CommentCollection
 
   """
   The account where the expense was submitted
@@ -2625,6 +2629,11 @@ type ExpensePermissions {
   Whether the current user can mark this expense as unpaid
   """
   canMarkAsUnpaid: Boolean!
+
+  """
+  Whether the current user can comment and see comments for this expense
+  """
+  canComment: Boolean!
 }
 
 """

--- a/pages/expense-legacy.js
+++ b/pages/expense-legacy.js
@@ -28,6 +28,7 @@ class ExpensePage extends React.Component {
     ExpenseId: PropTypes.number,
     data: PropTypes.object.isRequired, // from withData
     LoggedInUser: PropTypes.object,
+    loadingLoggedInUser: PropTypes.bool,
     expenseCreated: PropTypes.string, // actually a stringed boolean 'true'
   };
 
@@ -63,7 +64,7 @@ class ExpensePage extends React.Component {
   }
 
   render() {
-    const { slug, data, ExpenseId, LoggedInUser } = this.props;
+    const { slug, data, ExpenseId, LoggedInUser, loadingLoggedInUser } = this.props;
 
     if (!data || data.error || data.loading) {
       return <ErrorPage data={data} />;
@@ -118,6 +119,7 @@ class ExpensePage extends React.Component {
                 host={collective.host}
                 view="details"
                 LoggedInUser={LoggedInUser}
+                loadingLoggedInUser={loadingLoggedInUser}
                 allowPayAction={!this.state.isPayActionLocked}
                 lockPayAction={() => this.setState({ isPayActionLocked: true })}
                 unlockPayAction={() => this.setState({ isPayActionLocked: false })}

--- a/pages/expense.js
+++ b/pages/expense.js
@@ -29,6 +29,7 @@ import { Box, Flex } from '../components/Grid';
 import I18nFormatters, { getI18nLink, I18nSupportLink } from '../components/I18nFormatters';
 import CommentIcon from '../components/icons/CommentIcon';
 import PrivateInfoIcon from '../components/icons/PrivateInfoIcon';
+import LoadingPlaceholder from '../components/LoadingPlaceholder';
 import MessageBox from '../components/MessageBox';
 import Page from '../components/Page';
 import StyledButton from '../components/StyledButton';
@@ -263,7 +264,7 @@ class ExpensePage extends React.Component {
   });
 
   getThreadItems = memoizeOne((comments, activities) => {
-    return sortBy([...comments, ...activities], 'createdAt');
+    return sortBy([...(comments || []), ...activities], 'createdAt');
   });
 
   onSuccessMsgDismiss = () => {
@@ -471,28 +472,49 @@ class ExpensePage extends React.Component {
                 />
               </Box>
             )}
+            {!expense?.permissions.canComment && (
+              <Box my={4}>
+                {loadingLoggedInUser || isRefetchingDataForUser ? (
+                  <LoadingPlaceholder height={76} borderRadius={8} />
+                ) : (
+                  <MessageBox type="info" px={4}>
+                    <Flex alignItems="center">
+                      <PrivateInfoIcon size={42} withoutTooltip />
+                      <P ml={3} fontSize="Paragraph" lineHeight="Paragraph">
+                        <FormattedMessage
+                          id="expense.privateCommentsWarning"
+                          defaultMessage="The comments for this expense are private, you need to be authenticated as a host/collective admin or as an owner to see them."
+                        />
+                      </P>
+                    </Flex>
+                  </MessageBox>
+                )}
+              </Box>
+            )}
             {expense && (
               <Box mb={3} pt={3}>
                 <Thread
                   collective={collective}
-                  items={this.getThreadItems(expense.comments.nodes, expense.activities)}
+                  items={this.getThreadItems(expense.comments?.nodes, expense.activities)}
                   onCommentDeleted={this.onCommentDeleted}
                 />
               </Box>
             )}
-            <Flex mt="40px">
-              <Box display={['none', null, 'block']} flex="0 0" p={3}>
-                <CommentIcon size={24} color="lightgrey" />
-              </Box>
-              <Box flex="1 1" maxWidth={[null, null, 'calc(100% - 56px)']}>
-                <CommentForm
-                  id="new-comment-on-expense"
-                  ExpenseId={expense && expense.id}
-                  disabled={!expense}
-                  onSuccess={this.onCommentAdded}
-                />
-              </Box>
-            </Flex>
+            {expense?.permissions.canComment && (
+              <Flex mt="40px">
+                <Box display={['none', null, 'block']} flex="0 0" p={3}>
+                  <CommentIcon size={24} color="lightgrey" />
+                </Box>
+                <Box flex="1 1" maxWidth={[null, null, 'calc(100% - 56px)']}>
+                  <CommentForm
+                    id="new-comment-on-expense"
+                    ExpenseId={expense && expense.id}
+                    disabled={!expense}
+                    onSuccess={this.onCommentAdded}
+                  />
+                </Box>
+              </Flex>
+            )}
           </Box>
           <Flex flex="1 1" justifyContent={['center', null, 'flex-start', 'flex-end']} pt={80}>
             <Box minWidth={270} width={['100%', null, null, 275]} px={2}>

--- a/pages/expense.js
+++ b/pages/expense.js
@@ -483,7 +483,7 @@ class ExpensePage extends React.Component {
                       <P ml={3} fontSize="Paragraph" lineHeight="Paragraph">
                         <FormattedMessage
                           id="expense.privateCommentsWarning"
-                          defaultMessage="The comments for this expense are private, you need to be authenticated as a host/collective admin or as an owner to see them."
+                          defaultMessage="Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them."
                         />
                       </P>
                     </Flex>


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-api/pull/4050
Resolve https://github.com/opencollective/opencollective/issues/3216

![image](https://user-images.githubusercontent.com/1556356/84478228-3ead4680-ac91-11ea-92b2-a48764b60e89.png)

Also implemented the same fix for `/legacy`:
![image](https://user-images.githubusercontent.com/1556356/84478636-f2aed180-ac91-11ea-9ad2-682318fceeed.png)
