### PR TITLE
hasProcessButtons: Fix misleading condition

### DIFF
--- a/components/expenses/ProcessExpenseButtons.js
+++ b/components/expenses/ProcessExpenseButtons.js
@@ -39,8 +39,8 @@ export const hasProcessButtons = permissions => {
 
   return (
     permissions.canApprove ||
+    permissions.canUnapprove ||
     permissions.canReject ||
-    permissions.canPay ||
     permissions.canPay ||
     permissions.canMarkAsUnpaid
   );


### PR DESCRIPTION
Fix an issue that's not looking good but has no real incidence (because `Unapprove` button is never displayed alone).