### PR TITLE
Fix contributor avatar by passing image/imageUrl

### DIFF
--- a/components/Avatar.js
+++ b/components/Avatar.js
@@ -78,7 +78,7 @@ Avatar.propTypes = {
 export const ContributorAvatar = ({ contributor, radius, ...styleProps }) => {
   const image = contributor.isIncognito
     ? defaultImage['ANONYMOUS']
-    : getCollectiveImage({ slug: contributor.collectiveSlug });
+    : getCollectiveImage({ slug: contributor.collectiveSlug, imageUrl: contributor.image });
 
   return <StyledAvatar size={radius} type={contributor.type} src={image} title={contributor.name} {...styleProps} />;
 };
@@ -87,6 +87,7 @@ ContributorAvatar.propTypes = {
   /** Collective object */
   contributor: PropTypes.shape({
     name: PropTypes.string,
+    image: PropTypes.string,
     collectiveSlug: PropTypes.string,
     isIncognito: PropTypes.bool,
     type: PropTypes.oneOf(['USER', 'COLLECTIVE', 'FUND', 'ORGANIZATION', 'CHAPTER', 'ANONYMOUS']),


### PR DESCRIPTION
that way, it will includes the hash and avatar should be refreshed as soon as they change

Fix: https://github.com/opencollective/opencollective/issues/3210 https://github.com/opencollective/opencollective/issues/3428