### PR TITLE
Tier: Better support for endsAt

### DIFF
--- a/components/collective-page/sections/Contribute.js
+++ b/components/collective-page/sections/Contribute.js
@@ -13,6 +13,7 @@ import { TierTypes } from '../../../lib/constants/tiers-types';
 import { getErrorFromGraphqlException } from '../../../lib/errors';
 import { isPastEvent } from '../../../lib/events';
 import { API_V2_CONTEXT } from '../../../lib/graphql/helpers';
+import { isTierExpired } from '../../../lib/tier-utils';
 
 import { getCollectivePageQueryVariables } from '../../../pages/collective-page';
 import Container from '../../Container';
@@ -249,7 +250,7 @@ class SectionContribute extends React.PureComponent {
             collective,
             tier,
             hideContributors: hasNoContributor,
-            disableCTA: !canContribute,
+            disableCTA: !canContribute || isTierExpired(tier),
           },
         });
       }

--- a/components/contribute-cards/ContributeTier.js
+++ b/components/contribute-cards/ContributeTier.js
@@ -6,6 +6,7 @@ import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import { ContributionTypes } from '../../lib/constants/contribution-types';
 import { TierTypes } from '../../lib/constants/tiers-types';
 import { formatCurrency, getPrecisionFromAmount } from '../../lib/currency-utils';
+import { isTierExpired } from '../../lib/tier-utils';
 
 import FormattedMoneyAmount from '../FormattedMoneyAmount';
 import { Box, Flex } from '../Grid';
@@ -47,7 +48,7 @@ const ContributeTier = ({ intl, collective, tier, ...props }) => {
   const isFlexibleAmount = tier.amountType === 'FLEXIBLE';
   const minAmount = isFlexibleAmount ? tier.minimumAmount : tier.amount;
   const raised = tier.interval ? tier.stats.totalRecurringDonations : tier.stats.totalDonated;
-  const isPassed = tier.endsAt && new Date() > new Date(tier.endsAt);
+  const isPassed = isTierExpired(tier);
   const tierType = getContributionTypeFromTier(tier, isPassed);
 
   let description;

--- a/components/tier-page/index.js
+++ b/components/tier-page/index.js
@@ -6,6 +6,7 @@ import { withRouter } from 'next/router';
 import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 
+import { isTierExpired } from '../../lib/tier-utils';
 // Open Collective Frontend imports
 import { getWebsiteUrl } from '../../lib/utils';
 
@@ -160,7 +161,7 @@ class TierPage extends Component {
     const canEdit = LoggedInUser && LoggedInUser.canEditCollective(collective);
     const amountRaised = tier.interval ? tier.stats.totalRecurringDonations : tier.stats.totalDonated;
     const shareBlock = this.renderShareBlock();
-    const isPassed = tier.endsAt && new Date(tier.endsAt) < new Date();
+    const isPassed = isTierExpired(tier);
 
     return (
       <Container pb={4}>

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -183,6 +183,11 @@ interface Account {
   The address associated to this account. This field is always public for collectives and events.
   """
   location: Location
+
+  """
+  Categories set by Open Collective to help moderation.
+  """
+  categories: [String]!
   stats: AccountStats
 }
 
@@ -632,6 +637,7 @@ type Bot implements Account {
   The address associated to this account. This field is always public for collectives and events.
   """
   location: Location
+  categories: [String]!
   stats: AccountStats
 }
 
@@ -828,6 +834,7 @@ type Collective implements Account & AccountWithHost & AccountWithContributions 
   The address associated to this account. This field is always public for collectives and events.
   """
   location: Location
+  categories: [String]!
   stats: AccountStats
 
   """
@@ -2453,7 +2460,9 @@ type Credit implements Transaction {
   type: TransactionType
   description: String
   amount: Amount!
+  amountInHostCurrency: Amount!
   netAmount: Amount!
+  taxAmount: Amount!
   platformFee: Amount!
   hostFee: Amount!
   paymentProcessorFee: Amount!
@@ -2470,6 +2479,10 @@ type Credit implements Transaction {
   The permissions given to current logged in user for this transaction
   """
   permissions: TransactionPermissions!
+
+  """
+  Account that emitted the gift card used for this transaction (if any)
+  """
   giftCardEmitterAccount: Account
   fromAccount: Account
   toAccount: Account
@@ -2635,7 +2648,9 @@ type Debit implements Transaction {
   type: TransactionType
   description: String
   amount: Amount!
+  amountInHostCurrency: Amount!
   netAmount: Amount!
+  taxAmount: Amount!
   platformFee: Amount!
   hostFee: Amount!
   paymentProcessorFee: Amount!
@@ -2652,6 +2667,10 @@ type Debit implements Transaction {
   The permissions given to current logged in user for this transaction
   """
   permissions: TransactionPermissions!
+
+  """
+  Account that emitted the gift card used for this transaction (if any)
+  """
   giftCardEmitterAccount: Account
   fromAccount: Account
   toAccount: Account
@@ -2826,6 +2845,7 @@ type Event implements Account & AccountWithHost & AccountWithContributions {
   The address associated to this account. This field is always public for collectives and events.
   """
   location: Location
+  categories: [String]!
   stats: AccountStats
 
   """
@@ -3595,6 +3615,7 @@ type Fund implements Account & AccountWithHost & AccountWithContributions {
   The address associated to this account. This field is always public for collectives and events.
   """
   location: Location
+  categories: [String]!
   stats: AccountStats
 
   """
@@ -3842,6 +3863,7 @@ type Host implements Account {
   The address associated to this account. This field is always public for collectives and events.
   """
   location: Location
+  categories: [String]!
   stats: AccountStats
   hostFeePercent: Int
   totalHostedCollectives: Int
@@ -4139,6 +4161,7 @@ type Individual implements Account {
     - Hosts can see the address of users submitting expenses to their collectives
   """
   location: Location
+  categories: [String]!
   stats: AccountStats
   firstName: String
   lastName: String
@@ -4762,6 +4785,7 @@ type Order {
   legacyId: Int!
   description: String
   amount: Amount!
+  quantity: Int
   status: OrderStatus
   frequency: ContributionFrequency
   tier: Tier
@@ -4788,6 +4812,7 @@ type Order {
   Platform contribution attached to the Order.
   """
   platformContributionAmount: Amount
+  taxes: [OrderTax]!
 
   """
   This represents a MemberOf relationship (ie: Collective backed by an Individual) attached to the Order.
@@ -4881,6 +4906,11 @@ enum OrderStatus {
   PENDING
   PLEDGED
   REQUIRE_CLIENT_CONFIRMATION
+}
+
+type OrderTax {
+  type: OrderTaxType!
+  percentage: Int!
 }
 
 """
@@ -5094,6 +5124,7 @@ type Organization implements Account {
     - Hosts can see the address of organizations submitting expenses to their collectives
   """
   location: Location
+  categories: [String]!
   stats: AccountStats
 
   """
@@ -5440,6 +5471,7 @@ type Project implements Account & AccountWithHost & AccountWithContributions {
   The address associated to this account. This field is always public for collectives and events.
   """
   location: Location
+  categories: [String]!
   stats: AccountStats
 
   """
@@ -5759,6 +5791,11 @@ type Query {
     account: AccountReferenceInput
 
     """
+    Reference of the host where this expense was submitted
+    """
+    host: AccountReferenceInput
+
+    """
     Only expenses that match these tags
     """
     tags: [String]
@@ -5782,6 +5819,11 @@ type Query {
     Only return expenses that were created after this date
     """
     dateFrom: ISODateTime
+
+    """
+    Only return expenses that were created after this date
+    """
+    dateTo: ISODateTime
 
     """
     The term to search
@@ -5861,6 +5903,7 @@ type Tier {
   customFields: JSON
   amountType: TierAmountType!
   minimumAmount: Amount!
+  endsAt: ISODateTime
 }
 
 enum TierAmountType {
@@ -5914,7 +5957,9 @@ interface Transaction {
   type: TransactionType
   description: String
   amount: Amount!
+  amountInHostCurrency: Amount!
   netAmount: Amount!
+  taxAmount: Amount!
   platformFee: Amount!
   hostFee: Amount
   paymentProcessorFee: Amount

--- a/lib/tier-utils.js
+++ b/lib/tier-utils.js
@@ -77,3 +77,7 @@ export const isFixedContribution = (tier, fixedAmount, fixedInterval) => {
   const isFlexible = tier && tier.amountType === AmountTypes.FLEXIBLE;
   return !isFlexible && forceInterval && forceAmount;
 };
+
+export const isTierExpired = tier => {
+  return tier?.endsAt && new Date(tier.endsAt) < new Date();
+};

--- a/pages/new-contribution-flow.js
+++ b/pages/new-contribution-flow.js
@@ -12,6 +12,7 @@ import { GQLV2_PAYMENT_METHOD_TYPES } from '../lib/constants/payment-methods';
 import { generateNotFoundError, getErrorFromGraphqlException } from '../lib/errors';
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
 import { floatAmountToCents } from '../lib/math';
+import { isTierExpired } from '../lib/tier-utils';
 import { compose, parseToBoolean } from '../lib/utils';
 
 import Container from '../components/Container';
@@ -205,7 +206,7 @@ class NewContributionFlowPage extends React.Component {
       return this.renderMessage('info', intl.formatMessage(messages.emptyTier, intlParams), true);
     } else if (this.props.tierId && !tier) {
       return this.renderMessage('warning', intl.formatMessage(messages.missingTier), true);
-    } else if (tier && tier.endsAt && new Date(tier.endsAt) < new Date()) {
+    } else if (tier && isTierExpired(tier)) {
       return this.renderMessage('warning', intl.formatMessage(messages.expiredTier), true);
     } else if (account.settings.disableCustomContributions && !tier) {
       return this.renderMessage('warning', intl.formatMessage(messages.disableCustomContributions), true);
@@ -349,6 +350,7 @@ const accountWithTierQuery = gqlV2/* GraphQL */ `
       customFields
       availableQuantity
       maxQuantity
+      endsAt
       amount {
         valueInCents
         currency


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-api/pull/4594

Adds support for `endsAt` on the contribution flow revamp and properly disable the CTA on the tier card.