### PR TITLE
fix(contribute-flow): remove minimum amount message for fixed tiers

### DIFF
--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -202,13 +202,15 @@ const StepDetails = ({
           </StyledInputField>
         )}
       </Flex>
-      <Flex fontSize="12px" color="black.500" flexDirection="column" alignItems="flex-end" mb={3}>
-        <FormattedMessage
-          id="contribuion.minimumAmount"
-          values={{ minAmount: formatCurrency(minAmount, currency), currency: currency }}
-          defaultMessage={'Minimum amount: {minAmount} {currency}'}
-        />
-      </Flex>
+      {!disabledAmount && (
+        <Flex fontSize="12px" color="black.500" flexDirection="column" alignItems="flex-end" mb={3}>
+          <FormattedMessage
+            id="contribuion.minimumAmount"
+            values={{ minAmount: formatCurrency(minAmount, currency), currency: currency }}
+            defaultMessage={'Minimum amount: {minAmount} {currency}'}
+          />
+        </Flex>
+      )}
       {showInterval && (
         <StyledInputField
           label={<FormattedMessage id="contribution.interval.label" defaultMessage="Frequency" />}


### PR DESCRIPTION

Resolve [3412](https://github.com/opencollective/opencollective/issues/3412)

# Description

Remove invalid minimum amount message for fixed tiers since the contribution amount is fixed.

# Screenshots

## Fixed tier one time contribution screenshot
![fixed-tier-one-time](https://user-images.githubusercontent.com/55011368/90529559-794fc580-e191-11ea-962b-5f5eeb84edc2.png)
## Fixed tier recurring contribution screenshot
![fixed-tier-recurring](https://user-images.githubusercontent.com/55011368/90529575-7ce34c80-e191-11ea-8306-4ac5b5bf8fce.png)
