### PR TITLE
i18n-iso-countries: Use fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12735,13 +12735,13 @@
       "dependencies": {
         "colors": {
           "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "resolved": "http://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
           "dev": true
         },
         "commander": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
           "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
           "dev": true
         }
@@ -13972,9 +13972,8 @@
       "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
     },
     "i18n-iso-countries": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/i18n-iso-countries/-/i18n-iso-countries-6.0.0.tgz",
-      "integrity": "sha512-2YOLRUNrnOq/sVchB6PfOgZ4E0rRMfxxy+QMhjv+2fiJHMidmmmb24UPHwXmzxyybB8mFPU+/uE46ebLOJIrpQ==",
+      "version": "github:Betree/node-i18n-iso-countries#40b669544fe95c3f2e5c49c5bfc11cf3b055f9b4",
+      "from": "github:Betree/node-i18n-iso-countries#fix/remove-arrow-functions",
       "requires": {
         "diacritics": "1.3.0"
       }
@@ -14033,7 +14032,7 @@
     },
     "immutable": {
       "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+      "resolved": "http://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
       "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
     },
     "import-fresh": {
@@ -24465,7 +24464,7 @@
       "dependencies": {
         "ast-types": {
           "version": "0.7.8",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
+          "resolved": "http://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
           "integrity": "sha1-kC0uDWDQcb3NRtwRXhgJ7RHBOKk=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "glob": "7.1.6",
     "graphql": "15.3.0",
     "helmet": "4.1.0",
-    "i18n-iso-countries": "6.0.0",
+    "i18n-iso-countries": "Betree/node-i18n-iso-countries#fix/remove-arrow-functions",
     "jsdom": "16.4.0",
     "jsonwebtoken": "8.5.1",
     "load-script": "1.0.0",


### PR DESCRIPTION
Resolve [an issue](https://sentry.io/organizations/open-collective/issues/1824483877) that is spamming Sentry right now. Not sure when [my fix](https://github.com/michaelwittig/node-i18n-iso-countries/pull/194) will be merged, so it's safer to switch to the fork while we wait.  