### PR TITLE
Introduce service limiter

### DIFF
--- a/server/hyperwatch.js
+++ b/server/hyperwatch.js
@@ -61,6 +61,17 @@ const load = async app => {
 
   app.use(expressInput.middleware());
 
+  app.use((req, res, next) => {
+    req.hyperwatch.getIdentity = async () => {
+      let log = req.hyperwatch.augmentedLog;
+      if (!log) {
+        log = req.hyperwatch.augmentedLog = await req.hyperwatch.getAugmentedLog({ fast: true });
+      }
+      return log.getIn(['identity']) || log.getIn(['request', 'address']);
+    };
+    next();
+  });
+
   pipeline.registerInput(expressInput);
 
   // Filter 'main' node

--- a/server/rate-limiter.js
+++ b/server/rate-limiter.js
@@ -28,10 +28,11 @@ const load = async app => {
 
   const lookup = async (req, res, opts, next) => {
     if (!whitelist(req)) {
-      if (req.hyperwatch && req.hyperwatch.getAugmentedLog) {
-        const log = await req.hyperwatch.getAugmentedLog({ fast: true });
-        req.hyperwatch.identity = log.getIn(['identity']) || log.getIn(['request', 'address']);
-        opts.lookup = 'hyperwatch.identity';
+      if (!req.identity && req.hyperwatch) {
+        req.identity = await req.hyperwatch.getIdentity();
+      }
+      if (req.identity) {
+        opts.lookup = 'identity';
       } else {
         opts.lookup = 'ip';
       }

--- a/server/service-limiter.js
+++ b/server/service-limiter.js
@@ -1,0 +1,48 @@
+const debug = require('debug');
+
+const logger = require('./logger');
+
+const nonEssentialRobots = ['Ahrefs', 'Bluechip Backlinks', 'Semrush', 'SpiderFoot', 'WebMeUp'];
+
+const essentialRobots = ['Facebook', 'Pingdom', 'Twitter'];
+
+const debugServiceLevel = debug('serviceLevel');
+
+let serviceLevel = 0;
+
+function increaseServiceLevel(newLevel) {
+  debugServiceLevel(`Increasing service level to ${newLevel}`);
+  if (newLevel > serviceLevel) {
+    serviceLevel = newLevel;
+  }
+}
+
+const onServiceLimited = (req, res) => {
+  logger.info(`Service limited for '${req.ip}' '${req.headers['user-agent']}'`);
+  const message = `Service Limited. Try again later. Please contact support@opencollective.com if it persists.`;
+  res.status(503).send(message);
+};
+
+async function serviceLimiterMiddleware(req, res, next) {
+  if (!req.identity && req.hyperwatch) {
+    req.identity = await req.hyperwatch.getIdentity();
+  }
+  if (serviceLevel < 100) {
+    if (req.identity && nonEssentialRobots.include(req.identity)) {
+      onServiceLimited(req, res, next);
+      return;
+    }
+  }
+  if (serviceLevel < 50) {
+    if (req.identity && !essentialRobots.include(req.identity)) {
+      onServiceLimited(req, res, next);
+      return;
+    }
+  }
+  next();
+}
+
+module.exports = {
+  serviceLimiterMiddleware,
+  increaseServiceLevel,
+};


### PR DESCRIPTION
- smoother boot time by limiting traffic when the app starts
- ability to set SERVICE_LEVEL in the environment if we need it

Service Levels:
- between 0 and 49: all identified robots blocked but not Facebook, Twitter and Pingdom
- between 50 and 99: all identified robots allowed but not Ahrefs, Bluechip Backlinks, Semrush, SpiderFoot, WebMeUp
- 100: no service restriction
