### PR TITLE
Remove option to send invoices by email

### DIFF
--- a/components/edit-collective/Form.js
+++ b/components/edit-collective/Form.js
@@ -154,14 +154,6 @@ class EditCollectiveForm extends React.Component {
         id: 'Fields.website',
         defaultMessage: 'Website',
       },
-      'sendInvoiceByEmail.label': {
-        id: 'collective.sendInvoiceByEmail.label',
-        defaultMessage: 'Invoices',
-      },
-      'sendInvoiceByEmail.description': {
-        id: 'collective.sendInvoiceByEmail.description',
-        defaultMessage: 'Include a PDF of receipts with your monthly report email',
-      },
       'application.label': {
         id: 'collective.application.label',
         defaultMessage: 'Open to Applications',
@@ -246,7 +238,6 @@ class EditCollectiveForm extends React.Component {
 
     collective.slug = collective.slug ? collective.slug.replace(/.*\//, '') : '';
     collective.tos = get(collective, 'settings.tos');
-    collective.sendInvoiceByEmail = get(collective, 'settings.sendInvoiceByEmail');
     collective.application = get(collective, 'settings.apply');
     collective.markdown = get(collective, 'settings.markdown');
 
@@ -725,15 +716,6 @@ class EditCollectiveForm extends React.Component {
           className: 'horizontal',
           defaultValue: get(this.state.collective, 'settings.tos'),
           when: () => collective.isHost,
-        },
-      ],
-      advanced: [
-        {
-          name: 'sendInvoiceByEmail',
-          className: 'horizontal',
-          type: 'switch',
-          defaultValue: get(this.state.collective, 'settings.sendInvoiceByEmail'),
-          when: () => section === 'advanced' && (collective.type === 'USER' || collective.type === 'ORGANIZATION'),
         },
       ],
     };

--- a/components/edit-collective/index.js
+++ b/components/edit-collective/index.js
@@ -59,13 +59,11 @@ class EditCollective extends React.Component {
     collective.settings = {
       ...this.props.collective.settings,
       editor: collective.markdown ? 'markdown' : 'html',
-      sendInvoiceByEmail: collective.sendInvoiceByEmail,
       apply: collective.application,
       tos: collective.tos,
     };
 
     delete collective.markdown;
-    delete collective.sendInvoiceByEmail;
     delete collective.tos;
     delete collective.application;
 

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -226,8 +226,6 @@
   "collective.pending.description": "This collective is pending approval from the host ({host}).",
   "collective.section.backers.organizations.title": "{n} {n, plural, one {organització dona} other {organizacions donen}} suport a {collective}",
   "collective.section.backers.users.title": "{n} {n, plural, one {persona suporta} other {persones suporten}} a {collective}",
-  "collective.sendInvoiceByEmail.description": "Include a PDF of receipts with your monthly report email",
-  "collective.sendInvoiceByEmail.label": "Factures",
   "collective.sendMoney.description": "PayPal is activated by default, you don't have to configure anything.",
   "collective.slug.label": "url",
   "collective.stats.balance.title": "Saldo disponible",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -226,8 +226,6 @@
   "collective.pending.description": "This collective is pending approval from the host ({host}).",
   "collective.section.backers.organizations.title": "{n} {n, plural, one {organization is} other {organizations are}} supporting {collective}",
   "collective.section.backers.users.title": "{n} {n, plural, one {individual is} other {individuals are}} supporting {collective}",
-  "collective.sendInvoiceByEmail.description": "Include a PDF of receipts with your monthly report email",
-  "collective.sendInvoiceByEmail.label": "Faktury",
   "collective.sendMoney.description": "PayPal is activated by default, you don't have to configure anything.",
   "collective.slug.label": "url",
   "collective.stats.balance.title": "Dostupný zůstatek",

--- a/lang/de.json
+++ b/lang/de.json
@@ -226,8 +226,6 @@
   "collective.pending.description": "Dieses Collective wartet auf die Genehmigung des Hosts ({host}).",
   "collective.section.backers.organizations.title": "{n} {n, plural, one {Organisation unterstützt} other {Organisationen unterstützen}} {collective}",
   "collective.section.backers.users.title": "{n} {n, plural, one {Person unterstützt} other {Personen unterstützen}} {collective}",
-  "collective.sendInvoiceByEmail.description": "Fügen Sie Ihrer monatlichen Berichts-E-Mail eine PDF mit Bescheinigungen bei",
-  "collective.sendInvoiceByEmail.label": "Rechnungen",
   "collective.sendMoney.description": "PayPal ist standardmäßig aktiviert, Sie müssen nichts konfigurieren.",
   "collective.slug.label": "url",
   "collective.stats.balance.title": "Verfügbarer Betrag",

--- a/lang/en.json
+++ b/lang/en.json
@@ -226,8 +226,6 @@
   "collective.pending.description": "This collective is pending approval from the host ({host}).",
   "collective.section.backers.organizations.title": "{n} {n, plural, one {organization is} other {organizations are}} supporting {collective}",
   "collective.section.backers.users.title": "{n} {n, plural, one {individual is} other {individuals are}} supporting {collective}",
-  "collective.sendInvoiceByEmail.description": "Include a PDF of receipts with your monthly report email",
-  "collective.sendInvoiceByEmail.label": "Invoices",
   "collective.sendMoney.description": "PayPal is activated by default, you don't have to configure anything.",
   "collective.slug.label": "url",
   "collective.stats.balance.title": "Available balance",

--- a/lang/es.json
+++ b/lang/es.json
@@ -226,8 +226,6 @@
   "collective.pending.description": "Este colectivo está pendiente de aprobación del patrocinador fiscal ({host}).",
   "collective.section.backers.organizations.title": "{n} {n, plural, one {organización está} other {organizaciones están}} apoyando a {collective}",
   "collective.section.backers.users.title": "{n} {n, plural, one {individual is} other {individuals are}} supporting {collective}",
-  "collective.sendInvoiceByEmail.description": "Incluir un PDF de recibos con su correo electrónico mensual",
-  "collective.sendInvoiceByEmail.label": "Facturas",
   "collective.sendMoney.description": "PayPal está activado automáticamente, no tienes que configurar nada.",
   "collective.slug.label": "url",
   "collective.stats.balance.title": "Balance disponible:",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -226,8 +226,6 @@
   "collective.pending.description": "Ce collectif est en attente d'approbation de l'hôte ({host}).",
   "collective.section.backers.organizations.title": "{n} {n, plural, one {organisation soutient} other {organisations soutiennent}} {collective}",
   "collective.section.backers.users.title": "{n} {n, plural, one {personne soutient} other {personnes soutiennent}} {collective}",
-  "collective.sendInvoiceByEmail.description": "Inclure un PDF contenant les reçus dans l'email de rapport mensuel",
-  "collective.sendInvoiceByEmail.label": "Factures",
   "collective.sendMoney.description": "PayPal est activé par défaut, vous n'avez rien à configurer.",
   "collective.slug.label": "URL",
   "collective.stats.balance.title": "Solde disponible",

--- a/lang/it.json
+++ b/lang/it.json
@@ -226,8 +226,6 @@
   "collective.pending.description": "Questa collettivo è in attesa di approvazione da parte dell'ospite ({host}).",
   "collective.section.backers.organizations.title": "{n} {n, plural, one {organizzazione sta} other {organizzazioni stanno}} sostenendo {collective}",
   "collective.section.backers.users.title": "{n} {n, plural, one {persona sta} other {persone stanno}} sostenendo {collective}",
-  "collective.sendInvoiceByEmail.description": "Includi un PDF di ricevute con la tua email di rapporto mensile",
-  "collective.sendInvoiceByEmail.label": "Fatture",
   "collective.sendMoney.description": "PayPal è attivato per impostazione predefinita, non devi configurare nulla.",
   "collective.slug.label": "url",
   "collective.stats.balance.title": "Bilancio disponibile",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -226,8 +226,6 @@
   "collective.pending.description": "This collective is pending approval from the host ({host}).",
   "collective.section.backers.organizations.title": "{n} {n, plural, one {つの組織が} other {つの組織が}} {collective} をサポートしています",
   "collective.section.backers.users.title": "{n} {n, plural, one {individual is} other {individuals are}} supporting {collective}",
-  "collective.sendInvoiceByEmail.description": "Include a PDF of receipts with your monthly report email",
-  "collective.sendInvoiceByEmail.label": "請求書",
   "collective.sendMoney.description": "PayPal is activated by default, you don't have to configure anything.",
   "collective.slug.label": "URL",
   "collective.stats.balance.title": "利用可能な残高:",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -226,8 +226,6 @@
   "collective.pending.description": "This collective is pending approval from the host ({host}).",
   "collective.section.backers.organizations.title": "{n} {n, plural, one {organization is} other {organizations are}} supporting {collective}",
   "collective.section.backers.users.title": "{n}명의 {n, plural, one {개인이} other {개인이}} {collective}를 지원함",
-  "collective.sendInvoiceByEmail.description": "Include a PDF of receipts with your monthly report email",
-  "collective.sendInvoiceByEmail.label": "청구서",
   "collective.sendMoney.description": "PayPal은 기본적으로 활성화되어 있지만, 아무것도 설정하지 않으셨습니다.",
   "collective.slug.label": "url",
   "collective.stats.balance.title": "사용 가능 잔액",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -226,8 +226,6 @@
   "collective.pending.description": "Dit collectief wacht op goedkeuring van de beheerder ({host}).",
   "collective.section.backers.organizations.title": "{n} {n, plural, one {organisatie} other {organisaties}} steunen {collective}",
   "collective.section.backers.users.title": "{n} {n, plural, one {individual is} other {individuals are}} supporting {collective}",
-  "collective.sendInvoiceByEmail.description": "Voeg een PDF toe van ontvangstbewijzen met je maandelijkse rapportage e-mail",
-  "collective.sendInvoiceByEmail.label": "Facturen",
   "collective.sendMoney.description": "PayPal is activated by default, you don't have to configure anything.",
   "collective.slug.label": "url",
   "collective.stats.balance.title": "Beschikbaar saldo",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -226,8 +226,6 @@
   "collective.pending.description": "Este coletivo está com uma aprovação pendente do organizador ({host}).",
   "collective.section.backers.organizations.title": "{n} {n, plural, one {organização está} other {organizações estão}} apoiando {collective}",
   "collective.section.backers.users.title": "{n} {n, plural, one {indivíduo está} other {indivíduos estão}} apoiando {collective}",
-  "collective.sendInvoiceByEmail.description": "Inclua um PDF de recibos com seu relatório mensal por email",
-  "collective.sendInvoiceByEmail.label": "Faturas",
   "collective.sendMoney.description": "PayPal is activated by default, you don't have to configure anything.",
   "collective.slug.label": "link",
   "collective.stats.balance.title": "Balanço disponível",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -226,8 +226,6 @@
   "collective.pending.description": "Коллектив ждёт одобрения от хоста ({host}).",
   "collective.section.backers.organizations.title": "{n} {n, plural, one {организация} other {организации}} поддерживают {collective}",
   "collective.section.backers.users.title": "{n} {n, plural, one {individual is} other {individuals are}} supporting {collective}",
-  "collective.sendInvoiceByEmail.description": "Включить PDF копии чеков в ваш ежемесячный отчёт на почту",
-  "collective.sendInvoiceByEmail.label": "Счета",
   "collective.sendMoney.description": "PayPal активирован по умолчанию, вам не нужно ничего настраивать.",
   "collective.slug.label": "url",
   "collective.stats.balance.title": "Доступный остаток",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -226,8 +226,6 @@
   "collective.pending.description": "This collective is pending approval from the host ({host}).",
   "collective.section.backers.organizations.title": "{n} {n, plural, one {organization is} other {organizations are}} supporting {collective}",
   "collective.section.backers.users.title": "{n} {n, plural, one {individual is} other {individuals are}} supporting {collective}",
-  "collective.sendInvoiceByEmail.description": "Include a PDF of receipts with your monthly report email",
-  "collective.sendInvoiceByEmail.label": "发票",
   "collective.sendMoney.description": "PayPal is activated by default, you don't have to configure anything.",
   "collective.slug.label": "链接",
   "collective.stats.balance.title": "可用余额",


### PR DESCRIPTION
This option couldn't work as the endpoint for it was removed more than one year ago (see https://github.com/opencollective/opencollective-api/pull/4274).

![image](https://user-images.githubusercontent.com/1556356/88524177-4a628b80-cff9-11ea-8f1a-0358524dabbe.png)
