### PR TITLE
Validate and Redirect slugs starting/ending with Hyphen

### DIFF
--- a/components/create-collective/CreateCollectiveForm.js
+++ b/components/create-collective/CreateCollectiveForm.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import themeGet from '@styled-system/theme-get';
 import { Field, Form, Formik } from 'formik';
+import { trim } from 'lodash';
 import { withRouter } from 'next/router';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import slugify from 'slugify';
@@ -67,6 +68,10 @@ const messages = defineMessages({
     id: 'createCollective.form.error.slug',
     defaultMessage: 'Please use fewer than 30 characters',
   },
+  errorSlugHyphen: {
+    id: 'createCollective.form.error.slug.hyphen',
+    defaultMessage: 'Collective slug can not start nor end with hyphen',
+  },
 });
 
 const formatGithubRepoName = repoName => {
@@ -121,6 +126,9 @@ class CreateCollectiveForm extends React.Component {
 
       if (values.slug.length > 30) {
         errors.slug = intl.formatMessage(messages.errorSlug);
+      }
+      if (values.slug !== trim(values.slug, '-')) {
+        errors.slug = intl.formatMessage(messages.errorSlugHyphen);
       }
 
       if (values.description.length > 160) {
@@ -196,7 +204,7 @@ class CreateCollectiveForm extends React.Component {
                     strict: true,
                   };
 
-                  return slugify(value, slugOptions);
+                  return trim(slugify(value, slugOptions), '-');
                 };
 
                 const handleSlugChange = e => {

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -469,6 +469,7 @@
   "createCollective.form.error.description": "Please use fewer than 160 characters",
   "createCollective.form.error.name": "Please use fewer than 50 characters",
   "createCollective.form.error.slug": "Please use fewer than 30 characters",
+  "createCollective.form.error.slug.hyphen": "Collective slug can not start nor end with hyphen",
   "createCollective.form.nameLabel": "What's the name of your collective?",
   "createCollective.form.slugLabel": "What URL would you like?",
   "createCollective.form.suggestedLabel": "Suggested",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -469,6 +469,7 @@
   "createCollective.form.error.description": "Please use fewer than 160 characters",
   "createCollective.form.error.name": "Please use fewer than 50 characters",
   "createCollective.form.error.slug": "Please use fewer than 30 characters",
+  "createCollective.form.error.slug.hyphen": "Collective slug can not start nor end with hyphen",
   "createCollective.form.nameLabel": "What's the name of your collective?",
   "createCollective.form.slugLabel": "Jakou adresu URL byste chtěli?",
   "createCollective.form.suggestedLabel": "Navrhované",

--- a/lang/de.json
+++ b/lang/de.json
@@ -469,6 +469,7 @@
   "createCollective.form.error.description": "Please use fewer than 160 characters",
   "createCollective.form.error.name": "Please use fewer than 50 characters",
   "createCollective.form.error.slug": "Please use fewer than 30 characters",
+  "createCollective.form.error.slug.hyphen": "Collective slug can not start nor end with hyphen",
   "createCollective.form.nameLabel": "What's the name of your collective?",
   "createCollective.form.slugLabel": "What URL would you like?",
   "createCollective.form.suggestedLabel": "Suggested",

--- a/lang/en.json
+++ b/lang/en.json
@@ -469,6 +469,7 @@
   "createCollective.form.error.description": "Please use fewer than 160 characters",
   "createCollective.form.error.name": "Please use fewer than 50 characters",
   "createCollective.form.error.slug": "Please use fewer than 30 characters",
+  "createCollective.form.error.slug.hyphen": "Collective slug can not start nor end with hyphen",
   "createCollective.form.nameLabel": "What's the name of your collective?",
   "createCollective.form.slugLabel": "What URL would you like?",
   "createCollective.form.suggestedLabel": "Suggested",

--- a/lang/es.json
+++ b/lang/es.json
@@ -469,6 +469,7 @@
   "createCollective.form.error.description": "Por favor, utiliza menos de 160 caracteres",
   "createCollective.form.error.name": "Por favor, usa menos de 50 caracteres",
   "createCollective.form.error.slug": "Por favor, utiliza menos de 30 caracteres",
+  "createCollective.form.error.slug.hyphen": "Collective slug can not start nor end with hyphen",
   "createCollective.form.nameLabel": "¿Cuál es el nombre de tu colectivo?",
   "createCollective.form.slugLabel": "¿Qué URL te gustaría?",
   "createCollective.form.suggestedLabel": "Sugerido",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -469,6 +469,7 @@
   "createCollective.form.error.description": "Veuillez utiliser moins de 160 caractères",
   "createCollective.form.error.name": "Veuillez utiliser moins de 50 caractères",
   "createCollective.form.error.slug": "Veuillez utiliser moins de 30 caractères",
+  "createCollective.form.error.slug.hyphen": "Collective slug can not start nor end with hyphen",
   "createCollective.form.nameLabel": "Quel est le nom de votre collectif ?",
   "createCollective.form.slugLabel": "Quelle URL aimeriez-vous ?",
   "createCollective.form.suggestedLabel": "Suggéré",

--- a/lang/it.json
+++ b/lang/it.json
@@ -469,6 +469,7 @@
   "createCollective.form.error.description": "Utilizza meno di 160 caratteri",
   "createCollective.form.error.name": "Utilizza meno di 50 caratteri",
   "createCollective.form.error.slug": "Si prega di utilizzare meno di 30 caratteri",
+  "createCollective.form.error.slug.hyphen": "Collective slug can not start nor end with hyphen",
   "createCollective.form.nameLabel": "Qual è il nome del vostro collettivo?",
   "createCollective.form.slugLabel": "Quale URL vorresti usare?",
   "createCollective.form.suggestedLabel": "Suggested",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -469,6 +469,7 @@
   "createCollective.form.error.description": "Please use fewer than 160 characters",
   "createCollective.form.error.name": "Please use fewer than 50 characters",
   "createCollective.form.error.slug": "Please use fewer than 30 characters",
+  "createCollective.form.error.slug.hyphen": "Collective slug can not start nor end with hyphen",
   "createCollective.form.nameLabel": "What's the name of your collective?",
   "createCollective.form.slugLabel": "What URL would you like?",
   "createCollective.form.suggestedLabel": "提案",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -469,6 +469,7 @@
   "createCollective.form.error.description": "160자보다 적게 사용해주세요",
   "createCollective.form.error.name": "50자보다 적게 사용해주세요",
   "createCollective.form.error.slug": "30자보다 적게 사용해주세요",
+  "createCollective.form.error.slug.hyphen": "Collective slug can not start nor end with hyphen",
   "createCollective.form.nameLabel": "집단의 이름이 무엇인가요?",
   "createCollective.form.slugLabel": "어떤 URL을 사용하시겠어요?",
   "createCollective.form.suggestedLabel": "제안됨",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -469,6 +469,7 @@
   "createCollective.form.error.description": "Please use fewer than 160 characters",
   "createCollective.form.error.name": "Please use fewer than 50 characters",
   "createCollective.form.error.slug": "Please use fewer than 30 characters",
+  "createCollective.form.error.slug.hyphen": "Collective slug can not start nor end with hyphen",
   "createCollective.form.nameLabel": "What's the name of your collective?",
   "createCollective.form.slugLabel": "What URL would you like?",
   "createCollective.form.suggestedLabel": "Suggested",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -469,6 +469,7 @@
   "createCollective.form.error.description": "Por favor, não use mais do que 160 caracteres",
   "createCollective.form.error.name": "Por favor, não use mais do que 50 caracteres",
   "createCollective.form.error.slug": "Por favor, não use mais do que 30 caracteres",
+  "createCollective.form.error.slug.hyphen": "Collective slug can not start nor end with hyphen",
   "createCollective.form.nameLabel": "Qual é o nome do seu Coletivo?",
   "createCollective.form.slugLabel": "Que URL gostaria de usar?",
   "createCollective.form.suggestedLabel": "Sugerido",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -469,6 +469,7 @@
   "createCollective.form.error.description": "Please use fewer than 160 characters",
   "createCollective.form.error.name": "Please use fewer than 50 characters",
   "createCollective.form.error.slug": "Please use fewer than 30 characters",
+  "createCollective.form.error.slug.hyphen": "Collective slug can not start nor end with hyphen",
   "createCollective.form.nameLabel": "What's the name of your collective?",
   "createCollective.form.slugLabel": "What URL would you like?",
   "createCollective.form.suggestedLabel": "Suggested",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -469,6 +469,7 @@
   "createCollective.form.error.description": "Please use fewer than 160 characters",
   "createCollective.form.error.name": "Please use fewer than 50 characters",
   "createCollective.form.error.slug": "Please use fewer than 30 characters",
+  "createCollective.form.error.slug.hyphen": "Collective slug can not start nor end with hyphen",
   "createCollective.form.nameLabel": "What's the name of your collective?",
   "createCollective.form.slugLabel": "What URL would you like?",
   "createCollective.form.suggestedLabel": "Suggested",

--- a/server/routes.js
+++ b/server/routes.js
@@ -4,7 +4,7 @@ const url = require('url');
 
 const express = require('express');
 const proxy = require('express-http-proxy');
-const { template } = require('lodash');
+const { template, trim } = require('lodash');
 
 const intl = require('./intl');
 const pages = require('./pages');
@@ -108,6 +108,19 @@ module.exports = (expressApp, nextApp) => {
       global.__coverage__ = {};
     });
   }
+
+  // Correct slug links that end or start with hyphen
+  app.use((req, res, next) => {
+    if (req.path) {
+      const path = req.path.split('/');
+      const slug = path[1];
+      if (trim(slug, '-') != slug) {
+        path[1] = trim(slug, '-');
+        return res.redirect(301, path.join('/'));
+      }
+    }
+    next();
+  });
 
   app.get('/:collectiveSlug/:verb(contribute|donate)/button:size(|@2x).png', maxAge(86400), (req, res) => {
     const color = req.query.color === 'blue' ? 'blue' : 'white';


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/3356
Requires https://github.com/opencollective/opencollective-api/pull/4392

- [ ] DO NOT MERGE THIS BEFORE FIXING EXISTING SLUGS