### PR TITLE
Remove currencies pre-fetch in expense page

### DIFF
--- a/components/expenses/graphql/fragments.js
+++ b/components/expenses/graphql/fragments.js
@@ -67,9 +67,6 @@ const hostFieldsFragment = gqlV2/* GraphQL */ `
       transferwisePayouts
       transferwisePayoutsLimit
     }
-    transferwise {
-      availableCurrencies
-    }
   }
 `;
 


### PR DESCRIPTION
We only need currencies when editing or creating.
