### PR TITLE
Add EditPayPalAccount to the "Receiving Money" menu

### DIFF
--- a/components/edit-collective/EditPayPalAccount.js
+++ b/components/edit-collective/EditPayPalAccount.js
@@ -79,9 +79,6 @@ const EditPayPalAccount = props => {
       if (!values.clientId) {
         errors.clientId = 'Required';
       }
-      if (!values.webhookId) {
-        errors.webhookId = 'Required';
-      }
       return errors;
     },
   });
@@ -129,13 +126,7 @@ const EditPayPalAccount = props => {
             <StyledInput type="text" {...inputProps} onChange={formik.handleChange} value={formik.values.token} />
           )}
         </StyledInputField>
-        <StyledInputField
-          mt={2}
-          name="webhookId"
-          label="Webhook ID"
-          error={(formik.touched.token && formik.errors.token) || createError?.message.replace('GraphQL error: ', '')}
-          disabled={isCreating}
-        >
+        <StyledInputField mt={2} name="webhookId" label="Webhook ID" disabled={isCreating}>
           {inputProps => (
             <StyledInput type="text" {...inputProps} onChange={formik.handleChange} value={formik.values.webhookId} />
           )}

--- a/components/edit-collective/sections/ReceivingMoney.js
+++ b/components/edit-collective/sections/ReceivingMoney.js
@@ -2,6 +2,8 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl } from 'react-intl';
 
+import hasFeature, { FEATURES } from '../../../lib/allowed-features';
+
 import { H3 } from '../../Text';
 
 import BankTransfer from './BankTransfer';
@@ -22,6 +24,11 @@ class ReceivingMoney extends React.Component {
 
   render() {
     const services = ['stripe'];
+
+    if (hasFeature(this.props.collective, FEATURES.PAYPAL_DONATIONS)) {
+      services.push('paypal');
+    }
+
     return (
       <Fragment>
         {!this.state.hideTopsection && (

--- a/lib/allowed-features.js
+++ b/lib/allowed-features.js
@@ -12,6 +12,7 @@ export const FEATURES = {
   RECEIVE_EXPENSES: 'RECEIVE_EXPENSES',
   UPDATES: 'UPDATES',
   TRANSFERWISE: 'TRANSFERWISE',
+  PAYPAL_DONATIONS: 'PAYPAL_DONATIONS',
   PAYPAL_PAYOUTS: 'PAYPAL_PAYOUTS',
   TWO_FACTOR_AUTH: 'TWO_FACTOR_AUTH',
 };
@@ -34,6 +35,7 @@ export const FEATURE_FLAGS = {
   [FEATURES.CONVERSATIONS]: 'settings.features.conversations',
   [FEATURES.COLLECTIVE_GOALS]: 'settings.collectivePage.showGoals',
   [FEATURES.UPDATES]: 'settings.features.updates',
+  [FEATURES.PAYPAL_DONATIONS]: 'settings.features.paypalDonations',
   [FEATURES.PAYPAL_PAYOUTS]: 'settings.features.paypalPayouts',
   [FEATURES.TWO_FACTOR_AUTH]: 'settings.features.twoFactorAuth',
 };


### PR DESCRIPTION
Since we use the same Connected Account to both receive and send money through PayPal, I added a new feature flag that will enable a collective to connect to PayPal in order to receive donations with the existing form.
For that to work, I also made the Webhook ID field optional, since that's not used to receive donations.