### PR TITLE
Use named functions for HOC/Hooks

### DIFF
--- a/lib/hooks/useGlobalBlur.js
+++ b/lib/hooks/useGlobalBlur.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default (ref, callback) => {
+const useGlobalBlur = (ref, callback) => {
   const wasOutside = e => {
     const currentRef = ref instanceof HTMLElement ? ref : ref?.current;
     callback(!currentRef?.contains(e.target));
@@ -11,3 +11,5 @@ export default (ref, callback) => {
     return () => document.removeEventListener('mousedown', wasOutside, false);
   });
 };
+
+export default useGlobalBlur;

--- a/lib/withData.js
+++ b/lib/withData.js
@@ -13,7 +13,7 @@ function getComponentDisplayName(Component) {
   return Component.displayName || Component.name || 'Unknown';
 }
 
-export default ComposedComponent => {
+const withData = ComposedComponent => {
   return class WithData extends React.Component {
     static async getInitialProps(ctx) {
       // Initial serverState with apollo (empty)
@@ -118,3 +118,5 @@ export default ComposedComponent => {
     }
   };
 };
+
+export default withData;

--- a/lib/withLoggedInUser.js
+++ b/lib/withLoggedInUser.js
@@ -40,7 +40,7 @@ const maybeRefreshAccessToken = async (currentToken, twoFactorAuthenticatorCode)
   return currentToken;
 };
 
-export default WrappedComponent => {
+const withLoggedInUser = WrappedComponent => {
   return class withLoggedInUser extends React.Component {
     static async getInitialProps(context) {
       return typeof WrappedComponent.getInitialProps === 'function'
@@ -133,3 +133,5 @@ export default WrappedComponent => {
     }
   };
 };
+
+export default withLoggedInUser;


### PR DESCRIPTION
To resolve the following warning that appeared in dev with latest NextJS update:

```
./lib/withLoggedInUser.js
Anonymous arrow functions cause Fast Refresh to not preserve local component state.
Please add a name to your function, for example:

Before
export default () => <div />;

After
const Named = () => <div />;
export default Named;
```