### PR TITLE
Update page URL to updated slug & refetch logged in user

### DIFF
--- a/components/edit-collective/index.js
+++ b/components/edit-collective/index.js
@@ -4,6 +4,7 @@ import { defineMessages, injectIntl } from 'react-intl';
 
 import { defaultBackgroundImage } from '../../lib/constants/collectives';
 import { getErrorFromGraphqlException } from '../../lib/errors';
+import { Router } from '../../server/pages';
 
 import Body from '../Body';
 import CollectiveNavbar from '../CollectiveNavbar';
@@ -18,6 +19,7 @@ class EditCollective extends React.Component {
   static propTypes = {
     collective: PropTypes.object.isRequired, // passed from Page with addCollectiveToEditData
     LoggedInUser: PropTypes.object.isRequired, // passed from Page with withUser
+    refetchLoggedInUser: PropTypes.func.isRequired, // passed from Page with withUser
     editCollective: PropTypes.func.isRequired, // passed from Page with addEditCollectiveMutation
     intl: PropTypes.object.isRequired, // from injectIntl
   };
@@ -70,6 +72,10 @@ class EditCollective extends React.Component {
     try {
       await this.props.editCollective(collective);
       this.setState({ status: 'saved', result: { error: null } });
+      if (Router.router.query.slug !== collective.slug) {
+        Router.replaceRoute('editCollective', { slug: collective.slug });
+        await this.props.refetchLoggedInUser();
+      }
       setTimeout(() => {
         this.setState({ status: null });
       }, 3000);

--- a/pages/editCollective.js
+++ b/pages/editCollective.js
@@ -35,6 +35,7 @@ class EditCollectivePage extends React.Component {
     data: PropTypes.object, // from withData
     LoggedInUser: PropTypes.object, // from withLoggedInUser
     loadingLoggedInUser: PropTypes.bool, // from withLoggedInUser
+    refetchLoggedInUser: PropTypes.func, // from withUser
     editCollective: PropTypes.func.isRequired, // from addEditCollectiveMutation
   };
 
@@ -61,7 +62,7 @@ class EditCollectivePage extends React.Component {
   }
 
   render() {
-    const { data, editCollective, LoggedInUser, loadingLoggedInUser } = this.props;
+    const { data, editCollective, LoggedInUser, loadingLoggedInUser, refetchLoggedInUser } = this.props;
     const collective = get(data, 'Collective') || this.state.Collective;
 
     if ((data && data.loading) || loadingLoggedInUser) {
@@ -93,7 +94,12 @@ class EditCollectivePage extends React.Component {
     return (
       <div>
         <GraphQLContext.Provider value={data}>
-          <EditCollective collective={collective} LoggedInUser={LoggedInUser} editCollective={editCollective} />
+          <EditCollective
+            collective={collective}
+            LoggedInUser={LoggedInUser}
+            editCollective={editCollective}
+            refetchLoggedInUser={refetchLoggedInUser}
+          />
         </GraphQLContext.Provider>
       </div>
     );


### PR DESCRIPTION
Resolves opencollective/opencollective#3314

# Description

Added a fix to update the page URL to the updated slug onSubmit and refetch the logged-in User.

![](https://github.com/brymut/github-gifs/blob/master/ezgif.com-video-to-gif%20(3).gif?raw=true)

However, seeing an error message in the console what seems to be a Graphql error (screenshot below):
`[GraphQL error]: Message: No collective found with slug new-new-collective1, Location: [object Object], Path: Collective`

The slug in the error message is the previous slug before the edit, and is introduced when I add the `await this.props.retchLoggedInUser()`

![](https://github.com/brymut/github-gifs/blob/master/refetchissue.png?raw=true)