### PR TITLE
Fix amount + platform fee amount display bug on order success page

### DIFF
--- a/components/contribution-flow/ContributorCardWithTier.js
+++ b/components/contribution-flow/ContributorCardWithTier.js
@@ -64,7 +64,7 @@ const ContributorCardWithTier = ({ contribution, ...props }) => {
             <Flex>
               <P fontSize="14px" lineHeight="20px" fontWeight="bold">
                 <FormattedMoneyAmount
-                  amount={(contribution.amount.value + (contribution.platformContributionAmount?.value || 0)) * 100}
+                  amount={contribution.amount.value * 100}
                   currency={contribution.amount.currency}
                   frequency={contribution.frequency}
                 />
@@ -81,10 +81,10 @@ const ContributorCardWithTier = ({ contribution, ...props }) => {
                   <P fontSize="12px" lineHeight="20px" color="primary.600" ml={1}>
                     (
                     <FormattedMoneyAmount
-                      amount={contribution.amount.value * 100}
+                      amount={(contribution.amount.value - contribution.platformContributionAmount?.value) * 100}
                       currency={contribution.amount.currency}
                       showCurrencyCode={false}
-                      precision={0}
+                      precision={2}
                       amountStyles={{ fontWeight: 'normal', color: 'primary.600' }}
                     />{' '}
                     +{' '}
@@ -92,7 +92,7 @@ const ContributorCardWithTier = ({ contribution, ...props }) => {
                       amount={contribution.platformContributionAmount?.value * 100}
                       currency={contribution.amount.currency}
                       showCurrencyCode={false}
-                      precision={0}
+                      precision={2}
                       amountStyles={{ fontWeight: 'normal', color: 'primary.600' }}
                     />
                     )


### PR DESCRIPTION
Relates https://opencollective.freshdesk.com/a/tickets/10520

Customer said they were charged £6 + £1 platform fee instead of the £5.00 + £0.50 platform fee they thought they gave.

Order amount and transaction amounts were fine in the database.

I was able to reproduce locally using the same donation amount (£5.00 + £0.50)

![Screenshot 2020-10-26 at 12 34 02](https://user-images.githubusercontent.com/37520401/97174446-06169100-178a-11eb-915e-48bf2a344680.png)

It was just an error in how we calculated the amounts to display.