### PR TITLE
Fix conditionals and permissions for reject contribution

### DIFF
--- a/components/transactions/TransactionDetails.js
+++ b/components/transactions/TransactionDetails.js
@@ -52,14 +52,7 @@ const DetailsContainer = styled(Flex)`
   }
 `;
 
-const TransactionDetails = ({
-  displayActions,
-  transaction,
-  isRoot,
-  isHostAdmin,
-  isToCollectiveAdmin,
-  onMutationSuccess,
-}) => {
+const TransactionDetails = ({ displayActions, transaction, onMutationSuccess }) => {
   const intl = useIntl();
   const { loading: loadingInvoice, callWith: downloadInvoiceWith } = useAsyncCall(saveInvoice);
   const {
@@ -79,17 +72,11 @@ const TransactionDetails = ({
     order,
     expense,
     isRejected,
-    createdAt,
   } = transaction;
   const isCredit = type === TransactionTypes.CREDIT;
   const hasOrder = order !== null;
-  // calculate 30 days ago from transaction
-  const thirtyDaysInMillisecond = 1000 * 60 * 60 * 24 * 30;
-  const transactionIsOlderThanThirtyDays = Date.parse(createdAt) < Date.now() - thirtyDaysInMillisecond;
 
   // permissions
-  const collectiveAdminCanRefund = isToCollectiveAdmin && transactionIsOlderThanThirtyDays;
-  const userCanRejectOrRefund = isRoot || isHostAdmin || collectiveAdminCanRefund;
   const collectiveHasRejectContributionFeature = hasFeature(toAccount, FEATURES.REJECT_CONTRIBUTION);
   const showRejectContribution =
     parseToBoolean(getEnvVar('REJECT_CONTRIBUTION')) || collectiveHasRejectContributionFeature;
@@ -146,18 +133,11 @@ const TransactionDetails = ({
           {displayActions && ( // Let us overide so we can hide buttons in the collective page
             <React.Fragment>
               <Flex justifyContent="flex-end">
-                {showRefundButton && (
-                  <TransactionRefundButton
-                    id={id}
-                    disabled={userCanRejectOrRefund}
-                    onMutationSuccess={onMutationSuccess}
-                  />
-                )}
+                {showRefundButton && <TransactionRefundButton id={id} onMutationSuccess={onMutationSuccess} />}
                 {showRejectButton && (
                   <TransactionRejectButton
                     id={id}
                     canRefund={permissions?.canRefund && !isRefunded}
-                    disabled={userCanRejectOrRefund}
                     onMutationSuccess={onMutationSuccess}
                   />
                 )}

--- a/components/transactions/TransactionItem.js
+++ b/components/transactions/TransactionItem.js
@@ -228,9 +228,6 @@ const TransactionItem = ({ displayActions, collective, transaction, onMutationSu
         <TransactionDetails
           displayActions={displayActions}
           transaction={transaction}
-          isRoot={isRoot}
-          isHostAdmin={isHostAdmin}
-          isToCollectiveAdmin={isToCollectiveAdmin}
           onMutationSuccess={onMutationSuccess}
         />
       )}

--- a/components/transactions/TransactionRefundButton.js
+++ b/components/transactions/TransactionRefundButton.js
@@ -11,7 +11,6 @@ import { Box, Flex } from '../Grid';
 import MessageBox from '../MessageBox';
 import MessageBoxGraphqlError from '../MessageBoxGraphqlError';
 import StyledButton from '../StyledButton';
-import StyledTooltip from '../StyledTooltip';
 
 export const refundTransactionMutation = gqlV2/* GraphQL */ `
   mutation RefundTransaction($transaction: TransactionReferenceInput!) {
@@ -43,41 +42,22 @@ const TransactionRefundButton = props => {
     setError(null);
   };
 
-  const rejectButton = (
-    <StyledButton
-      buttonSize="small"
-      buttonStyle="secondary"
-      minWidth={140}
-      background="transparent"
-      textTransform="capitalize"
-      onClick={() => setEnabled(true)}
-      disabled={props.disabled}
-    >
-      <Flex alignItems="center" justifyContent="space-evenly">
-        <Undo size={16} />
-        <FormattedMessage id="transaction.refund.btn" defaultMessage="refund" />
-      </Flex>
-    </StyledButton>
-  );
-
   return (
     <Flex flexDirection="column">
       <Box>
-        {props.disabled ? (
-          <StyledTooltip
-            type="light"
-            content={
-              <FormattedMessage
-                id="transaction.error.thirtydays"
-                defaultMessage="Collective admins cannot refund or reject contributions older than 30 days."
-              />
-            }
-          >
-            {rejectButton}
-          </StyledTooltip>
-        ) : (
-          rejectButton
-        )}
+        <StyledButton
+          buttonSize="small"
+          buttonStyle="secondary"
+          minWidth={140}
+          background="transparent"
+          textTransform="capitalize"
+          onClick={() => setEnabled(true)}
+        >
+          <Flex alignItems="center" justifyContent="space-evenly">
+            <Undo size={16} />
+            <FormattedMessage id="transaction.refund.btn" defaultMessage="refund" />
+          </Flex>
+        </StyledButton>
         <ConfirmationModal
           show={isEnabled}
           onClose={closeModal}
@@ -110,7 +90,6 @@ const TransactionRefundButton = props => {
 
 TransactionRefundButton.propTypes = {
   id: PropTypes.string.isRequired,
-  disabled: PropTypes.bool,
   onMutationSuccess: PropTypes.func,
 };
 

--- a/components/transactions/TransactionRejectButton.js
+++ b/components/transactions/TransactionRejectButton.js
@@ -11,7 +11,6 @@ import { Box, Flex } from '../Grid';
 import MessageBox from '../MessageBox';
 import MessageBoxGraphqlError from '../MessageBoxGraphqlError';
 import StyledButton from '../StyledButton';
-import StyledTooltip from '../StyledTooltip';
 
 import TransactionRejectMessageForm from './TransactionRejectMessageForm';
 
@@ -51,42 +50,23 @@ const TransactionRejectButton = props => {
     setError(null);
   };
 
-  const rejectButton = (
-    <StyledButton
-      buttonSize="small"
-      buttonStyle="dangerSecondary"
-      minWidth={140}
-      background="transparent"
-      textTransform="capitalize"
-      onClick={() => setEnabled(true)}
-      ml={props.canRefund ? 2 : 0}
-      disabled={props.disabled}
-    >
-      <Flex alignItems="center" justifyContent="space-evenly">
-        <MinusCircle size={16} />
-        <FormattedMessage id="actions.reject" defaultMessage="Reject" />
-      </Flex>
-    </StyledButton>
-  );
-
   return (
     <Flex flexDirection="column">
       <Box>
-        {props.disabled ? (
-          <StyledTooltip
-            type="light"
-            content={
-              <FormattedMessage
-                id="transaction.error.thirtydays"
-                defaultMessage="Collective admins cannot refund or reject contributions older than 30 days."
-              />
-            }
-          >
-            {rejectButton}
-          </StyledTooltip>
-        ) : (
-          rejectButton
-        )}
+        <StyledButton
+          buttonSize="small"
+          buttonStyle="dangerSecondary"
+          minWidth={140}
+          background="transparent"
+          textTransform="capitalize"
+          onClick={() => setEnabled(true)}
+          ml={props.canRefund ? 2 : 0}
+        >
+          <Flex alignItems="center" justifyContent="space-evenly">
+            <MinusCircle size={16} />
+            <FormattedMessage id="actions.reject" defaultMessage="Reject" />
+          </Flex>
+        </StyledButton>
         <ConfirmationModal
           show={isEnabled}
           onClose={closeModal}
@@ -125,7 +105,6 @@ const TransactionRejectButton = props => {
 TransactionRejectButton.propTypes = {
   id: PropTypes.string.isRequired,
   canRefund: PropTypes.bool,
-  disabled: PropTypes.bool,
   onMutationSuccess: PropTypes.func,
 };
 

--- a/components/transactions/graphql/fragments.js
+++ b/components/transactions/graphql/fragments.js
@@ -41,6 +41,7 @@ export const transactionsQueryCollectionFragment = gqlV2/* GraphQL */ `
         type
         imageUrl
         isIncognito
+        settings
         ... on Collective {
           host {
             name

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1541,7 +1541,6 @@
   "Transaction.by": "by {name}",
   "transaction.details": "transaction details",
   "transaction.downloadPDF": "Download (pdf)",
-  "transaction.error.thirtydays": "Collective admins cannot refund or reject contributions older than 30 days.",
   "Transaction.from": "from {name}",
   "transaction.fxrate": "fx rate",
   "transaction.hostFeeInHostCurrency": "{percentage} host fee",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1541,7 +1541,6 @@
   "Transaction.by": "by {name}",
   "transaction.details": "podrobnosti o transakci",
   "transaction.downloadPDF": "Stáhnout (pdf)",
-  "transaction.error.thirtydays": "Collective admins cannot refund or reject contributions older than 30 days.",
   "Transaction.from": "from {name}",
   "transaction.fxrate": "kurz",
   "transaction.hostFeeInHostCurrency": "{percentage} host fee",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1541,7 +1541,6 @@
   "Transaction.by": "by {name}",
   "transaction.details": "Transaktionsdetails",
   "transaction.downloadPDF": "Download (pdf)",
-  "transaction.error.thirtydays": "Collective admins cannot refund or reject contributions older than 30 days.",
   "Transaction.from": "von {name}",
   "transaction.fxrate": "fx rate",
   "transaction.hostFeeInHostCurrency": "{percentage} host fee",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1541,7 +1541,6 @@
   "Transaction.by": "by {name}",
   "transaction.details": "transaction details",
   "transaction.downloadPDF": "Download (pdf)",
-  "transaction.error.thirtydays": "Collective admins cannot refund or reject contributions older than 30 days.",
   "Transaction.from": "from {name}",
   "transaction.fxrate": "fx rate",
   "transaction.hostFeeInHostCurrency": "{percentage} host fee",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1541,7 +1541,6 @@
   "Transaction.by": "by {name}",
   "transaction.details": "detalles de la transacción",
   "transaction.downloadPDF": "Descargar (pdf)",
-  "transaction.error.thirtydays": "Collective admins cannot refund or reject contributions older than 30 days.",
   "Transaction.from": "from {name}",
   "transaction.fxrate": "tasa fx",
   "transaction.hostFeeInHostCurrency": "{percentage} tasa del espónsor fiscal",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1541,7 +1541,6 @@
   "Transaction.by": "par {name}",
   "transaction.details": "détails de la transaction",
   "transaction.downloadPDF": "Télécharger (pdf)",
-  "transaction.error.thirtydays": "Collective admins cannot refund or reject contributions older than 30 days.",
   "Transaction.from": "de {name}",
   "transaction.fxrate": "taux de change",
   "transaction.hostFeeInHostCurrency": "commission de l'hôte: {percentage}",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1541,7 +1541,6 @@
   "Transaction.by": "by {name}",
   "transaction.details": "dettagli transazione",
   "transaction.downloadPDF": "Scarica (pdf)",
-  "transaction.error.thirtydays": "Collective admins cannot refund or reject contributions older than 30 days.",
   "Transaction.from": "from {name}",
   "transaction.fxrate": "fx rate",
   "transaction.hostFeeInHostCurrency": "{percentage} host fee",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1541,7 +1541,6 @@
   "Transaction.by": "by {name}",
   "transaction.details": "取引の詳細",
   "transaction.downloadPDF": "ダウンロード (PDF)",
-  "transaction.error.thirtydays": "Collective admins cannot refund or reject contributions older than 30 days.",
   "Transaction.from": "from {name}",
   "transaction.fxrate": "為替レート",
   "transaction.hostFeeInHostCurrency": "手数料 {percentage}",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1541,7 +1541,6 @@
   "Transaction.by": "by {name}",
   "transaction.details": "transaction details",
   "transaction.downloadPDF": "다운로드 (pdf)",
-  "transaction.error.thirtydays": "Collective admins cannot refund or reject contributions older than 30 days.",
   "Transaction.from": "from {name}",
   "transaction.fxrate": "fx rate",
   "transaction.hostFeeInHostCurrency": "{percentage} host fee",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1541,7 +1541,6 @@
   "Transaction.by": "by {name}",
   "transaction.details": "transaction details",
   "transaction.downloadPDF": "Download (pdf)",
-  "transaction.error.thirtydays": "Collective admins cannot refund or reject contributions older than 30 days.",
   "Transaction.from": "from {name}",
   "transaction.fxrate": "fx rate",
   "transaction.hostFeeInHostCurrency": "{percentage} host fee",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1541,7 +1541,6 @@
   "Transaction.by": "by {name}",
   "transaction.details": "detalhes da transação",
   "transaction.downloadPDF": "Baixar (pdf)",
-  "transaction.error.thirtydays": "Collective admins cannot refund or reject contributions older than 30 days.",
   "Transaction.from": "from {name}",
   "transaction.fxrate": "taxa de câmbio",
   "transaction.hostFeeInHostCurrency": "{percentage} taxa do organizador",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1541,7 +1541,6 @@
   "Transaction.by": "от {name}",
   "transaction.details": "детали транзакции",
   "transaction.downloadPDF": "Загрузить (pdf)",
-  "transaction.error.thirtydays": "Collective admins cannot refund or reject contributions older than 30 days.",
   "Transaction.from": "от {name}",
   "transaction.fxrate": "fx rate",
   "transaction.hostFeeInHostCurrency": "{percentage} комиссия представителя",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1541,7 +1541,6 @@
   "Transaction.by": "by {name}",
   "transaction.details": "transaction details",
   "transaction.downloadPDF": "Download (pdf)",
-  "transaction.error.thirtydays": "Collective admins cannot refund or reject contributions older than 30 days.",
   "Transaction.from": "from {name}",
   "transaction.fxrate": "fx rate",
   "transaction.hostFeeInHostCurrency": "{percentage} host fee",


### PR DESCRIPTION
* Adds `settings` to `toAccount` graphql query so we can check the Collective settings
* Relies on API for permissions
* Removes displaying buttons for Collective admins if transaction is older than 30 days (because we're relying on the API permissions to display the buttons at all now, it reduces code on the frontend, and I don't think there's a point displaying the disabled buttons if the Collective admin can't refund/reject)