### PR TITLE
Minor UX and bug fixes for 2FA login box

### DIFF
--- a/components/SignInOrJoinFree.js
+++ b/components/SignInOrJoinFree.js
@@ -158,7 +158,9 @@ class SignInOrJoinFree extends React.Component {
               twoFactorAuthenticatorCode: '',
             }}
             onSubmit={(values, actions) => {
-              this.props.submitTwoFactorAuthenticatorCode(values, actions);
+              this.props.submitTwoFactorAuthenticatorCode(values).then(() => {
+                actions.setSubmitting(false);
+              });
             }}
           >
             {formik => {
@@ -199,9 +201,9 @@ class SignInOrJoinFree extends React.Component {
                       minHeight="36px"
                       buttonStyle="primary"
                       type="submit"
-                      onSubmit={handleSubmit}
                       disabled={values.twoFactorAuthenticatorCode.length < 6}
                       loading={isSubmitting}
+                      onSubmit={handleSubmit}
                       data-cy="signin-two-factor-auth-button"
                     >
                       <FormattedMessage id="TwoFactorAuth.Setup.Form.VerifyButton" defaultMessage="Verify" />

--- a/components/UserProvider.js
+++ b/components/UserProvider.js
@@ -87,6 +87,7 @@ class UserProvider extends React.Component {
         loadingLoggedInUser: false,
         errorLoggedInUser: null,
         LoggedInUser,
+        enforceTwoFactorAuthForLoggedInUser: false,
       });
       return LoggedInUser;
     } catch (error) {

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1063,7 +1063,6 @@
   "loggingout": "logging out",
   "login.askAnother": "You can ask for a new sign in link using the form below.",
   "login.failed": "Sign In failed: {message}.",
-  "login.warning.2fa": "Security challenge: {message}.",
   "ManagedFunds": "Managed funds",
   "map.viewLarger": "View Larger Map",
   "Member.Role.ACCOUNTANT": "Accountant",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1063,7 +1063,6 @@
   "loggingout": "odhlašování",
   "login.askAnother": "You can ask for a new sign in link using the form below.",
   "login.failed": "Sign In failed: {message}.",
-  "login.warning.2fa": "Security challenge: {message}.",
   "ManagedFunds": "Managed funds",
   "map.viewLarger": "Zobrazit větší mapu",
   "Member.Role.ACCOUNTANT": "Accountant",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1063,7 +1063,6 @@
   "loggingout": "Abmelden",
   "login.askAnother": "Sie können über das untenstehende Formular einen neuen Login-Link anfragen.",
   "login.failed": "Anmeldung fehlgeschlagen: {message}.",
-  "login.warning.2fa": "Security challenge: {message}.",
   "ManagedFunds": "Managed funds",
   "map.viewLarger": "View Larger Map",
   "Member.Role.ACCOUNTANT": "Accountant",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1063,7 +1063,6 @@
   "loggingout": "logging out",
   "login.askAnother": "You can ask for a new sign in link using the form below.",
   "login.failed": "Sign In failed: {message}.",
-  "login.warning.2fa": "Security challenge: {message}.",
   "ManagedFunds": "Managed funds",
   "map.viewLarger": "View Larger Map",
   "Member.Role.ACCOUNTANT": "Accountant",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1063,7 +1063,6 @@
   "loggingout": "desconectando",
   "login.askAnother": "Puede solicitar un nuevo enlace de inicio de sesión utilizando el siguiente formulario.",
   "login.failed": "Registro fallido: {message}.",
-  "login.warning.2fa": "Security challenge: {message}.",
   "ManagedFunds": "Fondos gestionados",
   "map.viewLarger": "View Larger Map",
   "Member.Role.ACCOUNTANT": "Accountant",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1063,7 +1063,6 @@
   "loggingout": "se déconnecter",
   "login.askAnother": "Vous pouvez demander un nouveau lien en utilisant le formulaire ci-dessous.",
   "login.failed": "Connexion échouée : {message}.",
-  "login.warning.2fa": "Défi de sécurité : {message}.",
   "ManagedFunds": "Fonds gérés",
   "map.viewLarger": "Voir la carte plus grande",
   "Member.Role.ACCOUNTANT": "Accountant",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1063,7 +1063,6 @@
   "loggingout": "logging out",
   "login.askAnother": "You can ask for a new sign in link using the form below.",
   "login.failed": "Sign In failed: {message}.",
-  "login.warning.2fa": "Security challenge: {message}.",
   "ManagedFunds": "Managed funds",
   "map.viewLarger": "View Larger Map",
   "Member.Role.ACCOUNTANT": "Accountant",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1063,7 +1063,6 @@
   "loggingout": "ログアウト",
   "login.askAnother": "You can ask for a new sign in link using the form below.",
   "login.failed": "ログインに失敗しました: {message}",
-  "login.warning.2fa": "Security challenge: {message}.",
   "ManagedFunds": "Managed funds",
   "map.viewLarger": "より大きい地図の表示",
   "Member.Role.ACCOUNTANT": "Accountant",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1063,7 +1063,6 @@
   "loggingout": "logging out",
   "login.askAnother": "You can ask for a new sign in link using the form below.",
   "login.failed": "Sign In failed: {message}.",
-  "login.warning.2fa": "Security challenge: {message}.",
   "ManagedFunds": "Managed funds",
   "map.viewLarger": "View Larger Map",
   "Member.Role.ACCOUNTANT": "Accountant",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1063,7 +1063,6 @@
   "loggingout": "logging out",
   "login.askAnother": "You can ask for a new sign in link using the form below.",
   "login.failed": "Sign In failed: {message}.",
-  "login.warning.2fa": "Security challenge: {message}.",
   "ManagedFunds": "Managed funds",
   "map.viewLarger": "View Larger Map",
   "Member.Role.ACCOUNTANT": "Accountant",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1063,7 +1063,6 @@
   "loggingout": "saindo",
   "login.askAnother": "Você pode pedir um novo link para entrar usando o formulário abaixo.",
   "login.failed": "Falha no login: {message}.",
-  "login.warning.2fa": "Security challenge: {message}.",
   "ManagedFunds": "Managed funds",
   "map.viewLarger": "Visualizar Mapa Maior",
   "Member.Role.ACCOUNTANT": "Accountant",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1063,7 +1063,6 @@
   "loggingout": "выйти",
   "login.askAnother": "You can ask for a new sign in link using the form below.",
   "login.failed": "Выход не удался: {message}.",
-  "login.warning.2fa": "Security challenge: {message}.",
   "ManagedFunds": "Управление фондами",
   "map.viewLarger": "View Larger Map",
   "Member.Role.ACCOUNTANT": "Accountant",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1063,7 +1063,6 @@
   "loggingout": "注销",
   "login.askAnother": "You can ask for a new sign in link using the form below.",
   "login.failed": "Sign In failed: {message}.",
-  "login.warning.2fa": "Security challenge: {message}.",
   "ManagedFunds": "Managed funds",
   "map.viewLarger": "View Larger Map",
   "Member.Role.ACCOUNTANT": "Accountant",

--- a/pages/signin.js
+++ b/pages/signin.js
@@ -119,26 +119,17 @@ class SigninPage extends React.Component {
     }
 
     const error = errorLoggedInUser || this.state.error;
-    const warning = error ? error.includes('Two-factor authentication is enabled') : null;
 
     return (
       <React.Fragment>
-        {error && (
-          <MessageBox type={warning ? 'warning' : 'error'} withIcon mb={4} data-cy="signin-message-box">
+        {error && !error.includes('Two-factor authentication is enabled') && (
+          <MessageBox type="error" withIcon mb={4} data-cy="signin-message-box">
             <strong>
-              {warning ? (
-                <FormattedMessage
-                  id="login.warning.2fa"
-                  defaultMessage="Security challenge: {message}."
-                  values={{ message: error }}
-                />
-              ) : (
-                <FormattedMessage
-                  id="login.failed"
-                  defaultMessage="Sign In failed: {message}."
-                  values={{ message: error }}
-                />
-              )}
+              <FormattedMessage
+                id="login.failed"
+                defaultMessage="Sign In failed: {message}."
+                values={{ message: error }}
+              />
             </strong>
             <br />
             {!error?.includes('Two-factor authentication') && (
@@ -154,10 +145,9 @@ class SigninPage extends React.Component {
           form={form}
           routes={this.getRoutes()}
           enforceTwoFactorAuthForLoggedInUser={enforceTwoFactorAuthForLoggedInUser}
-          submitTwoFactorAuthenticatorCode={(values, actions) => {
+          submitTwoFactorAuthenticatorCode={values => {
             const localStorage2FAToken = getFromLocalStorage(LOCAL_STORAGE_KEYS.ACCESS_TOKEN);
-            this.props.login(localStorage2FAToken, values.twoFactorAuthenticatorCode);
-            actions.setSubmitting(false);
+            return this.props.login(localStorage2FAToken, values.twoFactorAuthenticatorCode);
           }}
         />
       </React.Fragment>

--- a/test/cypress/integration/07-signin.test.js
+++ b/test/cypress/integration/07-signin.test.js
@@ -196,7 +196,6 @@ describe('signin with 2FA', () => {
   it('can signin with 2fa enabled', () => {
     // now login with 2FA enabled
     cy.login({ email: user.email, redirect: '/apex' });
-    cy.getByDataCy('signin-message-box').contains('Two-factor authentication is enabled on this account');
     cy.getByDataCy('signin-two-factor-auth-input').type('123456');
     cy.getByDataCy('signin-two-factor-auth-button').click();
     cy.getByDataCy('signin-message-box').contains(


### PR DESCRIPTION
This fixes:

* `loading` state on button when you submit the 2FA code
* if you sign in then sign out and go back to the sign in page, the 2FA box won't still be there
* removes `warning` error above 2FA box when you are first asked for the code

Relates https://github.com/opencollective/opencollective/issues/3515