### PR TITLE
ContributionFlow: Behavior for free tickets

### DIFF
--- a/components/new-contribution-flow/index.js
+++ b/components/new-contribution-flow/index.js
@@ -396,7 +396,7 @@ class ContributionFlow extends React.Component {
     const { stepDetails, stepPayment, stepSummary } = this.state;
     const isFixedContribution = this.isFixedContribution(tier, fixedAmount, fixedInterval);
     const minAmount = this.getTierMinAmount(tier);
-    const noPaymentRequired = minAmount === 0 && get(stepDetails, 'amount') === 0;
+    const noPaymentRequired = minAmount === 0 && (isFixedContribution || stepDetails?.amount === 0);
 
     const steps = [
       {
@@ -420,7 +420,7 @@ class ContributionFlow extends React.Component {
     ];
 
     // Show the summary step only if the order has tax
-    if (this.taxesMayApply(collective, collective.parent, host, tier)) {
+    if (!noPaymentRequired && this.taxesMayApply(collective, collective.parent, host, tier)) {
       steps.push({
         name: 'summary',
         label: intl.formatMessage(stepsLabels.summary),
@@ -429,7 +429,7 @@ class ContributionFlow extends React.Component {
     }
 
     // Hide step payment if using a free tier with fixed price
-    if (!(minAmount === 0 && isFixedContribution)) {
+    if (!noPaymentRequired) {
       steps.push({
         name: 'payment',
         label: intl.formatMessage(stepsLabels.payment),

--- a/lib/tier-utils.js
+++ b/lib/tier-utils.js
@@ -1,10 +1,11 @@
-import { isNil, uniq } from 'lodash';
+import { isNil, min, uniq } from 'lodash';
 
 import { CollectiveType } from './constants/collectives';
 import { AmountTypes } from './constants/tiers-types';
 
 const DEFAULT_PRESETS = [500, 1000, 2000, 5000];
 const DEFAULT_FUNDS_PRESETS = [100000, 200000, 500000, 1000000];
+const DEFAULT_MINIMUM_AMOUNT = 100;
 
 /**
  * Get the min authorized amount for order, in cents.
@@ -13,13 +14,15 @@ const DEFAULT_FUNDS_PRESETS = [100000, 200000, 500000, 1000000];
 export const getTierMinAmount = tier => {
   if (!tier) {
     // When making a donation, min amount is $1
-    return 100;
+    return DEFAULT_MINIMUM_AMOUNT;
   } else if (tier.amountType === AmountTypes.FIXED) {
     return tier.amount?.valueInCents || 0;
-  } else if (tier.minimumAmount) {
+  } else if (tier.minimumAmount.valueInCents !== null) {
     return tier.minimumAmount.valueInCents;
-  } else {
+  } else if (tier.presets?.length && min(tier.presets) === 0) {
     return 0;
+  } else {
+    return DEFAULT_MINIMUM_AMOUNT;
   }
 };
 


### PR DESCRIPTION
- Fix support for free tickets when tier is `FLEXIBLE` and has 0 has one of the presets
- Never display payment step for free tickets