### PR TITLE
Deprecate the "Schedule for Payment" option

### DIFF
--- a/components/expenses/PayExpenseModal.js
+++ b/components/expenses/PayExpenseModal.js
@@ -34,10 +34,6 @@ const PAYOUT_ACTION_TYPE = defineMessages({
     id: 'Expense.PayAuto',
     defaultMessage: '{payoutMethodLabel} (Automatic)',
   },
-  schedule: {
-    id: 'Expense.ScheduleForPayment',
-    defaultMessage: '{payoutMethodLabel} (Schedule for Payout)',
-  },
 });
 
 const getPayoutLabel = (intl, type) => {
@@ -49,27 +45,23 @@ const generatePayoutOptions = (intl, payoutMethodType, host) => {
   if (payoutMethodType === PayoutMethodType.OTHER) {
     return [{ label: payoutMethodLabel, value: { forceManual: true, action: 'PAY' } }];
   } else {
-    const defaultTypes = [
+    const automaticAction =
+      hasFeature(host, FEATURES.PAYPAL_PAYOUTS) &&
+      payoutMethodType === PayoutMethodType.PAYPAL &&
+      host.supportedPayoutMethods?.includes('PAYPAL')
+        ? 'SCHEDULE_FOR_PAYMENT'
+        : 'PAY';
+
+    return [
       {
         label: intl.formatMessage(PAYOUT_ACTION_TYPE.auto, { payoutMethodLabel }),
-        value: { forceManual: false, action: 'PAY' },
+        value: { forceManual: false, action: automaticAction },
       },
       {
         label: intl.formatMessage(PAYOUT_ACTION_TYPE.manual, { payoutMethodLabel }),
         value: { forceManual: true, action: 'PAY' },
       },
     ];
-    if (
-      hasFeature(host, FEATURES.PAYPAL_PAYOUTS) &&
-      payoutMethodType === PayoutMethodType.PAYPAL &&
-      host.supportedPayoutMethods?.includes('PAYPAL')
-    ) {
-      defaultTypes.unshift({
-        label: intl.formatMessage(PAYOUT_ACTION_TYPE.schedule, { payoutMethodLabel }),
-        value: { action: 'SCHEDULE_FOR_PAYMENT' },
-      });
-    }
-    return defaultTypes;
   }
 };
 

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -779,7 +779,6 @@
   "Expense.RequestDetails": "Request Details",
   "Expense.SaveChanges": "Save changes",
   "expense.scheduledForPayment": "Scheduled for payment",
-  "Expense.ScheduleForPayment": "{payoutMethodLabel} (Schedule for Payout)",
   "expense.status": "Status",
   "Expense.SubmittedBy": "Submitted by {name}",
   "Expense.SubmittedByOnDate": "Submitted by {name} on {date, date, long}",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -779,7 +779,6 @@
   "Expense.RequestDetails": "Request Details",
   "Expense.SaveChanges": "Uložit změny",
   "expense.scheduledForPayment": "Scheduled for payment",
-  "Expense.ScheduleForPayment": "{payoutMethodLabel} (Schedule for Payout)",
   "expense.status": "Status",
   "Expense.SubmittedBy": "Odeslal/a {name}",
   "Expense.SubmittedByOnDate": "Odeslal/a {name} {date, date, long}",

--- a/lang/de.json
+++ b/lang/de.json
@@ -779,7 +779,6 @@
   "Expense.RequestDetails": "Request Details",
   "Expense.SaveChanges": "Save changes",
   "expense.scheduledForPayment": "Scheduled for payment",
-  "Expense.ScheduleForPayment": "{payoutMethodLabel} (Schedule for Payout)",
   "expense.status": "Status",
   "Expense.SubmittedBy": "Submitted by {name}",
   "Expense.SubmittedByOnDate": "Submitted by {name} on {date, date, long}",

--- a/lang/en.json
+++ b/lang/en.json
@@ -779,7 +779,6 @@
   "Expense.RequestDetails": "Request Details",
   "Expense.SaveChanges": "Save changes",
   "expense.scheduledForPayment": "Scheduled for payment",
-  "Expense.ScheduleForPayment": "{payoutMethodLabel} (Schedule for Payout)",
   "expense.status": "Status",
   "Expense.SubmittedBy": "Submitted by {name}",
   "Expense.SubmittedByOnDate": "Submitted by {name} on {date, date, long}",

--- a/lang/es.json
+++ b/lang/es.json
@@ -779,7 +779,6 @@
   "Expense.RequestDetails": "Request Details",
   "Expense.SaveChanges": "Guardar los cambios",
   "expense.scheduledForPayment": "Scheduled for payment",
-  "Expense.ScheduleForPayment": "{payoutMethodLabel} (Schedule for Payout)",
   "expense.status": "Status",
   "Expense.SubmittedBy": "Enviado por {name}",
   "Expense.SubmittedByOnDate": "Enviado por {name} el {date, date, long}",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -779,7 +779,6 @@
   "Expense.RequestDetails": "Request Details",
   "Expense.SaveChanges": "Sauvegarder",
   "expense.scheduledForPayment": "Paiement programmé",
-  "Expense.ScheduleForPayment": "{payoutMethodLabel} (Programmer le paiement)",
   "expense.status": "Statut",
   "Expense.SubmittedBy": "Postée par {name}",
   "Expense.SubmittedByOnDate": "Postée par {name} le {date, date, long}",

--- a/lang/it.json
+++ b/lang/it.json
@@ -779,7 +779,6 @@
   "Expense.RequestDetails": "Request Details",
   "Expense.SaveChanges": "Save changes",
   "expense.scheduledForPayment": "Scheduled for payment",
-  "Expense.ScheduleForPayment": "{payoutMethodLabel} (Schedule for Payout)",
   "expense.status": "Status",
   "Expense.SubmittedBy": "Submitted by {name}",
   "Expense.SubmittedByOnDate": "Submitted by {name} on {date, date, long}",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -779,7 +779,6 @@
   "Expense.RequestDetails": "Request Details",
   "Expense.SaveChanges": "変更を保存",
   "expense.scheduledForPayment": "Scheduled for payment",
-  "Expense.ScheduleForPayment": "{payoutMethodLabel} (Schedule for Payout)",
   "expense.status": "Status",
   "Expense.SubmittedBy": "Submitted by {name}",
   "Expense.SubmittedByOnDate": "Submitted by {name} on {date, date, long}",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -779,7 +779,6 @@
   "Expense.RequestDetails": "Request Details",
   "Expense.SaveChanges": "Save changes",
   "expense.scheduledForPayment": "Scheduled for payment",
-  "Expense.ScheduleForPayment": "{payoutMethodLabel} (Schedule for Payout)",
   "expense.status": "Status",
   "Expense.SubmittedBy": "Submitted by {name}",
   "Expense.SubmittedByOnDate": "Submitted by {name} on {date, date, long}",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -779,7 +779,6 @@
   "Expense.RequestDetails": "Request Details",
   "Expense.SaveChanges": "Save changes",
   "expense.scheduledForPayment": "Scheduled for payment",
-  "Expense.ScheduleForPayment": "{payoutMethodLabel} (Schedule for Payout)",
   "expense.status": "Status",
   "Expense.SubmittedBy": "Submitted by {name}",
   "Expense.SubmittedByOnDate": "Submitted by {name} on {date, date, long}",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -779,7 +779,6 @@
   "Expense.RequestDetails": "Request Details",
   "Expense.SaveChanges": "Save changes",
   "expense.scheduledForPayment": "Scheduled for payment",
-  "Expense.ScheduleForPayment": "{payoutMethodLabel} (Schedule for Payout)",
   "expense.status": "Status",
   "Expense.SubmittedBy": "Submitted by {name}",
   "Expense.SubmittedByOnDate": "Submitted by {name} on {date, date, long}",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -779,7 +779,6 @@
   "Expense.RequestDetails": "Request Details",
   "Expense.SaveChanges": "Сохранить изменения",
   "expense.scheduledForPayment": "Scheduled for payment",
-  "Expense.ScheduleForPayment": "{payoutMethodLabel} (Schedule for Payout)",
   "expense.status": "Статус",
   "Expense.SubmittedBy": "Отправлено {name}",
   "Expense.SubmittedByOnDate": "Отправлено {name} {date, date, long}",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -779,7 +779,6 @@
   "Expense.RequestDetails": "Request Details",
   "Expense.SaveChanges": "Save changes",
   "expense.scheduledForPayment": "Scheduled for payment",
-  "Expense.ScheduleForPayment": "{payoutMethodLabel} (Schedule for Payout)",
   "expense.status": "Status",
   "Expense.SubmittedBy": "Submitted by {name}",
   "Expense.SubmittedByOnDate": "Submitted by {name} on {date, date, long}",


### PR DESCRIPTION
Makes PayPal Payouts the default automatic payment method when
available.