### PR TITLE
Always display twitter settings in Connected Accounts

### DIFF
--- a/components/edit-collective/EditConnectedAccount.js
+++ b/components/edit-collective/EditConnectedAccount.js
@@ -162,6 +162,9 @@ class EditConnectedAccount extends React.Component {
         {connectedAccount && (
           <Flex flexDirection="column">
             <Box>{intl.formatMessage(this.messages[`collective.connectedAccounts.${service}.connected`], vars)}</Box>
+            {connectedAccount.service === 'twitter' && (
+              <EditTwitterAccount collective={collective} connectedAccount={connectedAccount} />
+            )}
             <Box mt={1}>
               <StyledButton buttonSize="small" onClick={() => this.connect(service)}>
                 {intl.formatMessage(this.messages['collective.connectedAccounts.reconnect.button'])}
@@ -171,9 +174,6 @@ class EditConnectedAccount extends React.Component {
               </StyledButton>
             </Box>
           </Flex>
-        )}
-        {connectedAccount && connectedAccount.service === 'twitter' && collective.type === 'ORGANIZATION' && (
-          <EditTwitterAccount collective={collective} connectedAccount={connectedAccount} />
         )}
       </Flex>
     );


### PR DESCRIPTION
Was not a good decision to only display for ORGANIZATION in 

https://github.com/opencollective/opencollective-frontend/commit/3b321904fee76954661fe92117dad43f93ac168e
https://github.com/opencollective/opencollective-frontend/pull/2753