### PR TITLE
CollectivePage: Show budget section with just expenses

### DIFF
--- a/lib/collective-sections.js
+++ b/lib/collective-sections.js
@@ -133,10 +133,11 @@ export const filterSectionsByData = (sections, collective, isAdmin, isHostAdmin)
   // Some sections are hidden for non-admins (usually when there's no data)
   if (!isAdmin && !isHostAdmin) {
     const { updates, transactions, balance } = collective.stats || {};
+    const expenses = collective.expenses || [];
     if (!updates) {
       toRemove.add(Sections.UPDATES);
     }
-    if (!collective.balance && !balance && !(transactions && transactions.all)) {
+    if (!collective.balance && !balance && !(transactions && transactions.all) && !expenses.length) {
       toRemove.add(Sections.BUDGET);
     }
     if (!collective.hasLongDescription && !collective.longDescription) {


### PR DESCRIPTION
To resolve https://opencollective.freshdesk.com/a/tickets/7982

This will make sure we show the budget section when there's only expenses (no financial contributions).