### PR TITLE
E2E docs: update recommandations about local frontend server

### DIFF
--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -46,7 +46,8 @@ API_URL=http://localhost:3060
 API_KEY=dvl-1510egmf4a23d80342403fb599qd
 ```
 
-We recommend to run a build of the Frontend. It will be faster and more reliable.
+You can simply start a local server by running `npm run dev`. This is useful to quickly iterate
+when developing, but if you're looking for stable and reproducible results we recommend to run a build of the Frontend. It will be faster and more reliable. To do so:
 
 - `npm run build:e2e`
 


### PR DESCRIPTION
This is a followup on https://opencollective.slack.com/archives/C0RMV6F8C/p1602860867088600. I personally almost never use `npm run build:e2e` when working with Cypress and given that the script has been broken for the past two months I assume that most of the team does not either.

It's good to keep it to investigate the edge cases or for when you need to quickly run the tests, but `npm run dev` is just more convenient for developing.