### PR TITLE
Forbid collectives from hiding their funds

### DIFF
--- a/components/edit-collective/sections/EditCollectivePage.js
+++ b/components/edit-collective/sections/EditCollectivePage.js
@@ -109,6 +109,9 @@ const CollectiveSectionEntry = ({
   if (collectiveType !== CollectiveType.FUND && collectiveType !== CollectiveType.PROJECT) {
     options = options.filter(({ value }) => value !== 'ADMIN');
   }
+  if (section === 'budget' && ![CollectiveType.FUND, CollectiveType.PROJECT].includes(collectiveType)) {
+    options = options.filter(({ value }) => value !== 'DISABLED');
+  }
 
   let defaultValue;
   if (!isEnabled) {


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/3324
Requires https://github.com/opencollective/opencollective-api/pull/4208

Hiding the budget section is only enabled for Funds and Projects (which are a kind of fund sub-collective).