### PR TITLE
ExpenseForm: Allow to empty address

### DIFF
--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -201,7 +201,7 @@ const ExpenseFormBody = ({
     if (!values.payeeLocation?.address && values.payee?.location) {
       setLocationFromPayee(formik, values.payee);
     }
-  }, [values.payee, values.payeeLocation?.address]);
+  }, [values.payee]);
 
   // Load values from localstorage
   React.useEffect(() => {


### PR DESCRIPTION
Fix a bug that was preventing to remove your address from the field