### PR TITLE
Script to build E2E server locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   },
   "scripts": {
     "build": "npm-run-all build:updates build:next build:server",
-    "build:e2e": "cross-env NODE_ENV=production OC_ENV=e2e npm run build",
+    "build:e2e": "cross-env NODE_ENV=development OC_ENV=e2e npm run build",
     "build:clean": "shx rm -rf dist .next",
     "build:langs": "npm run langs:update",
     "build:next": "cross-env scripts/build_next.sh",


### PR DESCRIPTION
`data-cy` are stripped in `production` env, so we need to build the e2e test server as `development`.