### PR TITLE
Make styled radio list a controlled component

### DIFF
--- a/components/StyledRadioList.js
+++ b/components/StyledRadioList.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { find } from 'lodash';
+import { find, isUndefined } from 'lodash';
 
 import Container from './Container';
 import { Box } from './Grid';
@@ -47,6 +47,14 @@ export const getItems = (options, keyGetter) => {
   );
 };
 
+const getValueFromProps = props => {
+  if (!isUndefined(props.value)) {
+    return props.value;
+  } else {
+    return props.defaultValue;
+  }
+};
+
 /**
  * Component for controlling a list of radio inputs
  */
@@ -62,26 +70,14 @@ const StyledRadioList = ({
   labelProps,
   ...props
 }) => {
-  const [selected, setSelected] = useState(props.defaultValue);
+  const [localStateSelected, setSelected] = useState(getValueFromProps(props));
   const keyExtractor = getKeyExtractor(options, keyGetter);
   const items = getItems(options, keyExtractor);
   const defaultValueStr = props.defaultValue !== undefined && props.defaultValue.toString();
+  const valueFromProps = getValueFromProps(props);
+  const selected = isUndefined(valueFromProps) ? localStateSelected : valueFromProps;
   return (
-    <Container
-      id={id}
-      as="fieldset"
-      border="none"
-      m={0}
-      p={0}
-      {...containerProps}
-      onChange={event => {
-        event.stopPropagation();
-        const target = event.target;
-        const selectedItem = find(items, item => item.key === target.value);
-        onChange({ type: 'fieldset', name, key: selectedItem.key, value: selectedItem.value });
-        setSelected(target.value);
-      }}
-    >
+    <Container id={id} as="fieldset" border="none" m={0} p={0} {...containerProps}>
       {items.map(({ value, key }, index) => (
         <Container as="label" cursor="pointer" htmlFor={id && key + id} key={key} width={1} m={0} {...labelProps}>
           {children({
@@ -95,9 +91,17 @@ const StyledRadioList = ({
                 name={name}
                 id={id && key + id}
                 value={key}
-                defaultChecked={props.defaultValue !== undefined && defaultValueStr === key}
+                defaultChecked={isUndefined(props.defaultValue) ? undefined : defaultValueStr === key}
+                checked={isUndefined(props.value) ? undefined : props.value === key}
                 disabled={disabled || (value && value.disabled)} // disable a specific option or entire options
                 data-cy="radio-select"
+                onChange={event => {
+                  event.stopPropagation();
+                  const target = event.target;
+                  const selectedItem = find(items, item => item.key === target.value);
+                  onChange({ type: 'fieldset', name, key: selectedItem.key, value: selectedItem.value });
+                  setSelected(target.value);
+                }}
               />
             ),
           })}
@@ -125,6 +129,8 @@ StyledRadioList.propTypes = {
   name: PropTypes.string.isRequired,
   /** event handler for when a selection is made */
   onChange: PropTypes.func,
+  /** for controlled components */
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.object]),
   /** list or map of options to display */
   options: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.shape()])),

--- a/components/StyledRadioList.js
+++ b/components/StyledRadioList.js
@@ -47,14 +47,6 @@ export const getItems = (options, keyGetter) => {
   );
 };
 
-const getValueFromProps = props => {
-  if (!isUndefined(props.value)) {
-    return props.value;
-  } else {
-    return props.defaultValue;
-  }
-};
-
 /**
  * Component for controlling a list of radio inputs
  */
@@ -70,12 +62,11 @@ const StyledRadioList = ({
   labelProps,
   ...props
 }) => {
-  const [localStateSelected, setSelected] = useState(getValueFromProps(props));
+  const [localStateSelected, setSelected] = useState(props.defaultValue);
   const keyExtractor = getKeyExtractor(options, keyGetter);
   const items = getItems(options, keyExtractor);
   const defaultValueStr = props.defaultValue !== undefined && props.defaultValue.toString();
-  const valueFromProps = getValueFromProps(props);
-  const selected = isUndefined(valueFromProps) ? localStateSelected : valueFromProps;
+  const selected = !isUndefined(props.value) ? props.value : localStateSelected;
   return (
     <Container id={id} as="fieldset" border="none" m={0} p={0} {...containerProps}>
       {items.map(({ value, key }, index) => (


### PR DESCRIPTION
This is part of a different PR but making it separate as it may be causing issues

The `StyledRadioList` component wasn't able to be used as a controlled component yet so @Betree and I added this functionality

Then due to React console errors we moved the `onChange` to the `input` rather than the outer container