### PR TITLE
Opt out getDataFromTree in collective-page and home

### DIFF
--- a/lib/withData.js
+++ b/lib/withData.js
@@ -28,7 +28,10 @@ const withData = ComposedComponent => {
 
       try {
         // Run all GraphQL queries
-        await getDataFromTree(<ComposedComponent Component={Component} {...composedInitialProps} />, { client });
+        const skipDataFromTree = composedInitialProps.pageProps.skipDataFromTree || false;
+        if (!skipDataFromTree) {
+          await getDataFromTree(<ComposedComponent Component={Component} {...composedInitialProps} />, { client });
+        }
       } catch (error) {
         // Prevent Apollo Client GraphQL errors from crashing SSR.
         // Handle them in components via the data.error prop:

--- a/pages/collective-page.js
+++ b/pages/collective-page.js
@@ -51,13 +51,16 @@ class CollectivePage extends React.Component {
       res.set('Cache-Control', 'public, s-maxage=300');
     }
 
+    let skipDataFromTree = false;
+
     // If on server side
     if (req) {
       req.noStyledJsx = true;
       await preloadCollectivePageGraphlQueries(slug, client);
+      skipDataFromTree = true;
     }
 
-    return { slug, status, step, mode };
+    return { slug, status, step, mode, skipDataFromTree };
   }
 
   static propTypes = {

--- a/pages/index.js
+++ b/pages/index.js
@@ -43,10 +43,15 @@ HomePage.getInitialProps = ({ req, res }) => {
     res.set('Cache-Control', 'public, s-maxage=3600');
   }
 
+  let skipDataFromTree = false;
+
+  // If on server side
   if (req) {
     req.noStyledJsx = true;
+    skipDataFromTree = true;
   }
-  return {};
+
+  return { skipDataFromTree };
 };
 
 export default HomePage;


### PR DESCRIPTION
Shave some significant time in SSR rendering.

Collective Page Before:

<img width="1601" alt="Screenshot 2020-10-08 at 11 04 53" src="https://user-images.githubusercontent.com/806/95438217-48e90400-0956-11eb-9903-e9f78aee74c7.png">

Collective Page After :

<img width="1604" alt="Screenshot 2020-10-08 at 10 46 41" src="https://user-images.githubusercontent.com/806/95438256-54d4c600-0956-11eb-8247-4de4d29fe9ce.png">

This is Benchmarking from localhost Frontend to production API. The long idle grey bars should be much shorter in Frontend production because of reduced latency. As seen below:

<img width="1698" alt="Screenshot 2020-10-08 at 11 17 26" src="https://user-images.githubusercontent.com/806/95440079-c1e95b00-0958-11eb-8218-9bede96ef907.png">

<img width="1709" alt="Screenshot 2020-10-08 at 11 23 30" src="https://user-images.githubusercontent.com/806/95440068-bf870100-0958-11eb-8ae8-16fd60b1d0f7.png">
