### PR TITLE
chore(homepage): Fix safari stretched illustration 

### DIFF
--- a/components/home/sections/FiscalHost.js
+++ b/components/home/sections/FiscalHost.js
@@ -61,6 +61,13 @@ const FiscalHostCard = styled(Container)`
   ${background}
 `;
 
+const DiscoverLink = styled(StyledLink)`
+  &:hover {
+    color: #1a1e43;
+    text-decoration: underline !important;
+  }
+`;
+
 const FiscalHost = () => (
   <Wrapper mb={5} pt={4} mt={[null, null, null, null, 7]}>
     <Flex mx={[3, 4]} flexDirection="column" alignItems="center">
@@ -208,8 +215,7 @@ const FiscalHost = () => (
                   <Box my={[3, null, null, 0]}>
                     <StyledLink
                       as={Link}
-                      route="collective"
-                      params={{ slug: 'foundation' }}
+                      route="/foundation/apply"
                       whiteSpace="nowrap"
                       fontSize={['14px']}
                       lineHeight={['21px']}
@@ -272,8 +278,7 @@ const FiscalHost = () => (
                   <Box my={[3, null, null, 0]}>
                     <StyledLink
                       as={Link}
-                      route="collective"
-                      params={{ slug: 'opensource' }}
+                      route="/opensouce/apply"
                       whiteSpace="nowrap"
                       fontSize={['14px']}
                       lineHeight={['21px']}
@@ -340,8 +345,7 @@ const FiscalHost = () => (
                   <Box my={[3, null, null, 0]}>
                     <StyledLink
                       as={Link}
-                      route="collective"
-                      params={{ slug: 'europe' }}
+                      route="/europe/apply"
                       whiteSpace="nowrap"
                       fontSize={['14px']}
                       lineHeight={['21px']}
@@ -363,7 +367,7 @@ const FiscalHost = () => (
             </FiscalHostCard>
           </Container>
           <Box my={2} alignSelf={[null, 'center', null, 'flex-start']}>
-            <StyledLink
+            <DiscoverLink
               as={Link}
               route="hosts"
               fontSize={['15px']}
@@ -379,7 +383,7 @@ const FiscalHost = () => (
                   arrowIcon: <ArrowRight2 size="15" />,
                 }}
               />
-            </StyledLink>
+            </DiscoverLink>
           </Box>
         </Flex>
       </Flex>

--- a/components/home/sections/MakeCommunity.js
+++ b/components/home/sections/MakeCommunity.js
@@ -142,7 +142,7 @@ const MakeCommunity = () => {
         >
           <FormattedMessage id="home.whatIsGreatAboutOC" defaultMessage="What's great about Open Collective?" />
         </H2>
-        <Flex width={['288px', '414px', '548px', null, '696px']} mr={[null, 3, null, null, 4]}>
+        <Box width={['320px', '414px', '548px', null, '696px']} mr={[null, 3, null, null, 4]}>
           <Illustration
             alt="Make your community sustainable"
             src="/static/images/home/whatisgreataboutOC-Illustration-sm.png"
@@ -153,7 +153,7 @@ const MakeCommunity = () => {
             src="/static/images/home/whatisgreataboutOC-Illustration-2x.png"
             display={['none', 'inline-block']}
           />
-        </Flex>
+        </Box>
         <Box width={['288px', '224px', '396px']}>
           <H2
             mb={[null, 2]}


### PR DESCRIPTION
Following up #https://github.com/opencollective/opencollective-frontend/pull/4679

- Fix stretched illustration on Safari iPhone (Cause [here](https://stackoverflow.com/questions/57516373/image-stretching-in-flexbox-in-safari))
- Update fiscal host apply route to `/[fiscal host]/apply` 
- Set `Discover more` text-decoration to underline on hover. 