### PR TITLE
StyledTooltip: Fixes & enhancements

### DIFF
--- a/components/ApplyToHostBtn.js
+++ b/components/ApplyToHostBtn.js
@@ -88,7 +88,6 @@ class ApplyToHostBtn extends React.Component {
             />
             &nbsp;
             <StyledTooltip
-              type="light"
               content={
                 <FormattedMessage
                   id="host.hostFee.help"

--- a/components/CollectiveCallsToAction.js
+++ b/components/CollectiveCallsToAction.js
@@ -124,7 +124,6 @@ const CollectiveCallsToAction = ({
             <ApplyToHostBtn />
           ) : (
             <StyledTooltip
-              type="light"
               place="left"
               content={
                 <FormattedMessage


### PR DESCRIPTION
- Use portals, which will prevent DOM nesting warnings and layout issues when used in modals
- Don't wrap `children` when it's a func, instead pass it the necessary handlers