### PR TITLE
DashboardExpenses: Add missing fetch fields

### DIFF
--- a/components/host-dashboard/HostDashboardExpenses.js
+++ b/components/host-dashboard/HostDashboardExpenses.js
@@ -72,6 +72,8 @@ const dashboardExpensesQuery = gqlV2/* GraphQL */ `
           id
           name
           slug
+          currency
+          type
           ... on Collective {
             balance
           }


### PR DESCRIPTION
The missing `currency` was crashing the pay action