### PR TITLE
Refactor: update GraphQL mutates

### DIFF
--- a/components/ApplyToHostBtnLoggedIn.js
+++ b/components/ApplyToHostBtnLoggedIn.js
@@ -53,11 +53,14 @@ class ApplyToHostBtnLoggedIn extends React.Component {
 
   handleContinueBtn = async () => {
     const { host } = this.props;
-    const CollectiveInputType = {
-      id: this.inactiveCollective.id,
-      HostCollectiveId: host.id,
-    };
-    await this.props.editCollective(CollectiveInputType);
+    await this.props.editCollective({
+      variables: {
+        collective: {
+          id: this.inactiveCollective.id,
+          HostCollectiveId: host.id,
+        },
+      },
+    });
     this.setState({ showModal: false });
   };
 
@@ -237,11 +240,7 @@ const addInactiveCollectivesData = graphql(inactiveCollectivesQuery, {
 });
 
 const addApplyToHostMutation = graphql(applyToHostMutation, {
-  props: ({ mutate }) => ({
-    editCollective: async CollectiveInputType => {
-      return await mutate({ variables: { collective: CollectiveInputType } });
-    },
-  }),
+  name: 'editCollective',
 });
 
 const addGraphql = compose(addInactiveCollectivesData, addApplyToHostMutation);

--- a/components/Comment.js
+++ b/components/Comment.js
@@ -95,7 +95,7 @@ class Comment extends React.Component {
 
   async save() {
     const comment = pick(this.state.comment, ['id', 'html']);
-    await this.props.editComment(comment);
+    await this.props.editComment({ variables: { comment } });
     this.setState({ modified: false, mode: 'details' });
   }
 

--- a/components/CommentsWithData.js
+++ b/components/CommentsWithData.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from '@apollo/react-hoc';
-import gql from 'graphql-tag';
 import { cloneDeep, get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 
+import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
 import { compose } from '../lib/utils';
 
 import PrivateInfoIcon from './icons/PrivateInfoIcon';
@@ -16,8 +16,6 @@ import LoadingPlaceholder from './LoadingPlaceholder';
 import LoginBtn from './LoginBtn';
 import MessageBox from './MessageBox';
 import { P } from './Text';
-
-const gqlV2 = gql; // Needed for lint validation of api v2 schema.
 
 class CommentsWithData extends React.Component {
   static propTypes = {
@@ -256,9 +254,7 @@ const createCommentMutation = gqlV2/* GraphQL */ `
 `;
 
 const addCreateCommentMutation = graphql(createCommentMutation, {
-  options: {
-    context: { apiVersion: '2' },
-  },
+  options: { context: API_V2_CONTEXT },
   props: ({ ownProps, mutate }) => ({
     createComment: async comment => {
       return await mutate({
@@ -291,9 +287,7 @@ const deleteCommentMutation = gqlV2/* GraphQL */ `
 `;
 
 const addDeleteCommentMutation = graphql(deleteCommentMutation, {
-  options: {
-    context: { apiVersion: '2' },
-  },
+  options: { context: API_V2_CONTEXT },
   props: ({ ownProps, mutate }) => ({
     deleteComment: async id => {
       return await mutate({
@@ -348,14 +342,8 @@ const editCommentMutation = gqlV2/* GraphQL */ `
 `;
 
 const addEditCommentMutation = graphql(editCommentMutation, {
-  options: {
-    context: { apiVersion: '2' },
-  },
-  props: ({ mutate }) => ({
-    editComment: async comment => {
-      return await mutate({ variables: { comment } });
-    },
-  }),
+  name: 'editComment',
+  options: { context: API_V2_CONTEXT },
 });
 
 const addGraphql = compose(

--- a/components/CreateVirtualCardsForm.js
+++ b/components/CreateVirtualCardsForm.js
@@ -263,7 +263,8 @@ class CreateVirtualCardsForm extends Component {
       }
 
       this.setState({ submitting: true });
-      const params = {
+      const variables = {
+        CollectiveId: this.props.collectiveId,
         amount: values.amount,
         PaymentMethodId: paymentMethod.id,
         expiryDate: values.expiryDate,
@@ -272,14 +273,14 @@ class CreateVirtualCardsForm extends Component {
       };
 
       if (deliverType === 'email') {
-        params.emails = values.emails;
-        params.customMessage = values.customMessage;
+        variables.emails = values.emails;
+        variables.customMessage = values.customMessage;
       } else if (deliverType === 'manual') {
-        params.numberOfVirtualCards = values.numberOfVirtualCards;
+        variables.numberOfVirtualCards = values.numberOfVirtualCards;
       }
 
       this.props
-        .createVirtualCards(params)
+        .createVirtualCards({ variables })
         .then(({ data }) => {
           this.setState({ createdVirtualCards: data.createVirtualCards, submitting: false });
           window.scrollTo(0, 0);
@@ -758,15 +759,7 @@ const createVirtualCardsMutation = gql`
 `;
 
 const addCreateVirtualCardsMutation = graphql(createVirtualCardsMutation, {
-  props: ({ mutate, ownProps }) => ({
-    createVirtualCards: variables =>
-      mutate({
-        variables: {
-          ...variables,
-          CollectiveId: ownProps.collectiveId,
-        },
-      }),
-  }),
+  name: 'createVirtualCards',
 });
 
 const addGraphql = compose(addCollectiveSourcePaymentMethodsQuery, addCreateVirtualCardsMutation);

--- a/components/PublishUpdateBtnWithData.js
+++ b/components/PublishUpdateBtnWithData.js
@@ -30,7 +30,7 @@ class PublishUpdateBtn extends React.Component {
   async onClick() {
     const { id } = this.props;
     const { notificationAudience } = this.state;
-    await this.props.publishUpdate(id, notificationAudience);
+    await this.props.publishUpdate({ variables: { id, notificationAudience } });
   }
 
   handleNotificationChange(selected) {
@@ -183,11 +183,7 @@ const updateQuery = gql`
 const addUpdateData = graphql(updateQuery);
 
 const addPublishUpdateMutation = graphql(publishUpdateMutation, {
-  props: ({ mutate }) => ({
-    publishUpdate: async (id, notificationAudience) => {
-      return await mutate({ variables: { id, notificationAudience } });
-    },
-  }),
+  name: 'publishUpdate',
 });
 
 const addGraphql = compose(addPublishUpdateMutation, addUpdateData);

--- a/components/SendMoneyToCollectiveBtn.js
+++ b/components/SendMoneyToCollectiveBtn.js
@@ -20,7 +20,7 @@ class SendMoneyToCollectiveBtn extends React.Component {
     toCollective: PropTypes.object.isRequired,
     LoggedInUser: PropTypes.object.isRequired,
     data: PropTypes.object,
-    createOrder: PropTypes.func,
+    sendMoneyToCollective: PropTypes.func,
     confirmTransfer: PropTypes.func,
     isTransferApproved: PropTypes.bool,
   };
@@ -58,7 +58,7 @@ class SendMoneyToCollectiveBtn extends React.Component {
       paymentMethod: { uuid: paymentMethods[0].uuid },
     };
     try {
-      await this.props.createOrder(order);
+      await this.props.sendMoneyToCollective({ variables: { order } });
       this.setState({ loading: false });
     } catch (e) {
       const error = e.message && e.message.replace(/GraphQL error:/, '');
@@ -146,11 +146,7 @@ const sendMoneyToCollectiveMutation = gql`
 `;
 
 const addSendMoneyToCollectiveMutation = graphql(sendMoneyToCollectiveMutation, {
-  props: ({ mutate }) => ({
-    createOrder: async order => {
-      return await mutate({ variables: { order } });
-    },
-  }),
+  name: 'sendMoneyToCollective',
 });
 
 const addGraphql = compose(addPaymentMethodsData, addSendMoneyToCollectiveMutation);

--- a/components/StyledUpdate.js
+++ b/components/StyledUpdate.js
@@ -112,7 +112,7 @@ class StyledUpdate extends Component {
     }
 
     try {
-      await this.props.deleteUpdate(this.props.update.id);
+      await this.props.deleteUpdate({ variables: { id: this.props.update.id } });
       Router.pushRoute('collective', { slug: this.props.collective.slug });
     } catch (err) {
       // TODO: this should be reported to the user
@@ -122,7 +122,7 @@ class StyledUpdate extends Component {
 
   save = async update => {
     update.id = get(this.props, 'update.id');
-    await this.props.editUpdate(update);
+    await this.props.editUpdate({ variables: { update } });
     this.setState({ modified: false, mode: 'details' });
   };
 
@@ -340,22 +340,12 @@ const deleteUpdateMutation = gql`
   }
 `;
 
-/* TODO(GraphQL): refactor unnecessary mutate */
 const addEditUpdateMutation = graphql(editUpdateMutation, {
-  props: ({ mutate }) => ({
-    editUpdate: async update => {
-      return await mutate({ variables: { update } });
-    },
-  }),
+  name: 'editUpdate',
 });
 
-/* TODO(GraphQL): refactor unnecessary mutate */
 const addDeleteUpdateMutation = graphql(deleteUpdateMutation, {
-  props: ({ mutate }) => ({
-    deleteUpdate: async updateID => {
-      return await mutate({ variables: { id: updateID } });
-    },
-  }),
+  name: 'deleteUpdate',
 });
 
 const addGraphql = compose(addEditUpdateMutation, addDeleteUpdateMutation);

--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -481,7 +481,8 @@ class CreateOrderPage extends React.Component {
     };
 
     try {
-      const orderCreated = (await createOrder(order)).data.createOrder;
+      const res = await createOrder({ variables: { order } });
+      const orderCreated = res.data.createOrder;
       if (orderCreated.stripeError) {
         this.handleStripeError(orderCreated);
       } else {
@@ -505,7 +506,7 @@ class CreateOrderPage extends React.Component {
     this.setState({ submitting: true, error: null });
 
     try {
-      const res = await this.props.confirmOrder(order);
+      const res = await this.props.confirmOrder({ variables: { order } });
       const orderConfirmed = res.data.confirmOrder;
       if (orderConfirmed.stripeError) {
         this.handleStripeError(orderConfirmed);
@@ -1316,9 +1317,7 @@ const createOrderMutation = gql`
 `;
 
 const addCreateOrderMutation = graphql(createOrderMutation, {
-  props: ({ mutate }) => ({
-    createOrder: order => mutate({ variables: { order } }),
-  }),
+  name: 'createOrder',
 });
 
 const confirmOrderMutation = gql`
@@ -1331,9 +1330,7 @@ const confirmOrderMutation = gql`
 `;
 
 const addConfirmOrderMutation = graphql(confirmOrderMutation, {
-  props: ({ mutate }) => ({
-    confirmOrder: order => mutate({ variables: { order } }),
-  }),
+  name: 'confirmOrder',
 });
 
 const addGraphql = compose(addCreateCollectiveMutation, addCreateOrderMutation, addConfirmOrderMutation);

--- a/components/edit-collective/EditTwitterAccount.js
+++ b/components/edit-collective/EditTwitterAccount.js
@@ -118,7 +118,7 @@ class EditTwitterAccount extends React.Component {
 
   async onClick() {
     const connectedAccount = pick(this.state.connectedAccount, ['id', 'settings']);
-    await this.props.editConnectedAccount(connectedAccount);
+    await this.props.editConnectedAccount({ variables: { connectedAccount } });
     this.setState({ isModified: false });
   }
 
@@ -217,11 +217,7 @@ const editConnectedAccountMutation = gql`
 `;
 
 const addEditConnectedAccountMutation = graphql(editConnectedAccountMutation, {
-  props: ({ mutate }) => ({
-    editConnectedAccount: async connectedAccount => {
-      return await mutate({ variables: { connectedAccount } });
-    },
-  }),
+  name: 'editConnectedAccount',
 });
 
 export default injectIntl(addEditConnectedAccountMutation(EditTwitterAccount));

--- a/components/edit-collective/EditUserEmailForm.js
+++ b/components/edit-collective/EditUserEmailForm.js
@@ -101,7 +101,7 @@ class EditUserEmailForm extends React.Component {
               onClick={async () => {
                 this.setState({ isSubmitting: true });
                 try {
-                  const { data } = await updateUserEmail(newEmail);
+                  const { data } = await updateUserEmail({ variables: { email: newEmail } });
                   this.setState({
                     step: LoggedInUser.email === newEmail ? 'initial' : 'success',
                     error: null,
@@ -125,7 +125,7 @@ class EditUserEmailForm extends React.Component {
                 onClick={async () => {
                   this.setState({ isResendingConfirmation: true });
                   try {
-                    await updateUserEmail(newEmail);
+                    await updateUserEmail({ variables: { email: newEmail } });
                     this.setState({ isResendingConfirmation: false, step: 'already-sent', error: null });
                   } catch (e) {
                     this.setState({ error: e.message.replace('GraphQL error: ', ''), isResendingConfirmation: false });
@@ -185,11 +185,7 @@ const updateUserEmailMutation = gql`
 `;
 
 const addUpdateUserEmailMutation = graphql(updateUserEmailMutation, {
-  props: ({ mutate }) => ({
-    updateUserEmail: email => {
-      return mutate({ variables: { email } });
-    },
-  }),
+  name: 'updateUserEmail',
 });
 
 export default addUpdateUserEmailMutation(addloggedInUserEmailData(EditUserEmailForm));

--- a/components/edit-collective/sections/CollectiveGoals.js
+++ b/components/edit-collective/sections/CollectiveGoals.js
@@ -26,12 +26,13 @@ const BORDER = '1px solid #efefef';
 class CollectiveGoals extends React.Component {
   static propTypes = {
     collective: PropTypes.shape({
+      id: PropTypes.number.isRequired,
       slug: PropTypes.string.isRequired,
       settings: PropTypes.object,
     }).isRequired,
     currency: PropTypes.string.isRequired,
     intl: PropTypes.object.isRequired,
-    updateSettings: PropTypes.func.isRequired,
+    editCollectiveSettings: PropTypes.func.isRequired,
     title: PropTypes.string,
   };
 
@@ -136,13 +137,16 @@ class CollectiveGoals extends React.Component {
   handleSubmit = async () => {
     try {
       this.setState({ isSubmitting: true });
-
-      await this.props.updateSettings({
-        ...this.props.collective.settings,
-        goals: this.state.goals,
-        collectivePage: this.state.collectivePage,
+      await this.props.editCollectiveSettings({
+        variables: {
+          id: this.props.collective.id,
+          settings: {
+            ...this.props.collective.settings,
+            goals: this.state.goals,
+            collectivePage: this.state.collectivePage,
+          },
+        },
       });
-
       this.setState({ isSubmitting: false, isTouched: false, submitted: true });
       setTimeout(() => this.setState({ submitted: false }), 2000);
     } catch (e) {
@@ -291,9 +295,7 @@ const editCollectiveSettingsMutation = gql`
 `;
 
 const addEditCollectiveSettingsMutation = graphql(editCollectiveSettingsMutation, {
-  props: ({ ownProps, mutate }) => ({
-    updateSettings: settings => mutate({ variables: { id: ownProps.collective.id, settings } }),
-  }),
+  name: 'editCollectiveSettings',
 });
 
 export default injectIntl(addEditCollectiveSettingsMutation(CollectiveGoals));

--- a/components/edit-collective/sections/Members.js
+++ b/components/edit-collective/sections/Members.js
@@ -46,7 +46,7 @@ class Members extends React.Component {
     /** @ignore from injectIntl */
     intl: PropTypes.object.isRequired,
     /** @ignore from Apollo */
-    mutate: PropTypes.func.isRequired,
+    editCoreContributors: PropTypes.func.isRequired,
     /** @ignore from Apollo */
     data: PropTypes.shape({
       loading: PropTypes.bool,
@@ -184,7 +184,7 @@ class Members extends React.Component {
 
     try {
       this.setState({ isSubmitting: true, error: null });
-      await this.props.mutate({
+      await this.props.editCoreContributors({
         variables: {
           collectiveId: this.props.collective.id,
           members: this.state.members.map(member => ({
@@ -433,7 +433,9 @@ const editCoreContributorsMutation = gql`
   ${memberFieldsFragment}
 `;
 
-const addEditCoreContributorsMutation = graphql(editCoreContributorsMutation);
+const addEditCoreContributorsMutation = graphql(editCoreContributorsMutation, {
+  name: 'editCoreContributors',
+});
 
 const addGraphql = compose(addCoreContributorsData, addEditCoreContributorsMutation);
 

--- a/components/expenses/ApproveExpenseBtn.js
+++ b/components/expenses/ApproveExpenseBtn.js
@@ -24,7 +24,7 @@ class ApproveExpenseBtn extends React.Component {
   async onClick() {
     const { id } = this.props;
     try {
-      await this.props.approveExpense(id);
+      await this.props.approveExpense({ variables: { id } });
       await this.props.refetch();
     } catch (e) {
       const error = getErrorFromGraphqlException(e).message;
@@ -53,11 +53,7 @@ const approveExpenseMutation = gql`
 `;
 
 const addApproveExpenseMutation = graphql(approveExpenseMutation, {
-  props: ({ mutate }) => ({
-    approveExpense: async id => {
-      return await mutate({ variables: { id } });
-    },
-  }),
+  name: 'approveExpense',
 });
 
 export default addApproveExpenseMutation(ApproveExpenseBtn);

--- a/components/expenses/Expense.js
+++ b/components/expenses/Expense.js
@@ -171,7 +171,7 @@ class Expense extends React.Component {
 
   handleUnapproveExpense = async id => {
     try {
-      await this.props.unapproveExpense(id);
+      await this.props.unapproveExpense({ variables: { id } });
       this.setState({ showUnapproveModal: false });
       await this.props.refetch();
     } catch (err) {
@@ -181,7 +181,7 @@ class Expense extends React.Component {
 
   handleDeleteExpense = async id => {
     try {
-      await this.props.deleteExpense(id);
+      await this.props.deleteExpense({ variables: { id } });
       this.setState({ showDeleteExpenseModal: false, error: null });
       await this.props.refetch();
     } catch (err) {
@@ -196,7 +196,7 @@ class Expense extends React.Component {
         id: this.props.expense.id,
         ...this.state.expense,
       };
-      await this.props.editExpense(expense);
+      await this.props.editExpense({ variables: { expense } });
       this.setState({ modified: false, mode: 'details', isSubmitting: false });
     } catch (e) {
       this.setState({ isSubmitting: false });
@@ -622,11 +622,7 @@ const deleteExpenseMutation = gql`
 `;
 
 const addDeleteExpenseMutation = graphql(deleteExpenseMutation, {
-  props: ({ mutate }) => ({
-    deleteExpense: async id => {
-      return await mutate({ variables: { id } });
-    },
-  }),
+  name: 'deleteExpense',
 });
 
 const unapproveExpenseMutation = gql`
@@ -639,11 +635,7 @@ const unapproveExpenseMutation = gql`
 `;
 
 const addUnapproveExpenseMutation = graphql(unapproveExpenseMutation, {
-  props: ({ mutate }) => ({
-    unapproveExpense: async id => {
-      return await mutate({ variables: { id } });
-    },
-  }),
+  name: 'unapproveExpense',
 });
 
 const editExpenseMutation = gql`
@@ -674,11 +666,7 @@ const editExpenseMutation = gql`
 `;
 
 const addEditExpenseMutation = graphql(editExpenseMutation, {
-  props: ({ mutate }) => ({
-    editExpense: async expense => {
-      return await mutate({ variables: { expense } });
-    },
-  }),
+  name: 'editExpense',
 });
 
 const addGraphql = compose(addUnapproveExpenseMutation, addEditExpenseMutation, addDeleteExpenseMutation);

--- a/components/expenses/MarkExpenseAsPaidBtn.js
+++ b/components/expenses/MarkExpenseAsPaidBtn.js
@@ -23,7 +23,7 @@ class MarkExpenseAsPaidBtn extends React.Component {
     platformFeeInCollectiveCurrency: PropTypes.number,
     lock: PropTypes.func,
     unlock: PropTypes.func,
-    mutate: PropTypes.func,
+    payExpense: PropTypes.func.isRequired,
     refetch: PropTypes.func,
     intl: PropTypes.object.isRequired,
     onError: PropTypes.func,
@@ -52,7 +52,7 @@ class MarkExpenseAsPaidBtn extends React.Component {
     this.setState({ loading: true });
 
     try {
-      await this.props.mutate({
+      await this.props.payExpense({
         variables: {
           id: expense.id,
           paymentProcessorFeeInCollectiveCurrency: this.props.paymentProcessorFeeInCollectiveCurrency,
@@ -128,5 +128,8 @@ class MarkExpenseAsPaidBtn extends React.Component {
   }
 }
 
-const addMutation = graphql(payExpenseMutation);
-export default addMutation(injectIntl(MarkExpenseAsPaidBtn));
+const addPayExpenseMutation = graphql(payExpenseMutation, {
+  name: 'payExpense',
+});
+
+export default injectIntl(addPayExpenseMutation(MarkExpenseAsPaidBtn));

--- a/components/expenses/MarkOrderAsPaidBtn.js
+++ b/components/expenses/MarkOrderAsPaidBtn.js
@@ -18,7 +18,6 @@ class MarkOrderAsPaidBtn extends React.Component {
     super(props);
     this.state = {
       loading: false,
-      paymentProcessorFeeInHostCurrency: 0,
     };
     this.onClick = this.onClick.bind(this);
   }
@@ -30,7 +29,7 @@ class MarkOrderAsPaidBtn extends React.Component {
     }
     this.setState({ loading: true });
     try {
-      await this.props.markOrderAsPaid(order.id, this.state.paymentProcessorFeeInHostCurrency);
+      await this.props.markOrderAsPaid({ variables: { id: order.id } });
       this.setState({ loading: false });
     } catch (e) {
       const error = e.message && e.message.replace(/GraphQL error:/, '');
@@ -114,11 +113,7 @@ const markOrderAsPaidMutation = gql`
 `;
 
 const addMarkOrderAsPaidMutation = graphql(markOrderAsPaidMutation, {
-  props: ({ mutate }) => ({
-    markOrderAsPaid: async id => {
-      return await mutate({ variables: { id } });
-    },
-  }),
+  name: 'markOrderAsPaid',
 });
 
 export default addMarkOrderAsPaidMutation(MarkOrderAsPaidBtn);

--- a/components/expenses/Order.js
+++ b/components/expenses/Order.js
@@ -78,7 +78,7 @@ class Order extends React.Component {
 
   handleCancelOrder = async id => {
     try {
-      await this.props.markPendingOrderAsExpired(id);
+      await this.props.markPendingOrderAsExpired({ variables: { id } });
       this.setState({
         showCancelOrderModal: false,
       });
@@ -337,7 +337,7 @@ class Order extends React.Component {
 }
 
 const markPendingOrderAsExpiredMutation = gql`
-  mutation markPendingOrderAsExpired($id: Int!) {
+  mutation MarkPendingOrderAsExpired($id: Int!) {
     markPendingOrderAsExpired(id: $id) {
       id
       status
@@ -352,12 +352,8 @@ const markPendingOrderAsExpiredMutation = gql`
   }
 `;
 
-const addMutation = graphql(markPendingOrderAsExpiredMutation, {
-  props: ({ mutate }) => ({
-    markPendingOrderAsExpired: async id => {
-      return await mutate({ variables: { id } });
-    },
-  }),
+const addMarkPendingOrderAsExpiredMutation = graphql(markPendingOrderAsExpiredMutation, {
+  name: 'markPendingOrderAsExpired',
 });
 
-export default addMutation(injectIntl(Order));
+export default addMarkPendingOrderAsExpiredMutation(injectIntl(Order));

--- a/components/expenses/PayExpenseBtnLegacy.js
+++ b/components/expenses/PayExpenseBtnLegacy.js
@@ -25,7 +25,7 @@ class PayExpenseBtnLegacy extends React.Component {
     platformFeeInCollectiveCurrency: PropTypes.number,
     lock: PropTypes.func,
     unlock: PropTypes.func,
-    mutate: PropTypes.func,
+    payExpense: PropTypes.func.isRequired,
     refetch: PropTypes.func,
     intl: PropTypes.object.isRequired,
     onError: PropTypes.func,
@@ -68,7 +68,7 @@ class PayExpenseBtnLegacy extends React.Component {
     this.setState({ loading: true });
 
     try {
-      await this.props.mutate({
+      await this.props.payExpense({
         variables: {
           id: expense.id,
           paymentProcessorFeeInCollectiveCurrency: this.props.paymentProcessorFeeInCollectiveCurrency,
@@ -174,5 +174,8 @@ class PayExpenseBtnLegacy extends React.Component {
   }
 }
 
-const addMutation = graphql(payExpenseMutation);
-export default addMutation(injectIntl(PayExpenseBtnLegacy));
+const addPayExpenseMutation = graphql(payExpenseMutation, {
+  name: 'payExpense',
+});
+
+export default injectIntl(addPayExpenseMutation(PayExpenseBtnLegacy));

--- a/components/expenses/PayoutMethodSelect.js
+++ b/components/expenses/PayoutMethodSelect.js
@@ -138,14 +138,13 @@ class PayoutMethodSelect extends React.Component {
     }
   }
 
-  removePayoutMethod(payoutMethod) {
-    return this.props.removePayoutMethod(payoutMethod.id).then(() => {
-      this.setState({ removingPayoutMethod: null });
-      this.props.onRemove(payoutMethod);
-      if (this.props.payoutMethod?.id === payoutMethod.id) {
-        this.props.onChange({ value: null });
-      }
-    });
+  async removePayoutMethod(payoutMethod) {
+    await this.props.removePayoutMethod({ variables: { id: payoutMethod.id } });
+    this.setState({ removingPayoutMethod: null });
+    this.props.onRemove(payoutMethod);
+    if (this.props.payoutMethod?.id === payoutMethod.id) {
+      this.props.onChange({ value: null });
+    }
   }
 
   formatOptionLabel = ({ value }, { context }) => {
@@ -246,7 +245,7 @@ class PayoutMethodSelect extends React.Component {
 }
 
 const removePayoutMethodMutation = gqlV2/* GraphQL */ `
-  mutation removePayoutMethod($id: String!) {
+  mutation RemovePayoutMethod($id: String!) {
     removePayoutMethod(payoutMethodId: $id) {
       id
       isSaved
@@ -255,9 +254,8 @@ const removePayoutMethodMutation = gqlV2/* GraphQL */ `
 `;
 
 const addRemovePayoutMethodMutation = graphql(removePayoutMethodMutation, {
-  props: ({ mutate }) => ({
-    removePayoutMethod: id => mutate({ variables: { id }, context: API_V2_CONTEXT }),
-  }),
+  name: 'removePayoutMethod',
+  options: { context: API_V2_CONTEXT },
 });
 
 export default React.memo(injectIntl(addRemovePayoutMethodMutation(PayoutMethodSelect)));

--- a/components/expenses/RejectExpenseBtn.js
+++ b/components/expenses/RejectExpenseBtn.js
@@ -24,7 +24,7 @@ class RejectExpenseBtn extends React.Component {
   async onClick() {
     const { id } = this.props;
     try {
-      await this.props.rejectExpense(id);
+      await this.props.rejectExpense({ variables: { id } });
       await this.props.refetch();
     } catch (e) {
       const error = getErrorFromGraphqlException(e).message;
@@ -53,11 +53,7 @@ const rejectExpensemutation = gql`
 `;
 
 const addRejectExpensemutation = graphql(rejectExpensemutation, {
-  props: ({ mutate }) => ({
-    rejectExpense: async id => {
-      return await mutate({ variables: { id } });
-    },
-  }),
+  name: 'rejectExpense',
 });
 
 export default addRejectExpensemutation(RejectExpenseBtn);

--- a/components/host-dashboard/HostDashboardActionsBanner.js
+++ b/components/host-dashboard/HostDashboardActionsBanner.js
@@ -250,6 +250,8 @@ const addFundsToCollectiveMutation = gql`
   }
 `;
 
-const addMutation = graphql(addFundsToCollectiveMutation, { name: 'addFundsToCollective' });
+const addMutation = graphql(addFundsToCollectiveMutation, {
+  name: 'addFundsToCollective',
+});
 
 export default addMutation(injectIntl(HostDashboardActionsBanner));

--- a/components/onboarding-modal/OnboardingModal.js
+++ b/components/onboarding-modal/OnboardingModal.js
@@ -119,8 +119,8 @@ class OnboardingModal extends React.Component {
     mode: PropTypes.string,
     collective: PropTypes.object,
     LoggedInUser: PropTypes.object,
-    EditCollectiveMembers: PropTypes.func,
-    EditCollectiveContact: PropTypes.func,
+    editCollectiveMembers: PropTypes.func,
+    editCollectiveContact: PropTypes.func,
     showOnboardingModal: PropTypes.bool,
     setShowOnboardingModal: PropTypes.func,
     intl: PropTypes.object.isRequired,
@@ -172,16 +172,18 @@ class OnboardingModal extends React.Component {
   submitAdmins = async () => {
     try {
       this.setState({ isSubmitting: true });
-      await this.props.EditCollectiveMembers({
-        collectiveId: this.props.collective.id,
-        members: this.state.members.map(member => ({
-          id: member.id,
-          role: member.role,
-          member: {
-            id: member.member.id,
-            name: member.member.name,
-          },
-        })),
+      await this.props.editCollectiveMembers({
+        variables: {
+          collectiveId: this.props.collective.id,
+          members: this.state.members.map(member => ({
+            id: member.id,
+            role: member.role,
+            member: {
+              id: member.member.id,
+              name: member.member.name,
+            },
+          })),
+        },
       });
     } catch (e) {
       const errorMsg = getErrorFromGraphqlException(e).message;
@@ -196,9 +198,7 @@ class OnboardingModal extends React.Component {
     };
     try {
       this.setState({ isSubmitting: true });
-      await this.props.EditCollectiveContact({
-        collective,
-      });
+      await this.props.editCollectiveContact({ variables: { collective } });
     } catch (e) {
       const errorMsg = getErrorFromGraphqlException(e).message;
       throw new Error(errorMsg);
@@ -414,13 +414,7 @@ const editCollectiveMembersMutation = gql`
 `;
 
 const addEditCollectiveMembersMutation = graphql(editCollectiveMembersMutation, {
-  props: ({ mutate }) => ({
-    EditCollectiveMembers: async ({ collectiveId, members }) => {
-      return await mutate({
-        variables: { collectiveId, members },
-      });
-    },
-  }),
+  name: 'editCollectiveMembers',
 });
 
 // GraphQL for editing Collective contact info
@@ -436,13 +430,7 @@ const editCollectiveContactMutation = gql`
 `;
 
 const addEditCollectiveContactMutation = graphql(editCollectiveContactMutation, {
-  props: ({ mutate }) => ({
-    EditCollectiveContact: async ({ collective }) => {
-      return await mutate({
-        variables: { collective },
-      });
-    },
-  }),
+  name: 'editCollectiveContact',
 });
 
 const addGraphql = compose(addEditCollectiveMembersMutation, addEditCollectiveContactMutation);

--- a/lib/graphql/mutations.js
+++ b/lib/graphql/mutations.js
@@ -40,24 +40,6 @@ const editCollectiveMutation = gql`
   ${editCollectivePageFieldsFragment}
 `;
 
-const archiveCollectiveMutation = gql`
-  mutation ArchiveCollective($id: Int!) {
-    archiveCollective(id: $id) {
-      id
-      isArchived
-    }
-  }
-`;
-
-const unarchiveCollectiveMutation = gql`
-  mutation UnarchiveCollective($id: Int!) {
-    unarchiveCollective(id: $id) {
-      id
-      isArchived
-    }
-  }
-`;
-
 export const addCreateCollectiveMutation = graphql(createCollectiveMutation, {
   props: ({ mutate }) => ({
     createCollective: async collective => {
@@ -180,22 +162,6 @@ export const addEditCollectiveMutation = graphql(editCollectiveMutation, {
 
       CollectiveInputType.location = pick(collective.location, ['name', 'address', 'lat', 'long', 'country']);
       return await mutate({ variables: { collective: CollectiveInputType } });
-    },
-  }),
-});
-
-export const addArchiveCollectiveMutation = graphql(archiveCollectiveMutation, {
-  props: ({ mutate }) => ({
-    archiveCollective: async id => {
-      return await mutate({ variables: { id } });
-    },
-  }),
-});
-
-export const addUnarchiveCollectiveMutation = graphql(unarchiveCollectiveMutation, {
-  props: ({ mutate }) => ({
-    unarchiveCollective: async id => {
-      return await mutate({ variables: { id } });
     },
   }),
 });

--- a/pages/confirmEmail.js
+++ b/pages/confirmEmail.js
@@ -53,7 +53,7 @@ class ConfirmEmailPage extends React.Component {
   async triggerEmailValidation() {
     try {
       this.setState({ validationTriggered: true });
-      await this.props.confirmUserEmail(this.props.token);
+      await this.props.confirmUserEmail({ variables: { token: this.props.token } });
       setTimeout(this.props.refetchLoggedInUser, 3000);
       this.setState({ status: 'success' });
     } catch (e) {
@@ -127,11 +127,7 @@ const confirmUserEmailMutation = gql`
 `;
 
 export const addConfirmUserEmailMutation = graphql(confirmUserEmailMutation, {
-  props: ({ mutate }) => ({
-    confirmUserEmail: token => {
-      return mutate({ variables: { token } });
-    },
-  }),
+  name: 'confirmUserEmail',
 });
 
 export default withUser(addConfirmUserEmailMutation(ConfirmEmailPage));

--- a/pages/confirmOrder.js
+++ b/pages/confirmOrder.js
@@ -57,7 +57,7 @@ class ConfirmOrderPage extends React.Component {
   async triggerRequest() {
     try {
       this.setState({ isRequestSent: true });
-      const res = await this.props.confirmOrder(this.props.id);
+      const res = await this.props.confirmOrder({ variables: { order: { id: this.props.id } } });
       const orderConfirmed = res.data.confirmOrder;
       if (orderConfirmed.stripeError) {
         this.handleStripeError(orderConfirmed);
@@ -91,7 +91,7 @@ class ConfirmOrderPage extends React.Component {
     this.setState({ status: ConfirmOrderPage.SUBMITTING, error: null });
 
     try {
-      const res = await this.props.confirmOrder(order);
+      const res = await this.props.confirmOrder({ variables: { order: { id: order.id } } });
       const orderConfirmed = res.data.confirmOrder;
       if (orderConfirmed.stripeError) {
         this.handleStripeError(orderConfirmed);
@@ -157,10 +157,8 @@ const confirmOrderMutation = gql`
   }
 `;
 
-export const addConfirmOrderMutation = graphql(confirmOrderMutation, {
-  props: ({ mutate }) => ({
-    confirmOrder: id => mutate({ variables: { order: { id } } }),
-  }),
+const addConfirmOrderMutation = graphql(confirmOrderMutation, {
+  name: 'confirmOrder',
 });
 
 export default withUser(addConfirmOrderMutation(ConfirmOrderPage));

--- a/pages/create-expense.js
+++ b/pages/create-expense.js
@@ -159,8 +159,10 @@ class CreateExpensePage extends React.Component {
       this.setState({ isSubmitting: true, error: null });
       const { expense } = this.state;
       const result = await this.props.createExpense({
-        account: { id: this.props.data.account.id },
-        expense: prepareExpenseForSubmit(expense),
+        variables: {
+          account: { id: this.props.data.account.id },
+          expense: prepareExpenseForSubmit(expense),
+        },
       });
 
       // Clear local storage backup if expense submitted successfully
@@ -471,12 +473,8 @@ const createExpenseMutation = gqlV2/* GraphQL */ `
 `;
 
 const addCreateExpenseMutation = graphql(createExpenseMutation, {
+  name: 'createExpense',
   options: { context: API_V2_CONTEXT },
-  props: ({ mutate }) => ({
-    createExpense: async variables => {
-      return mutate({ variables });
-    },
-  }),
 });
 
 export default withUser(addCreateExpensePageData(withRouter(addCreateExpenseMutation(injectIntl(CreateExpensePage)))));

--- a/pages/createExpense.js
+++ b/pages/createExpense.js
@@ -50,7 +50,7 @@ class CreateExpensePage extends React.Component {
       expense.PayoutMethod = this.getPayoutMethod(expense);
       delete expense.paypalEmail;
       delete expense.payoutMethod;
-      const res = await this.props.createExpense(expense);
+      const res = await this.props.createExpense({ variables: { expense } });
       const expenseCreated = res.data.createExpense;
       Router.pushRoute(`/${this.props.slug}/expenses/${expenseCreated.id}/legacy?createSuccess=true`);
     } catch (e) {
@@ -99,7 +99,7 @@ class CreateExpensePage extends React.Component {
 }
 
 const createExpenseMutation = gql`
-  mutation createExpense($expense: ExpenseInputType!) {
+  mutation CreateExpense($expense: ExpenseInputType!) {
     createExpense(expense: $expense) {
       id
       description
@@ -212,11 +212,7 @@ const createExpensePageQuery = gql`
 `;
 
 const addCreateExpenseMutation = graphql(createExpenseMutation, {
-  props: ({ mutate }) => ({
-    createExpense: async expense => {
-      return await mutate({ variables: { expense } });
-    },
-  }),
+  name: 'createExpense',
 });
 
 const addCreateExpensePageData = graphql(createExpensePageQuery);

--- a/pages/createPledge.js
+++ b/pages/createPledge.js
@@ -725,7 +725,6 @@ const createPledgeMutation = gql`
   }
 `;
 
-/* TODO(GraphQL): refactor unnecessary mutate */
 export const addCreatePledgeMutation = graphql(createPledgeMutation, {
   props: ({ mutate }) => ({
     createPledge: async (order, collective) => {

--- a/pages/createUpdate.js
+++ b/pages/createUpdate.js
@@ -64,7 +64,7 @@ class CreateUpdatePage extends React.Component {
     } = this.props;
     try {
       update.collective = { id: Collective.id };
-      const res = await this.props.createUpdate(update);
+      const res = await this.props.createUpdate({ variables: { update } });
       this.setState({ isModified: false });
       return Router.pushRoute(`/${Collective.slug}/updates/${res.data.createUpdate.slug}`);
     } catch (e) {
@@ -186,11 +186,7 @@ const createUpdateMutation = gql`
 `;
 
 const addCreateUpdateMutation = graphql(createUpdateMutation, {
-  props: ({ mutate }) => ({
-    createUpdate: async update => {
-      return await mutate({ variables: { update } });
-    },
-  }),
+  name: 'createUpdate',
 });
 
 const addGraphql = compose(addCollectiveCoverData, addCreateUpdateMutation);

--- a/pages/expense.js
+++ b/pages/expense.js
@@ -108,8 +108,8 @@ class ExpensePage extends React.Component {
     client: PropTypes.object.isRequired,
     /** from withData */
     data: PropTypes.object.isRequired,
-    /** from withData */
-    mutate: PropTypes.func.isRequired,
+    /** from addEditExpenseMutation */
+    editExpense: PropTypes.func.isRequired,
     /** from injectIntl */
     intl: PropTypes.object,
     expensesTags: PropTypes.arrayOf(
@@ -203,7 +203,7 @@ class ExpensePage extends React.Component {
     try {
       this.setState({ isSubmitting: true, error: null });
       const { editedExpense } = this.state;
-      await this.props.mutate({ variables: { expense: prepareExpenseForSubmit(editedExpense) } });
+      await this.props.editExpense({ variables: { expense: prepareExpenseForSubmit(editedExpense) } });
       this.setState({ status: PAGE_STATUS.VIEW, isSubmitting: false, editedExpense: undefined, error: null });
     } catch (e) {
       this.setState({ error: getErrorFromGraphqlException(e), isSubmitting: false });
@@ -537,15 +537,12 @@ class ExpensePage extends React.Component {
 }
 
 const addExpensePageData = graphql(expensePageQuery, {
-  options: {
-    context: API_V2_CONTEXT,
-  },
+  options: { context: API_V2_CONTEXT },
 });
 
 const addEditExpenseMutation = graphql(editExpenseMutation, {
-  options: {
-    context: API_V2_CONTEXT,
-  },
+  name: 'editExpense',
+  options: { context: API_V2_CONTEXT },
 });
 
 export default injectIntl(addExpensePageData(withApollo(withUser(addEditExpenseMutation(ExpensePage)))));

--- a/pages/redeem.js
+++ b/pages/redeem.js
@@ -62,7 +62,7 @@ class RedeemPage extends React.Component {
   static propTypes = {
     refetchLoggedInUser: PropTypes.func.isRequired, // from withUser
     intl: PropTypes.object.isRequired, // from injectIntl
-    claimPaymentMethod: PropTypes.func.isRequired, // from redeemMutation
+    redeemPaymentMethod: PropTypes.func.isRequired, // from addRedeemPaymentMethodMutation
     LoggedInUser: PropTypes.object, // from withUser
     loadingLoggedInUser: PropTypes.bool, // from withUser
     code: PropTypes.string,
@@ -108,12 +108,12 @@ class RedeemPage extends React.Component {
     const { code, email, name } = this.state.form;
     try {
       if (this.props.LoggedInUser) {
-        await this.props.claimPaymentMethod(code);
+        await this.props.redeemPaymentMethod({ variables: { code } });
         await this.props.refetchLoggedInUser();
         Router.pushRoute('redeemed', { code, collectiveSlug: this.props.collectiveSlug });
         return;
       } else {
-        await this.props.claimPaymentMethod(code, { email, name });
+        await this.props.redeemPaymentMethod({ variables: { code, user: { email, name } } });
       }
       // TODO: need to know from API if an account was created or not
       // TODO: or refuse to create an account automatically and ask to sign in
@@ -295,11 +295,7 @@ const redeemPaymentMethodMutation = gql`
 `;
 
 const addRedeemPaymentMethodMutation = graphql(redeemPaymentMethodMutation, {
-  props: ({ mutate }) => ({
-    claimPaymentMethod: async (code, user) => {
-      return await mutate({ variables: { code, user } });
-    },
-  }),
+  name: 'redeemPaymentMethod',
 });
 
 const addGraphql = compose(addRedeemPageData, addRedeemPaymentMethodMutation);


### PR DESCRIPTION
Generally avoid to re-create a custom `mutate` function when we can rely on the one provided by Apollo.

In a few cases, also refactor to React Hooks.