### PR TITLE
Fix depcheck CI failure by downgrading depcheck to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "commit": "git-cz",
     "cypress:open": "cross-env TZ=UTC cypress open",
     "cypress:run": "cross-env TZ=UTC cypress run",
-    "depcheck": "npx depcheck",
+    "depcheck": "npx depcheck@1.2.0",
     "deploy:production": "cross-env ./scripts/pre-deploy.sh production && git push production master",
     "deploy:staging": "cross-env ./scripts/pre-deploy.sh staging && git push -f staging master",
     "dev": "node --icu-data-dir=node_modules/full-icu server",


### PR DESCRIPTION
This corrects the depcheck failure observed at https://github.com/opencollective/opencollective-frontend/runs/1375735374?check_suite_focus=true by downgrading the depcheck to 1.2.0

cc: @sbinlondon 