### PR TITLE
Revert "chore(deps): bump react-intl from 5.4.8 to 5.5.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3738,81 +3738,36 @@
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@formatjs/intl-datetimeformat": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-datetimeformat/-/intl-datetimeformat-2.4.1.tgz",
-      "integrity": "sha512-WH19o2CksJoSR9E0BK5vRQGaveys6nH6GGJGZK7WlocSttcw2Yy+Umo/9R9+Zu/qki0acTcndjk6nt3eOO5IGw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-datetimeformat/-/intl-datetimeformat-2.4.0.tgz",
+      "integrity": "sha512-EDVt4q+qJZOJOyQPg1WHRHTVL4N/iiapLVGZLdEFEa8AFfjLvHt5DYx7jN8qz5ZqRZVP3AP6M4ObeTl54y3mPw==",
       "requires": {
-        "@formatjs/intl-getcanonicallocales": "^1.3.2",
-        "@formatjs/intl-utils": "^3.8.3"
-      },
-      "dependencies": {
-        "@formatjs/intl-utils": {
-          "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-3.8.3.tgz",
-          "integrity": "sha512-AVHjyIcWA+VEZQNbTFbzbchykmsavUNaU7mryarphgLp2wqhadHPu2eKjF/cZX6FA3vEM/KJXqxxcrZkvYNduQ==",
-          "requires": {
-            "emojis-list": "^3.0.0"
-          }
-        },
-        "emojis-list": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
-        }
+        "@formatjs/intl-getcanonicallocales": "^1.3.1",
+        "@formatjs/intl-utils": "^3.8.2"
       }
     },
     "@formatjs/intl-displaynames": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-3.2.1.tgz",
-      "integrity": "sha512-77i8uE1B4wJMWnCVruaThz1ahYA7IlnDKsFqe73UTL1/Qj+Z5/uqu1fL7/zUQBhJeTROtpNUkTH+9WUgFykLYw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-3.2.0.tgz",
+      "integrity": "sha512-2F3e/CflgvUZkOghf4z4aGr9hz683BAaz6vhP2Mvp1nJoIUvMovVgMQrnn4ChmyhGzfJB4vJCQKd/N/KCRWNRg==",
       "requires": {
-        "@formatjs/intl-utils": "^3.8.3"
-      },
-      "dependencies": {
-        "@formatjs/intl-utils": {
-          "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-3.8.3.tgz",
-          "integrity": "sha512-AVHjyIcWA+VEZQNbTFbzbchykmsavUNaU7mryarphgLp2wqhadHPu2eKjF/cZX6FA3vEM/KJXqxxcrZkvYNduQ==",
-          "requires": {
-            "emojis-list": "^3.0.0"
-          }
-        },
-        "emojis-list": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
-        }
+        "@formatjs/intl-utils": "^3.8.2"
       }
     },
     "@formatjs/intl-getcanonicallocales": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-getcanonicallocales/-/intl-getcanonicallocales-1.3.2.tgz",
-      "integrity": "sha512-/GWYnHBeskb4aZxdz+oFTKO2I6xRKEoytFv/QnxxxoXLKV0LyvIryC9q8U7x/V2NgewI4IuwU/z6RH+pOm2MuQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-getcanonicallocales/-/intl-getcanonicallocales-1.3.1.tgz",
+      "integrity": "sha512-0E1ZOTwIB8zEjqnW4V7k0gBVdmtbXiLfq1sWhX28Uq59iTmo+zoADre9dIr15Sx6Kl+4JgC6Mu9/bP3F746Fjg==",
       "requires": {
         "cldr-core": "36.0.0"
       }
     },
     "@formatjs/intl-listformat": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-4.1.1.tgz",
-      "integrity": "sha512-6J0+UXZO5KcVEuIQ4v7G8I7Rk7p8qT8E47sXV3CkFySkqyYb9bUMC/9MpDuxxyacFQWS5BQS5szAqgB7Aj1uWQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-4.1.0.tgz",
+      "integrity": "sha512-pzbYcf+7XrPakWcxFtr7CI3bRfIjdljO6RqyOyyZuoEl6ioDLlt9uP4Be29r/VOLmH4ZBRTQHHZrMXWnmWY/8Q==",
       "requires": {
-        "@formatjs/intl-utils": "^3.8.3"
-      },
-      "dependencies": {
-        "@formatjs/intl-utils": {
-          "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-3.8.3.tgz",
-          "integrity": "sha512-AVHjyIcWA+VEZQNbTFbzbchykmsavUNaU7mryarphgLp2wqhadHPu2eKjF/cZX6FA3vEM/KJXqxxcrZkvYNduQ==",
-          "requires": {
-            "emojis-list": "^3.0.0"
-          }
-        },
-        "emojis-list": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
-        }
+        "@formatjs/intl-utils": "^3.8.2"
       }
     },
     "@formatjs/intl-numberformat": {
@@ -14250,41 +14205,28 @@
       "dev": true
     },
     "intl-messageformat": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.2.2.tgz",
-      "integrity": "sha512-RTHb4EDTuXOSzQ68V22cAVrKfFo+wbvy1MOo9SgfiUSKVtpytvUAs2soVnET42z/nqZqdDXW9itXm3hzUMqJOA==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.2.1.tgz",
+      "integrity": "sha512-MV7LJidaqpT+eKj0FTyeaF5lmLlL6U+SI+D+jW1WZC72kUrX8m3OAavSvaxW0w4FcAphNpwDu90ZrQF2Syqmng==",
       "requires": {
         "fast-memoize": "^2.5.2",
-        "intl-messageformat-parser": "^5.3.9"
+        "intl-messageformat-parser": "^5.3.8"
       },
       "dependencies": {
         "@formatjs/intl-numberformat": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-numberformat/-/intl-numberformat-5.4.1.tgz",
-          "integrity": "sha512-w9GRPRmD4EZ1gxbekVAMmLphwT7JzjYGmxPa1ZD4ukb0pmk+9Sb3Qy6BjOu59YsROAAMrct6EQqfc/H//EYRdA==",
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-numberformat/-/intl-numberformat-5.4.0.tgz",
+          "integrity": "sha512-gl8xUp745Hx8IgmofSi3AZJmbEBwxfNFgimeaIb2nlflVcIhtIo0RSyl93Es2V1+0R2Atg4gLC5vox3wGgz5/w==",
           "requires": {
-            "@formatjs/intl-utils": "^3.8.3"
+            "@formatjs/intl-utils": "^3.8.2"
           }
-        },
-        "@formatjs/intl-utils": {
-          "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-3.8.3.tgz",
-          "integrity": "sha512-AVHjyIcWA+VEZQNbTFbzbchykmsavUNaU7mryarphgLp2wqhadHPu2eKjF/cZX6FA3vEM/KJXqxxcrZkvYNduQ==",
-          "requires": {
-            "emojis-list": "^3.0.0"
-          }
-        },
-        "emojis-list": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
         },
         "intl-messageformat-parser": {
-          "version": "5.3.9",
-          "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-5.3.9.tgz",
-          "integrity": "sha512-TVrWaSYrSj8WnYUgZ5bsfIhTawPr0bWYw34Q3g8lj5uEOpjm6SmqUfBhVmTC+PsATnD5d0gyKtEi2ov8tcxrZw==",
+          "version": "5.3.8",
+          "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-5.3.8.tgz",
+          "integrity": "sha512-BxZp3IDmhURMOOK3eXgX2mA6Q3ytcLh0gaS0JTTQp1rsv1sMs+vGtFZHrmGk2HX3D3cnGiXtPrvG7SaeiWtODg==",
           "requires": {
-            "@formatjs/intl-numberformat": "^5.4.1"
+            "@formatjs/intl-numberformat": "^5.4.0"
           }
         }
       }
@@ -21964,59 +21906,46 @@
       }
     },
     "react-intl": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-5.5.0.tgz",
-      "integrity": "sha512-Do9eyp5Z4CZ2IGR3Y4ZcPj0VgW2XyJkU3zawEtehNPLbO/Yr8nunL9qMkQIWEHH+jeKk2/zne7l/YfS5fSSdcw==",
+      "version": "5.4.8",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-5.4.8.tgz",
+      "integrity": "sha512-UuTb0ztfQl0+Bs8CkDDOPPps35HNrWxrU8SvfzgmnVQotuRJAdsLS+4gWslDTiUrk6qSfla4R03BSvjivAmMFg==",
       "requires": {
-        "@formatjs/intl-datetimeformat": "^2.4.1",
-        "@formatjs/intl-displaynames": "^3.2.1",
-        "@formatjs/intl-listformat": "^4.1.1",
-        "@formatjs/intl-numberformat": "^5.4.1",
-        "@formatjs/intl-relativetimeformat": "^7.1.1",
-        "@formatjs/intl-utils": "^3.8.3",
+        "@formatjs/intl-datetimeformat": "^2.4.0",
+        "@formatjs/intl-displaynames": "^3.2.0",
+        "@formatjs/intl-listformat": "^4.1.0",
+        "@formatjs/intl-numberformat": "^5.4.0",
+        "@formatjs/intl-relativetimeformat": "^7.1.0",
+        "@formatjs/intl-utils": "^3.8.2",
         "@types/hoist-non-react-statics": "^3.3.1",
         "fast-memoize": "^2.5.2",
         "hoist-non-react-statics": "^3.3.2",
-        "intl-messageformat": "^9.2.2",
-        "intl-messageformat-parser": "^5.3.9",
+        "intl-messageformat": "^9.2.1",
+        "intl-messageformat-parser": "^5.3.8",
         "shallow-equal": "^1.2.1"
       },
       "dependencies": {
         "@formatjs/intl-numberformat": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-numberformat/-/intl-numberformat-5.4.1.tgz",
-          "integrity": "sha512-w9GRPRmD4EZ1gxbekVAMmLphwT7JzjYGmxPa1ZD4ukb0pmk+9Sb3Qy6BjOu59YsROAAMrct6EQqfc/H//EYRdA==",
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-numberformat/-/intl-numberformat-5.4.0.tgz",
+          "integrity": "sha512-gl8xUp745Hx8IgmofSi3AZJmbEBwxfNFgimeaIb2nlflVcIhtIo0RSyl93Es2V1+0R2Atg4gLC5vox3wGgz5/w==",
           "requires": {
-            "@formatjs/intl-utils": "^3.8.3"
+            "@formatjs/intl-utils": "^3.8.2"
           }
         },
         "@formatjs/intl-relativetimeformat": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-7.1.1.tgz",
-          "integrity": "sha512-NpWdVFnwB4AywW0mJMP9JlGJxS1H0LTFnAWFjywIxCPZVZVNlyru4IahGr0pDpIAezC+HcwH5gqdlc1Rw/l5vg==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-7.1.0.tgz",
+          "integrity": "sha512-hU2+hEuC2bIPfmByxFPMZ9ZJUd3fYxfmAmmmbGt6ILes9ZLwWoTXFANEQ7YNwnOv1w/fAfhQsSqg6RgJSxtGYA==",
           "requires": {
-            "@formatjs/intl-utils": "^3.8.3"
+            "@formatjs/intl-utils": "^3.8.2"
           }
-        },
-        "@formatjs/intl-utils": {
-          "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-3.8.3.tgz",
-          "integrity": "sha512-AVHjyIcWA+VEZQNbTFbzbchykmsavUNaU7mryarphgLp2wqhadHPu2eKjF/cZX6FA3vEM/KJXqxxcrZkvYNduQ==",
-          "requires": {
-            "emojis-list": "^3.0.0"
-          }
-        },
-        "emojis-list": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-          "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
         },
         "intl-messageformat-parser": {
-          "version": "5.3.9",
-          "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-5.3.9.tgz",
-          "integrity": "sha512-TVrWaSYrSj8WnYUgZ5bsfIhTawPr0bWYw34Q3g8lj5uEOpjm6SmqUfBhVmTC+PsATnD5d0gyKtEi2ov8tcxrZw==",
+          "version": "5.3.8",
+          "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-5.3.8.tgz",
+          "integrity": "sha512-BxZp3IDmhURMOOK3eXgX2mA6Q3ytcLh0gaS0JTTQp1rsv1sMs+vGtFZHrmGk2HX3D3cnGiXtPrvG7SaeiWtODg==",
           "requires": {
-            "@formatjs/intl-numberformat": "^5.4.1"
+            "@formatjs/intl-numberformat": "^5.4.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react-dropzone": "11.0.3",
     "react-easy-crop": "3.1.1",
     "react-geosuggest": "2.14.0",
-    "react-intl": "5.5.0",
+    "react-intl": "5.4.8",
     "react-markdown": "4.3.1",
     "react-popper": "2.2.3",
     "react-quill": "1.3.5",


### PR DESCRIPTION
Reverts opencollective/opencollective-frontend#4831 because of the following warning:

```
[React Intl] "defaultRichTextElements" was specified but "message" was not pre-compiled. 
Please consider using "@formatjs/cli" to pre-compile your messages for performance.
```