### PR TITLE
Multiple fixes on events

### DIFF
--- a/components/contribute-cards/AdminContributeCardsContainer.js
+++ b/components/contribute-cards/AdminContributeCardsContainer.js
@@ -23,7 +23,7 @@ const AdminContributeCardsContainer = ({
 }) => {
   const isEvent = collective.type === CollectiveType.EVENT;
   const createContributionTierRoute = isEvent
-    ? `/${collective.parentCollective?.slug || 'collective'}/events/${collective.slug}/edit#tiers`
+    ? `/${collective.parentCollective?.slug || 'collective'}/events/${collective.slug}/edit/tiers`
     : `/${collective.slug}/edit/tiers`;
 
   React.useEffect(() => {

--- a/components/edit-collective/index.js
+++ b/components/edit-collective/index.js
@@ -75,7 +75,8 @@ class EditCollective extends React.Component {
       const response = await this.props.editCollective(collective);
       const updatedCollective = response.data.editCollective;
       this.setState({ status: 'saved', result: { error: null } });
-      if (Router.router.query.slug !== updatedCollective.slug) {
+      const currentSlug = Router.router.query.eventSlug ?? Router.router.query.slug;
+      if (currentSlug !== updatedCollective.slug) {
         Router.replaceRoute('editCollective', {
           ...Router.router.query,
           slug: updatedCollective.slug,

--- a/pages/editEvent.js
+++ b/pages/editEvent.js
@@ -4,6 +4,7 @@ import { gql } from '@apollo/client';
 import { graphql } from '@apollo/client/react/hoc';
 
 import { addEditCollectiveMutation } from '../lib/graphql/mutations';
+import { editCollectivePageFieldsFragment } from '../lib/graphql/queries';
 import { compose } from '../lib/utils';
 
 import EditCollective from '../components/edit-collective';
@@ -32,8 +33,8 @@ class EditEventPage extends React.Component {
   render() {
     const { data, loadingLoggedInUser, editCollective } = this.props;
 
-    if (loadingLoggedInUser || !data.Collective) {
-      return <ErrorPage loading={loadingLoggedInUser} data={data} />;
+    if (loadingLoggedInUser || !data?.Collective) {
+      return <ErrorPage loading={loadingLoggedInUser || data?.loading} data={data} />;
     }
 
     const event = data.Collective;
@@ -44,44 +45,15 @@ class EditEventPage extends React.Component {
 const editEventPageQuery = gql`
   query EditEventPage($eventSlug: String) {
     Collective(slug: $eventSlug) {
-      id
-      type
-      slug
+      ...EditCollectivePageFields
       path
       createdByUser {
         id
       }
-      name
-      imageUrl
-      backgroundImage
-      description
-      longDescription
       startsAt
       endsAt
       timezone
-      currency
-      settings
-      isDeletable
-      isArchived
-      location {
-        name
-        address
-        country
-        lat
-        long
-      }
       tiers {
-        id
-        slug
-        type
-        name
-        description
-        amount
-        amountType
-        minimumAmount
-        presets
-        currency
-        maxQuantity
         stats {
           id
           availableQuantity
@@ -108,47 +80,18 @@ const editEventPageQuery = gql`
           all
         }
       }
-      members {
-        id
-        createdAt
-        role
-        member {
-          id
-          name
-          imageUrl
-          slug
-          twitterHandle
-          description
-        }
-      }
-      orders {
-        id
-        createdAt
-        quantity
-        publicMessage
-        fromCollective {
-          id
-          name
-          company
-          image # For Event Sponsors
-          imageUrl
-          slug
-          twitterHandle
-          description
-          ... on User {
-            email
-          }
-        }
-        tier {
-          id
-          name
-        }
-      }
     }
   }
+  ${editCollectivePageFieldsFragment}
 `;
 
-const addEditEventPageData = graphql(editEventPageQuery);
+const addEditEventPageData = graphql(editEventPageQuery, {
+  skip: props => props.loadingLoggedInUser || !props.LoggedInUser,
+  // The fetchPolicy is important for an edge case.
+  // Same component, different collective (moving from edit to another edit through the menu)
+  // Reloading data make sure we get the loading state and we re-initialize Form and sub-components
+  options: { fetchPolicy: 'network-only' },
+});
 
 const addGraphql = compose(addEditEventPageData, addEditCollectiveMutation);
 


### PR DESCRIPTION
- Fix unnecessary redirect when editing info
- Fix link to "Add tier" on collective page
- Use a fragment to make sure we fetch all the fields fetched on the `editCollective` page (fix https://opencollective.slack.com/archives/C6JTTA4SK/p1600357973057400)
- Wait to be authenticated to fetch the data (same policy than `editCollective`)