### PR TITLE
Performance: noStyledJsx optimization

### DIFF
--- a/pages/collective-page.js
+++ b/pages/collective-page.js
@@ -51,6 +51,10 @@ class CollectivePage extends React.Component {
       res.set('Cache-Control', 'public, s-maxage=300');
     }
 
+    if (req) {
+      req.noStyledJsx = true;
+    }
+
     return { slug, status, step, mode };
   }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -38,4 +38,11 @@ const HomePage = () => {
   );
 };
 
+HomePage.getInitialProps = ({ req }) => {
+  if (req) {
+    req.noStyledJsx = true;
+  }
+  return {};
+};
+
 export default HomePage;


### PR DESCRIPTION
**UPDATED**: always use the new recommended way to integrate styled components

Keep "noStyledJsx" to experiment with it and fade it out. Not necessarily for performance reasons.

