### PR TITLE
ReactIntl: Remove default messages

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -18,7 +18,8 @@
     [
       "react-intl",
       {
-        "messagesDir": "./dist/messages/"
+        "messagesDir": "./dist/messages/",
+        "removeDefaultMessage": true
       }
     ]
   ],


### PR DESCRIPTION
A simple config change to remove the `defaultMessage` when exporting strings with Babel. It's not required for us because we also export a `en.json` file.

| Page                                | Size   | Size (after) | Size change | 
|-------------------------------------|--------|--------------|-------------| 
| `/`                                 | 14,80  | 12,70        | -14,19 %    | 
| `/__test__/test-errors`             | 1,24   | 1,23         | -0,81 %     | 
| `/_app`                             | 19,70  | 19,70        | 0,00 %      | 
| `/_error`                           | 0,59   | 0,58         | -1,54 %     | 
| `/accept-financial-contributions`   | 25,70  | 24,00        | -6,61 %     | 
| `/applications`                     | 4,55   | 4,42         | -2,86 %     | 
| `/banner-iframe`                    | 11,30  | 11,00        | -2,65 %     | 
| `/button`                           | 0,89   | 0,88         | -0,23 %     | 
| `/collective-contact`               | 5,93   | 5,76         | -2,87 %     | 
| `/collective-page`                  | 83,00  | 79,10        | -4,70 %     | 
| `/collectives-iframe`               | 8,29   | 8,15         | -1,69 %     | 
| `/confirmCollectiveDeletion`        | 2,02   | 1,89         | -6,44 %     | 
| `/confirmEmail`                     | 2,14   | 2,07         | -3,27 %     | 
| `/confirmOrder`                     | 4,04   | 3,93         | -2,72 %     | 
| `/contribute`                       | 9,26   | 8,76         | -5,40 %     | 
| `/conversation`                     | 19,70  | 19,20        | -2,54 %     | 
| `/conversations`                    | 6,82   | 6,47         | -5,13 %     | 
| `/create-conversation`              | 10,30  | 9,80         | -4,85 %     | 
| `/create-expense`                   | 28,70  | 26,90        | -6,27 %     | 
| `/create-fund`                      | 7,96   | 7,59         | -4,65 %     | 
| `/create-project`                   | 6,07   | 5,86         | -3,46 %     | 
| `/createEvent`                      | 12,10  | 11,10        | -8,26 %     | 
| `/createExpense`                    | 11,40  | 10,40        | -8,77 %     | 
| `/createOrder`                      | 32,90  | 30,70        | -6,69 %     | 
| `/createOrganization`               | 9,40   | 9,02         | -4,04 %     | 
| `/createPledge`                     | 13,20  | 12,00        | -9,09 %     | 
| `/createUpdate`                     | 2,26   | 2,16         | -4,42 %     | 
| `/discover`                         | 9,12   | 8,77         | -3,84 %     | 
| `/editCollective`                   | 186,00 | 177,00       | -4,84 %     | 
| `/editEvent`                        | 185,00 | 176,00       | -4,86 %     | 
| `/expense`                          | 46,50  | 44,10        | -5,16 %     | 
| `/expense-legacy`                   | 26,80  | 24,70        | -7,84 %     | 
| `/expenses`                         | 12,90  | 12,20        | -5,43 %     | 
| `/expenses-legacy`                  | 25,60  | 24,00        | -6,25 %     | 
| `/host.dashboard`                   | 64,20  | 60,70        | -5,45 %     | 
| `/hosts`                            | 8,16   | 7,87         | -3,55 %     | 
| `/marketingPage`                    | 212,00 | 212,00       | 0,00 %      | 
| `/member-invitations`               | 6,25   | 5,91         | -5,44 %     | 
| `/new-create-collective`            | 12,80  | 11,20        | -12,50 %    | 
| `/order`                            | 2,26   | 2,21         | -2,21 %     | 
| `/orders`                           | 7,71   | 7,62         | -1,17 %     | 
| `/orderSuccess`                     | 12,20  | 11,80        | -3,28 %     | 
| `/pricing`                          | 14,70  | 12,70        | -13,61 %    | 
| `/recurring-contributions`          | 16,90  | 16,40        | -2,96 %     | 
| `/recurring-contributions-redirect` | 1,50   | 1,49         | -0,67 %     | 
| `/redeem`                           | 6,37   | 5,70         | -10,52 %    | 
| `/redeemed`                         | 10,70  | 10,30        | -3,74 %     | 
| `/search`                           | 7,59   | 7,35         | -3,16 %     | 
| `/signin`                           | 3,50   | 3,37         | -3,71 %     | 
| `/signinLinkSent`                   | 2,17   | 2,05         | -5,53 %     | 
| `/staticPage`                       | 20,10  | 20,10        | 0,00 %      | 
| `/tier`                             | 17,20  | 16,80        | -2,33 %     | 
| `/transactions`                     | 21,10  | 20,50        | -2,84 %     | 
| `/unsubscribeEmail`                 | 1,74   | 1,69         | -2,87 %     | 
| `/update`                           | 1,09   | 1,09         | 0,00 %      | 
| `/updatePaymentMethod`              | 5,97   | 5,81         | -2,68 %     | 
| `/updates`                          | 6,04   | 5,96         | -1,32 %     | 

