### PR TITLE
ContributionFlow: Add feature flags

### DIFF
--- a/components/SignInOrJoinFree.js
+++ b/components/SignInOrJoinFree.js
@@ -14,7 +14,7 @@ import CreateProfileFAQ from './faqs/CreateProfileFAQ';
 import CreateProfile from './CreateProfile';
 import { Box, Flex } from './Grid';
 import Link from './Link';
-import MessageBox from './MessageBox';
+import MessageBoxGraphqlError from './MessageBoxGraphqlError';
 import SignIn from './SignIn';
 import StyledButton from './StyledButton';
 import StyledCard from './StyledCard';
@@ -224,11 +224,7 @@ class SignInOrJoinFree extends React.Component {
 
     return (
       <Flex flexDirection="column" width={1} alignItems="center">
-        {error && (
-          <MessageBox type="error" withIcon mb={[3, 4]}>
-            {error.replace('GraphQL error: ', 'Error: ')}
-          </MessageBox>
-        )}
+        {error && <MessageBoxGraphqlError error={error} mb={[3, 4]} />}
         {enforceTwoFactorAuthForLoggedInUser ? (
           this.renderTwoFactorAuthBox()
         ) : (
@@ -248,29 +244,31 @@ class SignInOrJoinFree extends React.Component {
               <Flex flexDirection="column" width={1} alignItems="center">
                 <Flex justifyContent="center" width={1}>
                   <Box width={[0, null, null, 1 / 5]} />
-                  <CreateProfile
-                    email={email}
-                    onEmailChange={email => this.setState({ email })}
-                    onPersonalSubmit={this.createProfile}
-                    onOrgSubmit={this.createProfile}
-                    onSecondaryAction={routes.signin || (() => this.switchForm('signin'))}
-                    submitting={submitting}
-                    mx={[2, 4]}
-                    createPersonalProfileLabel={this.props.createPersonalProfileLabel}
-                    createOrganizationProfileLabel={this.props.createOrganizationProfileLabel}
-                  />
+                  <Box maxWidth={480} mx={[2, 4]} width="100%">
+                    <CreateProfile
+                      email={email}
+                      onEmailChange={email => this.setState({ email })}
+                      onPersonalSubmit={this.createProfile}
+                      onOrgSubmit={this.createProfile}
+                      onSecondaryAction={routes.signin || (() => this.switchForm('signin'))}
+                      submitting={submitting}
+                      createPersonalProfileLabel={this.props.createPersonalProfileLabel}
+                      createOrganizationProfileLabel={this.props.createOrganizationProfileLabel}
+                    />
+                    <P mt={4} color="black.500" fontSize="12px" mb={3} data-cy="join-conditions" textAlign="center">
+                      <FormattedMessage
+                        id="SignIn.legal"
+                        defaultMessage="By joining, you agree to our <tos-link>Terms of Service</tos-link> and <privacy-policy-link>Privacy Policy</privacy-policy-link>."
+                        values={{
+                          'tos-link': msg => <Link route="/tos">{msg}</Link>,
+                          'privacy-policy-link': msg => <Link route="/privacypolicy">{msg}</Link>,
+                        }}
+                      />
+                    </P>
+                  </Box>
+
                   <CreateProfileFAQ mt={4} display={['none', null, 'block']} width={1 / 5} minWidth="335px" />
                 </Flex>
-                <P mt={4} color="black.500" fontSize="12px" mb={3} data-cy="join-conditions">
-                  <FormattedMessage
-                    id="SignIn.legal"
-                    defaultMessage="By joining, you agree to our <tos-link>Terms of Service</tos-link> and <privacy-policy-link>Privacy Policy</privacy-policy-link>."
-                    values={{
-                      'tos-link': msg => <Link route="/tos">{msg}</Link>,
-                      'privacy-policy-link': msg => <Link route="/privacypolicy">{msg}</Link>,
-                    }}
-                  />
-                </P>
               </Flex>
             )}
           </Fragment>

--- a/components/StyledInputAmount.js
+++ b/components/StyledInputAmount.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { isUndefined } from 'lodash';
 
 import { getCurrencySymbol } from '../lib/currency-utils';
+import { floatAmountToCents } from '../lib/math';
 
 import StyledInputGroup from './StyledInputGroup';
 
@@ -22,14 +23,6 @@ const parseValueFromEvent = (e, precision, ignoreComma) => {
   } else {
     const parsedNumber = parseFloat(ignoreComma ? e.target.value.replace(',', '') : e.target.value);
     return isNaN(parsedNumber) ? NaN : parsedNumber.toFixed(precision);
-  }
-};
-
-const floatAmountToCents = floatAmount => {
-  if (isNaN(floatAmount) || floatAmount === null) {
-    return floatAmount;
-  } else {
-    return Math.round(floatAmount * 100);
   }
 };
 

--- a/components/new-contribution-flow/ContributionFlowStepsProgress.js
+++ b/components/new-contribution-flow/ContributionFlowStepsProgress.js
@@ -10,6 +10,7 @@ import StepsProgress from '../StepsProgress';
 import { Span } from '../Text';
 
 import { STEPS } from './constants';
+import { getTotalAmount } from './utils';
 
 // Styles for the steps label rendered in StepsProgress
 const StepLabel = styled(Span)`
@@ -44,7 +45,7 @@ const STEP_LABELS = defineMessages({
 
 const PrettyAmountFromStepDetails = ({ stepDetails, currency, isFreeTier }) => {
   if (stepDetails.amount) {
-    const totalAmount = stepDetails.amount + (stepDetails.feesOnTop || 0);
+    const totalAmount = stepDetails.amount + (stepDetails.platformContribution || 0);
     return <FormattedMoneyAmount interval={stepDetails.interval} currency={currency} amount={totalAmount} />;
   } else if (stepDetails.amount === 0 && isFreeTier) {
     return (
@@ -57,7 +58,7 @@ const PrettyAmountFromStepDetails = ({ stepDetails, currency, isFreeTier }) => {
   }
 };
 
-const StepInfo = ({ step, stepProfile, stepDetails, stepPayment, isFreeTier, currency }) => {
+const StepInfo = ({ step, stepProfile, stepDetails, stepPayment, stepSummary, isFreeTier, currency }) => {
   if (step.name === STEPS.PROFILE) {
     return get(stepProfile, 'name') || get(stepProfile, 'email', null);
   } else if (step.name === STEPS.DETAILS) {
@@ -70,7 +71,7 @@ const StepInfo = ({ step, stepProfile, stepDetails, stepPayment, isFreeTier, cur
       );
     }
   } else if (step.name === STEPS.PAYMENT) {
-    if (isFreeTier && get(stepDetails, 'totalAmount') === 0) {
+    if (isFreeTier && getTotalAmount(stepDetails, stepSummary) === 0) {
       return <FormattedMessage id="noPaymentRequired" defaultMessage="No payment required" />;
     } else {
       return get(stepPayment, 'title', null);
@@ -84,6 +85,7 @@ const ContributionFlowStepsProgress = ({
   stepProfile,
   stepDetails,
   stepPayment,
+  stepSummary,
   isSubmitted,
   loading,
   steps,
@@ -113,6 +115,7 @@ const ContributionFlowStepsProgress = ({
                 stepProfile={stepProfile}
                 stepDetails={stepDetails}
                 stepPayment={stepPayment}
+                stepSummary={stepSummary}
                 isFreeTier={isFreeTier}
                 currency={currency}
               />
@@ -131,6 +134,7 @@ ContributionFlowStepsProgress.propTypes = {
   stepProfile: PropTypes.object,
   stepDetails: PropTypes.object,
   stepPayment: PropTypes.object,
+  stepSummary: PropTypes.object,
   isSubmitted: PropTypes.bool,
   loading: PropTypes.bool,
   lastVisitedStep: PropTypes.object,

--- a/components/new-contribution-flow/FeesOnTopInput.js
+++ b/components/new-contribution-flow/FeesOnTopInput.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { isNil } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 
@@ -54,10 +55,22 @@ const getOptions = (amount, currency) => {
 const FeesOnTopInput = ({ currency, amount, fees, interval, onChange }) => {
   const options = React.useMemo(() => getOptions(amount, currency), [amount, currency]);
   const [selectedOption, setSelectedOption] = React.useState(options[1]);
+  const [isReady, setReady] = React.useState(false);
+
+  // Load initial value on mount
+  React.useEffect(() => {
+    if (!isNil(fees)) {
+      const option = options.find(({ value }) => value === fees) || options.find(({ value }) => value === 'CUSTOM');
+      setSelectedOption(option);
+    }
+    setReady(true);
+  }, []);
 
   // Dispatch new fees on top when amount changes
   React.useEffect(() => {
-    if (selectedOption.value === 0 && fees) {
+    if (!isReady) {
+      return;
+    } else if (selectedOption.value === 0 && fees) {
       onChange(0);
     } else if (selectedOption.percentage) {
       const newOption = getOptionFromPercentage(amount, currency, selectedOption.percentage);
@@ -66,7 +79,7 @@ const FeesOnTopInput = ({ currency, amount, fees, interval, onChange }) => {
         setSelectedOption(newOption);
       }
     }
-  }, [selectedOption, amount]);
+  }, [selectedOption, amount, isReady]);
 
   return (
     <div>
@@ -99,7 +112,7 @@ const FeesOnTopInput = ({ currency, amount, fees, interval, onChange }) => {
       </Flex>
       {selectedOption.value === 'CUSTOM' && (
         <Flex justifyContent="flex-end" mt={2}>
-          <StyledInputAmount id="feesOnTop" currency={currency} onChange={onChange} />
+          <StyledInputAmount id="feesOnTop" currency={currency} onChange={onChange} value={fees} />
         </Flex>
       )}
       <P fontSize="12px" lineHeight="18px" color="black.500" fontWeight="500" mt={2} textAlign={['left', 'right']}>

--- a/components/new-contribution-flow/StepDetails.js
+++ b/components/new-contribution-flow/StepDetails.js
@@ -131,9 +131,9 @@ const StepDetails = ({ onChange, data, collective, tier, showFeesOnTop }) => {
           <FeesOnTopInput
             currency={collective.currency}
             amount={data?.amount}
-            fees={data?.feesOnTop}
+            fees={data?.platformContribution}
             interval={data?.interval}
-            onChange={feesOnTop => dispatchChange('feesOnTop', feesOnTop)}
+            onChange={value => dispatchChange('platformContribution', value)}
           />
         </Box>
       )}
@@ -181,7 +181,7 @@ StepDetails.propTypes = {
   showFeesOnTop: PropTypes.bool,
   data: PropTypes.shape({
     amount: PropTypes.number,
-    feesOnTop: PropTypes.number,
+    platformContribution: PropTypes.number,
     quantity: PropTypes.number,
     interval: PropTypes.string,
     customFieldsData: PropTypes.object,

--- a/components/new-contribution-flow/StepDetails.js
+++ b/components/new-contribution-flow/StepDetails.js
@@ -22,10 +22,11 @@ import { H5, P, Span } from '../Text';
 import ChangeTierWarningModal from './ChangeTierWarningModal';
 import FeesOnTopInput from './FeesOnTopInput';
 import TierCustomFields from './TierCustomFields';
+import { getTotalAmount } from './utils';
 
 const StepDetails = ({ onChange, data, collective, tier, showFeesOnTop }) => {
   const intl = useIntl();
-  const [temporaryInterval, setTemporaryInterval] = React.useState(null);
+  const [temporaryInterval, setTemporaryInterval] = React.useState(undefined);
   const presets = React.useMemo(() => getTierPresets(tier, collective.type), [tier, collective.type]);
   const hasQuantity = tier?.type === TierTypes.TICKET || tier?.type === TierTypes.PRODUCT;
   const isFixedContribution = tier?.amountType === AmountTypes.FIXED;
@@ -52,7 +53,7 @@ const StepDetails = ({ onChange, data, collective, tier, showFeesOnTop }) => {
             defaultMessage="You’ll contribute with the amount of {amount}{interval, select, month { monthly} year { yearly} other {}}."
             values={{
               interval: tier.interval,
-              amount: <FormattedMoneyAmount amount={tier.amount.valueInCents} currency={collective.currency} />,
+              amount: <FormattedMoneyAmount amount={getTotalAmount(data)} currency={collective.currency} />,
             }}
           />
         </Box>
@@ -160,15 +161,19 @@ const StepDetails = ({ onChange, data, collective, tier, showFeesOnTop }) => {
           />
         </Box>
       )}
-      {temporaryInterval && (
+      {temporaryInterval !== undefined && (
         <ChangeTierWarningModal
           show
           tierName={tier.name}
           onClose={() => setTemporaryInterval(null)}
           onConfirm={() => {
             dispatchChange('interval', temporaryInterval);
-            setTemporaryInterval(null);
-            Router.pushRoute(`/${collective.slug}/new-donate/details`);
+            setTemporaryInterval(undefined);
+            Router.pushRoute('orderCollectiveNew', {
+              collectiveSlug: collective.slug,
+              verb: 'donate',
+              step: 'details',
+            });
           }}
         />
       )}

--- a/components/new-contribution-flow/index.js
+++ b/components/new-contribution-flow/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from '@apollo/client/react/hoc';
-import { find, get, pick } from 'lodash';
+import { find, get, isNil, pick } from 'lodash';
 import memoizeOne from 'memoize-one';
 import { defineMessages, injectIntl } from 'react-intl';
 import styled from 'styled-components';
@@ -11,17 +11,19 @@ import { getGQLV2FrequencyFromInterval } from '../../lib/constants/intervals';
 import { GQLV2_PAYMENT_METHOD_TYPES } from '../../lib/constants/payment-methods';
 import { TierTypes } from '../../lib/constants/tiers-types';
 import { TransactionTypes } from '../../lib/constants/transactions';
+import { getEnvVar } from '../../lib/env-utils';
 import { formatErrorMessage, getErrorFromGraphqlException } from '../../lib/errors';
 import { API_V2_CONTEXT, gqlV2 } from '../../lib/graphql/helpers';
 import { getStripe, stripeTokenToPaymentMethod } from '../../lib/stripe';
 import { getDefaultTierAmount, getTierMinAmount, isFixedContribution } from '../../lib/tier-utils';
+import { objectToQueryString } from '../../lib/url_helpers';
 import { getWebsiteUrl } from '../../lib/utils';
 import { Router } from '../../server/pages';
 
 import Container from '../../components/Container';
 import NewContributeFAQ from '../../components/faqs/NewContributeFAQ';
 import { Box, Grid } from '../../components/Grid';
-import { addSignupMutation } from '../../components/SignInOrJoinFree';
+import SignInOrJoinFree, { addSignupMutation } from '../../components/SignInOrJoinFree';
 
 import { isValidExternalRedirect } from '../../pages/external-redirect';
 import Loading from '../Loading';
@@ -29,6 +31,7 @@ import MessageBox from '../MessageBox';
 import Steps from '../Steps';
 import { withUser } from '../UserProvider';
 
+import { STEPS } from './constants';
 import ContributionFlowButtons from './ContributionFlowButtons';
 import ContributionFlowHeader from './ContributionFlowHeader';
 import ContributionFlowMainContainer from './ContributionFlowMainContainer';
@@ -83,6 +86,7 @@ class ContributionFlow extends React.Component {
     confirmOrder: PropTypes.func.isRequired,
     fixedInterval: PropTypes.string,
     fixedAmount: PropTypes.number,
+    platformContribution: PropTypes.number,
     skipStepDetails: PropTypes.bool,
     step: PropTypes.string,
     redirect: PropTypes.string,
@@ -108,6 +112,7 @@ class ContributionFlow extends React.Component {
         quantity: 1,
         interval: props.fixedInterval || props.tier?.interval,
         amount: props.fixedAmount || getDefaultTierAmount(props.tier),
+        platformContribution: props.platformContribution,
       },
     };
   }
@@ -117,6 +122,8 @@ class ContributionFlow extends React.Component {
     // TODO We're still relying on profiles from V1 (LoggedInUser)
     const fromAccount = typeof stepProfile.id === 'string' ? { id: stepProfile.id } : { legacyId: stepProfile.id };
     this.setState({ error: null });
+
+    const getAmount = (valueInCents, defaultValue) => (valueInCents ? { valueInCents } : defaultValue);
 
     try {
       const response = await this.props.createOrder({
@@ -129,11 +136,11 @@ class ContributionFlow extends React.Component {
             toAccount: pick(this.props.collective, ['id']),
             customData: stepDetails.customData,
             paymentMethod: await this.getPaymentMethod(),
-            platformContributionAmount: stepDetails.feesOnTop && { valueInCents: stepDetails.feesOnTop },
+            platformContributionAmount: getAmount(stepDetails.platformContribution, undefined),
             taxes: stepSummary && [
               {
                 type: 'VAT',
-                amount: stepSummary.amount || 0,
+                amount: getAmount(stepSummary.amount, 0),
                 country: stepSummary.countryISO,
                 idNumber: stepSummary.number,
               },
@@ -274,7 +281,6 @@ class ContributionFlow extends React.Component {
       verb: this.props.verb || 'new-donate',
       collectiveSlug: collective.slug,
       step: stepName === 'details' ? undefined : stepName,
-      totalAmount: this.props.fixedAmount ? this.props.fixedAmount.toString() : undefined,
       interval: this.props.fixedInterval || undefined,
       ...pick(this.props, ['interval', 'description', 'redirect']),
       ...routeParams,
@@ -414,6 +420,29 @@ class ContributionFlow extends React.Component {
     }
   }
 
+  getRedirectUrlForSignIn = () => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const { stepDetails } = this.state;
+    const stepDetailsParams = objectToQueryString({
+      amount: stepDetails.amount / 100,
+      interval: stepDetails.interval || undefined,
+      quantity: stepDetails.quantity !== 1 ? stepDetails.quantity : undefined,
+      platformContribution: !isNil(stepDetails.platformContribution)
+        ? stepDetails.platformContribution / 100
+        : undefined,
+    });
+
+    const path = window.location.pathname;
+    if (window.location.search) {
+      return `${path}${window.location.search}&${stepDetailsParams.slice(1)}`;
+    } else {
+      return `${path}${stepDetailsParams}`;
+    }
+  };
+
   render() {
     const { collective, tier, LoggedInUser, skipStepDetails } = this.props;
     const { error, isSubmitted, isSubmitting } = this.state;
@@ -461,58 +490,65 @@ class ContributionFlow extends React.Component {
                   stepProfile={this.state.stepProfile}
                   stepDetails={this.state.stepDetails}
                   stepPayment={this.state.stepPayment}
+                  stepSummary={this.state.stepSummary}
                   isSubmitted={this.state.isSubmitted}
                   loading={isValidating || isSubmitted || isSubmitting}
                   currency={collective.currency}
                   isFreeTier={this.getTierMinAmount(tier) === 0}
                 />
               </StepsProgressBox>
-              {/* main container */}
-              <Grid
-                px={[2, 3]}
-                gridTemplateColumns={[
-                  'minmax(200px, 600px)',
-                  null,
-                  '0fr minmax(300px, 600px) 1fr',
-                  '1fr minmax(300px, 600px) 1fr',
-                ]}
-              >
-                <Box />
-                <Box as="form" onSubmit={e => e.preventDefault()} maxWidth="100%">
-                  {error && (
-                    <MessageBox type="error" withIcon mb={3}>
-                      {formatErrorMessage(this.props.intl, error)}
-                    </MessageBox>
-                  )}
-                  <ContributionFlowMainContainer
-                    collective={collective}
-                    tier={tier}
-                    mainState={this.state}
-                    onChange={data => this.setState(data)}
-                    step={currentStep}
-                    showFeesOnTop={this.canHaveFeesOnTop()}
-                    onNewCardFormReady={({ stripe }) => this.setState({ stripe })}
-                  />
-                  <Box mt={[4, 5]}>
-                    <ContributionFlowButtons
-                      goNext={goNext}
-                      goBack={goBack}
+              {/* main container */}{' '}
+              {currentStep.name === STEPS.PROFILE && !LoggedInUser && !getEnvVar('ENABLE_GUEST_CONTRIBUTIONS') ? (
+                <SignInOrJoinFree defaultForm="create-account" redirect={this.getRedirectUrlForSignIn()} />
+              ) : (
+                <Grid
+                  px={[2, 3]}
+                  gridTemplateColumns={[
+                    'minmax(200px, 600px)',
+                    null,
+                    '0fr minmax(300px, 600px) 1fr',
+                    '1fr minmax(300px, 600px) 1fr',
+                  ]}
+                >
+                  <Box />
+                  <Box as="form" onSubmit={e => e.preventDefault()} maxWidth="100%">
+                    {error && (
+                      <MessageBox type="error" withIcon mb={3}>
+                        {formatErrorMessage(this.props.intl, error)}
+                      </MessageBox>
+                    )}
+
+                    <ContributionFlowMainContainer
+                      collective={collective}
+                      tier={tier}
+                      mainState={this.state}
+                      onChange={data => this.setState(data)}
                       step={currentStep}
-                      prevStep={prevStep}
-                      nextStep={nextStep}
-                      isRecurringContributionLoggedOut={!LoggedInUser && this.state.stepDetails?.interval}
-                      isValidating={isValidating || isSubmitted || isSubmitting}
-                      paypalButtonProps={this.getPaypalButtonProps()}
+                      showFeesOnTop={this.canHaveFeesOnTop()}
+                      onNewCardFormReady={({ stripe }) => this.setState({ stripe })}
                     />
+
+                    <Box mt={[4, 5]}>
+                      <ContributionFlowButtons
+                        goNext={goNext}
+                        goBack={goBack}
+                        step={currentStep}
+                        prevStep={prevStep}
+                        nextStep={nextStep}
+                        isRecurringContributionLoggedOut={!LoggedInUser && this.state.stepDetails?.interval}
+                        isValidating={isValidating || isSubmitted || isSubmitting}
+                        paypalButtonProps={this.getPaypalButtonProps()}
+                      />
+                    </Box>
                   </Box>
-                </Box>
-                <Box minWidth={[null, '300px']} mt={[4, null, 0]} ml={[0, 3, 4, 5]}>
-                  <Box maxWidth={['100%', null, 300]} px={[1, null, 0]}>
-                    <SafeTransactionMessage />
-                    <NewContributeFAQ mt={4} titleProps={{ mb: 2 }} />
+                  <Box minWidth={[null, '300px']} mt={[4, null, 0]} ml={[0, 3, 4, 5]}>
+                    <Box maxWidth={['100%', null, 300]} px={[1, null, 0]}>
+                      <SafeTransactionMessage />
+                      <NewContributeFAQ mt={4} titleProps={{ mb: 2 }} />
+                    </Box>
                   </Box>
-                </Box>
-              </Grid>
+                </Grid>
+              )}
             </Container>
           )
         }

--- a/components/new-contribution-flow/utils.js
+++ b/components/new-contribution-flow/utils.js
@@ -138,6 +138,6 @@ export const getTotalAmount = (stepDetails, stepSummary) => {
   const quantity = get(stepDetails, 'quantity') || 1;
   const amount = get(stepDetails, 'amount') || 0;
   const taxAmount = get(stepSummary, 'amount') || 0;
-  const platformFeeAmount = get(stepDetails, 'feesOnTop') || 0;
+  const platformFeeAmount = get(stepDetails, 'platformContribution') || 0;
   return quantity * (amount + platformFeeAmount) + taxAmount;
 };

--- a/env.js
+++ b/env.js
@@ -22,6 +22,8 @@ const defaults = {
   CLIENT_ANALYTICS_ENABLED: false,
   ONBOARDING_MODAL: true,
   NEW_HOST_APPLICATION_FLOW: false,
+  NEW_CONTRIBUTION_FLOW: false,
+  ENABLE_GUEST_CONTRIBUTIONS: false,
   TW_API_COLLECTIVE_SLUG: 'opencollective-host',
   OC_APPLICATION: 'frontend',
   OC_ENV: process.env.NODE_ENV || 'development',

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -118,6 +118,9 @@ export const getErrorFromGraphqlException = exception => {
   if (!firstError) {
     if (isError(exception) && exception.message.startsWith('Network')) {
       return createError(ERROR.NETWORK);
+    } else if (typeof exception === 'string') {
+      // When throwing errors directly from API (`throw new Error('...')`)
+      return createError(ERROR.UNKNOWN, { message: exception });
     } else {
       return createError();
     }

--- a/lib/math.js
+++ b/lib/math.js
@@ -33,3 +33,11 @@ export const abbreviateNumber = (number, precision = 0) => {
 
   return round(scaled) + SI_PREFIXES[tier];
 };
+
+export const floatAmountToCents = floatAmount => {
+  if (isNaN(floatAmount) || floatAmount === null) {
+    return floatAmount;
+  } else {
+    return Math.round(floatAmount * 100);
+  }
+};

--- a/next.config.js
+++ b/next.config.js
@@ -23,6 +23,8 @@ const nextConfig = {
         NEW_HOST_APPLICATION_FLOW: null,
         TW_API_COLLECTIVE_SLUG: null,
         OC_ENV: null,
+        NEW_CONTRIBUTION_FLOW: false,
+        ENABLE_GUEST_CONTRIBUTIONS: false,
       }),
     );
 

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -72,7 +72,9 @@ export default class IntlDocument extends Document {
     // They can later be read with getEnvVar()
     // Please, NEVER SECRETS!
     props.__NEXT_DATA__.env = pick(process.env, [
+      'ENABLE_GUEST_CONTRIBUTIONS',
       'IMAGES_URL',
+      'NEW_CONTRIBUTION_FLOW',
       'PAYPAL_ENVIRONMENT',
       'STRIPE_KEY',
       'SENTRY_DSN',

--- a/pages/new-contribution-flow.js
+++ b/pages/new-contribution-flow.js
@@ -11,6 +11,7 @@ import { CollectiveType } from '../lib/constants/collectives';
 import { GQLV2_PAYMENT_METHOD_TYPES } from '../lib/constants/payment-methods';
 import { generateNotFoundError, getErrorFromGraphqlException } from '../lib/errors';
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
+import { floatAmountToCents } from '../lib/math';
 import { compose, parseToBoolean } from '../lib/utils';
 
 import Container from '../components/Container';
@@ -76,9 +77,14 @@ class NewContributionFlowPage extends React.Component {
       }
     }
 
+    const getFloatAmount = amountStr => {
+      return !amountStr ? null : floatAmountToCents(parseFloat(amountStr));
+    };
+
     return {
       collectiveSlug: query.eventSlug || query.collectiveSlug,
-      totalAmount: parseInt(query.amount) * 100 || parseInt(query.totalAmount) || null,
+      totalAmount: getFloatAmount(query.amount) || parseInt(query.totalAmount) || null,
+      platformContribution: getFloatAmount(query.platformContribution),
       step: query.step || 'details',
       tierId: parseInt(query.tierId) || null,
       quantity: parseInt(query.quantity) || 1,
@@ -211,6 +217,7 @@ class NewContributionFlowPage extends React.Component {
           defaultQuantity={this.props.quantity}
           fixedInterval={this.props.interval}
           fixedAmount={this.props.totalAmount}
+          platformContribution={this.props.platformContribution}
           customData={this.props.customData}
           skipStepDetails={this.props.skipStepDetails}
           contributeAs={this.props.contributeAs}

--- a/pages/new-contribution-flow.js
+++ b/pages/new-contribution-flow.js
@@ -288,6 +288,7 @@ const accountFieldsFragment = gqlV2/* GraphQL */ `
     ... on Event {
       parent {
         id
+        slug
         location {
           country
         }
@@ -296,6 +297,7 @@ const accountFieldsFragment = gqlV2/* GraphQL */ `
     ... on Project {
       parent {
         id
+        slug
         location {
           country
         }

--- a/server/pages.js
+++ b/server/pages.js
@@ -103,7 +103,7 @@ let createOrderPage = 'createOrder';
 let orderSuccessPage = 'orderSuccess';
 let contributionFlowSteps = 'contributeAs|details|payment|summary';
 
-if (process.env.NEW_CONTRIBUTION_FLOW) {
+if (process.env.NEW_CONTRIBUTION_FLOW && process.env.NEW_CONTRIBUTION_FLOW !== 'false') {
   createOrderPage = 'new-contribution-flow';
   orderSuccessPage = 'new-contribution-flow';
   contributionFlowSteps += '|profile|success';
@@ -116,6 +116,11 @@ if (process.env.NEW_CONTRIBUTION_FLOW) {
   pages.add(
     'new-contribute',
     '/:collectiveSlug/:verb(new-contribute)/:tierSlug?-:tierId([0-9]+)/checkout/:step(details|profile|payment|success|summary)?',
+    'new-contribution-flow',
+  );
+  pages.add(
+    'new-order-event-tier',
+    `/:collectiveSlug/:verb(new-events|new-projects)/:eventSlug/order/:tierId/:step(details|profile|payment|success|summary)?`,
     'new-contribution-flow',
   );
 }

--- a/server/pages.js
+++ b/server/pages.js
@@ -99,64 +99,85 @@ pages.add('conversation', '/:collectiveSlug/conversations/:slug?-:id([a-z0-9]+)'
 // Contribute Flow
 // ---------------
 
+let createOrderPage = 'createOrder';
+let orderSuccessPage = 'orderSuccess';
+let contributionFlowSteps = 'contributeAs|details|payment|summary';
+
+if (process.env.NEW_CONTRIBUTION_FLOW) {
+  createOrderPage = 'new-contribution-flow';
+  orderSuccessPage = 'new-contribution-flow';
+  contributionFlowSteps += '|profile|success';
+} else {
+  pages.add(
+    'new-donate',
+    '/:collectiveSlug/:verb(new-donate)/:step(details|profile|payment|success)?',
+    'new-contribution-flow',
+  );
+  pages.add(
+    'new-contribute',
+    '/:collectiveSlug/:verb(new-contribute)/:tierSlug?-:tierId([0-9]+)/checkout/:step(details|profile|payment|success|summary)?',
+    'new-contribution-flow',
+  );
+}
+
 // Legacy create order route. Deprectated on 2019-02-12
 pages.add(
   'orderCollectiveTier',
   '/:collectiveSlug/:verb(order)/:tierId/:amount(\\d+)?/:interval(month|monthly|year|yearly)?',
-  'createOrder',
+  createOrderPage,
 );
 
 // Legacy tier route. Deprectated on 2019-06-07
 pages
   .add(
     'orderCollectiveTierLegacy',
-    '/:collectiveSlug/:verb(donate|pay|contribute|order|events)/tier/:tierId-:tierSlug?/:step(contributeAs|details|payment|summary)?',
-    'createOrder',
+    `/:collectiveSlug/:verb(donate|pay|contribute|order|events)/tier/:tierId-:tierSlug?/:step(${contributionFlowSteps})?`,
+    createOrderPage,
   )
   .add(
     'orderCollectiveTierLegacySuccess',
     '/:collectiveSlug/:verb(donate|pay|contribute|order|events)/tier/:tierId-:tierSlug?/:step(success)',
-    'orderSuccess',
+    orderSuccessPage,
   );
 
 // New Routes -> New flow
 pages
   .add(
     'orderCollectiveNew',
-    '/:collectiveSlug/:verb(donate|pay|order|events)/:step(contributeAs|details|payment|summary)?',
-    'createOrder',
+    `/:collectiveSlug/:verb(donate|pay|order|events)/:step(${contributionFlowSteps})?`,
+    createOrderPage,
   )
   .add(
     'orderCollectiveTierNew',
-    '/:collectiveSlug/:verb(contribute)/:tierSlug?-:tierId([0-9]+)/checkout/:step(contributeAs|details|payment|summary)?',
-    'createOrder',
+    `/:collectiveSlug/:verb(contribute)/:tierSlug?-:tierId([0-9]+)/checkout/:step(${contributionFlowSteps})?`,
+    createOrderPage,
   )
-  .add('orderCollectiveNewSuccess', '/:collectiveSlug/:verb(donate|pay|order|events)/:step(success)', 'orderSuccess')
+  .add('orderCollectiveNewSuccess', '/:collectiveSlug/:verb(donate|pay|order|events)/:step(success)', orderSuccessPage)
   .add(
     'orderCollectiveTierNewSuccess',
     '/:collectiveSlug/:verb(contribute)/:tierSlug?-:tierId([0-9]+)/checkout/:step(success)',
-    'orderSuccess',
+    orderSuccessPage,
   );
 
 // Generic Route
 pages.add(
   'orderCollective',
   '/:collectiveSlug/:verb(donate|pay|order|events)/:amount(\\d+)?/:interval(month|monthly|year|yearly)?/:description?',
-  'createOrder',
+  createOrderPage,
 );
 
 // Events
 pages.add(
   'orderEventTier',
-  '/:collectiveSlug/:verb(events|projects)/:eventSlug/order/:tierId/:step(contributeAs|details|payment|summary)?',
-  'createOrder',
+  `/:collectiveSlug/:verb(events|projects)/:eventSlug/order/:tierId/:step(${contributionFlowSteps})?`,
+  createOrderPage,
 );
 
 // Events
 pages.add(
   'orderEventTierSuccess',
   '/:collectiveSlug/:verb(events|projects)/:eventSlug/order/:tierId/:step(success)',
-  'orderSuccess',
+  orderSuccessPage,
 );
 
 // Pledges
@@ -199,17 +220,5 @@ pages.add(
 // New recurring contributions page
 pages.add('recurring-contributions', '/:slug/recurring-contributions');
 pages.add('subscriptions', '/:slug/subscriptions', 'recurring-contributions');
-
-// new contribution flow
-pages.add(
-  'new-donate',
-  '/:collectiveSlug/:verb(new-donate)/:step(details|profile|payment|success)?',
-  'new-contribution-flow',
-);
-pages.add(
-  'new-contribute',
-  '/:collectiveSlug/:verb(new-contribute)/:tierSlug?-:tierId([0-9]+)/checkout/:step(details|profile|payment|success|summary)?',
-  'new-contribution-flow',
-);
 
 module.exports = pages;


### PR DESCRIPTION
- `NEW_CONTRIBUTION_FLOW`: Make new contribution flow the default
- `ENABLE_GUEST_CONTRIBUTIONS`: Allow contributions without signin

This also implements:
- The temporary step profile with a `SignInOrJoinFree` form
- URL params for step details (`amount`, `totalAmount`, `interval`, `platformContribution`)
- The flow for ordering event tickets