### PR TITLE
Skip getAugmentedLog as it's too slow for reliable performance

### DIFF
--- a/server/rate-limiter.js
+++ b/server/rate-limiter.js
@@ -28,7 +28,8 @@ const load = async app => {
 
   const lookup = async (req, res, opts, next) => {
     if (!whitelist(req)) {
-      const log = await req.getAugmentedLog();
+      // const log = await req.getAugmentedLog();
+      const log = req.hyperwatch.rawLog;
       req.hyperwatch = req.hyperwatch || {};
       req.hyperwatch.identity = log.getIn(['identity']) || log.getIn(['request', 'address']);
       opts.lookup = 'hyperwatch.identity';


### PR DESCRIPTION
It's possibly doing some reverse ip lookups and dns resolution that are not acceptable there.

It should be revisited.