### PR TITLE
i18n: Add string for recurring contribution status

### DIFF
--- a/components/recurring-contributions/RecurringContributionsCard.js
+++ b/components/recurring-contributions/RecurringContributionsCard.js
@@ -38,6 +38,10 @@ const messages = defineMessages({
     id: 'Subscriptions.Activate',
     defaultMessage: 'Activate',
   },
+  tag: {
+    id: 'Subscriptions.Status',
+    defaultMessage: '{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution',
+  },
 });
 
 const activateRecurringContributionMutation = gqlV2/* GraphQL */ `
@@ -65,7 +69,7 @@ const RecurringContributionsCard = ({
   });
 
   const { formatMessage } = useIntl();
-  const statusTag = `${status} contribution`;
+  const statusTag = formatMessage(messages.tag, { status });
   const buttonText = status === 'ACTIVE' ? formatMessage(messages.manage) : formatMessage(messages.activate);
   const isAdmin = LoggedInUser && LoggedInUser.canEditCollective(account);
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -1358,6 +1358,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.Edit": "Edit",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Large",
   "table.head.medium": "Medium",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1358,6 +1358,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.Edit": "Edit",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Grande",
   "table.head.medium": "Medio",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1358,6 +1358,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.Edit": "Edit",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Large",
   "table.head.medium": "Moyen",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1358,6 +1358,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.Edit": "Edit",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Large",
   "table.head.medium": "Medium",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1358,6 +1358,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.Edit": "Edit",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Large",
   "table.head.medium": "Medium",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1358,6 +1358,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.Edit": "Edit",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Large",
   "table.head.medium": "Medium",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1358,6 +1358,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.Edit": "Edit",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Grande",
   "table.head.medium": "Medio",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1358,6 +1358,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.Edit": "Edit",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Large",
   "table.head.medium": "Medium",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1358,6 +1358,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.Edit": "Edit",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Large",
   "table.head.medium": "Medium",


### PR DESCRIPTION
The string for contribution status was not translated. It can appear difficult to translate those kind of dynamic strings, but react-intl has a `select` helper that simplifies it. More info: https://docs.opencollective.com/help/contributing/development/translations#use-select-when-a-value-has-a-limited-number-of-options