### PR TITLE
Make reject work with recurring contributions

### DIFF
--- a/components/recurring-contributions/RecurringContributionsCard.js
+++ b/components/recurring-contributions/RecurringContributionsCard.js
@@ -24,7 +24,7 @@ const messages = defineMessages({
   tag: {
     id: 'Subscriptions.Status',
     defaultMessage:
-      '{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}',
+      '{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} REJECTED {Rejected contribution} other {}}',
   },
 });
 
@@ -40,7 +40,7 @@ const RecurringContributionsCard = ({
   const [showPopup, setShowPopup] = useState(false);
   const { formatMessage } = useIntl();
   const isAdmin = LoggedInUser && LoggedInUser.canEditCollective(account);
-  const isError = status === ORDER_STATUS.ERROR;
+  const isError = status === ORDER_STATUS.ERROR || status === ORDER_STATUS.REJECTED;
   const isActive = status === ORDER_STATUS.ACTIVE || isError;
 
   return (

--- a/components/recurring-contributions/RecurringContributionsContainer.js
+++ b/components/recurring-contributions/RecurringContributionsContainer.js
@@ -21,6 +21,7 @@ const CollectiveCardContainer = styled.div`
 
 const filterContributions = (contributions, filterName) => {
   const isActive = ({ status }) => status === ORDER_STATUS.ACTIVE || status === ORDER_STATUS.ERROR;
+  const isInactive = ({ status }) => status === ORDER_STATUS.CANCELLED || status === ORDER_STATUS.REJECTED;
   switch (filterName) {
     case 'ACTIVE':
       return contributions.filter(isActive);
@@ -29,7 +30,7 @@ const filterContributions = (contributions, filterName) => {
     case 'YEARLY':
       return contributions.filter(contrib => isActive(contrib) && contrib.frequency === 'YEARLY');
     case 'CANCELLED':
-      return contributions.filter(contrib => contrib.status === ORDER_STATUS.CANCELLED);
+      return contributions.filter(isInactive);
     default:
       return [];
   }

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1450,7 +1450,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.FeesOnTopTooltip": "Contribution to collective plus contribution to the platform",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} REJECTED {Rejected contribution} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Large",
   "table.head.medium": "Medium",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1450,7 +1450,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.FeesOnTopTooltip": "Contribution to collective plus contribution to the platform",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} REJECTED {Rejected contribution} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Velký",
   "table.head.medium": "Střední",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1450,7 +1450,7 @@
   "Subscriptions.Cancelled": "Abbestellt",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.FeesOnTopTooltip": "Contribution to collective plus contribution to the platform",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} REJECTED {Rejected contribution} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Large",
   "table.head.medium": "Medium",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1450,7 +1450,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.FeesOnTopTooltip": "Contribution to collective plus contribution to the platform",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} REJECTED {Rejected contribution} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Large",
   "table.head.medium": "Medium",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1450,7 +1450,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.FeesOnTopTooltip": "Contribution to collective plus contribution to the platform",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} REJECTED {Rejected contribution} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Grande",
   "table.head.medium": "Medio",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1450,7 +1450,7 @@
   "Subscriptions.Cancelled": "Annulée",
   "Subscriptions.ContributedToDate": "Contribution à ce jour",
   "Subscriptions.FeesOnTopTooltip": "Contribution to collective plus contribution to the platform",
-  "Subscriptions.Status": "{status, select, ACTIVE {Contribution active} CANCELLED {Contribution annulée} ERROR {Erreur} other {}}",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} REJECTED {Rejected contribution} other {}}",
   "Subscriptions.Title": "Contributions récurrentes",
   "table.head.large": "Large",
   "table.head.medium": "Moyen",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1450,7 +1450,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.FeesOnTopTooltip": "Contribution to collective plus contribution to the platform",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} REJECTED {Rejected contribution} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Large",
   "table.head.medium": "Medium",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1450,7 +1450,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.FeesOnTopTooltip": "Contribution to collective plus contribution to the platform",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} REJECTED {Rejected contribution} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Large",
   "table.head.medium": "Medium",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1450,7 +1450,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.FeesOnTopTooltip": "Contribution to collective plus contribution to the platform",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} REJECTED {Rejected contribution} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "큰",
   "table.head.medium": "중간",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1450,7 +1450,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.FeesOnTopTooltip": "Contribution to collective plus contribution to the platform",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} REJECTED {Rejected contribution} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Large",
   "table.head.medium": "Medium",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1450,7 +1450,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.FeesOnTopTooltip": "Contribution to collective plus contribution to the platform",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} REJECTED {Rejected contribution} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Grande",
   "table.head.medium": "Medio",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1450,7 +1450,7 @@
   "Subscriptions.Cancelled": "Отменено",
   "Subscriptions.ContributedToDate": "Пожертвовано на текущий момент",
   "Subscriptions.FeesOnTopTooltip": "Contribution to collective plus contribution to the platform",
-  "Subscriptions.Status": "{status, select, ACTIVE {Активный вклад} CANCELLED {Отмененный вклад} ERROR {Ошибка} other {}}",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} REJECTED {Rejected contribution} other {}}",
   "Subscriptions.Title": "Периодические вклады",
   "table.head.large": "Large",
   "table.head.medium": "Medium",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1450,7 +1450,7 @@
   "Subscriptions.Cancelled": "Cancelled",
   "Subscriptions.ContributedToDate": "Contributed to date",
   "Subscriptions.FeesOnTopTooltip": "Contribution to collective plus contribution to the platform",
-  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} other {}}",
+  "Subscriptions.Status": "{status, select, ACTIVE {Active contribution} CANCELLED {Cancelled contribution} ERROR {Error} REJECTED {Rejected contribution} other {}}",
   "Subscriptions.Title": "Recurring contributions",
   "table.head.large": "Large",
   "table.head.medium": "Medium",


### PR DESCRIPTION
Updates recurring contributions section to display `REJECTED` recurring contributions as well in the 'Cancelled' section

<img width="893" alt="Screenshot 2020-09-24 at 14 14 30" src="https://user-images.githubusercontent.com/37520401/94149837-4ecbe900-fe70-11ea-8b4f-84fd1a920d5c.png">
