### PR TITLE
Fix: Collective Page crashes if user is not logged in

### DIFF
--- a/components/CollectiveNavbarActionsMenu.js
+++ b/components/CollectiveNavbarActionsMenu.js
@@ -109,7 +109,7 @@ const MenuOutline = styled(Container)`
 
 const getCollectivesNeedingAHost = user => {
   const memberships = uniqBy(
-    user.memberOf.filter(m => m.role === 'ADMIN'),
+    user?.memberOf.filter(m => m.role === 'ADMIN'),
     m => m.collective.id,
   );
   const collectives = memberships


### PR DESCRIPTION
User may be undefined in the case the user is not logged in.
Notice that `uniqBy` takes care to return always the same type, this means that passing an undefined iteratee will cause it to return an empty array.
```
TypeError: Cannot read property 'memberOf' of null
    at ie (CollectiveNavbarActionsMenu.js:112)
    at Ki (react-dom.production.min.js:153)
    at Lo (react-dom.production.min.js:175)
    at ya (react-dom.production.min.js:263)
    at su (react-dom.production.min.js:246)
    at uu (react-dom.production.min.js:246)
    at eu (react-dom.production.min.js:239)
    at react-dom.production.min.js:123
    at KqkS.t.unstable_runWithPriority (scheduler.production.min.js:19)
    at $l (react-dom.production.min.js:122)
    at ql (react-dom.production.min.js:123)
    at Bl (react-dom.production.min.js:122)
    at Ya (react-dom.production.min.js:230)
    at Object.enqueueSetState (react-dom.production.min.js:132)
    at r.w.setState (react.production.min.js:12)
    at UserProvider.js:86
    at c (runtime.js:45)
    at Generator._invoke (runtime.js:274)
    at Generator.forEach.e.<computed> [as next] (runtime.js:97)
    at r (asyncToGenerator.js:3)
    at s (asyncToGenerator.js:25)
```