### PR TITLE
Implement duplicate request handler

### DIFF
--- a/server/duplicate-handler.js
+++ b/server/duplicate-handler.js
@@ -1,0 +1,90 @@
+const debug = require('debug')('duplicateHandler');
+
+function duplicateHandler({ keyGenerator, skip, timeout } = {}) {
+  timeout = Number(timeout) || 30;
+
+  const requests = {};
+
+  // Garbage collection (not necessary under normal operation)
+  const gc = () => {
+    const ids = Object.keys(requests);
+    if (ids.length > 0) {
+      debug(`${ids.length} current registered requests`);
+    }
+    for (const id of ids) {
+      if (requests[id].registeredAt < new Date().getTime() - timeout * 1000) {
+        delete requests[id];
+      }
+    }
+  };
+
+  setInterval(gc, 1000);
+
+  return function handleDuplicate(req, res, next) {
+    if (skip && skip(req)) {
+      next();
+      return;
+    }
+
+    const id = keyGenerator ? keyGenerator(req) : req.url;
+
+    if (requests[id]) {
+      debug(`Duplicate request detected '${id}'`);
+      const origin = requests[id].origin;
+
+      // Prepare for duplicates
+      // We're lazily doing it only when the first duplicate arrives
+      if (!requests[id].duplicates) {
+        requests[id].duplicates = [];
+
+        const originResMethods = {};
+        for (const method of ['setHeader', 'end']) {
+          // Copy original methods
+          originResMethods[method] = origin.res[method];
+
+          origin.res[method] = function () {
+            // Apply on the origin method
+            originResMethods[method].apply(origin.res, arguments);
+
+            // Apply on duplicates method
+            for (const duplicate of requests[id].duplicates) {
+              // Copy properties because we don't listen when their set
+              if (method === 'send') {
+                duplicate.res.statusCode = origin.res.statusCode;
+                duplicate.res.statusMessage = origin.res.statusMessage;
+              }
+
+              duplicate.res[method].apply(duplicate.res, arguments);
+            }
+          };
+        }
+      }
+
+      // Make sure to copy headers from origin response
+      for (const [key, value] of Object.entries(origin.res.getHeaders())) {
+        res.setHeader(key, value);
+      }
+
+      // Registering duplicate
+      requests[id].duplicates.push({ req, res, next });
+
+      // That's all, wait on origin response to complete
+      return;
+    }
+
+    // Registering origin request
+    requests[id] = {
+      registeredAt: new Date().getTime(),
+      origin: { req, res, next },
+    };
+
+    // Release origin request
+    req.on('close', () => delete requests[id]);
+    res.on('end', () => delete requests[id]);
+    res.on('finish', () => delete requests[id]);
+
+    return next();
+  };
+}
+
+module.exports = duplicateHandler;


### PR DESCRIPTION
**The Case: Protecting ourselves from "Mastodon attacks"**

When someone is sharing a link on Mastodon, the message is quickly propagating on the network and each linked Mastodon instance is trying to fetch the page, likely to gather some metadata.

As shared in this screenshot, these are super stressful moments for our systems.

<img width="1284" alt="Screenshot 2020-09-23 at 17 45 35" src="https://user-images.githubusercontent.com/806/94400324-32c69100-0169-11eb-8fbb-69ad4a9acb34.png">

- CDN is not helping:
  - Our TTL on Collective page is only 5 minutes, cache is likely to be stale
  - Our CDN is maintaining a cache only at a data-center level, we will have at least one request per CDN data-center (193 locations in the world now)
  - Requests are coming too fast, cache doesn't have the time to be warm
- It's hurting:
  - It's mostly a Frontend issue currently, API was performing good in this current case
  - Frontend generation time for a Collective page is currently often > 1sec, it's too intensive to handle 10 such requests in parallel

**The Fix: handling duplicate requests only one time**

The proposed middleware registers each request currently processing. If a duplicate request is coming, instead of answering, it will "link" to the origin request, making sure that it's only processed once for all concurrent duplicate requests.

This solution is expected to be cheap and effective.

**Potential Alternatives**

- Static Collective Pages
- Fast Collective Pages
- Making sure cache is always warm on the CDN
- Caching of Collective Pages with locks to prevent duplicate processing