### PR TITLE
Expenses: allow simple text formatting for private notes

### DIFF
--- a/components/RichTextEditor.js
+++ b/components/RichTextEditor.js
@@ -84,6 +84,21 @@ const TrixEditorContainer = styled.div`
       }
     }
 
+    /** Hide some buttons on the simplified version */
+    ${props =>
+      props.version === 'simplified' &&
+      css({
+        '.trix-button-group--file-tools': {
+          display: 'none',
+        },
+        '.trix-button-group--block-tools .trix-button:not(.trix-button--icon-number-list):not(.trix-button--icon-bullet-list)': {
+          display: 'none',
+        },
+        '.trix-button--icon-bullet-list': {
+          borderLeft: 'none',
+        },
+      })}
+
     /** Hide some buttons on mobile */
     @media (max-width: 500px) {
       .trix-button--icon-strike,
@@ -148,6 +163,8 @@ export default class RichTextEditor extends React.Component {
     withStickyToolbar: PropTypes.bool,
     /** This component is borderless by default. Set this to `true` to change that. */
     withBorders: PropTypes.bool,
+    /** This component is borderless by default. Set this to `true` to change that. */
+    version: PropTypes.oneOf(['default', 'simplified']),
     /** Wether the field should be disabled */
     disabled: PropTypes.bool,
     /** If position is sticky, this prop defines the `top` property. Support responsive arrays */
@@ -158,6 +175,7 @@ export default class RichTextEditor extends React.Component {
     editorMinHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
     /** If truthy, will display a red outline */
     error: PropTypes.any,
+    'data-cy': PropTypes.string,
   };
 
   static defaultProps = {
@@ -166,6 +184,8 @@ export default class RichTextEditor extends React.Component {
     toolbarOffsetY: -62, // Default Trix toolbar height
     inputName: 'content',
     toolbarBackgroundColor: 'white',
+    version: 'default',
+    'data-cy': 'RichTextEditor',
   };
 
   constructor(props) {
@@ -371,7 +391,9 @@ export default class RichTextEditor extends React.Component {
       disabled,
       error,
       fontSize,
+      version,
     } = this.props;
+
     return !this.state.id ? (
       <LoadingPlaceholder height={editorMinHeight ? editorMinHeight + 56 : 200} />
     ) : (
@@ -382,9 +404,10 @@ export default class RichTextEditor extends React.Component {
         toolbarBackgroundColor={toolbarBackgroundColor}
         editorMinHeight={editorMinHeight}
         withBorders={withBorders}
+        version={version}
         isDisabled={disabled}
         error={error}
-        data-cy="RichTextEditor"
+        data-cy={this.props['data-cy']}
       >
         {this.state.error && (
           <MessageBox type="error" withIcon>

--- a/components/conversations/Thread.js
+++ b/components/conversations/Thread.js
@@ -108,4 +108,4 @@ Thread.propTypes = {
   theme: PropTypes.object,
 };
 
-export default withUser(withTheme(Thread));
+export default React.memo(withUser(withTheme(Thread)));

--- a/components/expenses/CreateExpenseFormLegacy.js
+++ b/components/expenses/CreateExpenseFormLegacy.js
@@ -11,9 +11,12 @@ import { getCurrencySymbol } from '../../lib/currency-utils';
 import Button from '../Button';
 import Container from '../Container';
 import DefinedTerm, { Terms } from '../DefinedTerm';
+import { Box } from '../Grid';
 import InputField from '../InputField';
 import SignInOrJoinFree from '../SignInOrJoinFree';
 import { P } from '../Text';
+
+import ExpenseNotesForm from './ExpenseNotesForm';
 
 class CreateExpenseForm extends React.Component {
   static propTypes = {
@@ -549,18 +552,13 @@ class CreateExpenseForm extends React.Component {
               <label>
                 <FormattedMessage id="expense.privateMessage" defaultMessage="Private instructions" />
               </label>
-              <InputField
-                type="textarea"
-                name="privateMessage"
-                onChange={privateMessage => this.handleChange('privateMessage', privateMessage)}
-                defaultValue={expense.privateMessage}
-                description={
-                  <FormattedMessage
-                    id="expense.privateMessage.description"
-                    defaultMessage="Private instructions for the host to reimburse your expense"
-                  />
-                }
-              />
+              <Box mb={3}>
+                <ExpenseNotesForm
+                  hideLabel
+                  onChange={e => this.handleChange('privateMessage', e.target.value)}
+                  defaultValue={expense.privateMessage}
+                />
+              </Box>
             </div>
 
             <div className="row">

--- a/components/expenses/ExpenseDetails.js
+++ b/components/expenses/ExpenseDetails.js
@@ -10,18 +10,19 @@ import { formatCurrency, getCurrencySymbol } from '../../lib/currency-utils';
 import { formatErrorMessage } from '../../lib/errors';
 import { imagePreview } from '../../lib/image-utils';
 import { getFromLocalStorage, LOCAL_STORAGE_KEYS } from '../../lib/local-storage';
-import { capitalize } from '../../lib/utils';
 
 import InputField from '../../components/InputField';
 
 import DefinedTerm, { Terms } from '../DefinedTerm';
 import { Box, Flex } from '../Grid';
+import HTMLContent from '../HTMLContent';
 import MessageBox from '../MessageBox';
 import StyledButton from '../StyledButton';
 import StyledLink from '../StyledLink';
 import StyledSpinner from '../StyledSpinner';
 
 import ExpenseInvoiceDownloadHelper from './ExpenseInvoiceDownloadHelper';
+import ExpenseNotesForm from './ExpenseNotesForm';
 import PayoutMethodData from './PayoutMethodData';
 import PayoutMethodTypeWithIcon from './PayoutMethodTypeWithIcon';
 import TransactionDetails from './TransactionDetails';
@@ -369,14 +370,16 @@ class ExpenseDetails extends React.Component {
               <label>
                 <FormattedMessage id="expense.privateNote" defaultMessage="private note" />
               </label>
-              {(!editMode || !isAuthor) && capitalize(expense.privateMessage)}
-              {editMode && (isAuthor || canEditExpense) && (
-                <InputField
-                  type="textarea"
-                  name="privateMessage"
-                  onChange={privateMessage => this.handleChange('privateMessage', privateMessage)}
-                  defaultValue={expense.privateMessage}
-                />
+              {!editMode ? (
+                <HTMLContent content={expense.privateMessage} fontSize="12px" />
+              ) : (
+                <Box mb={2}>
+                  <ExpenseNotesForm
+                    hideLabel
+                    onChange={e => this.handleChange('privateMessage', e.target.value)}
+                    defaultValue={expense.privateMessage}
+                  />
+                </Box>
               )}
             </div>
           )}

--- a/components/expenses/ExpenseNotesForm.js
+++ b/components/expenses/ExpenseNotesForm.js
@@ -2,9 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
+import { Box } from '../Grid';
 import PrivateInfoIcon from '../icons/PrivateInfoIcon';
+import RichTextEditor from '../RichTextEditor';
 import StyledInputField from '../StyledInputField';
-import StyledTextarea from '../StyledTextarea';
 import { Span } from '../Text';
 
 const msg = defineMessages({
@@ -24,25 +25,32 @@ const PrivateNoteLabel = () => {
   );
 };
 
-const ExpenseNotesForm = ({ onChange, disabled, defaultValue }) => {
+const ExpenseNotesForm = ({ onChange, disabled, defaultValue, hideLabel }) => {
   const { formatMessage } = useIntl();
   return (
     <StyledInputField
+      htmlFor="expense-privateMessage-input"
       name="privateMessage"
       required={false}
-      maxWidth={782}
-      label={<PrivateNoteLabel />}
+      label={hideLabel ? null : <PrivateNoteLabel />}
       labelProps={{ fontWeight: '500', fontSize: 'LeadCaption' }}
     >
       {inputProps => (
-        <StyledTextarea
-          {...inputProps}
-          placeholder={formatMessage(msg.notesPlaceholder)}
-          minHeight={72}
-          onChange={onChange}
-          disabled={disabled}
-          defaultValue={defaultValue}
-        />
+        <Box mt={2}>
+          <RichTextEditor
+            withBorders
+            version="simplified"
+            id={inputProps.id}
+            inputName={inputProps.name}
+            placeholder={formatMessage(msg.notesPlaceholder)}
+            minHeight={72}
+            onChange={onChange}
+            disabled={disabled}
+            defaultValue={defaultValue}
+            fontSize="LeadCaption"
+            data-cy="ExpenseNotesEditor"
+          />
+        </Box>
       )}
     </StyledInputField>
   );
@@ -51,6 +59,7 @@ const ExpenseNotesForm = ({ onChange, disabled, defaultValue }) => {
 ExpenseNotesForm.propTypes = {
   defaultValue: PropTypes.string,
   disabled: PropTypes.bool,
+  hideLabel: PropTypes.bool,
   onChange: PropTypes.func,
 };
 

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -764,7 +764,6 @@
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "expense.privateCommentsWarning": "Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them.",
   "expense.privateMessage": "Instruccions privades",
-  "expense.privateMessage.description": "Private instructions for the host to reimburse your expense",
   "expense.privateNote": "nova privada",
   "Expense.PrivateNote": "Private note",
   "expense.processing": "processing",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -764,7 +764,6 @@
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "expense.privateCommentsWarning": "Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them.",
   "expense.privateMessage": "Soukromé pokyny",
-  "expense.privateMessage.description": "Private instructions for the host to reimburse your expense",
   "expense.privateNote": "soukromá poznámka",
   "Expense.PrivateNote": "Private note",
   "expense.processing": "processing",

--- a/lang/de.json
+++ b/lang/de.json
@@ -764,7 +764,6 @@
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "expense.privateCommentsWarning": "Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them.",
   "expense.privateMessage": "Private instructions",
-  "expense.privateMessage.description": "Private instructions for the host to reimburse your expense",
   "expense.privateNote": "private note",
   "Expense.PrivateNote": "Private note",
   "expense.processing": "processing",

--- a/lang/en.json
+++ b/lang/en.json
@@ -764,7 +764,6 @@
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "expense.privateCommentsWarning": "Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them.",
   "expense.privateMessage": "Private instructions",
-  "expense.privateMessage.description": "Private instructions for the host to reimburse your expense",
   "expense.privateNote": "private note",
   "Expense.PrivateNote": "Private note",
   "expense.processing": "Processing",

--- a/lang/es.json
+++ b/lang/es.json
@@ -764,7 +764,6 @@
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "expense.privateCommentsWarning": "Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them.",
   "expense.privateMessage": "Instrucciones privadas",
-  "expense.privateMessage.description": "Instrucciones privadas para que el anfitrión reembolse sus gastos",
   "expense.privateNote": "nota privada",
   "Expense.PrivateNote": "Nota privada",
   "expense.processing": "Processing",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -764,7 +764,6 @@
   "Expense.PrivacyWarning": "Ce champ est public. N'ajoutez pas d'informations personnelles telles que des noms ou adresses.",
   "expense.privateCommentsWarning": "Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them.",
   "expense.privateMessage": "Instructions privées",
-  "expense.privateMessage.description": "Les instructions privées sont uniquement visible pour les administrateurs du compte en banque de votre collectif",
   "expense.privateNote": "note privée",
   "Expense.PrivateNote": "Note privée",
   "expense.processing": "Processing",

--- a/lang/it.json
+++ b/lang/it.json
@@ -764,7 +764,6 @@
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "expense.privateCommentsWarning": "Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them.",
   "expense.privateMessage": "Istruzioni private",
-  "expense.privateMessage.description": "Istruzioni private per l'host per rimborsare le tue spese",
   "expense.privateNote": "nota privata",
   "Expense.PrivateNote": "Nota privata",
   "expense.processing": "Processing",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -764,7 +764,6 @@
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "expense.privateCommentsWarning": "Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them.",
   "expense.privateMessage": "私的な指示",
-  "expense.privateMessage.description": "ホストが請求を払い戻すための私的な指示",
   "expense.privateNote": "プライベートノート",
   "Expense.PrivateNote": "自分用メモ",
   "expense.processing": "Processing",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -764,7 +764,6 @@
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "expense.privateCommentsWarning": "Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them.",
   "expense.privateMessage": "Private instructions",
-  "expense.privateMessage.description": "Private instructions for the host to reimburse your expense",
   "expense.privateNote": "private note",
   "Expense.PrivateNote": "Private note",
   "expense.processing": "processing",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -764,7 +764,6 @@
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "expense.privateCommentsWarning": "Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them.",
   "expense.privateMessage": "Private instructions",
-  "expense.privateMessage.description": "Private instructions for the host to reimburse your expense",
   "expense.privateNote": "private note",
   "Expense.PrivateNote": "Private note",
   "expense.processing": "Processing",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -764,7 +764,6 @@
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "expense.privateCommentsWarning": "Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them.",
   "expense.privateMessage": "Instruções privadas",
-  "expense.privateMessage.description": "Instruções privadas para o organizador reembolsar sua despesa",
   "expense.privateNote": "nota privada",
   "Expense.PrivateNote": "Nota privada",
   "expense.processing": "Processing",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -764,7 +764,6 @@
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "expense.privateCommentsWarning": "Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them.",
   "expense.privateMessage": "Личные инструкции",
-  "expense.privateMessage.description": "Личные инструкции для представителя для возмещения ваших расходов",
   "expense.privateNote": "личная заметка",
   "Expense.PrivateNote": "Private note",
   "expense.processing": "Processing",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -764,7 +764,6 @@
   "Expense.PrivacyWarning": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "expense.privateCommentsWarning": "Comments for this expense are private. You must be signed in as an admin or the expense submitter to view them.",
   "expense.privateMessage": "Private instructions",
-  "expense.privateMessage.description": "Private instructions for the host to reimburse your expense",
   "expense.privateNote": "private note",
   "Expense.PrivateNote": "Private note",
   "expense.processing": "Processing",

--- a/pages/expense.js
+++ b/pages/expense.js
@@ -26,6 +26,7 @@ import {
 } from '../components/expenses/graphql/fragments';
 import MobileCollectiveInfoStickyBar from '../components/expenses/MobileCollectiveInfoStickyBar';
 import { Box, Flex } from '../components/Grid';
+import HTMLContent from '../components/HTMLContent';
 import I18nFormatters, { getI18nLink, I18nSupportLink } from '../components/I18nFormatters';
 import CommentIcon from '../components/icons/CommentIcon';
 import PrivateInfoIcon from '../components/icons/PrivateInfoIcon';
@@ -409,9 +410,7 @@ class ExpensePage extends React.Component {
                           <FormattedMessage id="expense.notes" defaultMessage="Notes" />
                         </H5>
                         <PrivateNoteLabel mb={2} />
-                        <P color="black.700" mt={1} fontSize="LeadCaption" whiteSpace="pre-wrap">
-                          {expense.privateMessage}
-                        </P>
+                        <HTMLContent color="black.700" mt={1} fontSize="LeadCaption" content={expense.privateMessage} />
                       </Container>
                     )}
                   </React.Fragment>

--- a/test/cypress/integration/27-expenses.test.js
+++ b/test/cypress/integration/27-expenses.test.js
@@ -234,7 +234,7 @@ describe('Legacy expense flow', () => {
       cy.get('.inputField.paypalEmail input').type('{selectall}{del}');
       cy.get('.error').should('have.text', 'Please provide your PayPal email address (or change the payout method)');
       cy.get('.inputField.paypalEmail input').type('paypal@test.com');
-      cy.get('.inputField.privateMessage textarea').type('Some private note for the host');
+      cy.get('[data-cy="ExpenseNotesEditor"] trix-editor').type('Some private note for the host');
       cy.get('button[type=submit]').click();
       cy.get('[data-cy="expenseCreated"]').contains('success');
       cy.visit('/testcollective/expenses/legacy');
@@ -255,7 +255,7 @@ describe('Legacy expense flow', () => {
       cy.get('.LoginTopBarProfileButton').contains('testuseradmin', {
         timeout: 15000,
       });
-      cy.get('.inputField.privateMessage textarea').type('Some private note for the host');
+      cy.get('[data-cy="ExpenseNotesEditor"] trix-editor').type('Some private note for the host');
       cy.get('button[type=submit]').click();
       cy.get('[data-cy="expenseCreated"]').contains('success');
       cy.visit('/testcollective/expenses/legacy');
@@ -269,9 +269,7 @@ describe('Legacy expense flow', () => {
       cy.get('.Expenses .expense:first .inputField.description input').type(' edited');
       cy.get('.Expenses .expense:first .inputField.amount input').type('{selectall}13');
       cy.get('.Expenses .expense:first .inputField.category select').select('Team');
-      cy.get('.Expenses .expense:first .inputField.privateMessage textarea').type(
-        '{selectall}Another private note (edited)',
-      );
+      cy.get('[data-cy="ExpenseNotesEditor"] trix-editor').type('{selectall}Another private note (edited)');
       cy.get('.Expenses .expense:first .inputField.description input').focus();
       cy.wait(300);
       cy.getByDataCy('expense-edit-save-btn').click();


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-api/pull/4137

In the expense form, for the `Add notes` field, some users would benefit from having some basic formatting - especially to add links. This PR is a proof of concept to implement that.


# Todo

If accepted, the following items will have to be tackled before merging:

**API**
- Sanitize the field
- Make sure old entries have nothing risky set for this

**Frontend**
- Render the notes with a `HTMLContent` on the expense page and on the host dashboard

# Preview

## Default

![2020-06-24_09-19-35](https://user-images.githubusercontent.com/1556356/85515809-d39f3080-b5fd-11ea-8aeb-b080a5d5834f.png)

![2020-06-24_09-17-52](https://user-images.githubusercontent.com/1556356/85515818-d69a2100-b5fd-11ea-9a64-f524029d00a1.png)


## Borderless

![2020-06-24_09-19-03](https://user-images.githubusercontent.com/1556356/85515836-db5ed500-b5fd-11ea-8c02-a7e7474733a4.png)

![2020-06-24_09-18-53](https://user-images.githubusercontent.com/1556356/85515844-dc900200-b5fd-11ea-9200-4bb473f5104a.png)
