### PR TITLE
ExpenseForm: Update labels font-size

### DIFF
--- a/components/StyledCheckbox.js
+++ b/components/StyledCheckbox.js
@@ -138,13 +138,13 @@ class StyledCheckbox extends React.Component {
   }
 
   render() {
-    const { name, checked, label, disabled, size, inputId, width, alignItems, isLoading } = this.props;
+    const { name, checked, label, disabled, size, inputId, width, alignItems, isLoading, fontSize } = this.props;
     const realChecked = checked === undefined ? this.state.checked : checked;
 
     return (
       <CheckboxContainer
         onClick={() => this.onChange(!realChecked)}
-        fontSize={size}
+        fontSize={fontSize || size}
         size={size}
         width={width}
         alignItems={alignItems}
@@ -183,6 +183,7 @@ StyledCheckbox.propTypes = {
   label: PropTypes.node,
   /** An optional size */
   size: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
+  fontSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.array]),
   /** Set this to 'auto' to not take the full width */
   width: PropTypes.string,
   /** If true, the checkbox will be replaced by a spinner */

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -357,6 +357,7 @@ const ExpenseFormBody = ({
                           <StyledInputField
                             name={field.name}
                             label={formatMessage(msg.payeeLabel)}
+                            labelFontSize="13px"
                             flex="1"
                             mr={fieldsMarginRight}
                             mt={3}
@@ -385,6 +386,7 @@ const ExpenseFormBody = ({
                               <StyledInputField
                                 name={field.name}
                                 label={formatMessage(msg.country)}
+                                labelFontSize="13px"
                                 error={formatFormErrorMessage(intl, errors.payeeLocation?.country)}
                                 required
                                 minWidth={250}
@@ -408,6 +410,7 @@ const ExpenseFormBody = ({
                               <StyledInputField
                                 name={field.name}
                                 label={formatMessage(msg.address)}
+                                labelFontSize="13px"
                                 error={formatFormErrorMessage(intl, errors.payeeLocation?.address)}
                                 required
                                 minWidth={250}
@@ -430,6 +433,7 @@ const ExpenseFormBody = ({
                               <StyledInputField
                                 name={field.name}
                                 label={formatMessage(msg.invoiceInfo)}
+                                labelFontSize="13px"
                                 required={false}
                                 minWidth={250}
                                 mr={fieldsMarginRight}
@@ -461,6 +465,7 @@ const ExpenseFormBody = ({
                             mt={3}
                             minWidth={250}
                             label={formatMessage(msg.payoutOptionLabel)}
+                            labelFontSize="13px"
                             error={
                               isErrorType(errors.payoutMethod, ERROR.FORM_FIELD_REQUIRED)
                                 ? formatFormErrorMessage(intl, errors.payoutMethod)

--- a/components/expenses/ExpenseItemForm.js
+++ b/components/expenses/ExpenseItemForm.js
@@ -137,7 +137,7 @@ const ExpenseItemForm = ({ attachment, errors, onRemove, onUploadError, currency
             error={getError('description')}
             htmlFor={`${attachmentKey}-description`}
             label={formatMessage(msg.descriptionLabel)}
-            labelfontSize="13px"
+            labelFontSize="13px"
             required
           >
             {inputProps => <Field as={StyledInput} {...inputProps} />}
@@ -150,7 +150,7 @@ const ExpenseItemForm = ({ attachment, errors, onRemove, onUploadError, currency
               inputType="date"
               required
               label={formatMessage(msg.dateLabel)}
-              labelfontSize="13px"
+              labelFontSize="13px"
               flex={requireFile ? '1 1 44%' : '1 1 50%'}
               mt={3}
             >
@@ -173,7 +173,7 @@ const ExpenseItemForm = ({ attachment, errors, onRemove, onUploadError, currency
               htmlFor={`${attachmentKey}-amount`}
               label={formatMessage(msg.amountLabel)}
               required
-              labelfontSize="13px"
+              labelFontSize="13px"
               inputType="number"
               flex="1 1 30%"
               minWidth={150}

--- a/components/expenses/PayoutBankInformationForm.js
+++ b/components/expenses/PayoutBankInformationForm.js
@@ -91,6 +91,7 @@ const Input = props => {
           {({ field, meta }) => (
             <StyledInputField
               label={input.name}
+              labelFontSize="13px"
               required={input.required}
               error={(meta.touched || disabled) && meta.error}
             >
@@ -117,6 +118,7 @@ const Input = props => {
           {({ field, meta }) => (
             <StyledInputField
               label={input.name}
+              labelFontSize="13px"
               required={input.required}
               error={(meta.touched || disabled) && meta.error}
             >
@@ -345,7 +347,14 @@ const PayoutBankInformationForm = ({ isNew, getFieldName, host, fixedCurrency })
     <React.Fragment>
       <Field name={currencyFieldName} validate={validateCurrencyMinimumAmount}>
         {({ field, meta }) => (
-          <StyledInputField name={field.name} error={meta.error} label={formatMessage(msg.currency)} mt={3} mb={2}>
+          <StyledInputField
+            name={field.name}
+            error={meta.error}
+            label={formatMessage(msg.currency)}
+            labelFontSize="13px"
+            mt={3}
+            mb={2}
+          >
             {({ id }) => (
               <StyledSelect
                 inputId={id}

--- a/components/expenses/PayoutMethodForm.js
+++ b/components/expenses/PayoutMethodForm.js
@@ -83,6 +83,7 @@ const PayoutMethodForm = ({ payoutMethod, fieldsPrefix, host }) => {
               type="email"
               error={formatFormErrorMessage(intl, meta.error)}
               label={formatMessage(msg.email)}
+              labelFontSize="13px"
               disabled={!isNew}
               required
             >
@@ -99,6 +100,7 @@ const PayoutMethodForm = ({ payoutMethod, fieldsPrefix, host }) => {
               type="email"
               error={formatFormErrorMessage(intl, meta.error)}
               label={formatMessage(msg.content)}
+              labelFontSize="13px"
               disabled={!isNew}
               data-cy="payout-other-info"
               required
@@ -114,7 +116,9 @@ const PayoutMethodForm = ({ payoutMethod, fieldsPrefix, host }) => {
       {isNew && (
         <Box mt={3}>
           <Field name={getFieldName('isSaved')}>
-            {({ field }) => <StyledCheckbox label={formatMessage(msg.savePayout)} checked={field.value} {...field} />}
+            {({ field }) => (
+              <StyledCheckbox label={formatMessage(msg.savePayout)} fontSize="13px" checked={field.value} {...field} />
+            )}
           </Field>
         </Box>
       )}


### PR DESCRIPTION
Update the font sizes for labels on ExpenseForm to the latest figma version.

![image](https://user-images.githubusercontent.com/1556356/90635069-0003b180-e229-11ea-8e19-666a4a338912.png)
