### PR TITLE
fix: ensure that the support page is responsive

### DIFF
--- a/components/static-pages/support.md
+++ b/components/static-pages/support.md
@@ -6,4 +6,4 @@ We have team members answering from the USA, France, Belgium, Germany and New Ze
 
 To contact support, write by email to:
 
-<span style="font-size: 2em">[support@opencollective.com](mailto:support@opencollective.com)</span>
+<span style="font-size: 2em; word-break: break-all;">[support@opencollective.com](mailto:support@opencollective.com)</span>


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Fixes https://github.com/opencollective/opencollective/issues/3191#issue-629997583

# Description

Made the `e-mail` font responsive.
<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots

## Before
<img width="331" alt="before" src="https://user-images.githubusercontent.com/25279263/84985028-a401ab80-b159-11ea-9087-1fcb1a301275.png">

## After
<img width="313" alt="Screenshot 2020-06-24 at 12 31 35 PM" src="https://user-images.githubusercontent.com/25279263/85511727-b32fa000-b616-11ea-9f28-46b9938f7804.png">
