### PR TITLE
StyledInputAmount: Ignore scroll event

### DIFF
--- a/components/StyledInputAmount.js
+++ b/components/StyledInputAmount.js
@@ -83,6 +83,7 @@ const StyledInputAmount = ({
       inputMode="decimal"
       defaultValue={isUndefined(defaultValue) ? undefined : defaultValue / 100}
       value={isControlled ? getValue(value, rawValue) : undefined}
+      onWheel={e => e.preventDefault()}
       onChange={e => {
         e.stopPropagation();
         dispatchValue(e, parseValueFromEvent(e, precision));


### PR DESCRIPTION
There's a [suspicion](https://opencollective.freshdesk.com/a/tickets/7897) that users may be entering wrong amounts on expenses because they mistakenly scroll into the amount input. Disabling it as it potentially creates more problems than in improves the UX.