### PR TITLE
FormattedMoneyAmount: Set default precision to 2

### DIFF
--- a/components/ContributorCard.js
+++ b/components/ContributorCard.js
@@ -128,7 +128,7 @@ const ContributorCard = ({ intl, width, height, contributor, currency, isLoggedU
               <FormattedMessage id="ContributorCard.Total" defaultMessage="Total contributions" />
             </P>
             <P fontSize="Caption" fontWeight="bold">
-              <FormattedMoneyAmount amount={contributor.totalAmountDonated} currency={currency} />
+              <FormattedMoneyAmount amount={contributor.totalAmountDonated} currency={currency} precision={0} />
             </P>
           </React.Fragment>
         )}

--- a/components/FormattedMoneyAmount.js
+++ b/components/FormattedMoneyAmount.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { isNil } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 
+import { CurrencyPrecision } from '../lib/constants/currency-precision';
+
 import Currency from './Currency';
 import { Span } from './Text';
 
@@ -86,7 +88,7 @@ FormattedMoneyAmount.propTypes = {
 FormattedMoneyAmount.defaultProps = {
   abbreviate: false,
   abbreviateInterval: false,
-  precision: 0,
+  precision: CurrencyPrecision.DEFAULT,
   amountStyles: DEFAULT_AMOUNT_STYLES,
   showCurrencyCode: true,
 };

--- a/components/PledgeCard.js
+++ b/components/PledgeCard.js
@@ -33,6 +33,7 @@ const PledgeCard = ({ currency, fromCollective, interval, publicMessage, totalAm
           currency={currency}
           interval={interval}
           amountStyles={{ fontWeight: 'bold' }}
+          precision={0}
         />
       </Span>
     </P>

--- a/components/collective-page/TopContributors.js
+++ b/components/collective-page/TopContributors.js
@@ -115,6 +115,7 @@ const ContributorsBlock = ({ title, contributors, totalNbContributors, currency,
                         <FormattedMoneyAmount
                           amount={contributor.totalAmountDonated}
                           currency={currency}
+                          precision={0}
                           abbreviateAmount
                         />
                       </Span>

--- a/components/pricing/PricingTable.js
+++ b/components/pricing/PricingTable.js
@@ -202,6 +202,7 @@ const Cell = ({ content, header, height }) => {
                 currency="USD"
                 amountStyles={{ ...DEFAULT_AMOUNT_STYLES, fontSize: 20 }}
                 showCurrencyCode={false}
+                precision={0}
               />
             </Box>
             <Box as="span" display={['inline', null, 'none']}>
@@ -212,6 +213,7 @@ const Cell = ({ content, header, height }) => {
                 amountStyles={{ ...DEFAULT_AMOUNT_STYLES, fontSize: 20 }}
                 showCurrencyCode={false}
                 abbreviateInterval
+                precision={0}
               />
             </Box>
           </td>

--- a/components/tier-page/index.js
+++ b/components/tier-page/index.js
@@ -289,6 +289,7 @@ class TierPage extends Component {
                             abbreviateAmount={tier.goal > 1000000}
                             abbreviateInterval
                             amountStyles={{ fontWeight: 'bold', color: 'black.900' }}
+                            precision={0}
                           />
                         ),
                       }}
@@ -315,6 +316,7 @@ class TierPage extends Component {
                             interval={tier.interval}
                             amountStyles={{ fontWeight: 'bold', color: 'black.700' }}
                             abbreviateAmount={amountRaised > 1000000}
+                            precision={0}
                             abbreviateInterval
                           />
                         ),

--- a/test/cypress/integration/39-recurring-contributions.test.js
+++ b/test/cypress/integration/39-recurring-contributions.test.js
@@ -112,7 +112,7 @@ describe('Recurring contributions', () => {
       cy.getByDataCy('recurring-contribution-update-order-button').click();
       cy.wait('@updateorder', { responseTimeout: 15000 }).its('status').should('eq', 200);
       cy.getByDataCy('temporary-notification').contains('Your recurring contribution has been updated.');
-      cy.getByDataCy('recurring-contribution-amount-contributed').contains('$2 USD / month');
+      cy.getByDataCy('recurring-contribution-amount-contributed').contains('$2.00 USD / month');
     });
   });
 });


### PR DESCRIPTION
We had some issues (like [this one](https://github.com/opencollective/opencollective/issues/3195#issuecomment-640736382)) recently related to numbers being rounded when they shouldn't be. In the spirit of "It's better to display something ugly than to display inaccurate data", this PR changes the default rounding to `2` decimals (ie. `$10.53`).