### PR TITLE
i18n-iso-countries: Use raw JSONs

### DIFF
--- a/components/InputTypeCountry.js
+++ b/components/InputTypeCountry.js
@@ -1,16 +1,28 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import countries from 'i18n-iso-countries';
 import countriesEN from 'i18n-iso-countries/langs/en.json';
 import countriesFR from 'i18n-iso-countries/langs/fr.json';
+import countriesPT from 'i18n-iso-countries/langs/pt.json';
 import { isUndefined, orderBy, truncate } from 'lodash';
 import memoizeOne from 'memoize-one';
 import { FormattedMessage, injectIntl } from 'react-intl';
 
 import StyledSelect from './StyledSelect';
 
-countries.registerLocale(countriesEN);
-countries.registerLocale(countriesFR);
+const COUNTRY_NAMES = {
+  en: countriesEN.countries,
+  fr: countriesFR.countries,
+  pt: countriesPT.countries,
+};
+
+const getCountryName = (locale, country) => {
+  const names = COUNTRY_NAMES[locale]?.[country] ?? COUNTRY_NAMES.en[country];
+  if (Array.isArray(names)) {
+    return names[0];
+  } else {
+    return names;
+  }
+};
 
 class InputTypeCountry extends Component {
   static propTypes = {
@@ -32,12 +44,12 @@ class InputTypeCountry extends Component {
   static defaultProps = { name: 'country' };
 
   getCountryLabel(code, locale) {
-    const name = countries.getName(code, locale) || countries.getName(code, 'en');
+    const name = getCountryName(locale, code);
     return `${truncate(name, { length: 30 })} - ${code}`;
   }
 
   getOptions = memoizeOne(locale => {
-    const options = Object.keys(countries.getAlpha2Codes()).map(code => ({
+    const options = Object.keys(COUNTRY_NAMES.en).map(code => ({
       value: code,
       label: this.getCountryLabel(code, locale),
     }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -12885,13 +12885,13 @@
       "dependencies": {
         "colors": {
           "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "resolved": "http://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
           "dev": true
         },
         "commander": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
           "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
           "dev": true
         }
@@ -14122,8 +14122,8 @@
       "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
     },
     "i18n-iso-countries": {
-      "version": "github:Betree/node-i18n-iso-countries#40b669544fe95c3f2e5c49c5bfc11cf3b055f9b4",
-      "from": "github:Betree/node-i18n-iso-countries#fix/remove-arrow-functions",
+      "version": "6.0.0",
+      "resolved": "github:Betree/node-i18n-iso-countries#40b669544fe95c3f2e5c49c5bfc11cf3b055f9b4",
       "requires": {
         "diacritics": "1.3.0"
       }
@@ -14182,7 +14182,7 @@
     },
     "immutable": {
       "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+      "resolved": "http://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
       "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
     },
     "import-fresh": {
@@ -24644,7 +24644,7 @@
       "dependencies": {
         "ast-types": {
           "version": "0.7.8",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
+          "resolved": "http://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
           "integrity": "sha1-kC0uDWDQcb3NRtwRXhgJ7RHBOKk=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "glob": "7.1.6",
     "graphql": "15.3.0",
     "helmet": "4.1.1",
-    "i18n-iso-countries": "Betree/node-i18n-iso-countries#fix/remove-arrow-functions",
+    "i18n-iso-countries": "6.0.0",
     "jsdom": "16.4.0",
     "jsonwebtoken": "8.5.1",
     "load-script": "1.0.0",


### PR DESCRIPTION
Going back to main repo (reverting https://github.com/opencollective/opencollective-frontend/pull/5041) and use raw JSON instead of helpers functions because there are still some code that break IE11.

I've proposed that the library should transpile its code in https://github.com/michaelwittig/node-i18n-iso-countries/issues/193#issuecomment-695938514. In the meantime, we're sure that this implementation is 100% compatible with every browser.

Also added portuguese.