### PR TITLE
Increase expense and contribution policy character count

### DIFF
--- a/components/edit-collective/sections/Policies.js
+++ b/components/edit-collective/sections/Policies.js
@@ -22,7 +22,7 @@ import { H3, P } from '../../Text';
 
 import { getSettingsQuery } from './EditCollectivePage';
 
-const POLICY_MAX_LENGTH = 500;
+const POLICY_MAX_LENGTH = 3000; // 600 words * 5 characters average length word
 
 const updateFilterCategoriesMutation = gqlV2/* GraphQL */ `
   mutation UpdateFilterCategories($account: AccountReferenceInput!, $key: AccountSettingsKey!, $value: JSON!) {


### PR DESCRIPTION
The limit was set to 500 characters which is tiny.

Increased to 3000 (around 600 words) since Social Change Agency mentioned their template is around 500 words.