### PR TITLE
EditRecurringContributions: Update erroneous orders

### DIFF
--- a/components/StyledCollectiveCard.js
+++ b/components/StyledCollectiveCard.js
@@ -25,7 +25,7 @@ const getBackground = collective => {
 /**
  * A card to show a collective that supports including a custom body.
  */
-const StyledCollectiveCard = ({ collective, children, ...props }) => {
+const StyledCollectiveCard = ({ collective, tag, children, ...props }) => {
   return (
     <StyledCard {...props}>
       <Container style={{ background: getBackground(collective) }} backgroundSize="cover" height={100} px={3} pt={26}>
@@ -42,11 +42,15 @@ const StyledCollectiveCard = ({ collective, children, ...props }) => {
               {collective.name}
             </P>
           </LinkCollective>
-          <StyledTag display="inline-block" textTransform="uppercase" my={2}>
-            <I18nCollectiveTags
-              tags={getCollectiveMainTag(get(collective, 'host.id'), collective.tags, collective.type)}
-            />
-          </StyledTag>
+          {tag === undefined ? (
+            <StyledTag display="inline-block" textTransform="uppercase" my={2}>
+              <I18nCollectiveTags
+                tags={getCollectiveMainTag(get(collective, 'host.id'), collective.tags, collective.type)}
+              />
+            </StyledTag>
+          ) : (
+            tag
+          )}
         </Container>
         {children}
       </Flex>
@@ -57,6 +61,8 @@ const StyledCollectiveCard = ({ collective, children, ...props }) => {
 StyledCollectiveCard.propTypes = {
   /** Displayed below the top header of the card */
   children: PropTypes.node,
+  /** To replace the default tag. Set to `null` to hide tag */
+  tag: PropTypes.node,
   /** The collective to display */
   collective: PropTypes.shape({
     name: PropTypes.string.isRequired,

--- a/components/StyledTag.js
+++ b/components/StyledTag.js
@@ -135,12 +135,7 @@ StyledTag.propTypes = {
   closeButtonProps: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
   /** If defined, a close button will be displayed on the tag */
   onClose: PropTypes.func,
-  iconWidth: PropTypes.string,
-  iconHeight: PropTypes.string,
   backgroundColor: PropTypes.string,
-  iconColor: PropTypes.string,
-  iconDisplay: PropTypes.string,
-  iconAlign: PropTypes.string,
   variant: PropTypes.oneOf(['squared', 'rounded-right', 'rounded-left', 'rounded']),
   children: PropTypes.node,
   type: PropTypes.oneOf(Object.keys(TAG_TYPE_VARIANTS)),
@@ -148,10 +143,6 @@ StyledTag.propTypes = {
 
 StyledTag.defaultProps = {
   variant: 'squared',
-  iconHeight: '2.5em',
-  iconWidth: '2.5em',
-  iconBackgroundColor: 'rgba(33, 33, 33, 1)',
-  iconColor: 'white',
 };
 
 export default StyledTag;

--- a/components/collective-page/sections/RecurringContributions.js
+++ b/components/collective-page/sections/RecurringContributions.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { graphql } from '@apollo/react-hoc';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 
-import { API_V2_CONTEXT, gqlV2 } from '../../../lib/graphql/helpers';
+import { API_V2_CONTEXT } from '../../../lib/graphql/helpers';
 
 import { Dimensions } from '../_constants';
 import Container from '../../Container';
@@ -11,6 +11,7 @@ import { Box } from '../../Grid';
 import I18nFormatters from '../../I18nFormatters';
 import LoadingPlaceholder from '../../LoadingPlaceholder';
 import MessageBox from '../../MessageBox';
+import { recurringContributionsQuery } from '../../recurring-contributions/graphql/queries';
 import RecurringContributionsContainer from '../../recurring-contributions/RecurringContributionsContainer';
 import StyledFilters from '../../StyledFilters';
 import TemporaryNotification from '../../TemporaryNotification';
@@ -19,59 +20,13 @@ import { withUser } from '../../UserProvider';
 import ContainerSectionContent from '../ContainerSectionContent';
 import SectionTitle from '../SectionTitle';
 
-export const recurringContributionsPageQuery = gqlV2/* GraphQL */ `
-  query RecurringContributions($slug: String) {
-    account(slug: $slug) {
-      id
-      slug
-      name
-      type
-      description
-      settings
-      imageUrl
-      twitterHandle
-      orders {
-        totalCount
-        nodes {
-          id
-          paymentMethod {
-            id
-          }
-          amount {
-            value
-            currency
-          }
-          status
-          frequency
-          tier {
-            id
-            name
-          }
-          totalDonations {
-            value
-            currency
-          }
-          toAccount {
-            id
-            slug
-            name
-            description
-            tags
-            imageUrl
-            settings
-          }
-        }
-      }
-    }
-  }
-`;
-
 const FILTERS = {
   ACTIVE: 'ACTIVE',
   MONTHLY: 'MONTHLY',
   YEARLY: 'YEARLY',
   CANCELLED: 'CANCELLED',
 };
+
 const I18nFilters = defineMessages({
   [FILTERS.ACTIVE]: {
     id: 'Subscriptions.Active',
@@ -219,7 +174,7 @@ class SectionRecurringContributions extends React.Component {
   }
 }
 
-const getData = graphql(recurringContributionsPageQuery, {
+const getData = graphql(recurringContributionsQuery, {
   options: {
     context: API_V2_CONTEXT,
   },

--- a/components/recurring-contributions/RecurringContributionsCard.js
+++ b/components/recurring-contributions/RecurringContributionsCard.js
@@ -1,29 +1,19 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { get } from 'lodash';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
-import Avatar from '../Avatar';
+import { ORDER_STATUS } from '../../lib/constants/order-status';
+
 import Container from '../Container';
 import FormattedMoneyAmount from '../FormattedMoneyAmount';
-import { Flex } from '../Grid';
-import I18nCollectiveTags from '../I18nCollectiveTags';
-import LinkCollective from '../LinkCollective';
+import { Box } from '../Grid';
 import StyledButton from '../StyledButton';
-import StyledCard from '../StyledCard';
+import StyledCollectiveCard from '../StyledCollectiveCard';
 import StyledTag from '../StyledTag';
 import { P } from '../Text';
 import { withUser } from '../UserProvider';
 
 import RecurringContributionsPopUp from './RecurringContributionsPopUp';
-
-const getBackground = collective => {
-  const backgroundImage = collective.backgroundImageUrl || get(collective, 'parentCollective.backgroundImageUrl');
-  const primaryColor = get(collective.settings, 'collectivePage.primaryColor', '#1776E1');
-  return backgroundImage
-    ? `url(/static/images/collective-card-mask.svg) 0 0 / cover no-repeat, url(${backgroundImage}) 0 0 / cover no-repeat, ${primaryColor}`
-    : `url(/static/images/collective-card-mask.svg) 0 0 / cover no-repeat, ${primaryColor}`;
-};
 
 const messages = defineMessages({
   manage: {
@@ -32,7 +22,8 @@ const messages = defineMessages({
   },
   tag: {
     id: 'Subscriptions.Status',
-    defaultMessage: '{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution',
+    defaultMessage:
+      '{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}',
   },
 });
 
@@ -46,66 +37,61 @@ const RecurringContributionsCard = ({
   ...props
 }) => {
   const [showPopup, setShowPopup] = useState(false);
-
   const { formatMessage } = useIntl();
-  const statusTag = formatMessage(messages.tag, { status });
-  const buttonText = formatMessage(messages.manage);
   const isAdmin = LoggedInUser && LoggedInUser.canEditCollective(account);
-  const isActive = status === 'ACTIVE';
+  const isError = status === ORDER_STATUS.ERROR;
+  const isActive = status === ORDER_STATUS.ACTIVE || isError;
 
   return (
-    <StyledCard {...props}>
-      <Container style={{ background: getBackground(collective) }} backgroundSize="cover" height={100} px={3} pt={26}>
-        <Container border="2px solid white" borderRadius="25%" backgroundColor="white.full" width={68}>
-          <LinkCollective collective={collective}>
-            <Avatar collective={collective} radius={64} />
-          </LinkCollective>
-        </Container>
-      </Container>
-      <Flex flexDirection="column" justifyContent="space-around" height={260}>
-        <Container p={2}>
-          <P fontSize="LeadParagraph" fontWeight="bold" color="black.800">
-            {collective.name}
+    <StyledCollectiveCard
+      {...props}
+      collective={collective}
+      tag={
+        <StyledTag display="inline-block" textTransform="uppercase" my={2} type={isError ? 'error' : undefined}>
+          {formatMessage(messages.tag, { status })}
+        </StyledTag>
+      }
+    >
+      <Container p={3}>
+        <Box mb={3}>
+          <P fontSize="Paragraph" lineHeight="Paragraph" fontWeight="400">
+            <FormattedMessage id="Subscriptions.AmountContributed" defaultMessage="Amount contributed" />
           </P>
-          <StyledTag display="inline-block" textTransform="uppercase" my={2}>
-            <I18nCollectiveTags tags={statusTag} />
-          </StyledTag>
-        </Container>
-        <Container p={2} flexGrow={1} display="flex" flexDirection="column" justifyContent="space-around">
-          <Flex flexDirection="column">
-            <P fontSize="Paragraph" fontWeight="400">
-              <FormattedMessage id="Subscriptions.AmountContributed" defaultMessage="Amount contributed" />
-            </P>
-            <P fontSize="Paragraph" fontWeight="bold" data-cy="recurring-contribution-amount-contributed">
-              <FormattedMoneyAmount
-                amount={contribution.amount.value * 100}
-                interval={contribution.frequency.toLowerCase().slice(0, -2)}
-                currency={contribution.amount.currency}
-              />
-            </P>
-          </Flex>
-          <Flex flexDirection="column" mb={2}>
-            <P fontSize="Paragraph" fontWeight="400">
-              <FormattedMessage id="Subscriptions.ContributedToDate" defaultMessage="Contributed to date" />
-            </P>
-            <P fontSize="Paragraph">
-              <FormattedMoneyAmount
-                amount={contribution.totalDonations.value * 100}
-                currency={contribution.totalDonations.currency}
-              />
-            </P>
-          </Flex>
-          {isAdmin && isActive && (
-            <StyledButton
-              buttonSize="tiny"
-              onClick={() => setShowPopup(true)}
-              data-cy="recurring-contribution-edit-activate-button"
-            >
-              {buttonText}
-            </StyledButton>
-          )}
-        </Container>
-      </Flex>
+          <P
+            fontSize="Paragraph"
+            lineHeight="Paragraph"
+            fontWeight="bold"
+            data-cy="recurring-contribution-amount-contributed"
+          >
+            <FormattedMoneyAmount
+              amount={contribution.amount.value * 100}
+              interval={contribution.frequency.toLowerCase().slice(0, -2)}
+              currency={contribution.amount.currency}
+            />
+          </P>
+        </Box>
+        <Box mb={3}>
+          <P fontSize="Paragraph" lineHeight="Paragraph" fontWeight="400">
+            <FormattedMessage id="Subscriptions.ContributedToDate" defaultMessage="Contributed to date" />
+          </P>
+          <P fontSize="Paragraph" lineHeight="Paragraph">
+            <FormattedMoneyAmount
+              amount={contribution.totalDonations.value * 100}
+              currency={contribution.totalDonations.currency}
+            />
+          </P>
+        </Box>
+        {isAdmin && isActive && (
+          <StyledButton
+            buttonSize="tiny"
+            onClick={() => setShowPopup(true)}
+            data-cy="recurring-contribution-edit-activate-button"
+            width="100%"
+          >
+            {formatMessage(messages.manage)}
+          </StyledButton>
+        )}
+      </Container>
       {showPopup && (
         <RecurringContributionsPopUp
           contribution={contribution}
@@ -115,7 +101,7 @@ const RecurringContributionsCard = ({
           account={account}
         />
       )}
-    </StyledCard>
+    </StyledCollectiveCard>
   );
 };
 

--- a/components/recurring-contributions/RecurringContributionsContainer.js
+++ b/components/recurring-contributions/RecurringContributionsContainer.js
@@ -3,12 +3,16 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 
+import { ORDER_STATUS } from '../../lib/constants/order-status';
+
 import Container from '../Container';
 import { Flex } from '../Grid';
 import { fadeIn } from '../StyledKeyframes';
 import { P } from '../Text';
 
 import RecurringContributionsCard from './RecurringContributionsCard';
+
+import EmptyCollectivesSectionImageSVG from '../collective-page/images/EmptyCollectivesSectionImage.svg';
 
 const CollectiveCardContainer = styled.div`
   animation: ${fadeIn} 0.2s;
@@ -29,33 +33,24 @@ const CollectiveCardContainer = styled.div`
   }
 `;
 
-import EmptyCollectivesSectionImageSVG from '../collective-page/images/EmptyCollectivesSectionImage.svg';
+const filterContributions = (contributions, filterName) => {
+  const isActive = ({ status }) => status === ORDER_STATUS.ACTIVE || status === ORDER_STATUS.ERROR;
+  switch (filterName) {
+    case 'ACTIVE':
+      return contributions.filter(isActive);
+    case 'MONTHLY':
+      return contributions.filter(contrib => isActive(contrib) && contrib.frequency === 'MONTHLY');
+    case 'YEARLY':
+      return contributions.filter(contrib => isActive(contrib) && contrib.frequency === 'YEARLY');
+    case 'CANCELLED':
+      return contributions.filter(contrib => contrib.status === ORDER_STATUS.CANCELLED);
+    default:
+      return [];
+  }
+};
 
 const RecurringContributionsContainer = ({ recurringContributions, filter, createNotification, account }) => {
-  const activeRecurringContributions = recurringContributions.nodes.filter(
-    contribution => contribution.status === 'ACTIVE',
-  );
-  const monthlyRecurringContributions = activeRecurringContributions.filter(
-    contribution => contribution.status === 'ACTIVE' && contribution.frequency === 'MONTHLY',
-  );
-  const yearlyRecurringContributions = activeRecurringContributions.filter(
-    contribution => contribution.status === 'ACTIVE' && contribution.frequency === 'YEARLY',
-  );
-  const cancelledRecurringContributions = recurringContributions.nodes.filter(
-    contribution => contribution.status === 'CANCELLED',
-  );
-
-  let displayedRecurringContributions;
-  if (filter === 'ACTIVE') {
-    displayedRecurringContributions = activeRecurringContributions;
-  } else if (filter === 'MONTHLY') {
-    displayedRecurringContributions = monthlyRecurringContributions;
-  } else if (filter === 'YEARLY') {
-    displayedRecurringContributions = yearlyRecurringContributions;
-  } else if (filter === 'CANCELLED') {
-    displayedRecurringContributions = cancelledRecurringContributions;
-  }
-
+  const displayedRecurringContributions = filterContributions(recurringContributions.nodes, filter);
   return (
     <Container mt={4}>
       {displayedRecurringContributions.length ? (

--- a/components/recurring-contributions/RecurringContributionsPopUp.js
+++ b/components/recurring-contributions/RecurringContributionsPopUp.js
@@ -42,7 +42,6 @@ const PopUpMenu = styled(Flex)`
   z-index: 1000;
   background: white;
   border-radius: 8px;
-  border: 1px solid ${themeGet('colors.black.300')};
   box-shadow: 0px 2px 7px rgba(0, 0, 0, 0.5);
 `;
 
@@ -67,7 +66,7 @@ const RecurringContributionsPopUp = ({ contribution, status, createNotification,
     context: API_V2_CONTEXT,
   });
 
-  const mainMenu = menuState === 'mainMenu' && status === 'ACTIVE';
+  const mainMenu = menuState === 'mainMenu' && (status === 'ACTIVE' || status === 'ERROR');
   const cancelMenu = menuState === 'cancelMenu';
   const updateTierMenu = menuState === 'updateTierMenu';
   const paymentMethodMenu = menuState === 'paymentMethodMenu';

--- a/components/recurring-contributions/UpdateOrderPopUp.js
+++ b/components/recurring-contributions/UpdateOrderPopUp.js
@@ -35,6 +35,7 @@ const updateOrderMutation = gqlV2/* GraphQL */ `
   mutation updateOrderTierOrAmount($order: OrderReferenceInput!, $amount: AmountInput, $tier: TierReferenceInput) {
     updateOrder(order: $order, amount: $amount, tier: $tier) {
       id
+      status
       amount {
         value
         currency

--- a/components/recurring-contributions/UpdatePaymentMethodPopUp.js
+++ b/components/recurring-contributions/UpdatePaymentMethodPopUp.js
@@ -65,6 +65,7 @@ const updatePaymentMethodMutation = gqlV2/* GraphQL */ `
   mutation updatePaymentMethod($order: OrderReferenceInput!, $paymentMethod: PaymentMethodReferenceInput!) {
     updateOrder(order: $order, paymentMethod: $paymentMethod) {
       id
+      status
       paymentMethod {
         id
       }

--- a/components/recurring-contributions/graphql/queries.js
+++ b/components/recurring-contributions/graphql/queries.js
@@ -1,0 +1,47 @@
+import { gqlV2 } from '../../../lib/graphql/helpers';
+
+export const recurringContributionsQuery = gqlV2/* GraphQL */ `
+  query RecurringContributions($slug: String) {
+    account(slug: $slug) {
+      id
+      slug
+      name
+      type
+      settings
+      imageUrl
+      orders(filter: OUTGOING, status: [ACTIVE, CANCELLED]) {
+        totalCount
+        nodes {
+          id
+          paymentMethod {
+            id
+          }
+          amount {
+            value
+            currency
+          }
+          status
+          frequency
+          tier {
+            id
+            name
+          }
+          totalDonations {
+            value
+            currency
+          }
+          toAccount {
+            id
+            slug
+            name
+            type
+            description
+            tags
+            imageUrl
+            settings
+          }
+        }
+      }
+    }
+  }
+`;

--- a/components/recurring-contributions/graphql/queries.js
+++ b/components/recurring-contributions/graphql/queries.js
@@ -9,7 +9,7 @@ export const recurringContributionsQuery = gqlV2/* GraphQL */ `
       type
       settings
       imageUrl
-      orders(filter: OUTGOING, status: [ACTIVE, CANCELLED]) {
+      orders(filter: OUTGOING, onlySubscriptions: true) {
         totalCount
         nodes {
           id

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1355,7 +1355,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.Edit": "Edit",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Large",
   "table.head.medium": "Medium",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1355,7 +1355,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.Edit": "Edit",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Velký",
   "table.head.medium": "Střední",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1355,7 +1355,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.Edit": "Edit",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Large",
   "table.head.medium": "Medium",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1355,7 +1355,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.Edit": "Edit",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Large",
   "table.head.medium": "Medium",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1355,7 +1355,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.Edit": "Edit",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Grande",
   "table.head.medium": "Medio",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1355,7 +1355,7 @@
   "Subscriptions.Cancelled": "Annulée",
   "Subscriptions.ContributedToDate": "Contribution à ce jour",
   "Subscriptions.Edit": "Editer",
-  "Subscriptions.Status": "Contribution {status, select, ACTIVE {Active} CANCELLED {Annulée}}",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
   "Subscriptions.Title": "Contributions récurrentes",
   "table.head.large": "Large",
   "table.head.medium": "Moyen",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1355,7 +1355,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.Edit": "Edit",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Large",
   "table.head.medium": "Medium",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1355,7 +1355,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.Edit": "Edit",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Large",
   "table.head.medium": "Medium",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1355,7 +1355,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.Edit": "Edit",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "큰",
   "table.head.medium": "중간",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1355,7 +1355,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.Edit": "Edit",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Large",
   "table.head.medium": "Medium",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1355,7 +1355,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.Edit": "Edit",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Grande",
   "table.head.medium": "Medio",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1355,7 +1355,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.Edit": "Edit",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Large",
   "table.head.medium": "Medium",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1355,7 +1355,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.Edit": "Edit",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active} CANCELLED {Cancelled}} contribution",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Large",
   "table.head.medium": "Medium",

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -95,9 +95,14 @@ interface Account {
     filter: AccountOrdersFilter
     status: [OrderStatus]
     tierSlug: String
+
+    """
+    Only returns orders that have an subscription (monthly/yearly)
+    """
+    onlySubscriptions: Boolean
     orderBy: ChronologicalOrderInput
   ): OrderCollection
-  settings: JSON
+  settings: JSON!
   conversations(
     limit: Int
     offset: Int
@@ -256,6 +261,11 @@ type Activity {
   The person who triggered the action, if any
   """
   individual: Individual
+
+  """
+  Data attached to this activity (if any)
+  """
+  data: JSON!
 }
 
 enum ActivityType {
@@ -407,9 +417,14 @@ type Bot implements Account {
     filter: AccountOrdersFilter
     status: [OrderStatus]
     tierSlug: String
+
+    """
+    Only returns orders that have an subscription (monthly/yearly)
+    """
+    onlySubscriptions: Boolean
     orderBy: ChronologicalOrderInput = { field: CREATED_AT, direction: DESC }
   ): OrderCollection
-  settings: JSON
+  settings: JSON!
   conversations(
     limit: Int
     offset: Int
@@ -553,9 +568,14 @@ type Collective implements Account {
     filter: AccountOrdersFilter
     status: [OrderStatus]
     tierSlug: String
+
+    """
+    Only returns orders that have an subscription (monthly/yearly)
+    """
+    onlySubscriptions: Boolean
     orderBy: ChronologicalOrderInput = { field: CREATED_AT, direction: DESC }
   ): OrderCollection
-  settings: JSON
+  settings: JSON!
   conversations(
     limit: Int
     offset: Int
@@ -2269,9 +2289,14 @@ type Event implements Account {
     filter: AccountOrdersFilter
     status: [OrderStatus]
     tierSlug: String
+
+    """
+    Only returns orders that have an subscription (monthly/yearly)
+    """
+    onlySubscriptions: Boolean
     orderBy: ChronologicalOrderInput = { field: CREATED_AT, direction: DESC }
   ): OrderCollection
-  settings: JSON
+  settings: JSON!
   conversations(
     limit: Int
     offset: Int
@@ -2898,9 +2923,14 @@ type Fund implements Account {
     filter: AccountOrdersFilter
     status: [OrderStatus]
     tierSlug: String
+
+    """
+    Only returns orders that have an subscription (monthly/yearly)
+    """
+    onlySubscriptions: Boolean
     orderBy: ChronologicalOrderInput = { field: CREATED_AT, direction: DESC }
   ): OrderCollection
-  settings: JSON
+  settings: JSON!
   conversations(
     limit: Int
     offset: Int
@@ -3059,9 +3089,14 @@ type Host implements Account {
     filter: AccountOrdersFilter
     status: [OrderStatus]
     tierSlug: String
+
+    """
+    Only returns orders that have an subscription (monthly/yearly)
+    """
+    onlySubscriptions: Boolean
     orderBy: ChronologicalOrderInput = { field: CREATED_AT, direction: DESC }
   ): OrderCollection
-  settings: JSON
+  settings: JSON!
   conversations(
     limit: Int
     offset: Int
@@ -3264,9 +3299,14 @@ type Individual implements Account {
     filter: AccountOrdersFilter
     status: [OrderStatus]
     tierSlug: String
+
+    """
+    Only returns orders that have an subscription (monthly/yearly)
+    """
+    onlySubscriptions: Boolean
     orderBy: ChronologicalOrderInput = { field: CREATED_AT, direction: DESC }
   ): OrderCollection
-  settings: JSON
+  settings: JSON!
   conversations(
     limit: Int
     offset: Int
@@ -3919,9 +3959,14 @@ type Organization implements Account {
     filter: AccountOrdersFilter
     status: [OrderStatus]
     tierSlug: String
+
+    """
+    Only returns orders that have an subscription (monthly/yearly)
+    """
+    onlySubscriptions: Boolean
     orderBy: ChronologicalOrderInput = { field: CREATED_AT, direction: DESC }
   ): OrderCollection
-  settings: JSON
+  settings: JSON!
   conversations(
     limit: Int
     offset: Int
@@ -4154,9 +4199,14 @@ type Project implements Account {
     filter: AccountOrdersFilter
     status: [OrderStatus]
     tierSlug: String
+
+    """
+    Only returns orders that have an subscription (monthly/yearly)
+    """
+    onlySubscriptions: Boolean
     orderBy: ChronologicalOrderInput = { field: CREATED_AT, direction: DESC }
   ): OrderCollection
-  settings: JSON
+  settings: JSON!
   conversations(
     limit: Int
     offset: Int

--- a/pages/recurring-contributions.js
+++ b/pages/recurring-contributions.js
@@ -5,7 +5,7 @@ import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import styled from 'styled-components';
 
 import { generateNotFoundError } from '../lib/errors';
-import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
+import { API_V2_CONTEXT } from '../lib/graphql/helpers';
 
 import AuthenticatedPage from '../components/AuthenticatedPage';
 import { Dimensions } from '../components/collective-page/_constants';
@@ -16,57 +16,12 @@ import ErrorPage from '../components/ErrorPage';
 import { Box } from '../components/Grid';
 import I18nFormatters from '../components/I18nFormatters';
 import Loading from '../components/Loading';
+import { recurringContributionsQuery } from '../components/recurring-contributions/graphql/queries';
 import RecurringContributionsContainer from '../components/recurring-contributions/RecurringContributionsContainer';
 import StyledFilters from '../components/StyledFilters';
 import TemporaryNotification from '../components/TemporaryNotification';
 import { P } from '../components/Text';
 import { withUser } from '../components/UserProvider';
-
-export const recurringContributionsPageQuery = gqlV2/* GraphQL */ `
-  query RecurringContributions($slug: String) {
-    account(slug: $slug) {
-      id
-      slug
-      name
-      type
-      settings
-      imageUrl
-      orders(filter: OUTGOING, status: [ACTIVE, CANCELLED]) {
-        totalCount
-        nodes {
-          id
-          paymentMethod {
-            id
-          }
-          amount {
-            value
-            currency
-          }
-          status
-          frequency
-          tier {
-            id
-            name
-          }
-          totalDonations {
-            value
-            currency
-          }
-          toAccount {
-            id
-            slug
-            name
-            type
-            description
-            tags
-            imageUrl
-            settings
-          }
-        }
-      }
-    }
-  }
-`;
 
 const MainContainer = styled(Container)`
   max-width: ${Dimensions.MAX_SECTION_WIDTH}px;
@@ -222,7 +177,7 @@ class recurringContributionsPage extends React.Component {
   }
 }
 
-const getData = graphql(recurringContributionsPageQuery, {
+const getData = graphql(recurringContributionsQuery, {
   options: {
     context: API_V2_CONTEXT,
   },


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/3318
Require https://github.com/opencollective/opencollective-api/pull/4186

Show & allow users to update their recurring contributions with `ERROR` status:
![image](https://user-images.githubusercontent.com/1556356/86765379-6225a000-c049-11ea-9000-37441b21ab9c.png)


Also made the following changes:
- Use `StyledCollectiveCard` for code genericity & consistency
- Exported section & page queries in same file (same query)
- Some CSS enhancements to better match design (line-heights, borders)