### PR TITLE
Fix locale bug for "Other" platform fee selection

### DIFF
--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -873,7 +873,7 @@ class CreateOrderPage extends React.Component {
     }));
     platformFeeArray.push(
       { label: this.props.intl.formatMessage(messages.platformFeeNoContribution), value: 0 },
-      { label: this.props.intl.formatMessage(messages.platformFeeOther), value: 100 },
+      { label: this.props.intl.formatMessage(messages.platformFeeOther), value: 100, isCustomAmount: true },
     );
     return platformFeeArray;
   };
@@ -1007,10 +1007,10 @@ class CreateOrderPage extends React.Component {
                       </P>
                     </Flex>
                   </Flex>
-                  {stepDetails.platformFee?.label === 'Other' && (
+                  {stepDetails.platformFee?.isCustomAmount && (
                     <Box>
                       <StyledInputField
-                        label="Other amount"
+                        label={this.props.intl.formatMessage(messages.platformFeeOther)}
                         htmlFor="feesOnTopOtherAmount"
                         name="feesOnTopOtherAmount"
                         required


### PR DESCRIPTION
Fixes opencollective/opencollective#3361

![Screenshot 2020-07-27 at 13 43 28](https://user-images.githubusercontent.com/37520401/88542970-2f9b1180-d00f-11ea-925a-1642d8462de9.png)

If you select 'other' fee on top in a language besides English, it would not show the 'Other' field to type the amount. This was because the conditions to show it were based on the hardcoded 'Other' selection in the fees on top dropdown. This corrects it to be based on the internationalised string.