### PR TITLE
Revert hacks in the frontend to hide feesOnTop

### DIFF
--- a/components/budget/BudgetItemsList.js
+++ b/components/budget/BudgetItemsList.js
@@ -177,7 +177,7 @@ const DetailsContainer = styled.div`
 /**
  * A single item
  */
-const BudgetItem = ({ item, isInverted, isCompact, isFeesOnTop, canDownloadInvoice }) => {
+const BudgetItem = ({ item, isInverted, isCompact, canDownloadInvoice }) => {
   const [isExpanded, setExpanded] = React.useState(false);
 
   if (item.__typename === 'ExpenseType') {
@@ -204,7 +204,6 @@ const BudgetItem = ({ item, isInverted, isCompact, isFeesOnTop, canDownloadInvoi
             collective={item.collective}
             transaction={item}
             isInverted={isInverted}
-            isFeesOnTop={isFeesOnTop}
             isExpanded={isExpanded}
             setExpanded={setExpanded}
             order={item.order}
@@ -214,7 +213,6 @@ const BudgetItem = ({ item, isInverted, isCompact, isFeesOnTop, canDownloadInvoi
           <DetailsContainer isCompact={isCompact}>
             <OrderBudgetItemDetails
               collective={item.collective || item.fromCollective}
-              isFeesOnTop={isFeesOnTop}
               canDownloadInvoice={canDownloadInvoice}
               isInverted={isInverted}
               transaction={item}
@@ -239,9 +237,6 @@ BudgetItem.propTypes = {
   /** Use this if the place where the component is rendered isn't that big to compact it */
   isCompact: PropTypes.bool,
 
-  /** Use this if you want to change how Platform Fees are displayed */
-  isFeesOnTop: PropTypes.bool,
-
   /** If true, a button to download invoice will be displayed when possible */
   canDownloadInvoice: PropTypes.bool,
 };
@@ -251,7 +246,7 @@ BudgetItem.propTypes = {
  * types. You must provide items fetched from GraphQL, as the component will use the
  * `__typename` to know how to display item.
  */
-const BudgetItemsList = ({ items, isInverted, isCompact, canDownloadInvoice, isFeesOnTop }) => {
+const BudgetItemsList = ({ items, isInverted, isCompact, canDownloadInvoice }) => {
   return !items || items.length === 0 ? null : (
     <DebitCreditList>
       {items.map(item => (
@@ -260,7 +255,6 @@ const BudgetItemsList = ({ items, isInverted, isCompact, canDownloadInvoice, isF
           item={item}
           isInverted={isInverted}
           isCompact={isCompact}
-          isFeesOnTop={isFeesOnTop}
           canDownloadInvoice={canDownloadInvoice}
         />
       ))}

--- a/components/budget/OrderBudgetItem.js
+++ b/components/budget/OrderBudgetItem.js
@@ -23,21 +23,9 @@ import TransactionSign from '../TransactionSign';
 /** To separate individual information below description */
 const INFO_SEPARATOR = ' • ';
 
-const OrderBudgetItem = ({
-  collective,
-  fromCollective,
-  isInverted,
-  isExpanded,
-  setExpanded,
-  transaction,
-  order,
-  isFeesOnTop,
-}) => {
+const OrderBudgetItem = ({ collective, fromCollective, isInverted, isExpanded, setExpanded, transaction, order }) => {
   const isCredit = transaction.type === TransactionTypes.CREDIT;
-  let amount = transaction[isCredit ? 'amount' : 'netAmountInCollectiveCurrency'];
-  if (isFeesOnTop) {
-    amount = transaction.amount + transaction.platformFeeInHostCurrency;
-  }
+  const amount = transaction[isCredit ? 'amount' : 'netAmountInCollectiveCurrency'];
   if (isInverted) {
     [fromCollective, collective] = [collective, fromCollective];
   }
@@ -158,7 +146,6 @@ const OrderBudgetItem = ({
 
 OrderBudgetItem.propTypes = {
   isInverted: PropTypes.bool.isRequired,
-  isFeesOnTop: PropTypes.bool.isRequired,
   isExpanded: PropTypes.bool.isRequired,
   setExpanded: PropTypes.func.isRequired,
   fromCollective: PropTypes.shape({

--- a/components/budget/OrderBudgetItemDetails.js
+++ b/components/budget/OrderBudgetItemDetails.js
@@ -58,17 +58,14 @@ const getAmountDetailsStr = (amount, currency, transaction, platformFee) => {
   );
 };
 
-const OrderBudgetItemDetails = ({ collective, isInverted, isFeesOnTop, transaction, canDownloadInvoice }) => {
+const OrderBudgetItemDetails = ({ collective, isInverted, transaction, canDownloadInvoice }) => {
   const intl = useIntl();
   const isCredit = transaction.type === TransactionTypes.CREDIT;
   const hasRefund = Boolean(transaction && transaction.refundTransaction);
   const hasAccessToInvoice = canDownloadInvoice && transaction && transaction.uuid;
   const hasInvoiceBtn = hasAccessToInvoice && !hasRefund && (!isCredit || !isInverted);
-  const platformFee = isFeesOnTop ? undefined : transaction.platformFeeInHostCurrency;
-  let amount = transaction[isCredit ? 'amount' : 'netAmountInCollectiveCurrency'];
-  if (isFeesOnTop) {
-    amount = transaction.amount + transaction.platformFeeInHostCurrency;
-  }
+  const platformFee = transaction.platformFeeInHostCurrency;
+  const amount = transaction[isCredit ? 'amount' : 'netAmountInCollectiveCurrency'];
 
   return (
     <Flex flexWrap="wrap" justifyContent="space-between" alignItems="center">
@@ -117,7 +114,6 @@ OrderBudgetItemDetails.propTypes = {
   /** If true, debit and credit will be inverted. Useful to adapt based on who's viewing */
   isInverted: PropTypes.bool,
   isCredit: PropTypes.bool,
-  isFeesOnTop: PropTypes.bool,
   /** If true, a button to download invoice will be displayed when possible */
   canDownloadInvoice: PropTypes.bool,
   transaction: PropTypes.shape({

--- a/components/collective-page/graphql/queries.js
+++ b/components/collective-page/graphql/queries.js
@@ -34,7 +34,6 @@ export const getCollectivePageQuery = gql`
       isHost
       isIncognito
       hostFeePercent
-      platformFeePercent
       image
       imageUrl(height: 256)
       canApply

--- a/components/collective-page/sections/Budget.js
+++ b/components/collective-page/sections/Budget.js
@@ -50,7 +50,6 @@ const TransactionsAndExpensesQuery = gql`
 const SectionBudget = ({ collective, stats }) => {
   const monthlyRecurring =
     (stats.activeRecurringContributions?.monthly || 0) + (stats.activeRecurringContributions?.yearly || 0) / 12;
-  const isFeesOnTop = collective.platformFeePercent === 0 && get(collective, 'host.settings.feesOnTop');
   const isFund = collective.type === CollectiveType.FUND || collective.settings?.fund === true; // Funds MVP, to refactor
   const isProject = collective.type === CollectiveType.PROJECT;
   return (
@@ -88,7 +87,7 @@ const SectionBudget = ({ collective, stats }) => {
             const budgetItems = orderBy(budgetItemsUnsorted, i => new Date(i.createdAt), ['desc']).slice(0, 3);
             return (
               <Container flex="10" mb={3} width="100%" maxWidth={800}>
-                <BudgetItemsList items={budgetItems} isCompact isFeesOnTop={isFeesOnTop} />
+                <BudgetItemsList items={budgetItems} isCompact />
                 <Flex flexWrap="wrap" justifyContent="space-between" mt={3}>
                   <Box flex="1 1" mx={[0, 2]}>
                     <Link route="transactions" params={{ collectiveSlug: collective.slug }}>
@@ -191,8 +190,7 @@ SectionBudget.propTypes = {
     type: PropTypes.string.isRequired,
     currency: PropTypes.string.isRequired,
     isArchived: PropTypes.bool,
-    platformFeePercent: PropTypes.number,
-    settings: PropTypes.objec,
+    settings: PropTypes.object,
   }),
 
   /** Stats */

--- a/components/collective-page/sections/Transactions.js
+++ b/components/collective-page/sections/Transactions.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from '@apollo/react-hoc';
 import gql from 'graphql-tag';
-import { get, orderBy } from 'lodash';
+import { orderBy } from 'lodash';
 import memoizeOne from 'memoize-one';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 
@@ -137,7 +137,6 @@ class SectionTransactions extends React.Component {
     const { data, intl, collective, isAdmin, isRoot } = this.props;
     const { filter } = this.state;
     let showFilters = true;
-    const isFeesOnTop = collective.platformFeePercent === 0 && get(collective, 'host.settings.feesOnTop');
 
     if (!data || data.loading) {
       return <LoadingPlaceholder height={600} borderRadius={0} />;
@@ -182,12 +181,7 @@ class SectionTransactions extends React.Component {
         )}
 
         <ContainerSectionContent>
-          <BudgetItemsList
-            items={budgetItems}
-            canDownloadInvoice={isAdmin || isRoot}
-            isInverted
-            isFeesOnTop={isFeesOnTop}
-          />
+          <BudgetItemsList items={budgetItems} canDownloadInvoice={isAdmin || isRoot} isInverted />
           <Link route="transactions" params={{ collectiveSlug: collective.slug }}>
             <StyledButton mt={3} width="100%" buttonSize="small" fontSize="Paragraph">
               <FormattedMessage id="transactions.viewAll" defaultMessage="View All Transactions" /> →

--- a/components/expenses/Transaction.js
+++ b/components/expenses/Transaction.js
@@ -65,7 +65,6 @@ class Transaction extends React.Component {
       interval: PropTypes.oneOf(['month', 'year']),
     }),
     type: PropTypes.oneOf(['CREDIT', 'DEBIT']),
-    isFeesOnTop: PropTypes.bool, // whether or not this transaction refers to a refund
     isRefund: PropTypes.bool, // whether or not this transaction refers to a refund
     /** Choose between date (eg. 2018/12/09) or interval (eg. two months ago) */
     dateDisplayType: PropTypes.oneOf(['date', 'interval']),
@@ -128,8 +127,6 @@ class Transaction extends React.Component {
       paymentProcessorFeeInHostCurrency,
       dateDisplayType,
       expense,
-      isFeesOnTop,
-      platformFeeInHostCurrency,
     } = this.props;
 
     if (!fromCollective) {
@@ -137,10 +134,7 @@ class Transaction extends React.Component {
       return <div />;
     }
 
-    let amountToDisplay = isFeesOnTop ? amount + platformFeeInHostCurrency : amount;
-    if (['ORGANIZATION', 'USER'].includes(collective.type)) {
-      amountToDisplay = netAmountInCollectiveCurrency;
-    }
+    const amountToDisplay = ['ORGANIZATION', 'USER'].includes(collective.type) ? netAmountInCollectiveCurrency : amount;
 
     return (
       <Flex my={4}>

--- a/components/expenses/TransactionDetails.js
+++ b/components/expenses/TransactionDetails.js
@@ -47,7 +47,6 @@ class TransactionDetails extends React.Component {
     }),
     type: PropTypes.oneOf(['CREDIT', 'DEBIT']),
     isRefund: PropTypes.bool, // whether or not this transaction refers to a refund
-    isFeesOnTop: PropTypes.bool, // whether or not this transaction refers to a refund
     intl: PropTypes.object.isRequired,
     mode: PropTypes.string, // open or closed
     fromCollective: PropTypes.object,
@@ -111,15 +110,11 @@ class TransactionDetails extends React.Component {
       currency,
       hostCurrency,
       hostCurrencyFxRate,
-      isFeesOnTop,
-      platformFeeInHostCurrency,
     } = this.props;
 
     let initialAmount = amount;
     if (['ORGANIZATION', 'USER'].includes(collective.type)) {
       initialAmount = -netAmountInCollectiveCurrency;
-    } else if (isFeesOnTop) {
-      initialAmount = amount + platformFeeInHostCurrency;
     }
     let totalAmount = initialAmount;
     const amountDetails = [
@@ -129,11 +124,8 @@ class TransactionDetails extends React.Component {
       }),
     ];
     if (hostCurrencyFxRate && hostCurrencyFxRate !== 1) {
-      let amountInHostCurrency = amount * hostCurrencyFxRate;
+      const amountInHostCurrency = amount * hostCurrencyFxRate;
       totalAmount = amount;
-      if (isFeesOnTop) {
-        amountInHostCurrency = amountInHostCurrency + platformFeeInHostCurrency;
-      }
       amountDetails.push(
         ` (${intl.formatNumber(amountInHostCurrency / 100, {
           currency: hostCurrency,
@@ -158,11 +150,7 @@ class TransactionDetails extends React.Component {
       });
     };
 
-    if (isFeesOnTop) {
-      addFees(['taxAmount', 'hostFeeInHostCurrency', 'paymentProcessorFeeInHostCurrency']);
-    } else {
-      addFees(['taxAmount', 'hostFeeInHostCurrency', 'platformFeeInHostCurrency', 'paymentProcessorFeeInHostCurrency']);
-    }
+    addFees(['taxAmount', 'hostFeeInHostCurrency', 'platformFeeInHostCurrency', 'paymentProcessorFeeInHostCurrency']);
 
     let amountDetailsStr = amountDetails.length > 1 ? amountDetails.join(' ') : '';
 

--- a/components/expenses/Transactions.js
+++ b/components/expenses/Transactions.js
@@ -76,7 +76,6 @@ class Transactions extends React.Component {
     const isRoot = LoggedInUser && LoggedInUser.isRoot();
     const isHostAdmin = LoggedInUser && LoggedInUser.isHostAdmin(collective);
     const isCollectiveAdmin = LoggedInUser && LoggedInUser.canEditCollective(collective);
-    const isFeesOnTop = collective.platformFeePercent === 0 && collective.host?.settings?.feesOnTop;
 
     return (
       <div className="Transactions">
@@ -187,7 +186,6 @@ class Transactions extends React.Component {
               <Transaction
                 collective={collective}
                 {...transaction}
-                isFeesOnTop={isFeesOnTop}
                 isRefund={Boolean(transaction.refundTransaction)}
                 canRefund={this.canRefund(isRoot, isHostAdmin, isCollectiveAdmin)}
                 canDownloadInvoice={this.canDownloadInvoice(transaction, isRoot, isCollectiveAdmin)}

--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -651,7 +651,6 @@ const getCollectiveCoverQuery = gql`
       imageUrl
       isIncognito
       backgroundImage
-      platformFeePercent
       isHost
       isActive
       isArchived


### PR DESCRIPTION
Reverts #4215, #4225 and #4234.

These were hacks used to hide the platform fee before we split fees on top into dedicated transactions.
Since we clear the platform fee when we split transactions, this code is now useless.