### PR TITLE
RecurringContributions: Only fetch subscriptions

### DIFF
--- a/pages/recurring-contributions.js
+++ b/pages/recurring-contributions.js
@@ -31,7 +31,7 @@ export const recurringContributionsPageQuery = gqlV2/* GraphQL */ `
       type
       settings
       imageUrl
-      orders {
+      orders(filter: OUTGOING, status: [ACTIVE, CANCELLED]) {
         totalCount
         nodes {
           id


### PR DESCRIPTION
A performance improvement for the recurring contributions: we don't need to fetch all the orders for the collective, only the outgoing ones that are linked to a subscription.