### PR TITLE
Rename HostFields to a more specific name

### DIFF
--- a/pages/new-contribution-flow.js
+++ b/pages/new-contribution-flow.js
@@ -194,7 +194,7 @@ class NewContributionFlowPage extends React.Component {
 }
 
 const hostFieldsFragment = gqlV2/* GraphQL */ `
-  fragment HostFields on Host {
+  fragment ContributionFlowHostFields on Host {
     id
     slug
     name
@@ -227,22 +227,22 @@ const accountFieldsFragment = gqlV2/* GraphQL */ `
         }
       }
       host {
-        ...HostFields
+        ...ContributionFlowHostFields
       }
     }
     ... on Event {
       host {
-        ...HostFields
+        ...ContributionFlowHostFields
       }
     }
     ... on Fund {
       host {
-        ...HostFields
+        ...ContributionFlowHostFields
       }
     }
     ... on Project {
       host {
-        ...HostFields
+        ...ContributionFlowHostFields
       }
     }
   }


### PR DESCRIPTION
Fix a warning when building the app:

```
Automatically optimizing pages ...Warning: fragment with name HostFields already exists.
graphql-tag enforces all fragment names across your application to be unique; read more about
this in the docs: http://dev.apollodata.com/core/fragments.html#unique-names
```