### PR TITLE
feat: add "Pending invitations" link in user menu

### DIFF
--- a/components/TopBarProfileMenu.js
+++ b/components/TopBarProfileMenu.js
@@ -1,5 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
+import { gql } from '@apollo/client';
+import { Query } from '@apollo/client/react/components';
 import { Plus } from '@styled-icons/boxicons-regular';
 import { ChevronDown } from '@styled-icons/boxicons-regular/ChevronDown';
 import { Settings } from '@styled-icons/feather/Settings';
@@ -25,6 +27,14 @@ import StyledLink from './StyledLink';
 import StyledRoundButton from './StyledRoundButton';
 import { P } from './Text';
 import { withUser } from './UserProvider';
+
+const memberInvitationsCountQuery = gql`
+  query MemberInvitationsCount($memberCollectiveId: Int!) {
+    memberInvitations(MemberCollectiveId: $memberCollectiveId) {
+      id
+    }
+  }
+`;
 
 const CollectiveListItem = styled(ListItem)`
   @media (hover: hover) {
@@ -229,6 +239,30 @@ class TopBarProfileMenu extends React.Component {
                   </StyledLink>
                 </Link>
               </ListItem>
+              <Query
+                query={memberInvitationsCountQuery}
+                variables={{ memberCollectiveId: LoggedInUser.CollectiveId }}
+                fetchPolicy="network-only"
+              >
+                {({ data, loading }) =>
+                  loading === false &&
+                  data &&
+                  data.memberInvitations &&
+                  data.memberInvitations.length > 0 && (
+                    <ListItem py={1}>
+                      <Link route="member-invitations" passHref>
+                        <StyledLink color="#494D52" fontSize="1.2rem" fontFamily="montserratlight, arial">
+                          <FormattedMessage
+                            id="menu.pendingInvitations"
+                            defaultMessage="Pending Invitations ({numberOfInvitations})"
+                            values={{ numberOfInvitations: data.memberInvitations.length }}
+                          />
+                        </StyledLink>
+                      </Link>
+                    </ListItem>
+                  )
+                }
+              </Query>
               <ListItem py={1}>
                 <Link route="editCollective" params={{ slug: LoggedInUser.collective.slug }} passHref>
                   <StyledLink color="#494D52" fontSize="1.2rem" fontFamily="montserratlight, arial">

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1103,6 +1103,7 @@
   "menu.logout": "Log out",
   "menu.myAccount": "My account",
   "menu.organizations.none": "No organizations yet",
+  "menu.pendingInvitations": "Pending Invitations ({numberOfInvitations})",
   "menu.pricing": "Preu",
   "menu.profile": "Perfil",
   "menu.submitExpense": "Envia la despesa",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1103,6 +1103,7 @@
   "menu.logout": "Odhlásit se",
   "menu.myAccount": "Můj účet",
   "menu.organizations.none": "Zatím žádné organizace",
+  "menu.pendingInvitations": "Pending Invitations ({numberOfInvitations})",
   "menu.pricing": "Ceník",
   "menu.profile": "Profil",
   "menu.submitExpense": "Odeslat výdaj",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1103,6 +1103,7 @@
   "menu.logout": "Abmelden",
   "menu.myAccount": "Mein Konto",
   "menu.organizations.none": "Noch keine Organisationen",
+  "menu.pendingInvitations": "Pending Invitations ({numberOfInvitations})",
   "menu.pricing": "Preisgestaltung",
   "menu.profile": "Profil",
   "menu.submitExpense": "Ausgaben angeben",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1103,6 +1103,7 @@
   "menu.logout": "Log out",
   "menu.myAccount": "My account",
   "menu.organizations.none": "No organizations yet",
+  "menu.pendingInvitations": "Pending Invitations ({numberOfInvitations})",
   "menu.pricing": "Pricing",
   "menu.profile": "Profile",
   "menu.submitExpense": "Submit Expense",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1103,6 +1103,7 @@
   "menu.logout": "Desconectar",
   "menu.myAccount": "Mi cuenta",
   "menu.organizations.none": "Aún no hay organizaciones",
+  "menu.pendingInvitations": "Pending Invitations ({numberOfInvitations})",
   "menu.pricing": "Precios",
   "menu.profile": "Perfil",
   "menu.submitExpense": "Enviar gasto",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1103,6 +1103,7 @@
   "menu.logout": "Se déconnecter",
   "menu.myAccount": "Mon compte",
   "menu.organizations.none": "Aucune organisation",
+  "menu.pendingInvitations": "Pending Invitations ({numberOfInvitations})",
   "menu.pricing": "Tarifs",
   "menu.profile": "Profil",
   "menu.submitExpense": "Ajouter une dépense",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1103,6 +1103,7 @@
   "menu.logout": "Log out",
   "menu.myAccount": "Mio Account",
   "menu.organizations.none": "Ancora nessuna organizzazione",
+  "menu.pendingInvitations": "Pending Invitations ({numberOfInvitations})",
   "menu.pricing": "Pricing",
   "menu.profile": "Profilo",
   "menu.submitExpense": "Submit Expense",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1103,6 +1103,7 @@
   "menu.logout": "ログアウト",
   "menu.myAccount": "アカウント",
   "menu.organizations.none": "まだ組織がありません",
+  "menu.pendingInvitations": "Pending Invitations ({numberOfInvitations})",
   "menu.pricing": "料金",
   "menu.profile": "プロフィール",
   "menu.submitExpense": "経費申請する",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1103,6 +1103,7 @@
   "menu.logout": "로그아웃",
   "menu.myAccount": "내 계정",
   "menu.organizations.none": "No organizations yet",
+  "menu.pendingInvitations": "Pending Invitations ({numberOfInvitations})",
   "menu.pricing": "요금제",
   "menu.profile": "프로필",
   "menu.submitExpense": "Submit Expense",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1103,6 +1103,7 @@
   "menu.logout": "Log out",
   "menu.myAccount": "My account",
   "menu.organizations.none": "No organizations yet",
+  "menu.pendingInvitations": "Pending Invitations ({numberOfInvitations})",
   "menu.pricing": "Pricing",
   "menu.profile": "Profile",
   "menu.submitExpense": "Submit Expense",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1103,6 +1103,7 @@
   "menu.logout": "Sair",
   "menu.myAccount": "Minha conta",
   "menu.organizations.none": "Sem organizações",
+  "menu.pendingInvitations": "Pending Invitations ({numberOfInvitations})",
   "menu.pricing": "Preço",
   "menu.profile": "Perfil",
   "menu.submitExpense": "Enviar despesa",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1103,6 +1103,7 @@
   "menu.logout": "Выход",
   "menu.myAccount": "Мой профиль",
   "menu.organizations.none": "No organizations yet",
+  "menu.pendingInvitations": "Pending Invitations ({numberOfInvitations})",
   "menu.pricing": "Цены",
   "menu.profile": "Профиль",
   "menu.submitExpense": "Submit Expense",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1103,6 +1103,7 @@
   "menu.logout": "Log out",
   "menu.myAccount": "My account",
   "menu.organizations.none": "No organizations yet",
+  "menu.pendingInvitations": "Pending Invitations ({numberOfInvitations})",
   "menu.pricing": "定价",
   "menu.profile": "Profile",
   "menu.submitExpense": "Submit Expense",


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/3287

# Description

Dynamically fetch the count of member invitations, and if there are any, display a link in the format "Pending invitations (1)".
This is my first time contributing, so please let me know if I need to change anything or add tests!

# Screenshots

<img width="517" alt="image" src="https://user-images.githubusercontent.com/8061997/90574188-951a9200-e1b8-11ea-92c2-29cabe76f420.png">

