### PR TITLE
CSP: Configure for Sentry

### DIFF
--- a/server/content-security-policy.js
+++ b/server/content-security-policy.js
@@ -31,6 +31,7 @@ const COMMON_DIRECTIVES = {
     'wtfismyip.com',
     '*.paypal.com',
     '*.paypalobjects.com',
+    '*.sentry.io',
   ],
   scriptSrc: [
     SELF,
@@ -106,11 +107,17 @@ const getContentSecurityPolicyConfig = () => {
       return {
         reportOnly: false,
         directives: generateDirectives(),
+        reportUri: [
+          'https://o105108.ingest.sentry.io/api/1736806/security/?sentry_key=2ab0f7da3f56423d940f36370df8d625',
+        ],
       };
     } else if (process.env.WEBSITE_URL === 'https://opencollective.com') {
       return {
         reportOnly: true,
         directives: generateDirectives(),
+        reportUri: [
+          'https://o105108.ingest.sentry.io/api/1736806/security/?sentry_key=2ab0f7da3f56423d940f36370df8d625',
+        ],
       };
     } else {
       // Third party deploy, or Zeit deploy preview


### PR DESCRIPTION
This PR configures Sentry in two ways:
- Allows the sending of requests to `sentry.io` (connect-src)
- Set Sentry as the `report-uri`, so that it will collect future CSP issues