### PR TITLE
Enable edit sections for all collectives

### DIFF
--- a/components/collective-page/index.js
+++ b/components/collective-page/index.js
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types';
 import { throttle } from 'lodash';
 import memoizeOne from 'memoize-one';
 
+import { getFilteredSectionsForCollective } from '../../lib/collective-sections';
 import { CollectiveType } from '../../lib/constants/collectives';
 
-import CollectiveNavbar, { getFilteredSectionsForCollective } from '../CollectiveNavbar';
+import CollectiveNavbar from '../CollectiveNavbar';
 import Container from '../Container';
 
 import Hero from './hero/Hero';

--- a/components/edit-collective/Menu.js
+++ b/components/edit-collective/Menu.js
@@ -155,11 +155,9 @@ const isFeatureAllowed = (c, feature) => isFeatureAllowedForCollectiveType(c.typ
 const isFund = c => c.type === CollectiveType.FUND || c.settings?.fund === true; // Funds MVP, to refactor
 const isHost = c => c.isHost === true;
 const isCollective = c => c.type === CollectiveType.COLLECTIVE;
-const isProject = c => c.type === CollectiveType.PROJECT;
 
 const sectionsDisplayConditions = {
   [EDIT_COLLECTIVE_SECTIONS.INFO]: () => true,
-  [EDIT_COLLECTIVE_SECTIONS.COLLECTIVE_PAGE]: c => isCollective(c) || isFund(c) || isProject(c),
   [EDIT_COLLECTIVE_SECTIONS.COLLECTIVE_GOALS]: c => isCollective(c) && !isFund(c),
   [EDIT_COLLECTIVE_SECTIONS.CONNECTED_ACCOUNTS]: c => isHost(c) || (isCollective(c) && !isFund(c)),
   [EDIT_COLLECTIVE_SECTIONS.UPDATES]: c => isFeatureAllowed(c, FEATURES.UPDATES),

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -629,6 +629,7 @@
   "EditCollective.VAT.Own": "Use my own VAT number",
   "EditCollective.VATNumber": "NIF per a l'IVA",
   "EditCollective.VATNumber.Description": "Your European Value Added Tax (VAT) number",
+  "EditCollectivePage.EmptySection": "This section does not appear to have any associated data and will not appear publicly until it does.",
   "EditCollectivePage.Sections": "Page sections",
   "EditCollectivePage.SectionsDescription": "In this section you can use drag and drop to reorder the Profile Page sections.",
   "EditCollectivePage.ShowSection.AlwaysVisible": "Always visible",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -629,6 +629,7 @@
   "EditCollective.VAT.Own": "Použít mé vlastní DIČ",
   "EditCollective.VATNumber": "DIČ",
   "EditCollective.VATNumber.Description": "Your European Value Added Tax (VAT) number",
+  "EditCollectivePage.EmptySection": "This section does not appear to have any associated data and will not appear publicly until it does.",
   "EditCollectivePage.Sections": "Page sections",
   "EditCollectivePage.SectionsDescription": "In this section you can use drag and drop to reorder the Profile Page sections.",
   "EditCollectivePage.ShowSection.AlwaysVisible": "Always visible",

--- a/lang/de.json
+++ b/lang/de.json
@@ -629,6 +629,7 @@
   "EditCollective.VAT.Own": "Use my own VAT number",
   "EditCollective.VATNumber": "VAT number",
   "EditCollective.VATNumber.Description": "Your European Value Added Tax (VAT) number",
+  "EditCollectivePage.EmptySection": "This section does not appear to have any associated data and will not appear publicly until it does.",
   "EditCollectivePage.Sections": "Page sections",
   "EditCollectivePage.SectionsDescription": "In this section you can use drag and drop to reorder the Profile Page sections.",
   "EditCollectivePage.ShowSection.AlwaysVisible": "Always visible",

--- a/lang/en.json
+++ b/lang/en.json
@@ -629,6 +629,7 @@
   "EditCollective.VAT.Own": "Use my own VAT number",
   "EditCollective.VATNumber": "VAT number",
   "EditCollective.VATNumber.Description": "Your European Value Added Tax (VAT) number",
+  "EditCollectivePage.EmptySection": "This section does not appear to have any associated data and will not appear publicly until it does.",
   "EditCollectivePage.Sections": "Page sections",
   "EditCollectivePage.SectionsDescription": "In this section you can use drag and drop to reorder the Profile Page sections.",
   "EditCollectivePage.ShowSection.AlwaysVisible": "Always visible",

--- a/lang/es.json
+++ b/lang/es.json
@@ -629,6 +629,7 @@
   "EditCollective.VAT.Own": "Utilizar mi propio número de IVA",
   "EditCollective.VATNumber": "Número del IVA",
   "EditCollective.VATNumber.Description": "Tu número de Impuesto sobre el Valor Añadido europeo (IVA)",
+  "EditCollectivePage.EmptySection": "This section does not appear to have any associated data and will not appear publicly until it does.",
   "EditCollectivePage.Sections": "Page sections",
   "EditCollectivePage.SectionsDescription": "In this section you can use drag and drop to reorder the Profile Page sections.",
   "EditCollectivePage.ShowSection.AlwaysVisible": "Always visible",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -629,6 +629,7 @@
   "EditCollective.VAT.Own": "Utiliser mon propre numéro de TVA",
   "EditCollective.VATNumber": "Numéro de TVA",
   "EditCollective.VATNumber.Description": "Votre numéro de TVA intra-communautaire",
+  "EditCollectivePage.EmptySection": "This section does not appear to have any associated data and will not appear publicly until it does.",
   "EditCollectivePage.Sections": "Sections de page",
   "EditCollectivePage.SectionsDescription": "Sur cette page, vous pouvez utiliser le glisser-déposer pour réorganiser les sections de la page de profil.",
   "EditCollectivePage.ShowSection.AlwaysVisible": "Always visible",

--- a/lang/it.json
+++ b/lang/it.json
@@ -629,6 +629,7 @@
   "EditCollective.VAT.Own": "Usa il mio numero VAT personale",
   "EditCollective.VATNumber": "Numero VAT",
   "EditCollective.VATNumber.Description": "Il tuo numero di imposta sul valore aggiunto europeo (IVA)",
+  "EditCollectivePage.EmptySection": "This section does not appear to have any associated data and will not appear publicly until it does.",
   "EditCollectivePage.Sections": "Page sections",
   "EditCollectivePage.SectionsDescription": "In this section you can use drag and drop to reorder the Profile Page sections.",
   "EditCollectivePage.ShowSection.AlwaysVisible": "Always visible",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -629,6 +629,7 @@
   "EditCollective.VAT.Own": "Use my own VAT number",
   "EditCollective.VATNumber": "VAT 番号",
   "EditCollective.VATNumber.Description": "Your European Value Added Tax (VAT) number",
+  "EditCollectivePage.EmptySection": "This section does not appear to have any associated data and will not appear publicly until it does.",
   "EditCollectivePage.Sections": "Page sections",
   "EditCollectivePage.SectionsDescription": "In this section you can use drag and drop to reorder the Profile Page sections.",
   "EditCollectivePage.ShowSection.AlwaysVisible": "Always visible",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -629,6 +629,7 @@
   "EditCollective.VAT.Own": "내 VAT 번호 사용",
   "EditCollective.VATNumber": "VAT 번호",
   "EditCollective.VATNumber.Description": "유럽 연합 부가가치세 (VAT) 번호",
+  "EditCollectivePage.EmptySection": "This section does not appear to have any associated data and will not appear publicly until it does.",
   "EditCollectivePage.Sections": "Page sections",
   "EditCollectivePage.SectionsDescription": "In this section you can use drag and drop to reorder the Profile Page sections.",
   "EditCollectivePage.ShowSection.AlwaysVisible": "Always visible",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -629,6 +629,7 @@
   "EditCollective.VAT.Own": "Use my own VAT number",
   "EditCollective.VATNumber": "VAT number",
   "EditCollective.VATNumber.Description": "Your European Value Added Tax (VAT) number",
+  "EditCollectivePage.EmptySection": "This section does not appear to have any associated data and will not appear publicly until it does.",
   "EditCollectivePage.Sections": "Page sections",
   "EditCollectivePage.SectionsDescription": "In this section you can use drag and drop to reorder the Profile Page sections.",
   "EditCollectivePage.ShowSection.AlwaysVisible": "Always visible",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -629,6 +629,7 @@
   "EditCollective.VAT.Own": "Usar o meu número de VAT",
   "EditCollective.VATNumber": "Número de VAT",
   "EditCollective.VATNumber.Description": "Seu número de IVA (VAT)",
+  "EditCollectivePage.EmptySection": "This section does not appear to have any associated data and will not appear publicly until it does.",
   "EditCollectivePage.Sections": "Page sections",
   "EditCollectivePage.SectionsDescription": "In this section you can use drag and drop to reorder the Profile Page sections.",
   "EditCollectivePage.ShowSection.AlwaysVisible": "Always visible",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -629,6 +629,7 @@
   "EditCollective.VAT.Own": "Use my own VAT number",
   "EditCollective.VATNumber": "VAT number",
   "EditCollective.VATNumber.Description": "Your European Value Added Tax (VAT) number",
+  "EditCollectivePage.EmptySection": "This section does not appear to have any associated data and will not appear publicly until it does.",
   "EditCollectivePage.Sections": "Page sections",
   "EditCollectivePage.SectionsDescription": "In this section you can use drag and drop to reorder the Profile Page sections.",
   "EditCollectivePage.ShowSection.AlwaysVisible": "Always visible",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -629,6 +629,7 @@
   "EditCollective.VAT.Own": "Use my own VAT number",
   "EditCollective.VATNumber": "VAT number",
   "EditCollective.VATNumber.Description": "Your European Value Added Tax (VAT) number",
+  "EditCollectivePage.EmptySection": "This section does not appear to have any associated data and will not appear publicly until it does.",
   "EditCollectivePage.Sections": "Page sections",
   "EditCollectivePage.SectionsDescription": "In this section you can use drag and drop to reorder the Profile Page sections.",
   "EditCollectivePage.ShowSection.AlwaysVisible": "Always visible",

--- a/lib/__tests__/collective-sections.test.js
+++ b/lib/__tests__/collective-sections.test.js
@@ -1,0 +1,152 @@
+const {
+  getDefaultSectionsForCollective,
+  filterSectionsForUser,
+  filterSectionsByData,
+  getFilteredSectionsForCollective,
+} = require('../collective-sections');
+const { CollectiveType } = require('../constants/collectives');
+
+describe('Collective sections', () => {
+  describe('getDefaultSectionsForCollective', () => {
+    describe('COLLECTIVE', () => {
+      it('Returns the default sections', () => {
+        expect(getDefaultSectionsForCollective(CollectiveType.COLLECTIVE, false)).toEqual([
+          'goals',
+          'contribute',
+          'updates',
+          'conversations',
+          'budget',
+          'contributors',
+          'recurring-contributions',
+          'about',
+        ]);
+      });
+    });
+
+    describe('USER', () => {
+      it('Also works with INDIVIDUAL', () => {
+        expect(getDefaultSectionsForCollective('INDIVIDUAL', false)).toEqual([
+          'contributions',
+          'transactions',
+          'recurring-contributions',
+          'about',
+        ]);
+      });
+    });
+
+    describe('ORGANIZATION', () => {
+      it('Returns the default sections', () => {
+        expect(getDefaultSectionsForCollective(CollectiveType.ORGANIZATION, false)).toEqual([
+          'contributions',
+          'contributors',
+          'updates',
+          'conversations',
+          'transactions',
+          'recurring-contributions',
+          'about',
+        ]);
+      });
+
+      it('Returns the default sections when active', () => {
+        expect(getDefaultSectionsForCollective(CollectiveType.ORGANIZATION, true)).toEqual([
+          'contribute',
+          'contributions',
+          'contributors',
+          'updates',
+          'conversations',
+          'transactions',
+          'budget',
+          'recurring-contributions',
+          'about',
+        ]);
+      });
+    });
+
+    it('Returns an empty array for unknown types', () => {
+      expect(getDefaultSectionsForCollective()).toEqual([]);
+    });
+  });
+
+  describe('filterSectionsForUser', () => {
+    it('Works with legacy sections', () => {
+      const sections = ['contribute', 'updates', 'budget'];
+      expect(filterSectionsForUser(sections, false, false)).toEqual(sections);
+      expect(filterSectionsForUser(sections, true, false)).toEqual(sections);
+      expect(filterSectionsForUser(sections, false, true)).toEqual(sections);
+      expect(filterSectionsForUser(sections, true, true)).toEqual(sections);
+    });
+
+    it('Filters disabled sections', () => {
+      const sections = [
+        { section: 'contribute', isEnabled: true },
+        { section: 'updates', isEnabled: false },
+        { section: 'budget', isEnabled: true },
+      ];
+      const expected = ['contribute', 'budget'];
+      expect(filterSectionsForUser(sections, false, false)).toEqual(expected);
+      expect(filterSectionsForUser(sections, true, true)).toEqual(expected);
+    });
+
+    it('Filters if users do not have access', () => {
+      const sections = [
+        { section: 'contribute', isEnabled: true },
+        { section: 'updates', isEnabled: true, restrictedTo: ['ADMIN'] },
+        { section: 'budget', isEnabled: true },
+      ];
+
+      const sectionsIfAllowed = ['contribute', 'updates', 'budget'];
+      const sectionsIfNotAllowed = ['contribute', 'budget'];
+      expect(filterSectionsForUser(sections, false, false)).toEqual(sectionsIfNotAllowed);
+      expect(filterSectionsForUser(sections, true, false)).toEqual(sectionsIfAllowed);
+      expect(filterSectionsForUser(sections, false, true)).toEqual(sectionsIfAllowed);
+      expect(filterSectionsForUser(sections, true, true)).toEqual(sectionsIfAllowed);
+    });
+  });
+
+  describe('filterSectionsByData', () => {
+    describe('Contribute', () => {
+      it('Gets removed if not active (unless admin)', () => {
+        expect(filterSectionsByData(['contribute'], { isActive: true })).toEqual(['contribute']);
+        expect(filterSectionsByData(['contribute'], { isActive: false })).toEqual([]);
+        expect(filterSectionsByData(['contribute'], { isActive: false }, true)).toEqual(['contribute']);
+      });
+
+      it('Gets removed if no way to contribute (unless admin)', () => {
+        const collectiveWithoutContribs = { isActive: true, settings: { disableCustomContributions: true } };
+        expect(filterSectionsByData(['contribute'], collectiveWithoutContribs)).toEqual([]);
+        expect(filterSectionsByData(['contribute'], collectiveWithoutContribs, true)).toEqual(['contribute']);
+      });
+
+      it('Gets removed if event is passed (even if admin)', () => {
+        const event = { type: 'EVENT', isActive: true };
+        const pastDate = '2000-01-01';
+        const futureDate = new Date(new Date().getFullYear() + 1, 1).toUTCString();
+        expect(filterSectionsByData(['contribute'], { ...event, endsAt: pastDate })).toEqual([]);
+        expect(filterSectionsByData(['contribute'], { ...event, endsAt: pastDate }, true)).toEqual([]);
+        expect(filterSectionsByData(['contribute'], { ...event, endsAt: futureDate })).toEqual(['contribute']);
+      });
+    });
+  });
+
+  describe('getFilteredSectionsForCollective', () => {
+    describe('For USER collective', () => {
+      it('Filters for non-admins', () => {
+        const collective = { type: 'COLLECTIVE' };
+        expect(getFilteredSectionsForCollective(collective)).toEqual(['contributors']);
+        expect(getFilteredSectionsForCollective({ ...collective, isActive: true })).toContain('contribute');
+        expect(getFilteredSectionsForCollective({ ...collective, longDescription: 'Hi' })).toContain('about');
+      });
+
+      it('Filters for admins', () => {
+        const collective = { type: 'COLLECTIVE' };
+        expect(getFilteredSectionsForCollective(collective, true)).toEqual([
+          'contribute',
+          'updates',
+          'budget',
+          'contributors',
+          'about',
+        ]);
+      });
+    });
+  });
+});

--- a/lib/collective-sections.js
+++ b/lib/collective-sections.js
@@ -1,0 +1,197 @@
+/**
+ * There are 3 levels of filtering to know if a section should appear or not.
+ *
+ * 1. Status of the collective: the `type`, `isActive`
+ * 2. User's permissions: certain sections are displayed only to admins
+ * 3. The data: we won't display a section if it's empty
+ */
+
+import { get } from 'lodash';
+
+import { Sections } from '../components/collective-page/_constants';
+
+import { CollectiveType } from './constants/collectives';
+import hasFeature, { FEATURES } from './allowed-features';
+import { canOrderTicketsFromEvent, isPastEvent } from './events';
+
+// Define default sections based on collective type
+const DEFAULT_SECTIONS = {
+  [CollectiveType.ORGANIZATION]: [
+    Sections.CONTRIBUTE,
+    Sections.CONTRIBUTIONS,
+    Sections.CONTRIBUTORS,
+    Sections.UPDATES,
+    Sections.CONVERSATIONS,
+    Sections.TRANSACTIONS,
+    Sections.BUDGET,
+    Sections.RECURRING_CONTRIBUTIONS,
+    Sections.ABOUT,
+  ],
+  [CollectiveType.USER]: [
+    Sections.CONTRIBUTIONS,
+    Sections.TRANSACTIONS,
+    Sections.RECURRING_CONTRIBUTIONS,
+    Sections.ABOUT,
+  ],
+  [CollectiveType.COLLECTIVE]: [
+    Sections.GOALS,
+    Sections.CONTRIBUTE,
+    Sections.UPDATES,
+    Sections.CONVERSATIONS,
+    Sections.BUDGET,
+    Sections.CONTRIBUTORS,
+    Sections.RECURRING_CONTRIBUTIONS,
+    Sections.ABOUT,
+  ],
+  [CollectiveType.FUND]: [
+    Sections.CONTRIBUTE,
+    Sections.UPDATES,
+    Sections.PROJECTS,
+    Sections.BUDGET,
+    Sections.CONTRIBUTORS,
+    Sections.ABOUT,
+  ],
+  [CollectiveType.EVENT]: [
+    Sections.ABOUT,
+    Sections.TICKETS,
+    Sections.CONTRIBUTE,
+    Sections.PARTICIPANTS,
+    Sections.LOCATION,
+    Sections.BUDGET,
+  ],
+  [CollectiveType.PROJECT]: [Sections.ABOUT, Sections.CONTRIBUTE, Sections.BUDGET],
+};
+
+/**
+ * 1. Returns all the sections than can be used for this collective
+ */
+export const getDefaultSectionsForCollective = (type, isActive) => {
+  // Layer of compatibility with GQLV2
+  const typeKey = type === 'INDIVIDUAL' ? 'USER' : type;
+  const defaultSections = DEFAULT_SECTIONS[typeKey] || [];
+  const toRemove = new Set();
+
+  if (type === CollectiveType.ORGANIZATION) {
+    if (!isActive) {
+      toRemove.add(Sections.CONTRIBUTE);
+      toRemove.add(Sections.BUDGET);
+    }
+  }
+
+  return defaultSections.filter(section => !toRemove.has(section));
+};
+
+/**
+ * 2. Returns all the sections than can be used for this collective
+ */
+export const filterSectionsForUser = (collectiveSections, isAdmin, isHostAdmin) => {
+  const sections = [];
+  collectiveSections.forEach(sectionData => {
+    if (typeof sectionData === 'string') {
+      sections.push(sectionData);
+    } else if (sectionData.isEnabled) {
+      if (sectionData.restrictedTo && sectionData.restrictedTo.includes('ADMIN')) {
+        if (isAdmin || isHostAdmin) {
+          sections.push(sectionData.section);
+        }
+      } else {
+        sections.push(sectionData.section);
+      }
+    }
+  });
+
+  return sections;
+};
+
+/**
+ * 3. Filter the sections based on the data available
+ */
+export const filterSectionsByData = (sections, collective, isAdmin, isHostAdmin) => {
+  const toRemove = new Set();
+  collective = collective || {};
+  const isEvent = collective.type === CollectiveType.EVENT;
+
+  // Can't contribute anymore if the collective is archived or has no host
+  const hasCustomContribution = !collective.settings?.disableCustomContributions;
+  const hasTiers = Boolean(collective.tiers?.length || hasCustomContribution);
+  const hasContribute = collective.isActive && hasTiers;
+  const hasOtherWaysToContribute =
+    !isEvent && (collective.events?.length > 0 || collective.connectedCollectives?.length > 0);
+  if ((!hasContribute && !hasOtherWaysToContribute && !isAdmin) || isPastEvent(collective)) {
+    toRemove.add(Sections.CONTRIBUTE);
+  }
+
+  // Check opt-in features
+  if (!hasFeature(collective, FEATURES.COLLECTIVE_GOALS)) {
+    toRemove.add(Sections.GOALS);
+  }
+
+  if (!hasFeature(collective, FEATURES.CONVERSATIONS)) {
+    toRemove.add(Sections.CONVERSATIONS);
+  }
+
+  // Some sections are hidden for non-admins (usually when there's no data)
+  if (!isAdmin && !isHostAdmin) {
+    const { updates, transactions, balance } = collective.stats || {};
+    if (!updates) {
+      toRemove.add(Sections.UPDATES);
+    }
+    if (!collective.balance && !balance && !(transactions && transactions.all)) {
+      toRemove.add(Sections.BUDGET);
+    }
+    if (!collective.hasLongDescription && !collective.longDescription) {
+      toRemove.add(Sections.ABOUT);
+    }
+  }
+
+  if (collective.type === CollectiveType.ORGANIZATION) {
+    if (!hasFeature(collective, FEATURES.UPDATES)) {
+      toRemove.add(Sections.UPDATES);
+    }
+    if (!collective.isActive) {
+      toRemove.add(Sections.BUDGET);
+    } else {
+      toRemove.add(Sections.TRANSACTIONS);
+    }
+  }
+
+  // Recurring contributions
+  // don't display for TYPE=COLLECTIVE || ORGANIZATION if no active contributions
+  if (collective.type === CollectiveType.COLLECTIVE || collective.type === CollectiveType.ORGANIZATION) {
+    if (!collective.ordersFromCollective?.some(collective => collective.isSubscriptionActive)) {
+      toRemove.add(Sections.RECURRING_CONTRIBUTIONS);
+    }
+  }
+
+  if (isEvent) {
+    // Should not see tickets section if you can't order them
+    if ((!hasContribute && !isAdmin) || (!canOrderTicketsFromEvent(collective) && !isAdmin)) {
+      toRemove.add(Sections.TICKETS);
+    }
+
+    if (!collective.orders || collective.orders.length === 0) {
+      toRemove.add(Sections.PARTICIPANTS);
+    }
+
+    if (!(collective.location && collective.location.name)) {
+      toRemove.add(Sections.LOCATION);
+    }
+  }
+
+  return sections.filter(section => !toRemove.has(section));
+};
+
+/**
+ * Combine all the previous steps to directly get the sections that should be
+ * displayed for the user.
+ */
+export const getFilteredSectionsForCollective = (collective, isAdmin, isHostAdmin) => {
+  let sections = get(collective, 'settings.collectivePage.sections');
+  if (sections) {
+    sections = filterSectionsForUser(sections, isAdmin, isHostAdmin);
+  } else {
+    sections = getDefaultSectionsForCollective(collective?.type, collective?.isActive);
+  }
+
+  return filterSectionsByData(sections, collective, isAdmin, isHostAdmin);
+};


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/3257

This PR refactors how we filter sections, by moving the logic out of `CollectiveNavbar` to a new `lib/collective-sections.js`. This file now also has dedicated unit tests.

There's still some work to do to reconciliate this with the proposal made in https://github.com/opencollective/opencollective/issues/2807, but it will make the transition easier (and safer, now that we have tests).

## About the (disabled) info tooltip in edit menu
I've introduced a tooltip to surface "inactive" sections on the page, but because our query on this page uses GraphQL V2 we can't just fetch the data and re-use the existing code, so I've hidden this info box behind the `showMissingDataWarning` flag. This will be enabled either by https://github.com/opencollective/opencollective/issues/2807 or https://github.com/opencollective/opencollective/issues/3275.

![image](https://user-images.githubusercontent.com/1556356/86234290-f8b01800-bb96-11ea-9f93-bd59764cdbf9.png)
