### PR TITLE
CommentForm: Take event from parameter

### DIFF
--- a/components/conversations/CommentForm.js
+++ b/components/conversations/CommentForm.js
@@ -93,7 +93,7 @@ const CommentForm = ({
   const [validationError, setValidationError] = useState();
   const { formatMessage } = intl;
 
-  const submitForm = async () => {
+  const submitForm = async event => {
     event.preventDefault();
     event.stopPropagation();
     if (!html) {


### PR DESCRIPTION
Fix https://sentry.io/organizations/open-collective/issues/1848409340

The code was relying on the global `event` object. This global event is not supported by all browsers and its usage is usually discouraged. From [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/event):

> Note: This property can be fragile, in that there may be situations in which the returned Event is not the expected value. In addition, Window.event is not accurate for events dispatched within shadow trees.

