### PR TITLE
Implement CSP headers

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,2 +1,0 @@
-API_URL=http://localhost:3060
-API_KEY=dvl-1510egmf4a23d80342403fb599qd

--- a/README.md
+++ b/README.md
@@ -40,7 +40,12 @@ By default, it will try to connect to the Open Collective staging API, **you don
 In case you want to connect to the Open Collective API running locally:
 
 - clone, install and start [opencollective-api](https://github.com/opencollective/opencollective-api)
-- in this project, copy [`.env.local`](.env.local) to `.env`.
+- in this project, copy the following content to a `.env` file:
+
+```
+API_URL=http://localhost:3060
+API_KEY=dvl-1510egmf4a23d80342403fb599qd
+```
 
 ### Start
 

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -104,12 +104,7 @@ class Footer extends React.Component {
         >
           <Container display="flex" mt={3} width={[1, null, 1 / 3]} flexDirection="column" maxWidth="300px">
             <Flex justifyContent={['center', null, 'flex-start']}>
-              <object
-                type="image/svg+xml"
-                data="/static/images/opencollectivelogo-footer.svg"
-                height="20"
-                style={{ maxWidth: '100%' }}
-              />
+              <img src="/static/images/opencollectivelogo-footer.svg" style={{ maxWidth: '100%', height: '20px' }} />
             </Flex>
             <P textAlign={['center', null, 'left']} color="#6E747A" fontSize="1.4rem" py={2}>
               An organization for your community, transparent by design.

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -39,7 +39,12 @@ If it's not already setup, look at the "Install" instructions in the [README](RE
 
 Make sure the Frontend is talking to the local API:
 
-- copy [`.env.local`](.env.local) to `.env`.
+In your `.env`, paste the following content:
+
+```
+API_URL=http://localhost:3060
+API_KEY=dvl-1510egmf4a23d80342403fb599qd
+```
 
 We recommend to run a build of the Frontend. It will be faster and more reliable.
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,7 @@
 require('./env');
 
 const withSourceMaps = require('@zeit/next-source-maps')();
+const { getCSPHeaderForNextJS } = require('./server/content-security-policy');
 
 const nextConfig = {
   webpack: (config, { webpack, isServer, buildId }) => {
@@ -122,6 +123,14 @@ const nextConfig = {
     }
 
     return config;
+  },
+  async headers() {
+    const cspHeader = getCSPHeaderForNextJS();
+    if (cspHeader) {
+      return [{ source: '/', headers: [cspHeader] }];
+    } else {
+      return [];
+    }
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7843,11 +7843,6 @@
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
       "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA=="
     },
-    "bowser": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.9.0.tgz",
-      "integrity": "sha512-2ld76tuLBNFekRgmJfT2+3j5MIrP6bFict8WAIT3beq+srz1gcKNAdNKMqHqauQt63NmAa88HfP1/Ypa9Er3HA=="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -9290,11 +9285,6 @@
         "safe-buffer": "5.1.2"
       }
     },
-    "content-security-policy-builder": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/content-security-policy-builder/-/content-security-policy-builder-2.1.0.tgz",
-      "integrity": "sha512-/MtLWhJVvJNkA9dVLAp6fg9LxD2gfI6R2Fi1hPmfjYXSahJJzcfvoeDOxSyp4NvxMuwWv3WMssE9o31DoULHrQ=="
-    },
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
@@ -10403,11 +10393,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "dasherize": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dasherize/-/dasherize-2.0.0.tgz",
-      "integrity": "sha1-bYCcnNDPe7iVLYD8hPoT1H3bEwg="
-    },
     "data-uri-to-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.0.tgz",
@@ -10895,11 +10880,6 @@
         "domelementtype": "^2.0.1",
         "domhandler": "^3.0.0"
       }
-    },
-    "dont-sniff-mimetype": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/dont-sniff-mimetype/-/dont-sniff-mimetype-1.1.0.tgz",
-      "integrity": "sha512-ZjI4zqTaxveH2/tTlzS1wFp+7ncxNZaIEWYg3lzZRHkKf5zPT/MnEG6WL0BhHMJUabkh8GeU5NL5j+rEUCb7Ug=="
     },
     "dot-case": {
       "version": "3.0.3",
@@ -12576,11 +12556,6 @@
         "pend": "~1.2.0"
       }
     },
-    "feature-policy": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/feature-policy/-/feature-policy-0.3.0.tgz",
-      "integrity": "sha512-ZtijOTFN7TzCujt1fnNhfWPFPSHeZkesff9AXZj+UEjYBynWNUIYpC87Ve4wHzyexQsImicLu7WsC2LHq7/xrQ=="
-    },
     "fecha": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
@@ -12809,13 +12784,13 @@
       "dependencies": {
         "colors": {
           "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "resolved": "http://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
           "dev": true
         },
         "commander": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
           "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
           "dev": true
         }
@@ -13621,55 +13596,14 @@
       "dev": true
     },
     "helmet": {
-      "version": "3.23.3",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-3.23.3.tgz",
-      "integrity": "sha512-U3MeYdzPJQhtvqAVBPntVgAvNSOJyagwZwyKsFdyRa8TV3pOKVFljalPOCxbw5Wwf2kncGhmP0qHjyazIdNdSA==",
-      "requires": {
-        "depd": "2.0.0",
-        "dont-sniff-mimetype": "1.1.0",
-        "feature-policy": "0.3.0",
-        "helmet-crossdomain": "0.4.0",
-        "helmet-csp": "2.10.0",
-        "hide-powered-by": "1.1.0",
-        "hpkp": "2.0.0",
-        "hsts": "2.2.0",
-        "nocache": "2.1.0",
-        "referrer-policy": "1.2.0",
-        "x-xss-protection": "1.3.0"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-        }
-      }
-    },
-    "helmet-crossdomain": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/helmet-crossdomain/-/helmet-crossdomain-0.4.0.tgz",
-      "integrity": "sha512-AB4DTykRw3HCOxovD1nPR16hllrVImeFp5VBV9/twj66lJ2nU75DP8FPL0/Jp4jj79JhTfG+pFI2MD02kWJ+fA=="
-    },
-    "helmet-csp": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/helmet-csp/-/helmet-csp-2.10.0.tgz",
-      "integrity": "sha512-Rz953ZNEFk8sT2XvewXkYN0Ho4GEZdjAZy4stjiEQV3eN7GDxg1QKmYggH7otDyIA7uGA6XnUMVSgeJwbR5X+w==",
-      "requires": {
-        "bowser": "2.9.0",
-        "camelize": "1.0.0",
-        "content-security-policy-builder": "2.1.0",
-        "dasherize": "2.0.0"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.0.0.tgz",
+      "integrity": "sha512-HyoRKKHhWhO6+EBfgRLkuZR4/+NXc1nJB7x0bWwW89i9eoPciK0qUqyZNOA/zowpgrW9C4+J5toqMkZrpBOlkg=="
     },
     "hex-color-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
-    },
-    "hide-powered-by": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/hide-powered-by/-/hide-powered-by-1.1.0.tgz",
-      "integrity": "sha512-Io1zA2yOA1YJslkr+AJlWSf2yWFkKjvkcL9Ni1XSUqnGLr/qRQe2UI3Cn/J9MsJht7yEVCe0SscY1HgVMujbgg=="
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -13722,11 +13656,6 @@
         "wbuf": "^1.1.0"
       }
     },
-    "hpkp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hpkp/-/hpkp-2.0.0.tgz",
-      "integrity": "sha1-EOFCJk52IVpdMMROxD3mTe5tFnI="
-    },
     "hsl-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
@@ -13736,21 +13665,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
       "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg="
-    },
-    "hsts": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/hsts/-/hsts-2.2.0.tgz",
-      "integrity": "sha512-ToaTnQ2TbJkochoVcdXYm4HOCliNozlviNsg+X2XQLQvZNI/kCHR9rZxVYpJB3UPcHz80PgxRyWQ7PdU1r+VBQ==",
-      "requires": {
-        "depd": "2.0.0"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-        }
-      }
     },
     "html-comment-regex": {
       "version": "1.1.2",
@@ -14195,7 +14109,7 @@
     },
     "immutable": {
       "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+      "resolved": "http://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
       "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
     },
     "import-fresh": {
@@ -19410,11 +19324,6 @@
         "tslib": "^1.10.0"
       }
     },
-    "nocache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.1.0.tgz",
-      "integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q=="
-    },
     "node-dir": {
       "version": "0.1.17",
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
@@ -23672,11 +23581,6 @@
         "symbol-observable": "^1.2.0"
       }
     },
-    "referrer-policy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/referrer-policy/-/referrer-policy-1.2.0.tgz",
-      "integrity": "sha512-LgQJIuS6nAy1Jd88DCQRemyE3mS+ispwlqMk3b0yjZ257fI1v9c+/p6SD5gP5FGyXUIgrNOAfmyioHwZtYv2VA=="
-    },
     "reflect.ownkeys": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
@@ -26119,7 +26023,7 @@
       "dependencies": {
         "ast-types": {
           "version": "0.7.8",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
+          "resolved": "http://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
           "integrity": "sha1-kC0uDWDQcb3NRtwRXhgJ7RHBOKk=",
           "dev": true
         },
@@ -28012,11 +27916,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
       "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
-    },
-    "x-xss-protection": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/x-xss-protection/-/x-xss-protection-1.3.0.tgz",
-      "integrity": "sha512-kpyBI9TlVipZO4diReZMAHWtS0MMa/7Kgx8hwG/EuZLiA6sg4Ah/4TRdASHhRRN3boobzcYgFRUFSgHRge6Qhg=="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "glob": "7.1.6",
     "graphql": "14.7.0",
     "graphql-tag": "2.11.0",
-    "helmet": "3.23.3",
+    "helmet": "4.0.0",
     "i18n-iso-countries": "6.0.0",
     "jsdom": "16.3.0",
     "jsonwebtoken": "8.5.1",

--- a/server/content-security-policy.js
+++ b/server/content-security-policy.js
@@ -1,19 +1,41 @@
 const mergeWith = require('lodash/mergeWith');
+const { kebabCase } = require('lodash');
 const env = process.env.NODE_ENV;
 
 const SELF = "'self'";
-const NONE = "'none'";
 const UNSAFE_INLINE = "'unsafe-inline'";
+const UNSAFE_EVAL = "'unsafe-eval'";
 
 const COMMON_DIRECTIVES = {
   blockAllMixedContent: true,
   defaultSrc: [SELF],
-  imgSrc: [SELF, process.env.IMAGES_URL],
-  workerSrc: [NONE],
-  frameSrc: [
-    'https://www.youtube.com',
-    'https://opencollective.com/', // For widgets
+  imgSrc: [SELF, process.env.IMAGES_URL, 'data:', 't.paypal.com'],
+  workerSrc: [
+    SELF,
+    'blob:', // For confettis worker. TODO: Limit for nonce
   ],
+  styleSrc: [
+    SELF,
+    UNSAFE_INLINE, // For styled-components/styled-jsx. TODO: Limit for nonce
+  ],
+  connectSrc: [
+    SELF,
+    process.env.API_URL,
+    process.env.PDF_SERVICE_URL,
+    'wtfismyip.com',
+    '*.paypal.com',
+    '*.paypalobjects.com',
+  ],
+  scriptSrc: [
+    SELF,
+    UNSAFE_INLINE, // Required by current PayPal integration. https://developer.paypal.com/docs/checkout/troubleshoot/support/#browser-features-and-polyfills provides a way to deal with that through nonces.
+    'maps.googleapis.com',
+    'js.stripe.com',
+    '*.paypal.com',
+    '*.paypalobjects.com',
+  ],
+  frameSrc: ['www.youtube.com', 'opencollective.com', 'js.stripe.com', '*.paypal.com'],
+  objectSrc: ['opencollective.com'],
 };
 
 const generateDirectives = customValues => {
@@ -24,14 +46,44 @@ const generateDirectives = customValues => {
   });
 };
 
-module.exports = () => {
+/**
+ * A adapter inspired by  https://github.com/helmetjs/helmet/blob/master/middlewares/content-security-policy/index.ts
+ * to generate the header string. Usefull for plugging to Zeit.
+ */
+const getHeaderValueFromDirectives = directives => {
+  return Object.entries(directives)
+    .map(([rawDirectiveName, rawDirectiveValue]) => {
+      const directiveName = kebabCase(rawDirectiveName);
+
+      let directiveValue;
+      if (typeof rawDirectiveValue === 'string') {
+        directiveValue = ` ${rawDirectiveValue}`;
+      } else if (Array.isArray(rawDirectiveValue)) {
+        directiveValue = '';
+        for (const element of rawDirectiveValue) {
+          directiveValue = `${directiveValue} ${element}`;
+        }
+      } else if (typeof rawDirectiveValue === 'boolean' && !rawDirectiveValue) {
+        return '';
+      }
+
+      if (!directiveValue) {
+        return directiveName;
+      }
+
+      return `${directiveName}${directiveValue}`;
+    })
+    .filter(Boolean)
+    .join(';');
+};
+
+const getContentSecurityPolicyConfig = () => {
   if (env === 'development') {
     return {
       reportOnly: true,
       directives: generateDirectives({
         blockAllMixedContent: false,
-        styleSrc: [UNSAFE_INLINE], // For StyledComponents dev
-        scriptSrc: [UNSAFE_INLINE], // For NextJS scripts
+        scriptSrc: [UNSAFE_INLINE, UNSAFE_EVAL], // For NextJS scripts
       }),
     };
   } else if (env === 'production') {
@@ -43,9 +95,28 @@ module.exports = () => {
     } else if (process.env.WEBSITE_URL === 'https://opencollective.com') {
       // Disabled for production until ready
       return false;
+    } else {
+      // Third party deploy, or Zeit deploy preview
+      return {
+        reportOnly: true,
+        directives: generateDirectives(),
+      };
     }
   }
 
-  // Disable in other environments
+  // Disabled in other environments
   return false;
+};
+
+module.exports = {
+  getContentSecurityPolicyConfig,
+  getCSPHeaderForNextJS: () => {
+    const config = getContentSecurityPolicyConfig();
+    if (config) {
+      return {
+        key: config.reportOnly ? 'Content-Security-Policy-Report-Only' : 'Content-Security-Policy',
+        value: getHeaderValueFromDirectives(config.directives),
+      };
+    }
+  },
 };

--- a/server/content-security-policy.js
+++ b/server/content-security-policy.js
@@ -1,0 +1,51 @@
+const mergeWith = require('lodash/mergeWith');
+const env = process.env.NODE_ENV;
+
+const SELF = "'self'";
+const NONE = "'none'";
+const UNSAFE_INLINE = "'unsafe-inline'";
+
+const COMMON_DIRECTIVES = {
+  blockAllMixedContent: true,
+  defaultSrc: [SELF],
+  imgSrc: [SELF, process.env.IMAGES_URL],
+  workerSrc: [NONE],
+  frameSrc: [
+    'https://www.youtube.com',
+    'https://opencollective.com/', // For widgets
+  ],
+};
+
+const generateDirectives = customValues => {
+  return mergeWith(COMMON_DIRECTIVES, customValues, (objValue, srcValue) => {
+    if (Array.isArray(objValue)) {
+      return objValue.concat(srcValue);
+    }
+  });
+};
+
+module.exports = () => {
+  if (env === 'development') {
+    return {
+      reportOnly: true,
+      directives: generateDirectives({
+        blockAllMixedContent: false,
+        styleSrc: [UNSAFE_INLINE], // For StyledComponents dev
+        scriptSrc: [UNSAFE_INLINE], // For NextJS scripts
+      }),
+    };
+  } else if (env === 'production') {
+    if (process.env.WEBSITE_URL === 'https://staging.opencollective.com') {
+      return {
+        reportOnly: true,
+        directives: generateDirectives(),
+      };
+    } else if (process.env.WEBSITE_URL === 'https://opencollective.com') {
+      // Disabled for production until ready
+      return false;
+    }
+  }
+
+  // Disable in other environments
+  return false;
+};

--- a/server/index.js
+++ b/server/index.js
@@ -15,6 +15,7 @@ const routes = require('./routes');
 const { Sentry } = require('./sentry');
 const hyperwatch = require('./hyperwatch');
 const rateLimiter = require('./rate-limiter');
+const getContentSecurityPolicyConfig = require('./content-security-policy');
 
 const app = express();
 
@@ -35,7 +36,7 @@ nextApp.prepare().then(() => {
 
   rateLimiter(app);
 
-  app.use(helmet());
+  app.use(helmet({ contentSecurityPolicy: getContentSecurityPolicyConfig() }));
 
   app.use(cookieParser());
 

--- a/server/index.js
+++ b/server/index.js
@@ -15,7 +15,7 @@ const routes = require('./routes');
 const { Sentry } = require('./sentry');
 const hyperwatch = require('./hyperwatch');
 const rateLimiter = require('./rate-limiter');
-const getContentSecurityPolicyConfig = require('./content-security-policy');
+const { getContentSecurityPolicyConfig } = require('./content-security-policy');
 
 const app = express();
 


### PR DESCRIPTION
Current implementation:
- Send warnings in dev (but allows inline resources for scripts/styles)
- Send warnings on staging
- Is disabled on prod
- Updates helmet to 4.0.0
- Works with both custom Node server (with helmet) and default NextJS server

Next:
1. Try extensively on staging with `reportOnly`, fix eventual warnings
2. Enable on prod with `reportOnly`
3. Disable `reportOnly` on staging
4. Disable `reportOnly` on prod