### PR TITLE
Ignore original image folders in Heroku slug

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,2 @@
+public/static/images/create-collective/original
+public/static/images/home/original

--- a/components/onboarding-modal/OnboardingModal.js
+++ b/components/onboarding-modal/OnboardingModal.js
@@ -86,7 +86,7 @@ const ResponsiveModalOverlay = styled(ModalOverlay)`
 
 const ModalWithImage = styled(ResponsiveModal)`
   @media screen and (min-width: 40em) {
-    background: white url('/static/images/create-collective/original/onboardingSuccessIllustration.png');
+    background: white url('/static/images/create-collective/onboardingSuccessIllustration.png');
     background-repeat: no-repeat;
     background-size: 100%;
   }


### PR DESCRIPTION
Reduce the slug size to optimize the deploy.
```
remote: -----> Compressing...
remote:        Done: 264.9M
remote: -----> Launching...
``` 