### PR TITLE
Fix SSR compatibility with Pagination/fetchPolicy

### DIFF
--- a/components/Pagination.js
+++ b/components/Pagination.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withRouter } from 'next/router';
+import { useRouter } from 'next/router';
 import { FormattedMessage } from 'react-intl';
 
 import { Flex } from './Grid';
@@ -8,11 +8,15 @@ import Link from './Link';
 import StyledButton from './StyledButton';
 import { TextInput } from './StyledInput';
 
-const Pagination = ({ router, route, limit, offset, total, scrollToTopOnChange, isDisabled }) => {
-  const { pathname, query } = router;
+const Pagination = ({ route, limit, offset, total, scrollToTopOnChange, isDisabled }) => {
+  const router = useRouter();
   const totalPages = Math.ceil(total / limit);
   const currentPage = offset / limit + 1;
   isDisabled = isDisabled || totalPages <= 1;
+
+  if (!router) {
+    return null;
+  }
 
   const changePage = async ({ target, key }) => {
     if (key && key !== 'Enter') {
@@ -24,6 +28,7 @@ const Pagination = ({ router, route, limit, offset, total, scrollToTopOnChange, 
       return;
     }
 
+    const { pathname, query } = router;
     await router.push({ pathname, query: { ...query, offset: (value - 1) * limit } });
 
     if (scrollToTopOnChange) {
@@ -37,7 +42,7 @@ const Pagination = ({ router, route, limit, offset, total, scrollToTopOnChange, 
         <Link
           route={route || router.route.slice(1)}
           scroll={scrollToTopOnChange}
-          params={{ ...query, offset: offset - limit }}
+          params={{ ...router.query, offset: offset - limit }}
         >
           <StyledButton buttonSize="small" disabled={isDisabled}>
             <FormattedMessage id="Pagination.Prev" defaultMessage="Previous" />
@@ -71,7 +76,7 @@ const Pagination = ({ router, route, limit, offset, total, scrollToTopOnChange, 
         <Link
           route={route || router.route.slice(1)}
           scroll={scrollToTopOnChange}
-          params={{ ...query, offset: offset + limit }}
+          params={{ ...router.query, offset: offset + limit }}
         >
           <StyledButton buttonSize="small" disabled={isDisabled}>
             <FormattedMessage id="Pagination.Next" defaultMessage="Next" />
@@ -83,7 +88,6 @@ const Pagination = ({ router, route, limit, offset, total, scrollToTopOnChange, 
 };
 
 Pagination.propTypes = {
-  router: PropTypes.object,
   limit: PropTypes.number,
   offset: PropTypes.number,
   total: PropTypes.number,
@@ -97,4 +101,4 @@ Pagination.defaultProps = {
   scrollToTopOnChange: false,
 };
 
-export default withRouter(Pagination);
+export default Pagination;

--- a/lib/initClient.js
+++ b/lib/initClient.js
@@ -119,6 +119,7 @@ function createClient(initialState, graphqlUrl) {
     connectToDevTools: process.browser,
     ssrMode: !process.browser, // Disables forceFetch on the server (so queries are only run once)
     cache: cache.restore(initialState),
+    ssrForceFetchDelay: 100, // See https://www.apollographql.com/docs/react/performance/server-side-rendering/#store-rehydration
     link,
   });
 }

--- a/pages/discover.js
+++ b/pages/discover.js
@@ -1,10 +1,9 @@
 import React, { Fragment } from 'react';
-import PropTypes from 'prop-types';
 import { Query } from '@apollo/react-components';
 import gql from 'graphql-tag';
 import { get, times } from 'lodash';
-import { withRouter } from 'next/router';
-import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
+import { useRouter } from 'next/router';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import styled from 'styled-components';
 
 import { Link } from '../server/pages';
@@ -140,8 +139,10 @@ const I18nSortLabels = defineMessages({
   },
 });
 
-const DiscoverPage = ({ router, intl }) => {
-  const { query } = router;
+const DiscoverPage = () => {
+  const intl = useIntl();
+  const router = useRouter();
+  const query = router?.query || {};
 
   const params = {
     offset: Number(query.offset) || 0,
@@ -326,11 +327,4 @@ const DiscoverPage = ({ router, intl }) => {
   );
 };
 
-DiscoverPage.propTypes = {
-  /** @ignore from withRouter */
-  router: PropTypes.object,
-  /** @ignore from injectIntl */
-  intl: PropTypes.object,
-};
-
-export default withRouter(injectIntl(DiscoverPage));
+export default DiscoverPage;


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/3126

This PR resolves the issue of the discover page and the expenses page not being SSRed correctly. The root cause came from the `Pagination` component being passed an `undefined` Router object, which made it crash (we didn't see the error because they're not logged by default in https://github.com/opencollective/opencollective-frontend/blob/00688a2801eedf22d8d45c88199f5a3cf56ec72e/lib/withData.js#L72).

It's still unclear why the `router` object is undefined in one of the SSR render, my current hypothesis is that way we initialize styled-components forces an incomplete pre-render in https://github.com/opencollective/opencollective-frontend/blob/00688a2801eedf22d8d45c88199f5a3cf56ec72e/pages/_document.js#L43

---

I also replaced `withRouter` by `useRouter` in the two pages because it's what [NextJS recommends](https://nextjs.org/docs/api-reference/next/router#userouter).