### PR TITLE
Improve recurring contributions test 39 resilience

### DIFF
--- a/components/NewCreditCardForm.js
+++ b/components/NewCreditCardForm.js
@@ -113,7 +113,7 @@ class NewCreditCardFormWithoutStripe extends React.Component {
   render() {
     const { intl, error, hasSaveCheckBox, hidePostalCode } = this.props;
     return (
-      <Flex flexDirection="column" data-cy="new-credit-card-form">
+      <Flex flexDirection="column">
         <StyledCardElement
           hidePostalCode={hidePostalCode}
           onChange={this.onCardChange}

--- a/test/cypress/integration/39-recurring-contributions.test.js
+++ b/test/cypress/integration/39-recurring-contributions.test.js
@@ -29,7 +29,6 @@ describe('Recurring contributions', () => {
       cy.getByDataCy('recurring-contribution-menu-payment-option').click();
       cy.getByDataCy('recurring-contribution-payment-menu').should('exist');
       cy.getByDataCy('recurring-contribution-add-pm-button').click();
-      cy.getByDataCy('new-credit-card-form').should('exist');
       cy.wait(5000);
       cy.fillStripeInput({
         card: { creditCardNumber: 5555555555554444, expirationDate: '07/23', cvcCode: 713, postalCode: 12345 },


### PR DESCRIPTION
Related to opencollective/opencollective#3347

The test always got hung up on:

<img width="953" alt="Screenshot 2020-08-25 at 17 01 09" src="https://user-images.githubusercontent.com/37520401/91198566-9c7bf700-e6f4-11ea-9b5c-9ae33479b283.png">

Looking at similar tests that also use the new credit card form, they don't check for the presence of that element with `data-cy=new-credit-card-form`. They just wait a few seconds for Stripe to load, and then continue inputting the credit card number.

Running locally, this test never failed for me, but hopefully this might improve the resilience on CI.