### PR TITLE
fix(test): breaking internationalization test

### DIFF
--- a/test/cypress/integration/00-i18n.test.js
+++ b/test/cypress/integration/00-i18n.test.js
@@ -2,7 +2,7 @@ describe('Internationalization', () => {
   it('Can switch language from the footer', () => {
     cy.visit('/');
     cy.getByDataCy('language-switcher').click();
-    cy.contains('[data-cy="select-option"]', '🇫🇷 French - Français (100%)').click();
+    cy.contains('[data-cy="select-option"]', 'French').click();
     // Let's not make too much assumptions on the translation as they can easily change.
     // `Collectif` is the way we translate `Collective` in French and the word doesn't
     // exist in English, so it should be safe to look for that on the home page.


### PR DESCRIPTION
Following up https://github.com/opencollective/opencollective/issues/3347 to resolve https://github.com/opencollective/opencollective/issues/3347#issuecomment-674032241.

Fix: We should use a more consistent keyword from the language options (language name in this case) instead of matching the whole string. 