### PR TITLE
Refactor from NODE_ENV to OC_ENV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@ on:
 
 env:
   TZ: UTC
-  NODE_ENV: ci
+  OC_ENV: ci
+  NODE_ENV: test
   WEBSITE_URL: http://localhost:3000
   API_URL: http://localhost:3060
   API_KEY: dvl-1510egmf4a23d80342403fb599qd

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,8 @@ env:
   CI: true
   TZ: UTC
   E2E_TEST: 1
-  NODE_ENV: ci
+  OC_ENV: ci
+  NODE_ENV: ci # TODO: should be ideally development, test or production
   PGHOST: localhost
   PGUSER: postgres
   WEBSITE_URL: http://localhost:3000

--- a/components/ErrorPage.js
+++ b/components/ErrorPage.js
@@ -121,8 +121,8 @@ class ErrorPage extends React.Component {
   unknownError() {
     const message = get(this.props, 'data.error.message');
     const stackTrace = get(this.props, 'data.error.stack');
-    const expandError = process.env.NODE_ENV !== 'production';
-    const fontSize = ['ci', 'e2e', 'test'].includes(process.env.NODE_ENV) ? 22 : 13;
+    const expandError = process.env.OC_ENV !== 'production';
+    const fontSize = ['ci', 'e2e', 'test'].includes(process.env.OC_ENV) ? 22 : 13;
 
     return (
       <Flex flexDirection="column" alignItems="center" px={2} py={[4, 6]}>

--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -563,7 +563,7 @@ class CreateOrderPage extends React.Component {
   };
 
   isValidRedirect(url) {
-    const validationParams = process.env.NODE_ENV === 'production' ? {} : { require_tld: false };
+    const validationParams = process.env.OC_ENV === 'production' ? {} : { require_tld: false };
 
     return isURL(url, validationParams);
   }

--- a/env.js
+++ b/env.js
@@ -30,11 +30,11 @@ const defaults = {
   OC_SECRET: crypto.randomBytes(16).toString('hex'),
 };
 
-if (process.env.NODE_ENV === 'production') {
+if (['production', 'staging'].includes(process.env.OC_ENV)) {
   defaults.TW_API_COLLECTIVE_SLUG = 'opencollectiveinc';
 }
 
-if (process.env.NODE_ENV === 'e2e') {
+if (['e2e'].includes(process.env.OC_ENV)) {
   defaults.API_URL = 'http://localhost:3060';
   defaults.API_KEY = 'dvl-1510egmf4a23d80342403fb599qd';
 }

--- a/lib/constants/collectives.js
+++ b/lib/constants/collectives.js
@@ -33,7 +33,7 @@ export const defaultImage = {
 };
 
 /** The ID of the open source collective */
-export const OPENSOURCE_COLLECTIVE_ID = ['staging', 'production'].includes(process.env.NODE_ENV) ? 11004 : 9805;
+export const OPENSOURCE_COLLECTIVE_ID = ['staging', 'production'].includes(process.env.OC_ENV) ? 11004 : 9805;
 
 /**
  * Map categories to their main tag.

--- a/lib/graphql/mutations.js
+++ b/lib/graphql/mutations.js
@@ -64,7 +64,6 @@ export const addCreateCollectiveMutation = graphql(createCollectiveMutation, {
         'ParentCollectiveId',
         'isIncognito',
         'data',
-        CollectiveInputType,
       ]);
       CollectiveInputType.tiers = (collective.tiers || []).map(tier =>
         pick(tier, ['type', 'name', 'description', 'amount', 'maxQuantity']),

--- a/next.config.js
+++ b/next.config.js
@@ -13,6 +13,7 @@ const nextConfig = {
       // Set extra environment variables accessible through process.env.*
       // Will be replaced by webpack by their values!
       new webpack.EnvironmentPlugin({
+        OC_ENV: null,
         API_KEY: null,
         API_URL: null,
         PDF_SERVICE_URL: null,
@@ -22,7 +23,6 @@ const nextConfig = {
         ONBOARDING_MODAL: true,
         NEW_HOST_APPLICATION_FLOW: null,
         TW_API_COLLECTIVE_SLUG: null,
-        OC_ENV: null,
         NEW_CONTRIBUTION_FLOW: false,
         ENABLE_GUEST_CONTRIBUTIONS: false,
       }),
@@ -120,7 +120,7 @@ const nextConfig = {
       },
     });
 
-    if (['ci', 'e2e'].includes(process.env.NODE_ENV)) {
+    if (['ci', 'e2e'].includes(process.env.OC_ENV)) {
       config.optimization.minimize = false;
     }
 

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   },
   "scripts": {
     "build": "npm-run-all build:updates build:next build:server",
-    "build:e2e": "cross-env NODE_ENV=e2e npm run build",
+    "build:e2e": "cross-env NODE_ENV=production OC_ENV=e2e npm run build",
     "build:clean": "shx rm -rf dist .next",
     "build:langs": "npm run langs:update",
     "build:next": "cross-env scripts/build_next.sh",
@@ -138,7 +138,7 @@
     "prettier:write": "npm run prettier -- --write",
     "start": "node --icu-data-dir=node_modules/full-icu dist/server",
     "start:ci": "nyc --silent --exclude \".next/**\" node server",
-    "start:e2e": "cross-env TZ=UTC NODE_ENV=e2e node --icu-data-dir=node_modules/full-icu server",
+    "start:e2e": "cross-env TZ=UTC NODE_ENV=production OC_ENV=e2e node --icu-data-dir=node_modules/full-icu server",
     "styleguide:build": "styleguidist build",
     "styleguide:dev": "styleguidist server",
     "test": "npm run test:jest",
@@ -149,7 +149,7 @@
     "test:e2e:1": "CYPRESS_TEST_FILES=1*.js npm run cypress:run",
     "test:e2e:2": "CYPRESS_TEST_FILES=2*.js npm run cypress:run",
     "test:e2e:3": "CYPRESS_TEST_FILES=3*.js npm run cypress:run",
-    "test:jest": "cross-env TZ=UTC jest components lib pages",
+    "test:jest": "cross-env NODE_ENV=test TZ=UTC jest components lib pages",
     "test:update": "npm run test:jest -- --updateSnapshot"
   },
   "devDependencies": {

--- a/server/content-security-policy.js
+++ b/server/content-security-policy.js
@@ -1,6 +1,6 @@
 const mergeWith = require('lodash/mergeWith');
 const { kebabCase, omit } = require('lodash');
-const env = process.env.NODE_ENV;
+const env = process.env.OC_ENV;
 
 const SELF = "'self'";
 const UNSAFE_INLINE = "'unsafe-inline'";
@@ -95,7 +95,7 @@ const getHeaderValueFromDirectives = directives => {
 };
 
 const getContentSecurityPolicyConfig = () => {
-  if (env === 'development') {
+  if (env === 'development' || env === 'e2e') {
     return {
       reportOnly: true,
       directives: generateDirectives({
@@ -103,44 +103,38 @@ const getContentSecurityPolicyConfig = () => {
         scriptSrc: [UNSAFE_INLINE, UNSAFE_EVAL], // For NextJS scripts
       }),
     };
+  } else if (env === 'staging') {
+    return {
+      reportOnly: false,
+      directives: generateDirectives({
+        imgSrc: [
+          'opencollective-staging.s3.us-west-1.amazonaws.com',
+          'opencollective-staging.s3-us-west-1.amazonaws.com',
+        ],
+      }),
+      reportUri: ['https://o105108.ingest.sentry.io/api/1736806/security/?sentry_key=2ab0f7da3f56423d940f36370df8d625'],
+    };
   } else if (env === 'production') {
-    if (process.env.WEBSITE_URL === 'https://staging.opencollective.com') {
-      return {
-        reportOnly: false,
-        directives: generateDirectives({
-          imgSrc: [
-            'opencollective-staging.s3.us-west-1.amazonaws.com',
-            'opencollective-staging.s3-us-west-1.amazonaws.com',
-          ],
-        }),
-        reportUri: [
-          'https://o105108.ingest.sentry.io/api/1736806/security/?sentry_key=2ab0f7da3f56423d940f36370df8d625',
+    return {
+      reportOnly: true,
+      directives: generateDirectives({
+        imgSrc: [
+          'opencollective-production.s3.us-west-1.amazonaws.com',
+          'opencollective-production.s3-us-west-1.amazonaws.com',
         ],
-      };
-    } else if (process.env.WEBSITE_URL === 'https://opencollective.com') {
-      return {
-        reportOnly: true,
-        directives: generateDirectives({
-          imgSrc: [
-            'opencollective-production.s3.us-west-1.amazonaws.com',
-            'opencollective-production.s3-us-west-1.amazonaws.com',
-          ],
-        }),
-        reportUri: [
-          'https://o105108.ingest.sentry.io/api/1736806/security/?sentry_key=2ab0f7da3f56423d940f36370df8d625',
-        ],
-      };
-    } else {
-      // Third party deploy, or Zeit deploy preview
-      return {
-        reportOnly: true,
-        directives: generateDirectives(),
-      };
-    }
+      }),
+      reportUri: ['https://o105108.ingest.sentry.io/api/1736806/security/?sentry_key=2ab0f7da3f56423d940f36370df8d625'],
+    };
+  } else if (env === 'test' || env === 'ci') {
+    // Disabled
+    return false;
+  } else {
+    // Third party deploy, or Zeit deploy preview
+    return {
+      reportOnly: true,
+      directives: generateDirectives(),
+    };
   }
-
-  // Disabled in other environments
-  return false;
 };
 
 module.exports = {

--- a/server/hyperwatch.js
+++ b/server/hyperwatch.js
@@ -82,7 +82,7 @@ const load = async app => {
 
   // Configure access Logs in dev and production
 
-  const consoleLogOutput = process.env.NODE_ENV === 'development' ? 'console' : 'text';
+  const consoleLogOutput = process.env.OC_ENV === 'development' ? 'console' : 'text';
   pipeline.getNode('main').map(log => console.log(lib.logger.defaultFormatter.format(log, consoleLogOutput)));
 
   // Start

--- a/server/index.js
+++ b/server/index.js
@@ -21,8 +21,7 @@ const app = express();
 
 app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal'].concat(cloudflareIps));
 
-const env = process.env.NODE_ENV;
-const dev = env === 'development';
+const dev = process.env.NODE_ENV === 'development';
 
 const nextApp = next({ dev, dir: path.dirname(__dirname) });
 

--- a/server/intl.js
+++ b/server/intl.js
@@ -47,7 +47,7 @@ function middleware() {
     }
 
     // No auto-detection in test environments
-    if (['test', 'e2e', 'ci'].includes(process.env.NODE_ENV)) {
+    if (['test', 'e2e', 'ci'].includes(process.env.OC_ENV)) {
       req.locale = req.language || 'en';
     } else {
       req.locale = req.language || accepts(req).language(supportedLanguages) || 'en';

--- a/server/logger.js
+++ b/server/logger.js
@@ -3,7 +3,7 @@ const winston = require('winston');
 function getLogLevel() {
   if (process.env.LOG_LEVEL) {
     return process.env.LOG_LEVEL;
-  } else if (['test', 'e2e', 'ci'].includes(process.env.NODE_ENV)) {
+  } else if (['test', 'e2e', 'ci'].includes(process.env.OC_ENV)) {
     return 'warn';
   } else {
     return 'info';

--- a/server/routes.js
+++ b/server/routes.js
@@ -90,7 +90,7 @@ module.exports = (expressApp, nextApp) => {
    */
   app.get('/robots.txt', (req, res) => {
     res.setHeader('Content-Type', 'text/plain');
-    if (process.env.NODE_ENV !== 'production' || process.env.ROBOTS_DISALLOW) {
+    if (process.env.OC_ENV !== 'production' || process.env.ROBOTS_DISALLOW) {
       res.send('User-agent: *\nDisallow: /');
     } else {
       res.send('User-agent: *\nAllow: /');
@@ -98,7 +98,7 @@ module.exports = (expressApp, nextApp) => {
   });
 
   // This is used by Cypress to collect server side coverage
-  if (process.env.NODE_ENV === 'e2e' || process.env.E2E_TEST) {
+  if (process.env.OC_ENV === 'e2e' || process.env.E2E_TEST) {
     app.get('/__coverage__', (req, res) => {
       res.json({
         coverage: global.__coverage__ || null,

--- a/server/sentry.js
+++ b/server/sentry.js
@@ -6,11 +6,7 @@ const Sentry = require('@sentry/node');
  * Returns the Sentry environment based on env and current server.
  */
 const getSentryEnvironment = () => {
-  if (process.env.NODE_ENV === 'production') {
-    return process.env.WEBSITE_URL === 'https://staging.opencollective.com' ? 'staging' : 'production';
-  } else {
-    return process.env.NODE_ENV;
-  }
+  return process.env.OC_ENV;
 };
 
 /**


### PR DESCRIPTION
following directions from https://github.com/vercel/next.js/blob/master/errors/non-standard-node-env.md

- `NODE_ENV` should only be production/development/test
- `OC_ENV` should be production/staging/e2e/ci/test/development

What's changing:
- staging: `NODE_ENV=production OC_ENV=staging` (before `NODE_ENV=production OC_ENV=production`)
- e2e: `NODE_ENV=production OC_ENV=e2e` (before `NODE_ENV=e2e OC_ENV=e2e`)
- ci: `NODE_ENV=production OC_ENV=ci` (before `NODE_ENV=ci OC_ENV=ci`)

What's not changing:
- production: `NODE_ENV=production OC_ENV=production`
- test: `NODE_ENV=test OC_ENV=test`
- development: `NODE_ENV=development OC_ENV=development`

Todo:
- configure `OC_ENV` in production (default to NODE_ENV anyway)
- configure `OC_ENV` in staging
