### PR TITLE
Remove collective.user.added activity

### DIFF
--- a/lib/constants/notificationEvents.js
+++ b/lib/constants/notificationEvents.js
@@ -16,7 +16,6 @@ export default [
   'collective.transaction.created',
   'collective.update.created',
   'collective.update.published',
-  'collective.user.added',
   'organization.collective.created',
   'subscription.confirmed',
   'subscription.canceled',


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-api/pull/4725

That was not triggered anywhere and someone was recently confused while using it for a webhook.