### PR TITLE
EditPolicies: Show characters count

### DIFF
--- a/components/edit-collective/sections/Policies.js
+++ b/components/edit-collective/sections/Policies.js
@@ -164,6 +164,7 @@ const Policies = ({ collective }) => {
                 {...inputProps}
                 resize="none"
                 maxLength={POLICY_MAX_LENGTH}
+                showCount
                 height={'20rem'}
                 width={1}
                 fontSize="14px"
@@ -192,6 +193,7 @@ const Policies = ({ collective }) => {
                 {...inputProps}
                 resize="none"
                 maxLength={POLICY_MAX_LENGTH}
+                showCount
                 height={'20rem'}
                 width={1}
                 fontSize="14px"


### PR DESCRIPTION
Based on https://opencollective.slack.com/archives/C6JTTA4SK/p1603190434084800

A small enhancement to show the characters count on policies.

![Peek 2020-10-21 14-19](https://user-images.githubusercontent.com/1556356/96718554-77c89680-13a8-11eb-86e2-f889bd25d12a.gif)
