### PR TITLE
Add .next/cache to Heroku build cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "node": "12.13.0",
     "npm": "6.12.0"
   },
+  "cacheDirectories": [
+    ".next/cache"
+  ],
   "dependencies": {
     "@apollo/react-components": "3.1.5",
     "@apollo/react-hoc": "3.1.5",
@@ -134,6 +137,7 @@
     "graphql:update": "npm-run-all graphql:updateV1 graphql:updateV2",
     "graphql:updateV1": "npx get-graphql-schema http://localhost:3060/graphql > lib/graphql/schema.graphql && prettier lib/graphql/schema.graphql --write",
     "graphql:updateV2": "npx get-graphql-schema http://localhost:3060/graphql/v2 > lib/graphql/schemaV2.graphql && prettier lib/graphql/schemaV2.graphql --write",
+    "heroku-cleanup": "rm -rf .next/cache",
     "langs:build": "babel . --only \"components/*,lib/*,pages/*\" --out-dir dist --delete-dir-on-start",
     "langs:check": "cross-env scripts/check_translations.sh",
     "langs:translate": "babel-node scripts/translate.js",


### PR DESCRIPTION
Not sure if there's a specific reason why we're not caching the frontend build, but this would fix the warning:
```
Warning: No build cache found. Please configure build caching for faster rebuilds. Read more: https://err.sh/next.js/no-cache
```