### PR TITLE
CSP: Add sentry root domain

### DIFF
--- a/server/content-security-policy.js
+++ b/server/content-security-policy.js
@@ -31,6 +31,7 @@ const COMMON_DIRECTIVES = {
     'wtfismyip.com',
     '*.paypal.com',
     '*.paypalobjects.com',
+    'sentry.io',
     '*.sentry.io',
   ],
   scriptSrc: [


### PR DESCRIPTION
It seems that root domain is not included when you write `*.sentry.io`