### PR TITLE
Add nofollow attribute to StyledLink

### DIFF
--- a/components/PledgedCollectivePage.js
+++ b/components/PledgedCollectivePage.js
@@ -100,7 +100,7 @@ const PledgedCollectivePage = ({ collective }) => {
           <H2 as="h1">{collective.name}</H2>
 
           <Box mb={4} mt={3}>
-            <StyledLink href={website} color="primary.500" fontSize="12px">
+            <StyledLink href={website} color="primary.500" fontSize="12px" openInNewTabNoFollow>
               <ExternalLinkAlt size="1em" /> {website}
             </StyledLink>
           </Box>

--- a/components/StyledLink.js
+++ b/components/StyledLink.js
@@ -19,6 +19,12 @@ const StyledLink = styled.a.attrs(props => {
       rel: 'noopener noreferrer',
     };
   }
+  if (props.openInNewTabNoFollow) {
+    return {
+      target: '_blank',
+      rel: 'noopener noreferrer nofollow',
+    };
+  }
 })`
   color: ${props => themeGet(`colors.primary.${props.colorShade}`)};
   cursor: pointer;
@@ -106,6 +112,8 @@ StyledLink.propTypes = {
   truncateOverflow: PropTypes.bool,
   /** If true, the link will open in a new tab when clicked */
   openInNewTab: PropTypes.bool,
+  /** If true, the link will open in a new tab and also adds rel=nofollow */
+  openInNewTabNoFollow: PropTypes.bool,
   /** Color Shade, defaults to 500 */
   colorShade: PropTypes.number,
 };

--- a/components/collective-page/hero/Hero.js
+++ b/components/collective-page/hero/Hero.js
@@ -222,7 +222,7 @@ const Hero = ({ collective, host, isAdmin, onPrimaryColorChange, callsToAction, 
                     href={collective.website}
                     title={intl.formatMessage(Translations.website)}
                     aria-label="Website link"
-                    openInNewTab
+                    openInNewTabNoFollow
                   >
                     <StyledRoundButton size={32} mr={3}>
                       <Globe size={14} />


### PR DESCRIPTION
Since we use `StyledLink` for external links, adding the `nofollow` attribute (along with the current `noopener` and `noreferrer` attributes) ensure that we aren't giving an SEO boost to any external websites that are linked on i.e. Collective profiles.

I would like to add the same attribute to the sponsors widget that we embed on other websites as well.