### PR TITLE
Fix missing currency in BankTransfer form

### DIFF
--- a/components/edit-collective/sections/BankTransfer.js
+++ b/components/edit-collective/sections/BankTransfer.js
@@ -233,6 +233,7 @@ const BankTransfer = props => {
                       host={{ slug: TW_API_COLLECTIVE_SLUG }}
                       getFieldName={string => string}
                       fixedCurrency={fixedCurrency}
+                      ignoreBlockedCurrencies
                       isNew
                     />
                   </Flex>

--- a/components/expenses/PayoutBankInformationForm.js
+++ b/components/expenses/PayoutBankInformationForm.js
@@ -290,11 +290,11 @@ DetailsForm.propTypes = {
 };
 
 const availableCurrenciesQuery = gqlV2/* GraphQL */ `
-  query PayoutBankInformationAvailableCurrencies($slug: String) {
+  query PayoutBankInformationAvailableCurrencies($slug: String, $ignoreBlockedCurrencies: Boolean) {
     host(slug: $slug) {
       slug
       transferwise {
-        availableCurrencies
+        availableCurrencies(ignoreBlockedCurrencies: $ignoreBlockedCurrencies)
       }
     }
   }
@@ -303,10 +303,10 @@ const availableCurrenciesQuery = gqlV2/* GraphQL */ `
 /**
  * Form for payout bank information. Must be used with Formik.
  */
-const PayoutBankInformationForm = ({ isNew, getFieldName, host, fixedCurrency }) => {
+const PayoutBankInformationForm = ({ isNew, getFieldName, host, fixedCurrency, ignoreBlockedCurrencies }) => {
   const { data, loading } = useQuery(availableCurrenciesQuery, {
     context: API_V2_CONTEXT,
-    variables: { slug: host.slug },
+    variables: { slug: host.slug, ignoreBlockedCurrencies },
     // Skip fetching/loading if the currency is fixed or avaialbleCurrencies was pre-loaded
     skip: Boolean(fixedCurrency || host.transferwise?.availableCurrencies),
   });
@@ -393,6 +393,7 @@ PayoutBankInformationForm.propTypes = {
     }),
   }).isRequired,
   isNew: PropTypes.bool,
+  ignoreBlockedCurrencies: PropTypes.bool,
   getFieldName: PropTypes.func.isRequired,
   /** Enforces a fixedCurrency */
   fixedCurrency: PropTypes.string,

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -5672,6 +5672,11 @@ type Query {
     Identifiers to retrieve the tier
     """
     tier: TierReferenceInput!
+
+    """
+    If true, an error will be returned if the tier is missing
+    """
+    throwIfMissing: Boolean! = true
   ): Tier
   transactions(
     """
@@ -5788,6 +5793,11 @@ type Tier {
   frequency: ContributionFrequency
   presets: [Int]
   maxQuantity: Int
+
+  """
+  Number of tickets available. Returns null if there is no limit.
+  """
+  availableQuantity: Int
   customFields: JSON
   amountType: TierAmountType!
   minimumAmount: Amount!
@@ -5922,7 +5932,12 @@ type TransferWise {
     """
     accountDetails: JSON
   ): [TransferWiseRequiredField]
-  availableCurrencies: [JSONObject]
+  availableCurrencies(
+    """
+    Ignores blocklisted currencies, used to generate the bank information form for manual payments
+    """
+    ignoreBlockListedCurrencies: Boolean
+  ): [JSONObject]
 }
 
 type TransferWiseField {

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -5936,7 +5936,7 @@ type TransferWise {
     """
     Ignores blocklisted currencies, used to generate the bank information form for manual payments
     """
-    ignoreBlockListedCurrencies: Boolean
+    ignoreBlockedCurrencies: Boolean
   ): [JSONObject]
 }
 


### PR DESCRIPTION
Requires: https://github.com/opencollective/opencollective-api/pull/4550
Related: https://opencollective.freshdesk.com/a/tickets/9467

Some currencies were being blacklisted which makes no sense in this context since we're only generating a generic form that won't be used in TransferWise.