### PR TITLE
BannerIframe: use TopContributors component

### DIFF
--- a/components/collective-page/TopContributors.js
+++ b/components/collective-page/TopContributors.js
@@ -1,25 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { size, truncate } from 'lodash';
-import { FormattedDate, FormattedMessage } from 'react-intl';
+import { FormattedDate, FormattedMessage, useIntl } from 'react-intl';
 import styled from 'styled-components';
 
 import { CollectiveType } from '../../lib/constants/collectives';
-import withViewport from '../../lib/withViewport';
+import formatMemberRole from '../../lib/i18n/member-role';
 
 import { ContributorAvatar } from '../Avatar';
-import Container from '../Container';
 import FormattedMoneyAmount from '../FormattedMoneyAmount';
 import { Box, Flex } from '../Grid';
 import LinkContributor from '../LinkContributor';
-import { H4, P, Span } from '../Text';
-
-/** The container for Top Contributors view */
-const TopContributorsContainer = styled.div`
-  padding: 32px 16px;
-  margin-top: 48px;
-  background-color: #f5f7fa;
-`;
+import { P, Span } from '../Text';
 
 const ContributorsList = styled(Flex)`
   flex-wrap: wrap;
@@ -77,6 +69,7 @@ const getFlexBasisForCol = (nbContributors, totalContributors) => {
  * of contributors.
  */
 const ContributorsBlock = ({ title, contributors, totalNbContributors, currency, showTitle }) => {
+  const intl = useIntl();
   const isFillingFullscreen = contributors.length === totalNbContributors && contributors.length === 20;
   return (
     <Box flex="50% 1 3" style={{ flexBasis: getFlexBasisForCol(contributors.length, totalNbContributors) }}>
@@ -105,23 +98,31 @@ const ContributorsBlock = ({ title, contributors, totalNbContributors, currency,
                 </P>
               </LinkContributor>
               <P color="black.500" fontSize="10px" lineHeight="14px">
-                <FormattedMessage
-                  id="TotalDonatedSince"
-                  defaultMessage="{totalDonated} since {date}"
-                  values={{
-                    date: <FormattedDate value={contributor.since} month="short" year="numeric" />,
-                    totalDonated: (
-                      <Span fontWeight="bold">
-                        <FormattedMoneyAmount
-                          amount={contributor.totalAmountDonated}
-                          currency={currency}
-                          precision={0}
-                          abbreviateAmount
-                        />
-                      </Span>
-                    ),
-                  }}
-                />
+                {contributor.totalAmountDonated ? (
+                  <FormattedMessage
+                    id="TotalDonatedSince"
+                    defaultMessage="{totalDonated} since {date}"
+                    values={{
+                      date: <FormattedDate value={contributor.since} month="short" year="numeric" />,
+                      totalDonated: (
+                        <Span fontWeight="bold">
+                          <FormattedMoneyAmount
+                            amount={contributor.totalAmountDonated}
+                            currency={currency}
+                            precision={0}
+                            abbreviateAmount
+                          />
+                        </Span>
+                      ),
+                    }}
+                  />
+                ) : contributor.isAdmin ? (
+                  formatMemberRole(intl, 'ADMIN')
+                ) : contributor.isCore ? (
+                  formatMemberRole(intl, 'MEMBER')
+                ) : (
+                  formatMemberRole(intl, contributor.roles[0])
+                )}
               </P>
             </div>
           </ContributorItem>
@@ -189,17 +190,10 @@ const TopContributors = ({ organizations, individuals, currency }) => {
   const Blocks = nbIndividuals > nbOrgs ? [BlockIndividuals, BlockOrgs] : [BlockOrgs, BlockIndividuals];
 
   return (
-    <TopContributorsContainer>
-      <Container maxWidth={1090} m="0 auto" px={[15, 30]}>
-        <H4 fontWeight="normal" color="black.700" mb={3}>
-          <FormattedMessage id="SectionContribute.TopContributors" defaultMessage="Top financial contributors" />
-        </H4>
-        <Flex mt={2} flexWrap="wrap" justify-content="space-between">
-          {Blocks[0]}
-          {Blocks[1]}
-        </Flex>
-      </Container>
-    </TopContributorsContainer>
+    <Flex flexWrap="wrap" justify-content="space-between">
+      {Blocks[0]}
+      {Blocks[1]}
+    </Flex>
   );
 };
 
@@ -209,4 +203,4 @@ TopContributors.propTypes = {
   individuals: PropTypes.arrayOf(PropTypes.object),
 };
 
-export default withViewport(TopContributors);
+export default TopContributors;

--- a/components/collective-page/sections/Contribute.js
+++ b/components/collective-page/sections/Contribute.js
@@ -6,6 +6,7 @@ import { cloneDeep, orderBy, partition, set } from 'lodash';
 import memoizeOne from 'memoize-one';
 import dynamic from 'next/dynamic';
 import { FormattedMessage } from 'react-intl';
+import styled from 'styled-components';
 
 import { CollectiveType } from '../../../lib/constants/collectives';
 import { TierTypes } from '../../../lib/constants/tiers-types';
@@ -29,7 +30,7 @@ import Link from '../../Link';
 import LoadingPlaceholder from '../../LoadingPlaceholder';
 import StyledButton from '../../StyledButton';
 import StyledSpinner from '../../StyledSpinner';
-import { H3, P } from '../../Text';
+import { H3, H4, P } from '../../Text';
 import ContainerSectionContent from '../ContainerSectionContent';
 import ContributeCardsContainer from '../ContributeCardsContainer';
 import { editAccountSettingMutation } from '../graphql/mutations';
@@ -44,6 +45,13 @@ const AdminContributeCardsContainer = dynamic(() => import('../../contribute-car
     return <LoadingPlaceholder height={400} />;
   },
 });
+
+/** The container for Top Contributors view */
+const TopContributorsContainer = styled.div`
+  padding: 32px 16px;
+  margin-top: 48px;
+  background-color: #f5f7fa;
+`;
 
 const TIERS_ORDER_KEY = 'collectivePage.tiersOrder';
 
@@ -450,11 +458,21 @@ class SectionContribute extends React.PureComponent {
               </ContainerSectionContent>
             )}
             {!isEvent && (topOrganizations.length !== 0 || topIndividuals.length !== 0) && (
-              <TopContributors
-                organizations={topOrganizations}
-                individuals={topIndividuals}
-                currency={collective.currency}
-              />
+              <TopContributorsContainer>
+                <Container maxWidth={1090} m="0 auto" px={[15, 30]}>
+                  <H4 fontWeight="normal" color="black.700" mb={3}>
+                    <FormattedMessage
+                      id="SectionContribute.TopContributors"
+                      defaultMessage="Top financial contributors"
+                    />
+                  </H4>
+                  <TopContributors
+                    organizations={topOrganizations}
+                    individuals={topIndividuals}
+                    currency={collective.currency}
+                  />
+                </Container>
+              </TopContributorsContainer>
             )}
           </Fragment>
         )}

--- a/pages/banner-iframe.js
+++ b/pages/banner-iframe.js
@@ -1,14 +1,56 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { gql } from '@apollo/client';
+import { Query } from '@apollo/client/react/components';
 import { graphql } from '@apollo/client/react/hoc';
+import { partition } from 'lodash';
 import Head from 'next/head';
 import { FormattedMessage } from 'react-intl';
 
+import { CollectiveType } from '../lib/constants/collectives';
+import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
+
+import TopContributors from '../components/collective-page/TopContributors';
+import { Box, Flex } from '../components/Grid';
+import Loading from '../components/Loading';
 import MembersWithData from '../components/MembersWithData';
+import MessageBoxGraphqlError from '../components/MessageBoxGraphqlError';
+import StyledLink from '../components/StyledLink';
+import { H3 } from '../components/Text';
+
+const topContributorsQuery = gqlV2/* GraphQL */ `
+  query BannerTopContributors($collectiveSlug: String!) {
+    account(slug: $collectiveSlug, throwIfMissing: false) {
+      id
+      currency
+      slug
+      ... on AccountWithContributions {
+        contributors(limit: 150) {
+          totalCount
+          nodes {
+            id
+            name
+            roles
+            isAdmin
+            isCore
+            isBacker
+            since
+            image
+            description
+            collectiveSlug
+            totalAmountDonated
+            type
+            publicMessage
+            isIncognito
+          }
+        }
+      }
+    }
+  }
+`;
 
 class BannerIframe extends React.Component {
-  static getInitialProps({ query: { collectiveSlug, id, style }, req, res }) {
+  static getInitialProps({ query: { collectiveSlug, id, style, useNewFormat }, req, res }) {
     // Allow to be embedded as Iframe everywhere
     if (res) {
       res.removeHeader('X-Frame-Options');
@@ -17,7 +59,7 @@ class BannerIframe extends React.Component {
       }
     }
 
-    return { collectiveSlug, id, style };
+    return { collectiveSlug, id, style, useNewFormat: Boolean(useNewFormat) };
   }
 
   static propTypes = {
@@ -25,6 +67,7 @@ class BannerIframe extends React.Component {
     id: PropTypes.string, // from getInitialProps
     style: PropTypes.object, // from getInitialProps
     data: PropTypes.object.isRequired, // from withData
+    useNewFormat: PropTypes.bool,
   };
 
   constructor(props) {
@@ -73,8 +116,54 @@ class BannerIframe extends React.Component {
     window.parent.postMessage(message, '*');
   };
 
+  renderTopContributors = collective => {
+    const [orgs, individuals] = partition(collective.contributors.nodes, c => c.type !== CollectiveType.USER);
+    return <TopContributors organizations={orgs} individuals={individuals} currency={collective.currency} />;
+  };
+
+  renderNewFormat = () => {
+    return (
+      <Query
+        query={topContributorsQuery}
+        variables={{ collectiveSlug: this.props.collectiveSlug }}
+        context={API_V2_CONTEXT}
+      >
+        {({ data, error, loading }) =>
+          loading ? (
+            <Loading />
+          ) : error ? (
+            <MessageBoxGraphqlError error={error} />
+          ) : (
+            <Box>
+              <Flex flexDirection="column" alignItems="center" mb={3}>
+                <H3 fontSize="18px" lineHeight="28px">
+                  <FormattedMessage
+                    id="NewContributionFlow.Join"
+                    defaultMessage="Join {numberOfContributors} other fellow contributors"
+                    values={{ numberOfContributors: data.account.contributors.totalCount }}
+                  />
+                </H3>
+                <StyledLink openInNewTab href={`https://opencollective.com/${this.props.collectiveSlug}`}>
+                  <FormattedMessage
+                    id="widget.contributeOnOpenCollective"
+                    defaultMessage="Contribute on Open Collective"
+                  />
+                </StyledLink>
+              </Flex>
+              {this.renderTopContributors(data.account)}
+            </Box>
+          )
+        }
+      </Query>
+    );
+  };
+
   render() {
-    const { collectiveSlug, data } = this.props;
+    const { collectiveSlug, data, useNewFormat } = this.props;
+
+    if (useNewFormat) {
+      return this.renderNewFormat();
+    }
 
     let style;
     try {


### PR DESCRIPTION
A quick experiment to use the `TopContributors` component for the banner iframe. The main goal of this PR is to see how it looks like for different collectives, and eventually followup later to use this new layout by default. The expected benefits are:
- We'll be able to remove legacy code, including the `MembersWithData` and related
- Better responsiveness
- Better performances (because the `contributors` field is cached)
- Better design (this one is more compact)
- Design consistency

![Peek 2020-08-24 09-58](https://user-images.githubusercontent.com/1556356/91018857-6c4b3000-e5f0-11ea-9ed2-39202fe377cc.gif)

---

Still missing compared to current widget:
- Show total number of contributors
- Link to "Contribute on Open Collective"

---

To test:
- https://kivy.org/
- https://sdkman.io/
- https://visjs.org/
- https://casbin.org/