### PR TITLE
StyledComponents: Simplify responsive props

### DIFF
--- a/components/TopBarProfileMenu.js
+++ b/components/TopBarProfileMenu.js
@@ -208,7 +208,7 @@ class TopBarProfileMenu extends React.Component {
         data-cy="user-menu"
       >
         <Flex flexDirection={['column', 'row']} maxHeight={['calc(100vh - 68px)', '100%']}>
-          <Box order={[2, 1]} flex="10 1 50%" width={[1, 1, 1 / 2]} p={[3]} bg="#F7F8FA">
+          <Box order={[2, 1]} flex="10 1 50%" width={[1, 1, 1 / 2]} p={3} bg="#F7F8FA">
             <Hide xs>
               <Avatar collective={LoggedInUser.collective} radius={56} mr={2} />
               <P mt={2} color="#313233" fontWeight="500">

--- a/components/accept-financial-contributions/ApplyToHost.js
+++ b/components/accept-financial-contributions/ApplyToHost.js
@@ -176,7 +176,7 @@ class ApplyToHost extends React.Component {
                   lineHeight={['24px', '24px']}
                   color="black.600"
                   textAlign="center"
-                  order={[2]}
+                  order={2}
                   py={[2, 0]}
                 >
                   {intl.formatMessage(this.messages.interestedInHosting)}

--- a/components/accept-financial-contributions/StripeOrBankAccountPicker.js
+++ b/components/accept-financial-contributions/StripeOrBankAccountPicker.js
@@ -103,7 +103,7 @@ class StripeOrBankAccountPicker extends React.Component {
     const stripeAccount = find(host.connectedAccounts, { service: 'stripe' });
 
     return (
-      <Flex flexDirection="column" justifyContent="center" alignItems="center" my={[5]}>
+      <Flex flexDirection="column" justifyContent="center" alignItems="center" my={5}>
         <Box alignItems="center">
           <Flex justifyContent="center" alignItems="center" flexDirection={['column', 'row']}>
             <Container alignItems="center" width={[null, 280, 312]} mb={[2, 0]}>

--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -992,7 +992,7 @@ class CreateOrderPage extends React.Component {
                         my={2}
                         width="100%"
                       />
-                      <P fontSize="12px" color="colors.black.300" mt={1} textAlign={['right', null]}>
+                      <P fontSize="12px" color="colors.black.300" mt={1} textAlign="right">
                         <FormattedMessage
                           defaultMessage="Total contribution: {amount} {frequency}"
                           id="platformFee.totalContribution"

--- a/components/create-collective/ConnectGithub.js
+++ b/components/create-collective/ConnectGithub.js
@@ -76,9 +76,9 @@ class ConnectGithub extends React.Component {
     const { repositories, loadingRepos, error } = this.state;
 
     return (
-      <Flex flexDirection="column" m={[3, 0]} mb={[4]}>
+      <Flex flexDirection="column" m={[3, 0]} mb={4}>
         <Flex flexDirection="column" my={[2, 4]}>
-          <Box textAlign="left" minHeight={['32px']} marginLeft={['none', '224px']}>
+          <Box textAlign="left" minHeight="32px" marginLeft={['none', '224px']}>
             <BackButton asLink onClick={() => window && window.history.back()}>
               ←&nbsp;
               <FormattedMessage id="Back" defaultMessage="Back" />
@@ -96,7 +96,7 @@ class ConnectGithub extends React.Component {
               <FormattedMessage id="openSourceApply.GithubRepositories.title" defaultMessage="Pick a repository" />
             </H1>
           </Box>
-          <Box textAlign="center" minHeight={['24px']}>
+          <Box textAlign="center" minHeight="24px">
             <P fontSize="16px" color="black.600" mb={2}>
               <FormattedMessage
                 id="collective.subtitle.seeRepo"

--- a/components/create-collective/CreateCollectiveForm.js
+++ b/components/create-collective/CreateCollectiveForm.js
@@ -144,7 +144,7 @@ class CreateCollectiveForm extends React.Component {
           </Container>
         )}
         <Flex flexDirection="column" my={[2, 4]}>
-          <Box textAlign="left" minHeight={['32px']} marginLeft={['none', '224px']}>
+          <Box textAlign="left" minHeight="32px" marginLeft={['none', '224px']}>
             <BackButton asLink onClick={() => window && window.history.back()}>
               ←&nbsp;
               <FormattedMessage id="Back" defaultMessage="Back" />
@@ -161,7 +161,7 @@ class CreateCollectiveForm extends React.Component {
               <FormattedMessage id="home.create" defaultMessage="Create a Collective" />
             </H1>
           </Box>
-          <Box textAlign="center" minHeight={['24px']}>
+          <Box textAlign="center" minHeight="24px">
             <P fontSize="16px" color="black.600" mb={2}>
               <FormattedMessage
                 id="createCollective.subtitle.introduce"

--- a/components/create-collective/CreateOpenSourceCollective.js
+++ b/components/create-collective/CreateOpenSourceCollective.js
@@ -51,9 +51,9 @@ const CreateOpenSourceCollective = () => {
   const [error, setError] = useState();
 
   return (
-    <Flex flexDirection="column" m={[3, 0]} mb={[4]}>
+    <Flex flexDirection="column" m={[3, 0]} mb={4}>
       <Flex flexDirection="column" my={[2, 4]}>
-        <Box textAlign="left" minHeight={['32px']} marginLeft={['none', '224px']}>
+        <Box textAlign="left" minHeight="32px" marginLeft={['none', '224px']}>
           <BackButton asLink onClick={() => window && window.history.back()}>
             ←&nbsp;
             <FormattedMessage id="Back" defaultMessage="Back" />
@@ -70,7 +70,7 @@ const CreateOpenSourceCollective = () => {
             <FormattedMessage id="home.create" defaultMessage="Create a Collective" />
           </H1>
         </Box>
-        <Box textAlign="center" minHeight={['24px']}>
+        <Box textAlign="center" minHeight="24px">
           <P fontSize="16px" color="black.600" mb={2}>
             <FormattedMessage
               id="collective.subtitle.opensource"

--- a/components/create-collective/GithubRepositoryEntry.js
+++ b/components/create-collective/GithubRepositoryEntry.js
@@ -23,7 +23,7 @@ const RepositoryEntry = ({ radio, value, checked, changeRepoInfo }) => {
         <Flex>
           <Span mr={3}>{radio}</Span>
           <Span mr={3} color="black.300">
-            <Github size={[40]} />
+            <Github size={40} />
           </Span>
           <Flex flexDirection="column">
             <P fontWeight={500} fontSize="1.4rem">

--- a/components/create-fund/Form.js
+++ b/components/create-fund/Form.js
@@ -119,7 +119,7 @@ class CreateFundForm extends React.Component {
               <FormattedMessage id="createFund.create" defaultMessage="Create a Fund" />
             </H1>
           </Box>
-          <Box textAlign="center" minHeight={['24px']}>
+          <Box textAlign="center" minHeight="24px">
             <P fontSize="16px" color="black.600" mb={2}>
               <FormattedMessage
                 id="createFund.subtitle.introduce"

--- a/components/edit-collective/sections/Webhooks.js
+++ b/components/edit-collective/sections/Webhooks.js
@@ -247,7 +247,7 @@ class Webhooks extends React.Component {
 
         <Box width={[0.9, 0.75]} mx={['auto', 0]} my={3}>
           <StyledButton
-            width={[1]}
+            width={1}
             px={[0, 3, 0]}
             borderRadius={6}
             buttonSize="medium"

--- a/components/home/sections/CreateCollective.js
+++ b/components/home/sections/CreateCollective.js
@@ -58,7 +58,7 @@ const CreateCollective = () => {
       alignItems="center"
     >
       <Box width={['288px', '325px']} my={2} textAlign={['center', 'left']} mr={[null, 2]}>
-        <H4 fontSize={['24px']} lineHeight={['32px']} letterSpacing="-0.8px" fontWeight="bold">
+        <H4 fontSize="24px" lineHeight="32px" letterSpacing="-0.8px" fontWeight="bold">
           <FormattedMessage
             id="home.whatCanYouDoSection.areYouReady"
             defaultMessage="Are you ready to make your community sustainable?"

--- a/components/home/sections/Features.js
+++ b/components/home/sections/Features.js
@@ -178,7 +178,7 @@ const FeatureTitle = ({ id, intl, activeFeature, ...props }) => {
           <Illustration src={iconUrl} alt={`${id} icon`} />
         </Box>
         <Span
-          color={['black.800', 'black.900', null]}
+          color={['black.800', 'black.900']}
           active={id === activeFeature}
           fontWeight="500"
           textAlign={['center', 'left']}

--- a/components/home/sections/FiscalHost.js
+++ b/components/home/sections/FiscalHost.js
@@ -84,7 +84,7 @@ const FiscalHost = () => (
           mr={[null, null, 3, null, 4]}
           ml={[null, null, null, null, 4]}
         >
-          <Box width={['268px', '648px', null, '456px', '657px']} textAlign={['left']}>
+          <Box width={['268px', '648px', null, '456px', '657px']} textAlign="left">
             <SectionTitle
               display={[null, null, null, null, 'none']}
               color="black.900"
@@ -117,7 +117,7 @@ const FiscalHost = () => (
               fontWeight="500"
               fontSize={['15px', '20px']}
               lineHeight={['23px', '28px']}
-              letterSpacing={['-0.12px']}
+              letterSpacing="-0.12px"
             >
               <FormattedMessage
                 id="home.fiscalHostSection.explanation1"
@@ -153,9 +153,9 @@ const FiscalHost = () => (
             my={2}
             textAlign="left"
             color="black.900"
-            fontSize={['20px']}
-            lineHeight={['28px']}
-            letterSpacing={['-0.6px']}
+            fontSize="20px"
+            lineHeight="28px"
+            letterSpacing="-0.6px"
           >
             <FormattedMessage id="home.OC.fiscalHosts" defaultMessage="There are our fiscal hosts:" />
           </H5>
@@ -165,9 +165,9 @@ const FiscalHost = () => (
             textAlign="left"
             color="black.800"
             fontWeight="bold"
-            fontSize={['20px']}
-            lineHeight={['28px']}
-            letterSpacing={['-0.6px']}
+            fontSize="20px"
+            lineHeight="28px"
+            letterSpacing="-0.6px"
           >
             <FormattedMessage id="home.OC.fiscalHosts.xl" defaultMessage="Find the right fiscal host for you:" />
           </H5>
@@ -189,7 +189,7 @@ const FiscalHost = () => (
                 flexDirection={[null, null, null, 'column']}
                 width={[null, null, null, '292px']}
               >
-                <H3 fontSize={['20px']} lineHeight={['28px']} letterSpacing={['-0.6px']}>
+                <H3 fontSize="20px" lineHeight="28px" letterSpacing="-0.6px">
                   <FormattedMessage id="home.fiscalHostSection.OCF" defaultMessage="Open Collective Foundation" />
                 </H3>
                 <Container
@@ -200,9 +200,9 @@ const FiscalHost = () => (
                   mt={[null, 3, null, 1]}
                 >
                   <Box
-                    fontSize={['14px']}
-                    lineHeight={['21px']}
-                    letterSpacing={['-0.1px']}
+                    fontSize="14px"
+                    lineHeight="21px"
+                    letterSpacing="-0.1px"
                     color="black.800"
                     fontWeight="500"
                     mr={[null, null, null, 3]}
@@ -217,9 +217,9 @@ const FiscalHost = () => (
                       as={Link}
                       route="/foundation/apply"
                       whiteSpace="nowrap"
-                      fontSize={['14px']}
-                      lineHeight={['21px']}
-                      letterSpacing={['-0.1px']}
+                      fontSize="14px"
+                      lineHeight="21px"
+                      letterSpacing="-0.1px"
                       color="#DC5F7D"
                       fontWeight="500"
                     >
@@ -252,7 +252,7 @@ const FiscalHost = () => (
                 flexDirection={[null, null, null, 'column']}
                 width={[1, null, null, '292px']}
               >
-                <H3 fontSize={['20px']} lineHeight={['28px']} letterSpacing={['-0.6px']}>
+                <H3 fontSize="20px" lineHeight="28px" letterSpacing="-0.6px">
                   <FormattedMessage id="home.fiscalHostSection.OSC" defaultMessage="Open Source Collective" />
                 </H3>
                 <Container
@@ -263,9 +263,9 @@ const FiscalHost = () => (
                   mt={[null, 3, null, 1]}
                 >
                   <Box
-                    fontSize={['14px']}
-                    lineHeight={['21px']}
-                    letterSpacing={['-0.1px']}
+                    fontSize="14px"
+                    lineHeight="21px"
+                    letterSpacing="-0.1px"
                     color="black.800"
                     fontWeight="500"
                     mr={[null, null, null, 3]}
@@ -280,9 +280,9 @@ const FiscalHost = () => (
                       as={Link}
                       route="/opensouce/apply"
                       whiteSpace="nowrap"
-                      fontSize={['14px']}
-                      lineHeight={['21px']}
-                      letterSpacing={['-0.1px']}
+                      fontSize="14px"
+                      lineHeight="21px"
+                      letterSpacing="-0.1px"
                       color="#DC5F7D"
                       fontWeight="500"
                     >
@@ -319,7 +319,7 @@ const FiscalHost = () => (
                 flexDirection={[null, null, null, 'column']}
                 width={[1, null, null, '292px']}
               >
-                <H3 fontSize={['20px']} lineHeight={['28px']} letterSpacing={['-0.6px']}>
+                <H3 fontSize="20px" lineHeight="28px" letterSpacing="-0.6px">
                   <FormattedMessage id="home.fiscalHostSection.OCE" defaultMessage="Open Collective Europe" />
                 </H3>
                 <Container
@@ -330,9 +330,9 @@ const FiscalHost = () => (
                   mt={[null, 3, null, 1]}
                 >
                   <Box
-                    fontSize={['14px']}
-                    lineHeight={['21px']}
-                    letterSpacing={['-0.1px']}
+                    fontSize="14px"
+                    lineHeight="21px"
+                    letterSpacing="-0.1px"
                     color="black.800"
                     fontWeight="500"
                     mr={[null, null, null, 3]}
@@ -347,9 +347,9 @@ const FiscalHost = () => (
                       as={Link}
                       route="/europe/apply"
                       whiteSpace="nowrap"
-                      fontSize={['14px']}
-                      lineHeight={['21px']}
-                      letterSpacing={['-0.1px']}
+                      fontSize="14px"
+                      lineHeight="21px"
+                      letterSpacing="-0.1px"
                       color="#DC5F7D"
                       fontWeight="500"
                     >
@@ -370,9 +370,9 @@ const FiscalHost = () => (
             <DiscoverLink
               as={Link}
               route="hosts"
-              fontSize={['15px']}
-              lineHeight={['23px']}
-              letterSpacing={['-0.12px']}
+              fontSize="15px"
+              lineHeight="23px"
+              letterSpacing="-0.12px"
               color="#1A1E43"
               fontWeight="500"
             >

--- a/components/home/sections/JoinUs.js
+++ b/components/home/sections/JoinUs.js
@@ -90,21 +90,16 @@ const JoinUs = () => (
           >
             <Box width={['192px', 1]}>
               <H3
-                fontSize={['24px', '32px', null]}
+                fontSize={['24px', '32px']}
                 textAlign="left"
-                lineHeight={['25px', '40px', null]}
-                letterSpacing={['-0.08px', '-1.2px', null]}
+                lineHeight={['25px', '40px']}
+                letterSpacing={['-0.08px', '-1.2px']}
                 mb={2}
                 fontWeight="bold"
               >
                 <FormattedMessage id="home.create" defaultMessage="Create a Collective" />
               </H3>
-              <P
-                fontSize={['15px', null, null]}
-                color="black.700"
-                lineHeight={['23px', null, null]}
-                letterSpacing={['-0.12px']}
-              >
+              <P fontSize="15px" color="black.700" lineHeight="23px" letterSpacing="-0.12px">
                 <FormattedMessage id="home.joinUsSection.getStarted" defaultMessage="Get started now!" />
               </P>
             </Box>
@@ -118,28 +113,22 @@ const JoinUs = () => (
           <Wrapper color="black.900" my={4} width={['288px', '648px', '569px', null, '594px']} className="linkWrapper">
             <Container mb={2} width={['192px', 1]}>
               <H3
-                fontSize={['24px', '32px', null]}
+                fontSize={['24px', '32px']}
                 textAlign="left"
-                lineHeight={['25px', '40px', null]}
-                letterSpacing={['-0.08px', '-1.2px', null]}
+                lineHeight={['25px', '40px']}
+                letterSpacing={['-0.08px', '-1.2px']}
                 mb={2}
                 fontWeight="bold"
               >
                 <FormattedMessage id="home.joinUsSection.team" defaultMessage="Read our stories" />
               </H3>
               <Box width={[null, '460px']}>
-                <P
-                  fontSize={['15px', null, null]}
-                  lineHeight={['23px', null, null]}
-                  letterSpacing="-0.12px"
-                  color="black.700"
-                  display={[null, 'none']}
-                >
+                <P fontSize="15px" lineHeight="23px" letterSpacing="-0.12px" color="black.700" display={[null, 'none']}>
                   <FormattedMessage id="home.joinUsSection.joinTeam" defaultMessage="Know more about our impact." />
                 </P>
                 <P
-                  fontSize={['15px', null, null]}
-                  lineHeight={['23px', null, null]}
+                  fontSize="15px"
+                  lineHeight="23px"
                   letterSpacing="-0.12px"
                   color="black.700"
                   display={['none', 'block']}
@@ -160,10 +149,10 @@ const JoinUs = () => (
         <Wrapper color="black.900" my={4} width={['288px', '648px', '569px', null, '594px']}>
           <Container>
             <H3
-              fontSize={['24px', '32px', null]}
+              fontSize={['24px', '32px']}
               textAlign="left"
-              lineHeight={['25px', '40px', null]}
-              letterSpacing={['-0.08px', '-1.2px', null]}
+              lineHeight={['25px', '40px']}
+              letterSpacing={['-0.08px', '-1.2px']}
               mb={2}
               fontWeight="bold"
             >

--- a/components/home/sections/LearnMore.js
+++ b/components/home/sections/LearnMore.js
@@ -187,8 +187,8 @@ const LearnMore = () => {
                   alt={`${channel.id} illustration`}
                 />
               </IconWrapper>
-              <Box width={['288px', '306px', null, null, '289px']} height={[null, null, null, null, null]}>
-                <H3 fontSize={['20px']} lineHeight={['28px']} letterSpacing={['-0.6px']} mb={2} color="black.800">
+              <Box width={['288px', '306px', null, null, '289px']}>
+                <H3 fontSize="20px" lineHeight="28px" letterSpacing="-0.6px" mb={2} color="black.800">
                   {channel.name}
                 </H3>
                 <P
@@ -203,8 +203,8 @@ const LearnMore = () => {
                 <StyledLink
                   href={channel.link}
                   color="#DC5F7D"
-                  fontSize={['15px']}
-                  lineHeight={['23px']}
+                  fontSize="15px"
+                  lineHeight="23px"
                   letterSpacing="-0.12px"
                   my={2}
                 >
@@ -217,17 +217,17 @@ const LearnMore = () => {
       </Container>
       <Container display="flex" flexDirection={['column', 'row']} alignItems="center" justifyContent="center">
         <Box width={['288px', '332px', null, null, '360px']} textAlign={['center', 'left']} mr={[null, 4]}>
-          <H3 color="color.800" fontSize={['24px']} lineHeight={['32px']} letterSpacing={['-0.12px']} my={2}>
+          <H3 color="color.800" fontSize="24px" lineHeight="32px" letterSpacing="-0.12px" my={2}>
             <FormattedMessage id="home.contributeToPlatform" defaultMessage="Contribute to the platform!" />
           </H3>
-          <P color="color.700" fontSize={['18px']} lineHeight={['27px']} letterSpacing={['-0.2px']} my={3}>
+          <P color="color.700" fontSize="18px" lineHeight="27px" letterSpacing="-0.2px" my={3}>
             <FormattedMessage
               id="home.contributeToPlatform.description"
               defaultMessage="Open Collective is free for charitable initiatives. We rely on generosity of contributors like you to make this possible."
             />
           </P>
         </Box>
-        <DonateButtonWrapper width={['287px']} height={['300px']} my={3} ml={[null, 4]}>
+        <DonateButtonWrapper width="287px" height="300px" my={3} ml={[null, 4]}>
           <DonateButtonBG />
           <DonateButtonBGHover />
           <Link route="/opencollective/donate">

--- a/components/home/sections/MakeCommunity.js
+++ b/components/home/sections/MakeCommunity.js
@@ -87,7 +87,7 @@ const MakeCommunity = () => {
               </Span>
             </P>
           </Box>
-          <Box display="flex" flexDirection={['column', 'row']} alignItems={['center', null, null]}>
+          <Box display="flex" flexDirection={['column', 'row']} alignItems="center">
             <Link route="/create">
               <StyledButton minWidth={158} my={[2, null, 0]} mr={[0, 3]} buttonStyle="dark" whiteSpace="nowrap">
                 <FormattedMessage id="home.create" defaultMessage="Create a Collective" />

--- a/components/home/sections/WeAreOpen.js
+++ b/components/home/sections/WeAreOpen.js
@@ -17,11 +17,11 @@ const WeAreOpen = () => (
       mr={[null, 2, 5]}
     >
       <Box textAlign={['center', 'left']} width={['288px', 1]}>
-        <SectionTitle fontSize={['32px']} lineHeight={['40px']} letterSpacing={['-1.2px']} color="black.800">
+        <SectionTitle fontSize="32px" lineHeight="40px" letterSpacing="-1.2px" color="black.800">
           <FormattedMessage id="home.weAreOpenSection.title" defaultMessage="We are open in every way" />
         </SectionTitle>
       </Box>
-      <Box display={['block', 'none']} my={3} width={['224px']} height={['144px']}>
+      <Box display={['block', 'none']} my={3} width="224px" height="144px">
         <Illustration src="/static/images/home/weareopen-illustration-sm.png" alt="We are open in every way" />
       </Box>
       <Box my={2} width={['288px', 1]} textAlign={['center', 'left']}>

--- a/components/onboarding-modal/OnboardingContentBox.js
+++ b/components/onboarding-modal/OnboardingContentBox.js
@@ -70,15 +70,15 @@ class OnboardingContentBox extends React.Component {
     return (
       <Container display="flex" flexDirection="column" width={['90%', '80%']} alignItems="center">
         {step === 0 && (
-          <Flex flexDirection="column" alignItems="center" maxWidth={['336px']}>
+          <Flex flexDirection="column" alignItems="center" maxWidth="336px">
             <H1
               fontSize="20px"
               lineHeight="24px"
               fontWeight="bold"
               color="black.900"
               textAlign="center"
-              mb={[4]}
-              mx={[2, null]}
+              mb={4}
+              mx={2}
               data-cy="onboarding-collective-created"
             >
               <FormattedMessage
@@ -159,7 +159,7 @@ class OnboardingContentBox extends React.Component {
         )}
         {step === 2 && (
           <Fragment>
-            <Box maxWidth={['336px']}>
+            <Box maxWidth="336px">
               <H1 fontSize="20px" lineHeight="24px" fontWeight="bold" color="black.900" textAlign="center" mb={4}>
                 <FormattedMessage id="onboarding.contact.header" defaultMessage="Links and contact info" />
               </H1>

--- a/components/onboarding-modal/OnboardingModal.js
+++ b/components/onboarding-modal/OnboardingModal.js
@@ -272,16 +272,16 @@ class OnboardingModal extends React.Component {
               <ModalBody>
                 <Flex flexDirection="column" alignItems="center">
                   <Container display="flex" flexDirection="column" alignItems="center">
-                    <Box maxWidth={['336px']}>
+                    <Box maxWidth="336px">
                       <H1
                         fontSize="40px"
                         lineHeight="44px"
                         fontWeight="bold"
                         color="black.900"
                         textAlign="center"
-                        mt={[6]}
-                        mb={[4]}
-                        mx={[2, null]}
+                        mt={6}
+                        mb={4}
+                        mx={2}
                         data-cy="welcome-collective"
                       >
                         <FormattedMessage
@@ -290,8 +290,8 @@ class OnboardingModal extends React.Component {
                         />
                       </H1>
                     </Box>
-                    <Box maxWidth={['450px']}>
-                      <P fontSize="16px" lineHeight="24px" color="black.900" textAlign="center" mb={[4]} mx={[2, null]}>
+                    <Box maxWidth="450px">
+                      <P fontSize="16px" lineHeight="24px" color="black.900" textAlign="center" mb={4} mx={2}>
                         <FormattedMessage
                           id="onboarding.success.text"
                           defaultMessage="You're all set! Now you can make this space your own by customizing the look, start

--- a/components/pricing/tabs/HostOrganization.js
+++ b/components/pricing/tabs/HostOrganization.js
@@ -240,7 +240,7 @@ const HostOrganization = () => (
         >
           <FormattedMessage id="pricing.tab.welcome" defaultMessage="Welcome!" />
         </H1>
-        <P my={3} fontSize="14px" lineHeight="24px" letterSpacing={['-0.012em']}>
+        <P my={3} fontSize="14px" lineHeight="24px" letterSpacing="-0.012em">
           <FormattedMessage
             id="pricing.tab.hostOrganization.description"
             defaultMessage="You will be a <strong>Fiscal Host</strong> on our platform. That means you hold funds on behalf of Collectives. You decide which Collectives to accept and what if any fees to charge them."
@@ -254,7 +254,7 @@ const HostOrganization = () => (
       </Container>
 
       <Box textAlign="center" my={3}>
-        <P my={3} fontSize="14px" lineHeight="24px" letterSpacing={['-0.012em']}>
+        <P my={3} fontSize="14px" lineHeight="24px" letterSpacing="-0.012em">
           <StyledLink href={'/become-a-fiscal-host'}>
             <FormattedMessage
               id="pricing.fiscalHost.learnMore"

--- a/components/pricing/tabs/SingleCollectiveWithBankAccount.js
+++ b/components/pricing/tabs/SingleCollectiveWithBankAccount.js
@@ -123,7 +123,7 @@ const SingleCollectiveWithBankAccount = () => (
         <BackButton onClick={() => Router.pushRoute('pricing')} />
       </Box>
     </Container>
-    <Flex alignItems="center" justifyContent="center" flexDirection={['column', null]}>
+    <Flex alignItems="center" justifyContent="center" flexDirection="column">
       <Box textAlign="center" my={3}>
         <H1
           color="black.900"
@@ -134,7 +134,7 @@ const SingleCollectiveWithBankAccount = () => (
         >
           <FormattedMessage id="pricing.tab.welcome" defaultMessage="Welcome!" />
         </H1>
-        <P color="black.700" fontSize="14px" lineHeight="24px" letterSpacing={['-0.012em']}>
+        <P color="black.700" fontSize="14px" lineHeight="24px" letterSpacing="-0.012em">
           <FormattedMessage
             id="pricing.tab.description"
             defaultMessage="You will begin with the <strong>STARTER PLAN</strong>. This plan is <strong>FREE</strong> to set up!"
@@ -155,7 +155,7 @@ const SingleCollectiveWithBankAccount = () => (
           borderRadius="8px"
           ml={[null, null, 3]}
         >
-          <H3 my={2} fontSize={['24px', null, '16px']} lineHeight={['26px', null, '26px']} letterSpacing={['-0.008em']}>
+          <H3 my={2} fontSize={['24px', null, '16px']} lineHeight={['26px', null, '26px']} letterSpacing="-0.008em">
             <FormattedMessage id="pricing.starterPlans" defaultMessage="The STARTER PLAN includes:" />
           </H3>
           <Box as="ul" color="black.800" mt={3} px={3} fontSize="13px" lineHeight="21px" letterSpacing="-0.012em">

--- a/components/pricing/tabs/SingleCollectiveWithoutBankAccount.js
+++ b/components/pricing/tabs/SingleCollectiveWithoutBankAccount.js
@@ -59,34 +59,34 @@ const SingleCollectiveWithoutBankAccount = ({ data }) => {
           >
             <FormattedMessage id="pricing.tab.welcome" defaultMessage="Welcome!" />
           </H1>
-          <P my={3} fontSize="14px" lineHeight="24px" letterSpacing={['-0.012em']}>
+          <P my={3} fontSize="14px" lineHeight="24px" letterSpacing="-0.012em">
             <FormattedMessage
               id="pricing.tab.joinHost"
               defaultMessage="If you don't have access to a bank account you can use, please <strong>join a Fiscal Host</strong>!"
               values={I18nFormatters}
             />
           </P>
-          <P my={3} fontSize="14px" lineHeight="24px" letterSpacing={['-0.012em']}>
+          <P my={3} fontSize="14px" lineHeight="24px" letterSpacing="-0.012em">
             <FormattedMessage
               id="pricing.fiscalHost.description"
               defaultMessage="A Fiscal Host is an <strong>organization who offers fund-holding as a service</strong>. They keep your money in their bank account and  <strong>handle things like accounting, taxes, admin, payments, and liability</strong>-so you don’t have to!"
               values={I18nFormatters}
             />
           </P>
-          <P my={3} fontSize="14px" lineHeight="24px" letterSpacing={['-0.012em']}>
+          <P my={3} fontSize="14px" lineHeight="24px" letterSpacing="-0.012em">
             <FormattedMessage
               id="pricing.fiscalHost.reasonToJoin"
               defaultMessage="If you join a Fiscal Host, <strong>you don’t need to go on an Open Collective paid plan</strong>, as your Collective is already included. Each Fiscal Host sets their own fees and acceptance criteria for Collectives. Open Collective keeps a 5% of the donations you raise via credit card payments (Stripe). All other payment methods such as PayPal and Bank transfers are included in your Host's plan."
               values={I18nFormatters}
             />
           </P>
-          <P my={3} fontSize="14px" lineHeight="24px" letterSpacing={['-0.012em']}>
+          <P my={3} fontSize="14px" lineHeight="24px" letterSpacing="-0.012em">
             <FormattedMessage
               id="pricing.fiscalHost.applyOpenSource"
               defaultMessage="If you are an open source project, you can apply to join  the Open Source Collective."
             />
           </P>
-          <P my={3} fontSize="14px" lineHeight="24px" letterSpacing={['-0.012em']}>
+          <P my={3} fontSize="14px" lineHeight="24px" letterSpacing="-0.012em">
             <FormattedMessage
               id="pricing.fiscalHost.featured"
               defaultMessage="Below are some of our most popular hosts or <hosts-link>browse all of them</hosts-link>."
@@ -151,7 +151,7 @@ const SingleCollectiveWithoutBankAccount = ({ data }) => {
             </Box>
           ))}
         </HostsWrapper>
-        <P my={3} fontSize="14px" lineHeight="24px" letterSpacing={['-0.012em']}>
+        <P my={3} fontSize="14px" lineHeight="24px" letterSpacing="-0.012em">
           <StyledLink href={'/hosts'}>
             <FormattedMessage id="pricing.fiscalHost.more" defaultMessage="See more fiscal hosts" />
           </StyledLink>

--- a/components/transactions/TransactionsDownloadCSV.js
+++ b/components/transactions/TransactionsDownloadCSV.js
@@ -120,7 +120,7 @@ const TransactionsDownloadCSV = ({ collective, client }) => {
             buttonSize="small"
             minWidth={140}
             isBorderless
-            flexGrow={[1, null]}
+            flexGrow={1}
           >
             <FormattedMessage id="transactions.downloadcsvbutton" defaultMessage="Download CSV" />
             <IconDownload size="13px" style={{ marginLeft: '8px' }} />

--- a/components/transactions/TransactionsDownloadInvoices.js
+++ b/components/transactions/TransactionsDownloadInvoices.js
@@ -121,7 +121,7 @@ const TransactionsDownloadInvoices = ({ collective }) => {
       <PopupMenu
         placement="bottom-end"
         Button={({ onClick }) => (
-          <StyledButton onClick={onClick} buttonSize="small" minWidth={140} isBorderless flexGrow={[1, null]}>
+          <StyledButton onClick={onClick} buttonSize="small" minWidth={140} isBorderless flexGrow={1}>
             <FormattedMessage id="transactions.downloadinvoicesbutton" defaultMessage="Download Receipts" />
             <IconDownload size="13px" style={{ marginLeft: '8px' }} />
           </StyledButton>

--- a/pages/discover.js
+++ b/pages/discover.js
@@ -215,7 +215,7 @@ const DiscoverPage = () => {
               py={[20, 60]}
               width={1}
             >
-              <Flex width={[1]} justifyContent="left" flexWrap="wrap" mb={4} maxWidth={1200} m="0 auto">
+              <Flex width={1} justifyContent="left" flexWrap="wrap" mb={4} maxWidth={1200} m="0 auto">
                 <Flex width={[1, 0.8]} my={2}>
                   <NavList as="ul" p={0} justifyContent="space-between" width={1}>
                     <NavLinkContainer>


### PR DESCRIPTION
A small simplification on responsive props. Part of them come from what I think is a misconception on the effect the `null` value has:

**`null` value means `Don't do anything at this step`.**

- So writing this:
```jsx
<P border={['1px', null, null]} />
```

Will output:
```css
.paragraph {
  border: 1px;
}
```

In other terms, **adding `null` at the end of an array has no effect**.

- If you want to disable borders on some resolutions, you should do:
```jsx
<P border={['1px', 'none']} />
```

Which will output:
```css
.paragraph {
  border: 1px;
}

@media (min-width: 40em) {
  border: none;
}
```

---

The other changes for this PR are mostly cosmetic, simplifying arrays with only one value (ie. `[5] -> 5`). I'm not sure about the performance impact, but I find it simpler to not use arrays if we're not looking after responsiveness.