### PR TITLE
StyledSelect: Always use a portal

### DIFF
--- a/components/CreateCollectiveMiniForm.js
+++ b/components/CreateCollectiveMiniForm.js
@@ -353,7 +353,6 @@ const CreateCollectiveMiniForm = ({
                           <InputTypeCountry
                             {...field}
                             onChange={country => form.setFieldValue(name, country)}
-                            menuPortalTarget={document?.body}
                             maxMenuHeight={95}
                           />
                         );

--- a/components/StyledSelect.js
+++ b/components/StyledSelect.js
@@ -115,7 +115,9 @@ export const makeStyledSelect = SelectComponent => styled(SelectComponent).attrs
     error,
     controlStyles,
     isSearchable,
+    menuPortalTarget,
   }) => ({
+    menuPortalTarget: menuPortalTarget === null || typeof document === 'undefined' ? undefined : document.body,
     isDisabled: disabled || isDisabled,
     placeholder: placeholder || intl.formatMessage(Messages.placeholder),
     loadingMessage: () => intl.formatMessage(Messages.loading),
@@ -227,6 +229,8 @@ StyledSelect.propTypes = {
   /** Default option */
   defaultValue: PropTypes.object,
   controlStyles: PropTypes.object,
+  /** To render menu in a portal */
+  menuPortalTarget: PropTypes.any,
   // Styled-system
   ...propTypes.typography,
   ...propTypes.layout,

--- a/components/edit-collective/sections/EditCollectivePage.js
+++ b/components/edit-collective/sections/EditCollectivePage.js
@@ -145,7 +145,6 @@ const CollectiveSectionEntry = ({
           const restrictedTo = value === 'ADMIN' ? ['ADMIN'] : [];
           onSectionToggle(section, isEnabled, restrictedTo);
         }}
-        menuPortalTarget={document.body}
         formatOptionLabel={option => <Span fontSize="11px">{option.label}</Span>}
       />
       {/**

--- a/components/host-dashboard/AddFundsModal.js
+++ b/components/host-dashboard/AddFundsModal.js
@@ -203,7 +203,6 @@ const AddFunds = ({ host, collective, ...props }) => {
                       inputId={field.id}
                       types={['USER', 'ORGANIZATION']}
                       creatable
-                      menuPortalTarget={document.body}
                       error={field.error}
                       createCollectiveOptionalFields={['location.address', 'location.country']}
                       onBlur={() => form.setFieldTouched(field.name, true)}

--- a/components/new-contribution-flow/FeesOnTopInput.js
+++ b/components/new-contribution-flow/FeesOnTopInput.js
@@ -95,7 +95,6 @@ const FeesOnTopInput = ({ currency, amount, fees, interval, onChange }) => {
           options={options}
           onChange={setSelectedOption}
           value={selectedOption}
-          menuPortalTarget={typeof document === 'undefined' ? undefined : document.body}
         />
       </Flex>
       {selectedOption.value === 'CUSTOM' && (

--- a/components/onboarding-modal/OnboardingContentBox.js
+++ b/components/onboarding-modal/OnboardingContentBox.js
@@ -131,7 +131,6 @@ class OnboardingContentBox extends React.Component {
 
             <Flex my={2} px={3} flexDirection="column" width="100%">
               <CollectivePickerAsync
-                menuPortalTarget={document.body}
                 creatable
                 collective={null}
                 types={['USER']}

--- a/components/recurring-contributions/UpdateOrderPopUp.js
+++ b/components/recurring-contributions/UpdateOrderPopUp.js
@@ -211,7 +211,6 @@ const UpdateOrderPopUp = ({ setMenuState, contribution, createNotification, setS
                     <Fragment>
                       <StyledSelect
                         data-cy="tier-amount-select"
-                        menuPortalTarget={document.body}
                         onChange={setSelectedAmountOption}
                         value={selectedAmountOption}
                         options={amountOptions}


### PR DESCRIPTION
Fix the issue reported in https://opencollective.slack.com/archives/C8MUDBH9N/p1598882164002900 that prevented people from creating expenses by always rendering `StyledSelect`'s menu in a portal. Two arguments for making it the default:
1. It's not the first time we have such issue. Not rendering with portals is a problem whenever you render in a modal or if parent have some specific `display` property set.
2. We are not yet aware of any downside induced by rendering it in a portal

![image](https://user-images.githubusercontent.com/1556356/91729210-7f3ba280-eba4-11ea-902e-7b07726f05c4.png)
