### PR TITLE
increase color contrast to acceptable levels AAA

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -115,7 +115,7 @@ class Footer extends React.Component {
               An organization for your community, transparent by design.
             </P>
             <Container color="#6E747A" textAlign={['center', null, 'left']}>
-              <P as="div" fontSize="1.2rem" color="#555658" letterSpacing="1px" pb={2} pt={2}>
+              <P as="div" fontSize="1.2rem" color="black.800" letterSpacing="1px" pb={2} pt={2}>
                 <Span mr={1} style={{ verticalAlign: 'middle' }}>
                   LANGUAGES
                 </Span>
@@ -181,7 +181,7 @@ class Footer extends React.Component {
           <Flex as="nav" flexWrap="wrap" justifyContent="center" mt={3} flex="1 1 auto" order={['3', null, '2']}>
             {Object.keys(navigation).map(key => (
               <Box key={key} width={[0.5, null, 0.25]} mb={3}>
-                <P textAlign={['center', null, 'left']} fontSize="1.2rem" color="#555658" letterSpacing="1px" pb={3}>
+                <P textAlign={['center', null, 'left']} fontSize="1.2rem" color="black.800" letterSpacing="1px" pb={3}>
                   {key}
                 </P>
                 <FlexList justifyContent="center" flexDirection="column" pl={0} pr={2}>

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -115,7 +115,7 @@ class Footer extends React.Component {
               An organization for your community, transparent by design.
             </P>
             <Container color="#6E747A" textAlign={['center', null, 'left']}>
-              <P as="div" fontSize="1.2rem" color="#C2C6CC" letterSpacing="1px" pb={2} pt={2}>
+              <P as="div" fontSize="1.2rem" color="#555658" letterSpacing="1px" pb={2} pt={2}>
                 <Span mr={1} style={{ verticalAlign: 'middle' }}>
                   LANGUAGES
                 </Span>
@@ -181,7 +181,7 @@ class Footer extends React.Component {
           <Flex as="nav" flexWrap="wrap" justifyContent="center" mt={3} flex="1 1 auto" order={['3', null, '2']}>
             {Object.keys(navigation).map(key => (
               <Box key={key} width={[0.5, null, 0.25]} mb={3}>
-                <P textAlign={['center', null, 'left']} fontSize="1.2rem" color="#C2C6CC" letterSpacing="1px" pb={3}>
+                <P textAlign={['center', null, 'left']} fontSize="1.2rem" color="#555658" letterSpacing="1px" pb={3}>
                   {key}
                 </P>
                 <FlexList justifyContent="center" flexDirection="column" pl={0} pr={2}>


### PR DESCRIPTION
The current color contrast ratio of the link headings text in the footer is 1.47, WCAG recommends it be at least 4.5 for AA, but preferably 7 for maxium readability.  Since it looks very readable at 7, I've submitted a path to change this to a AAA compliant color.

# Description

Just changes the current inline foreground color of text to a more contrasting alternative for readability and WCAG compliance (effectively, just a shade).  Open the old and the new side by side, see the delta.  You can also open dev tools and check lighthouse or the inspector on the element to confirm it is compliant, but it is self-evidently readable.

# Screenshots
Join the movement is updated in the screenshot below to show the delta between these...
![Screenshot from 2020-07-27 13-28-05](https://user-images.githubusercontent.com/870501/88572382-0c6f6280-d00d-11ea-8d75-0663fbc36448.png)

