### PR TITLE
Signin page minor enhancements

### DIFF
--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1431,6 +1431,7 @@
   "SignIn.SuccessDetails": "You’ll be redirected from the link in the email, you can safely close this tab.",
   "signin.unknownEmail": "There is no user with this email address.",
   "signin.usingEmail": "Sign in using your email address:",
+  "signinLinkSent.": "<Link>Learn more</Link> about passwordless login.",
   "SkipOnboarding": "Skip onboarding",
   "SortBy": "Sort by",
   "startDateAndTime": "start date and time",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1431,6 +1431,7 @@
   "SignIn.SuccessDetails": "You’ll be redirected from the link in the email, you can safely close this tab.",
   "signin.unknownEmail": "There is no user with this email address.",
   "signin.usingEmail": "Sign in using your email address:",
+  "signinLinkSent.": "<Link>Learn more</Link> about passwordless login.",
   "SkipOnboarding": "Přeskočit průvodce",
   "SortBy": "Sort by",
   "startDateAndTime": "start date and time",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1431,6 +1431,7 @@
   "SignIn.SuccessDetails": "Sie werden von dem Link in der E-Mail weitergeleitet, Sie können diesen Tab schließen.",
   "signin.unknownEmail": "Es gibt kein Konto mit dieser E-Mail-Adresse.",
   "signin.usingEmail": "Melden Sie sich mit Ihrer E-Mail-Adresse an:",
+  "signinLinkSent.": "<Link>Learn more</Link> about passwordless login.",
   "SkipOnboarding": "Skip onboarding",
   "SortBy": "Sort by",
   "startDateAndTime": "start date and time",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1431,6 +1431,7 @@
   "SignIn.SuccessDetails": "You’ll be redirected from the link in the email, you can safely close this tab.",
   "signin.unknownEmail": "There is no user with this email address.",
   "signin.usingEmail": "Sign in using your email address:",
+  "signinLinkSent.": "<Link>Learn more</Link> about passwordless login.",
   "SkipOnboarding": "Skip onboarding",
   "SortBy": "Sort by",
   "startDateAndTime": "start date and time",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1431,6 +1431,7 @@
   "SignIn.SuccessDetails": "You’ll be redirected from the link in the email, you can safely close this tab.",
   "signin.unknownEmail": "No hay ningún usuario con esta dirección de correo electrónico.",
   "signin.usingEmail": "Inicia sesión con tu dirección de correo electrónico:",
+  "signinLinkSent.": "<Link>Learn more</Link> about passwordless login.",
   "SkipOnboarding": "Skip onboarding",
   "SortBy": "Sort by",
   "startDateAndTime": "fecha y hora de inicio",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1431,6 +1431,7 @@
   "SignIn.SuccessDetails": "Vous serez redirigé·e depuis le lien dans l'email, vous pouvez fermer cet onglet.",
   "signin.unknownEmail": "Il n'y a aucun utilisateur avec cette adresse e-mail.",
   "signin.usingEmail": "Connectez-vous avec votre adresse email :",
+  "signinLinkSent.": "<Link>Learn more</Link> about passwordless login.",
   "SkipOnboarding": "Ignorer l'introduction",
   "SortBy": "Trier par",
   "startDateAndTime": "date et heure de début",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1431,6 +1431,7 @@
   "SignIn.SuccessDetails": "You’ll be redirected from the link in the email, you can safely close this tab.",
   "signin.unknownEmail": "Non ci sono utenti con questo indirizzo email.",
   "signin.usingEmail": "Entra usando il tuo indirizzo email:",
+  "signinLinkSent.": "<Link>Learn more</Link> about passwordless login.",
   "SkipOnboarding": "Skip onboarding",
   "SortBy": "Sort by",
   "startDateAndTime": "start date and time",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1431,6 +1431,7 @@
   "SignIn.SuccessDetails": "You’ll be redirected from the link in the email, you can safely close this tab.",
   "signin.unknownEmail": "このメールアドレスを使っているユーザーはいません。",
   "signin.usingEmail": "メールアドレスでログイン:",
+  "signinLinkSent.": "<Link>Learn more</Link> about passwordless login.",
   "SkipOnboarding": "Skip onboarding",
   "SortBy": "Sort by",
   "startDateAndTime": "start date and time",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1431,6 +1431,7 @@
   "SignIn.SuccessDetails": "You’ll be redirected from the link in the email, you can safely close this tab.",
   "signin.unknownEmail": "There is no user with this email address.",
   "signin.usingEmail": "이메일 주소로 로그인하기:",
+  "signinLinkSent.": "<Link>Learn more</Link> about passwordless login.",
   "SkipOnboarding": "Skip onboarding",
   "SortBy": "Sort by",
   "startDateAndTime": "start date and time",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1431,6 +1431,7 @@
   "SignIn.SuccessDetails": "You’ll be redirected from the link in the email, you can safely close this tab.",
   "signin.unknownEmail": "There is no user with this email address.",
   "signin.usingEmail": "Sign in using your email address:",
+  "signinLinkSent.": "<Link>Learn more</Link> about passwordless login.",
   "SkipOnboarding": "Skip onboarding",
   "SortBy": "Sort by",
   "startDateAndTime": "start date and time",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1431,6 +1431,7 @@
   "SignIn.SuccessDetails": "Você será redirecionado pelo link no email, pode fechar esta aba tranquilamente.",
   "signin.unknownEmail": "Não há usuário com este endereço de e-mail.",
   "signin.usingEmail": "Entre com seu endereço de e-mail:",
+  "signinLinkSent.": "<Link>Learn more</Link> about passwordless login.",
   "SkipOnboarding": "Pular integração",
   "SortBy": "Sort by",
   "startDateAndTime": "data e hora de início",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1431,6 +1431,7 @@
   "SignIn.SuccessDetails": "You’ll be redirected from the link in the email, you can safely close this tab.",
   "signin.unknownEmail": "Нет пользователя с такой почтой.",
   "signin.usingEmail": "Авторизоваться по электронной почте:",
+  "signinLinkSent.": "<Link>Learn more</Link> about passwordless login.",
   "SkipOnboarding": "Skip onboarding",
   "SortBy": "Sort by",
   "startDateAndTime": "start date and time",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1431,6 +1431,7 @@
   "SignIn.SuccessDetails": "You’ll be redirected from the link in the email, you can safely close this tab.",
   "signin.unknownEmail": "There is no user with this email address.",
   "signin.usingEmail": "Sign in using your email address:",
+  "signinLinkSent.": "<Link>Learn more</Link> about passwordless login.",
   "SkipOnboarding": "Skip onboarding",
   "SortBy": "Sort by",
   "startDateAndTime": "start date and time",

--- a/pages/signinLinkSent.js
+++ b/pages/signinLinkSent.js
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 
 import Container from '../components/Container';
 import { Box, Flex } from '../components/Grid';
+import { getI18nLink } from '../components/I18nFormatters';
 import OpenEmailProviderButton from '../components/OpenEmailProviderButton';
 import Page from '../components/Page';
 import { H3, P } from '../components/Text';
@@ -36,11 +37,11 @@ class SignInLinkSent extends Component {
 
     return (
       <Page title="Login Link Sent">
-        <Container pt={[4, 5]} pb={6} px={2} background="linear-gradient(180deg, #EBF4FF, #FFFFFF)" textAlign="center">
+        <Container pt={[4, 5]} pb={6} px={3} background="linear-gradient(180deg, #EBF4FF, #FFFFFF)" textAlign="center">
           <Flex justifyContent="center" mb={4}>
             <Icon size="60" />
           </Flex>
-          <H3 as="h1" fontWeight="800">
+          <H3 as="h1" fontWeight="bold">
             <FormattedMessage id="SignIn.LinkSent" defaultMessage="Your magic link is on its way!" />
           </H3>
           <P fontSize="16px" lineHeight="24px" color="black.900" mt={4}>
@@ -50,10 +51,21 @@ class SignInLinkSent extends Component {
               values={{ email: <strong>{email}</strong> }}
             />
           </P>
-          <P color="black.700" mt={3}>
+          <P color="black.700" fontSize="14px" lineHeight="18px" my={4}>
             <FormattedMessage
               id="SignIn.SuccessDetails"
               defaultMessage="You’ll be redirected from the link in the email, you can safely close this tab."
+            />
+            <br />
+            <FormattedMessage
+              id="signinLinkSent."
+              defaultMessage="<Link>Learn more</Link> about passwordless login."
+              values={{
+                Link: getI18nLink({
+                  href: 'https://docs.opencollective.com/help/product/log-in-system',
+                  openInNewTab: true,
+                }),
+              }}
             />
           </P>
           <OpenEmailProviderButton email={email}>{button => <Box mt={3}>{button}</Box>}</OpenEmailProviderButton>


### PR DESCRIPTION
Add a link to the docs on the "Signin link sent" page, following the discussion in https://opencollective.slack.com/archives/C0RMV6F8C/p1598826929002000.

Also made a few changes in the layout to put more space as it felt more "packed" with this new line.

# Design changes

## Mobile

Before :arrow_right: After

<img src="https://user-images.githubusercontent.com/1556356/91831944-004a7680-ec45-11ea-9bf2-e92f3013eef0.png" width="400"/><img src="https://user-images.githubusercontent.com/1556356/91831881-e6109880-ec44-11ea-8af7-6d633624213a.png" width="400"/>
