### PR TITLE
Contribution flow: enhancements for step payment

### DIFF
--- a/components/accept-financial-contributions/AcceptContributionsMyselfOrOrg.js
+++ b/components/accept-financial-contributions/AcceptContributionsMyselfOrOrg.js
@@ -84,6 +84,20 @@ class AcceptContributionsMyselfOrOrg extends React.Component {
     };
   }
 
+  componentDidMount() {
+    this.loadHost();
+  }
+
+  componentDidUpdate() {
+    this.loadHost();
+  }
+
+  loadHost() {
+    if (!this.state.organization && this.props.collective.host) {
+      this.setState({ organization: this.props.collective.host });
+    }
+  }
+
   // GraphQL functions
   addHost = async (collective, host) => {
     const collectiveInput = {

--- a/components/new-contribution-flow/StepPayment.js
+++ b/components/new-contribution-flow/StepPayment.js
@@ -52,6 +52,10 @@ const paymentMethodsQuery = gqlV2/* GraphQL */ `
         type
         expiryDate
         providerType
+        sourcePaymentMethod {
+          id
+          providerType
+        }
         balance {
           valueInCents
           currency

--- a/components/new-contribution-flow/utils.js
+++ b/components/new-contribution-flow/utils.js
@@ -82,11 +82,13 @@ export const generatePaymentMethodOptions = (paymentMethods, stepProfile, stepDe
   };
 
   uniquePMs = uniquePMs.filter(({ paymentMethod }) => {
+    const sourceProviderType = paymentMethod.sourcePaymentMethod?.providerType ?? paymentMethod.providerType;
+
     if (paymentMethod.providerType === GQLV2_PAYMENT_METHOD_TYPES.GIFT_CARD && paymentMethod.limitedToHosts) {
       return matchesHostCollectiveId(paymentMethod);
-    } else if (paymentMethod.providerType === GQLV2_PAYMENT_METHOD_TYPES.PREPAID_BUDGET) {
+    } else if (sourceProviderType === GQLV2_PAYMENT_METHOD_TYPES.PREPAID_BUDGET) {
       return matchesHostCollectiveIdPrepaid(paymentMethod);
-    } else if (!hostHasStripe && paymentMethod.providerType === GQLV2_PAYMENT_METHOD_TYPES.CREDIT_CARD) {
+    } else if (!hostHasStripe && sourceProviderType === GQLV2_PAYMENT_METHOD_TYPES.CREDIT_CARD) {
       return false;
     } else {
       return true;

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -415,6 +415,7 @@
   "ContributionFlow.highContributionInfoMessage": "While we'll email you a donation receipt, we are still required to keep an address for donations over $5000 USD.",
   "ContributionFlow.lowContributionInfoMessage": "Every donation must be linked to an email account for legal reasons. Please provide a valid email.",
   "ContributionFlow.lowestContributionInfoMessage": "Please provide a valid email, we need to send you a receipt for your donation.",
+  "ContributionFlow.noSupportedPaymentMethods": "There is no payment provider available",
   "ContributionFlow.OrganizationProfile": "Organization profile",
   "ContributionFlow.PersonalProfile": "Personal profile",
   "ContributionFlow.PublicContribution": "Your name and contribution will be public.",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -415,6 +415,7 @@
   "ContributionFlow.highContributionInfoMessage": "While we'll email you a donation receipt, we are still required to keep an address for donations over $5000 USD.",
   "ContributionFlow.lowContributionInfoMessage": "Every donation must be linked to an email account for legal reasons. Please provide a valid email.",
   "ContributionFlow.lowestContributionInfoMessage": "Please provide a valid email, we need to send you a receipt for your donation.",
+  "ContributionFlow.noSupportedPaymentMethods": "There is no payment provider available",
   "ContributionFlow.OrganizationProfile": "Organization profile",
   "ContributionFlow.PersonalProfile": "Personal profile",
   "ContributionFlow.PublicContribution": "Your name and contribution will be public.",

--- a/lang/de.json
+++ b/lang/de.json
@@ -415,6 +415,7 @@
   "ContributionFlow.highContributionInfoMessage": "While we'll email you a donation receipt, we are still required to keep an address for donations over $5000 USD.",
   "ContributionFlow.lowContributionInfoMessage": "Every donation must be linked to an email account for legal reasons. Please provide a valid email.",
   "ContributionFlow.lowestContributionInfoMessage": "Please provide a valid email, we need to send you a receipt for your donation.",
+  "ContributionFlow.noSupportedPaymentMethods": "There is no payment provider available",
   "ContributionFlow.OrganizationProfile": "Organisationsprofil",
   "ContributionFlow.PersonalProfile": "Persönliches Profil",
   "ContributionFlow.PublicContribution": "Your name and contribution will be public.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -415,6 +415,7 @@
   "ContributionFlow.highContributionInfoMessage": "While we'll email you a donation receipt, we are still required to keep an address for donations over $5000 USD.",
   "ContributionFlow.lowContributionInfoMessage": "Every donation must be linked to an email account for legal reasons. Please provide a valid email.",
   "ContributionFlow.lowestContributionInfoMessage": "Please provide a valid email, we need to send you a receipt for your donation.",
+  "ContributionFlow.noSupportedPaymentMethods": "There is no payment provider available",
   "ContributionFlow.OrganizationProfile": "Organization profile",
   "ContributionFlow.PersonalProfile": "Personal profile",
   "ContributionFlow.PublicContribution": "Your name and contribution will be public.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -415,6 +415,7 @@
   "ContributionFlow.highContributionInfoMessage": "While we'll email you a donation receipt, we are still required to keep an address for donations over $5000 USD.",
   "ContributionFlow.lowContributionInfoMessage": "Every donation must be linked to an email account for legal reasons. Please provide a valid email.",
   "ContributionFlow.lowestContributionInfoMessage": "Please provide a valid email, we need to send you a receipt for your donation.",
+  "ContributionFlow.noSupportedPaymentMethods": "There is no payment provider available",
   "ContributionFlow.OrganizationProfile": "Organization profile",
   "ContributionFlow.PersonalProfile": "Personal profile",
   "ContributionFlow.PublicContribution": "Your name and contribution will be public.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -415,6 +415,7 @@
   "ContributionFlow.highContributionInfoMessage": "While we'll email you a donation receipt, we are still required to keep an address for donations over $5000 USD.",
   "ContributionFlow.lowContributionInfoMessage": "Every donation must be linked to an email account for legal reasons. Please provide a valid email.",
   "ContributionFlow.lowestContributionInfoMessage": "Veuillez fournir une adresse e-mail valide, nous devrons vous envoyer un reçu pour votre don.",
+  "ContributionFlow.noSupportedPaymentMethods": "There is no payment provider available",
   "ContributionFlow.OrganizationProfile": "Organization profile",
   "ContributionFlow.PersonalProfile": "Profil personnel",
   "ContributionFlow.PublicContribution": "Votre nom et votre contribution seront publics.",

--- a/lang/it.json
+++ b/lang/it.json
@@ -415,6 +415,7 @@
   "ContributionFlow.highContributionInfoMessage": "While we'll email you a donation receipt, we are still required to keep an address for donations over $5000 USD.",
   "ContributionFlow.lowContributionInfoMessage": "Every donation must be linked to an email account for legal reasons. Please provide a valid email.",
   "ContributionFlow.lowestContributionInfoMessage": "Please provide a valid email, we need to send you a receipt for your donation.",
+  "ContributionFlow.noSupportedPaymentMethods": "There is no payment provider available",
   "ContributionFlow.OrganizationProfile": "Organization profile",
   "ContributionFlow.PersonalProfile": "Personal profile",
   "ContributionFlow.PublicContribution": "Your name and contribution will be public.",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -415,6 +415,7 @@
   "ContributionFlow.highContributionInfoMessage": "While we'll email you a donation receipt, we are still required to keep an address for donations over $5000 USD.",
   "ContributionFlow.lowContributionInfoMessage": "Every donation must be linked to an email account for legal reasons. Please provide a valid email.",
   "ContributionFlow.lowestContributionInfoMessage": "Please provide a valid email, we need to send you a receipt for your donation.",
+  "ContributionFlow.noSupportedPaymentMethods": "There is no payment provider available",
   "ContributionFlow.OrganizationProfile": "Organization profile",
   "ContributionFlow.PersonalProfile": "Personal profile",
   "ContributionFlow.PublicContribution": "Your name and contribution will be public.",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -415,6 +415,7 @@
   "ContributionFlow.highContributionInfoMessage": "While we'll email you a donation receipt, we are still required to keep an address for donations over $5000 USD.",
   "ContributionFlow.lowContributionInfoMessage": "Every donation must be linked to an email account for legal reasons. Please provide a valid email.",
   "ContributionFlow.lowestContributionInfoMessage": "Please provide a valid email, we need to send you a receipt for your donation.",
+  "ContributionFlow.noSupportedPaymentMethods": "There is no payment provider available",
   "ContributionFlow.OrganizationProfile": "Organization profile",
   "ContributionFlow.PersonalProfile": "Personal profile",
   "ContributionFlow.PublicContribution": "Your name and contribution will be public.",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -415,6 +415,7 @@
   "ContributionFlow.highContributionInfoMessage": "While we'll email you a donation receipt, we are still required to keep an address for donations over $5000 USD.",
   "ContributionFlow.lowContributionInfoMessage": "Every donation must be linked to an email account for legal reasons. Please provide a valid email.",
   "ContributionFlow.lowestContributionInfoMessage": "Please provide a valid email, we need to send you a receipt for your donation.",
+  "ContributionFlow.noSupportedPaymentMethods": "There is no payment provider available",
   "ContributionFlow.OrganizationProfile": "Organization profile",
   "ContributionFlow.PersonalProfile": "Personal profile",
   "ContributionFlow.PublicContribution": "Your name and contribution will be public.",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -415,6 +415,7 @@
   "ContributionFlow.highContributionInfoMessage": "While we'll email you a donation receipt, we are still required to keep an address for donations over $5000 USD.",
   "ContributionFlow.lowContributionInfoMessage": "Every donation must be linked to an email account for legal reasons. Please provide a valid email.",
   "ContributionFlow.lowestContributionInfoMessage": "Please provide a valid email, we need to send you a receipt for your donation.",
+  "ContributionFlow.noSupportedPaymentMethods": "There is no payment provider available",
   "ContributionFlow.OrganizationProfile": "Organization profile",
   "ContributionFlow.PersonalProfile": "Personal profile",
   "ContributionFlow.PublicContribution": "Your name and contribution will be public.",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -415,6 +415,7 @@
   "ContributionFlow.highContributionInfoMessage": "While we'll email you a donation receipt, we are still required to keep an address for donations over $5000 USD.",
   "ContributionFlow.lowContributionInfoMessage": "Every donation must be linked to an email account for legal reasons. Please provide a valid email.",
   "ContributionFlow.lowestContributionInfoMessage": "Please provide a valid email, we need to send you a receipt for your donation.",
+  "ContributionFlow.noSupportedPaymentMethods": "There is no payment provider available",
   "ContributionFlow.OrganizationProfile": "Профиль организации",
   "ContributionFlow.PersonalProfile": "Личный профиль",
   "ContributionFlow.PublicContribution": "Ваше имя и вклад будут публичными.",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -415,6 +415,7 @@
   "ContributionFlow.highContributionInfoMessage": "While we'll email you a donation receipt, we are still required to keep an address for donations over $5000 USD.",
   "ContributionFlow.lowContributionInfoMessage": "Every donation must be linked to an email account for legal reasons. Please provide a valid email.",
   "ContributionFlow.lowestContributionInfoMessage": "Please provide a valid email, we need to send you a receipt for your donation.",
+  "ContributionFlow.noSupportedPaymentMethods": "There is no payment provider available",
   "ContributionFlow.OrganizationProfile": "Organization profile",
   "ContributionFlow.PersonalProfile": "Personal profile",
   "ContributionFlow.PublicContribution": "Your name and contribution will be public.",

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -5222,6 +5222,11 @@ type PaymentMethod {
   """
   balance: Amount!
   account: Account
+
+  """
+  For gift cards, this field will return to the source payment method
+  """
+  sourcePaymentMethod: PaymentMethod
   data: JSON
   limitedToHosts: [Host]
   expiryDate: ISODateTime
@@ -5293,6 +5298,7 @@ enum PaymentMethodType {
   ACCOUNT_BALANCE
   PAYPAL
   BANK_TRANSFER
+  ADDED_FUNDS
 }
 
 """
@@ -6038,7 +6044,7 @@ interface Transaction {
   isRefund: Boolean
   paymentMethod: PaymentMethod
   permissions: TransactionPermissions
-  isRejected: Boolean
+  isRejected: Boolean!
   refundTransaction: Transaction
 }
 

--- a/pages/new-contribution-flow.js
+++ b/pages/new-contribution-flow.js
@@ -188,7 +188,7 @@ class NewContributionFlowPage extends React.Component {
   }
 
   renderPageContent() {
-    const { router, data = {}, intl, step } = this.props;
+    const { router, data = {}, intl, step, LoggedInUser } = this.props;
     const { account, tier } = data;
 
     if (data.loading) {
@@ -201,6 +201,26 @@ class NewContributionFlowPage extends React.Component {
       return this.renderMessage('info', intl.formatMessage(messages.missingHost));
     } else if (!account.isActive) {
       return this.renderMessage('info', intl.formatMessage(messages.inactiveCollective));
+    } else if (!account.host.supportedPaymentMethods.length) {
+      const content = (
+        <React.Fragment>
+          <strong>
+            <FormattedMessage
+              id="ContributionFlow.noSupportedPaymentMethods"
+              defaultMessage="There is no payment provider available"
+            />
+          </strong>
+          <br />
+          {LoggedInUser?.isHostAdmin(account) && (
+            <Link route="accept-financial-contributions" params={{ slug: account.slug, path: 'organization' }}>
+              <StyledButton buttonStyle="primary" mt={3}>
+                <FormattedMessage id="contributions.startAccepting" defaultMessage="Start accepting contributions" />
+              </StyledButton>
+            </Link>
+          )}
+        </React.Fragment>
+      );
+      return this.renderMessage('info', content);
     } else if (tier?.availableQuantity === 0) {
       const intlParams = { type: tier.type, name: <q>{tier.name}</q> };
       return this.renderMessage('info', intl.formatMessage(messages.emptyTier, intlParams), true);


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-api/pull/4632

- Filter gift cards based on source payment methods (don't show gift cards linked to a credit card if collective's host has no Stripe)
- Add a message instead of the regular flow if there's no payment providers, that redirects to `/collectivewithoutstripe/accept-financial-contributions/organization`. Also added some code to make sure the page doesn't ask you to pick a new host.

![image](https://user-images.githubusercontent.com/1556356/94414861-20565280-017d-11eb-9c93-15a4c401d38d.png)

