### PR TITLE
Rename NewCollectivePage to CollectivePage

### DIFF
--- a/components/collective-page/README.md
+++ b/components/collective-page/README.md
@@ -1,6 +1,6 @@
 # Collective page
 
-This file documents some the development choices made for the new collective page, as well
+This file documents some the development choices made for the collective page, as well
 as some conventions that we must follow.
 
 ### Sections
@@ -14,7 +14,7 @@ The binding of the data to the section happens in `components/collective-page/in
 The following rule should ideally be applied when fetching data for a section:
 
 If the section is going to be displayed for the majority of the collectives (contribute, updates...etc)
-then we should fetch the data in the page container, `pages/new-collective-page.js`.
+then we should fetch the data in the page container, `pages/collective-page.js`.
 
 However if the section will only be displayed for certain collectives, under certain conditions or
 if it will only be displayed for users/organizations/hosts then the data should be fetched at the component

--- a/components/collective-page/sections/Contribute.js
+++ b/components/collective-page/sections/Contribute.js
@@ -13,7 +13,7 @@ import { getErrorFromGraphqlException } from '../../../lib/errors';
 import { isPastEvent } from '../../../lib/events';
 import { API_V2_CONTEXT } from '../../../lib/graphql/helpers';
 
-import { getCollectivePageQueryVariables } from '../../../pages/new-collective-page';
+import { getCollectivePageQueryVariables } from '../../../pages/collective-page';
 import Container from '../../Container';
 import ContainerOverlay from '../../ContainerOverlay';
 import { CONTRIBUTE_CARD_WIDTH } from '../../contribute-cards/Contribute';

--- a/pages/collective-page.js
+++ b/pages/collective-page.js
@@ -7,7 +7,7 @@ import { createGlobalStyle } from 'styled-components';
 
 import { generateNotFoundError } from '../lib/errors';
 
-import CollectivePage from '../components/collective-page';
+import CollectivePageContent from '../components/collective-page';
 import CollectiveNotificationBar from '../components/collective-page/CollectiveNotificationBar';
 import { getCollectivePageQuery } from '../components/collective-page/graphql/queries';
 import CollectiveThemeProvider from '../components/CollectiveThemeProvider';
@@ -49,7 +49,7 @@ const GlobalStyles = createGlobalStyle`
  * The main page to display collectives. Wrap route parameters and GraphQL query
  * to render `components/collective-page` with everything needed.
  */
-class NewCollectivePage extends React.Component {
+class CollectivePage extends React.Component {
   static getInitialProps({ req, res, query: { slug, status, step, mode } }) {
     if (res && req && (req.language || req.locale === 'en')) {
       res.set('Cache-Control', 'public, s-maxage=300');
@@ -169,7 +169,7 @@ class NewCollectivePage extends React.Component {
             />
             <CollectiveThemeProvider collective={collective}>
               {({ onPrimaryColorChange }) => (
-                <CollectivePage
+                <CollectivePageContent
                   collective={collective}
                   host={collective.host}
                   coreContributors={collective.coreContributors}
@@ -230,4 +230,4 @@ const getCollective = graphql(getCollectivePageQuery, {
   }),
 });
 
-export default withUser(getCollective(NewCollectivePage));
+export default withUser(getCollective(CollectivePage));

--- a/server/pages.js
+++ b/server/pages.js
@@ -79,9 +79,9 @@ pages.add(
   'new-create-collective',
 );
 
-// Events and Projects using new collective page
-pages.add('event', '/:parentCollectiveSlug/events/:slug', 'new-collective-page');
-pages.add('project', '/:parentCollectiveSlug/projects/:slug', 'new-collective-page');
+// Events and Projects using collective page
+pages.add('event', '/:parentCollectiveSlug/events/:slug', 'collective-page');
+pages.add('project', '/:parentCollectiveSlug/projects/:slug', 'collective-page');
 
 // Tier page
 // ---------------
@@ -179,15 +179,12 @@ pages.add(
 // Collective
 // ----------
 
-// New collective page - we keep the v2 alias because we shared some of these URLs by email
-pages.add('new-collective-page', '/:slug/v2');
-
 // Collective page
-pages.add('collective', '/:slug', 'new-collective-page');
+pages.add('collective', '/:slug', 'collective-page');
 pages.add(
   'collective-with-onboarding',
   '/:slug/:mode(onboarding)?/:step(administrators|contact|success)?',
-  'new-collective-page',
+  'collective-page',
 );
 
 // New accept financial contributions flow

--- a/test/cypress/integration/00-ssr-errors.test.js
+++ b/test/cypress/integration/00-ssr-errors.test.js
@@ -1,5 +1,5 @@
 const notFoundSlug = 'a-collective-that-does-not-exist';
-const notFoundURL = `/${notFoundSlug}/v2`;
+const notFoundURL = `/${notFoundSlug}`;
 
 it("fetching a collective page that doesn't exist returns a 404", () => {
   cy.request({ url: notFoundURL, failOnStatusCode: false }).then(resp => {

--- a/test/cypress/integration/04-collective.test.js
+++ b/test/cypress/integration/04-collective.test.js
@@ -4,7 +4,7 @@ import mockRecaptcha from '../mocks/recaptcha';
 import { disableSmoothScroll } from '../support/helpers';
 
 const scrollToSection = section => {
-  // Wait for new collective page to load before disabling smooth scroll
+  // Wait for collective page to load before disabling smooth scroll
   cy.get('[data-cy=collective-page-main]');
   disableSmoothScroll();
   cy.get(`#section-${section}`).scrollIntoView();
@@ -18,7 +18,7 @@ const uploadImage = ({ dropzone, fileName }) => {
   cy.wait(900);
 };
 
-describe('New collective page', () => {
+describe('Collective page', () => {
   let collectiveSlug = null;
   before(() => {
     cy.createHostedCollective({
@@ -27,11 +27,11 @@ describe('New collective page', () => {
       website: 'opencollective.com/testCollective',
     })
       .then(({ slug }) => (collectiveSlug = slug))
-      .then(() => cy.visit(`/${collectiveSlug}/v2`));
+      .then(() => cy.visit(`/${collectiveSlug}`));
   });
 
   beforeEach(() => {
-    cy.login({ redirect: `/${collectiveSlug}/v2` });
+    cy.login({ redirect: `/${collectiveSlug}` });
     cy.wait(900);
   });
 
@@ -118,7 +118,7 @@ describe('New collective page', () => {
         cy.get('[data-cy=edit-update-submit-btn]').click();
       });
       cy.get('[data-cy=PublishUpdateBtn] button').click();
-      cy.visit(`/${collectiveSlug}/v2`);
+      cy.visit(`/${collectiveSlug}`);
       scrollToSection(Sections.UPDATES);
       cy.get('[data-cy=view-all-updates-btn]').should('be.visible');
     });
@@ -165,9 +165,9 @@ describe('New collective page', () => {
   });
 });
 
-describe('New Collective page with euro currency', () => {
+describe('Collective page with euro currency', () => {
   before(() => {
-    cy.visit('/brusselstogether/v2');
+    cy.visit('/brusselstogether');
   });
 
   it('contributors amount in euro', () => {
@@ -216,7 +216,7 @@ describe('Edit public message after contribution', () => {
         cy.get('[data-cy=EditPublicMessagePopup]');
 
         // SECTION: Go to the collective page and change the public message
-        cy.visit(`/${slug}/v2`);
+        cy.visit(`/${slug}`);
         /** Cypress can't find the public message text unless we do this.
          * Probably related to this issue: https://github.com/cypress-io/cypress/issues/695
          */

--- a/test/cypress/integration/04-organization.test.js
+++ b/test/cypress/integration/04-organization.test.js
@@ -1,7 +1,7 @@
 describe('New organization profile', () => {
   /**
-   * Contributions section is already tested in `05-user_v2.test.js`
-   * About section is already tested in `04-collective_v2.test.js`
+   * Contributions section is already tested in `05-user.test.js`
+   * About section is already tested in `04-collective.test.js`
    */
   beforeEach(() => {
     cy.createCollective({ type: 'ORGANIZATION' }).then(collective => {
@@ -20,7 +20,7 @@ describe('New organization profile', () => {
   });
 
   describe('Transactions section', () => {
-    // The rest of the transactions section tests are in `05-user_v2.test.js`
+    // The rest of the transactions section tests are in `05-user.test.js`
     it("Has no filters (because organizations don't have expenses)", () => {
       cy.getByDataCy('filters').should('not.exist');
       cy.getByDataCy('section-transactions').click();

--- a/test/cypress/integration/05-user.test.js
+++ b/test/cypress/integration/05-user.test.js
@@ -1,6 +1,6 @@
 describe('New users profiles', () => {
   before(() => {
-    cy.visit('/xdamman/v2');
+    cy.visit('/xdamman');
   });
   describe('Contributions section', () => {
     it('Shows contributions with date since and amount contributed', () => {

--- a/test/cypress/integration/06-host.test.js
+++ b/test/cypress/integration/06-host.test.js
@@ -1,13 +1,13 @@
 describe('New host page', () => {
   /**
-   * About section is already tested in `04-collective_v2.test.js`
+   * About section is already tested in `04-collective.test.js`
    */
   before(() => {
-    cy.visit('/opensourceorg/v2');
+    cy.visit('/opensourceorg');
   });
 
   describe('Contributions section', () => {
-    // The rest of the contributions section is already tested in `05-user_v2.test.js`
+    // The rest of the contributions section is already tested in `05-user.test.js`
     it('Show fiscally hosted collectives', () => {
       cy.contains('[data-cy~="filter-button"]', 'Hosted Collectives').click();
       cy.contains('[data-cy=Contributions]', 'Open Source Collective');
@@ -25,7 +25,7 @@ describe('New host page', () => {
   });
 
   describe('Transactions section', () => {
-    // The rest of the transactions section tests are in `05-user_v2.test.js`
+    // The rest of the transactions section tests are in `05-user.test.js`
     it("Has no filters (because hosts don't create expenses)", () => {
       cy.contains('[data-cy~="filter-button"]', 'Expenses').should('not.exist');
     });


### PR DESCRIPTION
It's been almost a year since the release of the new collective page (time flies!) and the old one has already been removed completely. There's no point in calling it "_New_ Collective page" anymore.

**Breaking change**
This PR removes the support for the `/:collective/v2` URL