### PR TITLE
Mitigate double payment issue

### DIFF
--- a/components/expenses/ProcessExpenseButtons.js
+++ b/components/expenses/ProcessExpenseButtons.js
@@ -70,6 +70,11 @@ const ProcessExpenseButtons = ({
   const [processExpense, { loading, error }] = useMutation(processExpenseMutation, mutationOptions);
 
   const triggerAction = async (action, paymentParams) => {
+    // Prevent submitting the action if another one is being submitted at the same time
+    if (loading) {
+      return;
+    }
+
     setSelectedAction(action);
 
     try {


### PR DESCRIPTION
While not the final fix, this will help with https://github.com/opencollective/opencollective/issues/3502. Before this, a fast double click on the pay button could trigger two requests as the two events were dispatched before React updates the button `loading` prop.