### PR TITLE
Fix fonts

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -73,7 +73,7 @@ const nextConfig = {
     // Inspired by https://github.com/rohanray/next-fonts
     // Load Bootstrap and Font-Awesome fonts
     config.module.rules.push({
-      test: /fonts[\\/].*\.(woff|woff2|eot|ttf|otf|svg)$/,
+      test: /node_modules[\\/].*[\\/]fonts[\\/].*\.(woff|woff2|eot|ttf|otf|svg)$/,
       use: [
         {
           loader: 'url-loader',


### PR DESCRIPTION
Don't use url-loader for static fonts.

I don't think font-awesome/bootstrap fonts are still used somewhere, I'll followup next week by removing the rule entirely if I can confirm this assumption.