### PR TITLE
Fixes & enhancements for host updates

### DIFF
--- a/components/StyledUpdate.js
+++ b/components/StyledUpdate.js
@@ -17,6 +17,7 @@ import Container from './Container';
 import EditUpdateForm from './EditUpdateForm';
 import { Box, Flex } from './Grid';
 import Link from './Link';
+import LinkCollective from './LinkCollective';
 import MessageBox from './MessageBox';
 import PublishUpdateBtnWithData from './PublishUpdateBtnWithData';
 import StyledHr from './StyledHr';
@@ -154,7 +155,7 @@ class StyledUpdate extends Component {
                 }),
                 author: (
                   <Box as="span" mr={2} fontSize="12px">
-                    {update.fromCollective.name}
+                    <LinkCollective collective={update.fromCollective} />
                   </Box>
                 ),
               }}
@@ -164,12 +165,12 @@ class StyledUpdate extends Component {
           <Box as="span" mr={1} fontSize="12px">
             <FormattedMessage
               id="update.createdAtBy"
-              defaultMessage={'Created on {date} (draft) by {author}'}
+              defaultMessage="Created on {date} (draft) by {author}"
               values={{
                 date: formatDate(update.createdAt),
                 author: (
                   <Box as="span" mr={2} fontSize="12px">
-                    {update.fromCollective.name}
+                    <LinkCollective collective={update.fromCollective} />
                   </Box>
                 ),
               }}
@@ -292,9 +293,9 @@ class StyledUpdate extends Component {
             <Container width="100%">
               <Flex mb={2}>
                 <Container mr={20}>
-                  <a href={`/${update.fromCollective.slug}`} title={update.fromCollective.name}>
+                  <LinkCollective collective={update.fromCollective}>
                     <Avatar collective={update.fromCollective} radius={40} />
-                  </a>
+                  </LinkCollective>
                 </Container>
                 <Box>
                   {this.renderUpdateTitle()}

--- a/components/UpdatesWithData.js
+++ b/components/UpdatesWithData.js
@@ -17,7 +17,6 @@ class UpdatesWithData extends React.Component {
     limit: PropTypes.number,
     compact: PropTypes.bool, // compact view for homepage (can't edit update, don't show header)
     defaultAction: PropTypes.string, // "new" to open the new update form by default
-    includeHostedCollectives: PropTypes.bool,
     LoggedInUser: PropTypes.object,
     data: PropTypes.object,
     fetchMore: PropTypes.func,
@@ -40,7 +39,7 @@ class UpdatesWithData extends React.Component {
   }
 
   render() {
-    const { data, LoggedInUser, collective, compact, includeHostedCollectives } = this.props;
+    const { data, LoggedInUser, collective, compact } = this.props;
 
     if (data.error) {
       return <Error message={data.error.message} />;
@@ -90,7 +89,6 @@ class UpdatesWithData extends React.Component {
             editable={!compact}
             fetchMore={this.props.fetchMore}
             LoggedInUser={LoggedInUser}
-            includeHostedCollectives={includeHostedCollectives}
           />
         </Box>
       </div>
@@ -99,13 +97,8 @@ class UpdatesWithData extends React.Component {
 }
 
 const updatesQuery = gql`
-  query Updates($CollectiveId: Int!, $limit: Int, $offset: Int, $includeHostedCollectives: Boolean) {
-    allUpdates(
-      CollectiveId: $CollectiveId
-      limit: $limit
-      offset: $offset
-      includeHostedCollectives: $includeHostedCollectives
-    ) {
+  query Updates($CollectiveId: Int!, $limit: Int, $offset: Int) {
+    allUpdates(CollectiveId: $CollectiveId, limit: $limit, offset: $offset) {
       id
       slug
       title

--- a/pages/updates.js
+++ b/pages/updates.js
@@ -45,12 +45,7 @@ class UpdatesPage extends React.Component {
           />
 
           <div className="content">
-            <UpdatesWithData
-              collective={collective}
-              includeHostedCollectives={collective.isHost}
-              defaultAction={action}
-              LoggedInUser={LoggedInUser}
-            />
+            <UpdatesWithData collective={collective} defaultAction={action} LoggedInUser={LoggedInUser} />
           </div>
         </Body>
 


### PR DESCRIPTION
- Don't crash if fromCollective is null - Resolve https://sentry.io/organizations/open-collective/issues/1859762271/
- Don't show hosted collectives updates - this doesn't make much sense now that hosts can have their own updates, or at least it should be in a separate tab.