### PR TITLE
Expenses list: Improve behavior for host dashboard

### DIFF
--- a/components/expenses/ExpenseAdminActions.js
+++ b/components/expenses/ExpenseAdminActions.js
@@ -27,6 +27,24 @@ const deleteExpenseMutation = gqlV2/* GraphQL */ `
   }
 `;
 
+const removeExpenseFromCache = (cache, { data: { deleteExpense } }) => {
+  cache.modify({
+    fields: {
+      expenses(existingExpenses, { readField }) {
+        if (!existingExpenses?.nodes) {
+          return existingExpenses;
+        } else {
+          return {
+            ...existingExpenses,
+            totalCount: existingExpenses.totalCount - 1,
+            nodes: existingExpenses.nodes.filter(expense => deleteExpense.id !== readField('id', expense)),
+          };
+        }
+      },
+    },
+  });
+};
+
 const ButtonWithLabel = ({ label, icon, size, tooltipPosition, ...props }) => {
   return (
     <StyledTooltip content={label} delayHide={0} place={tooltipPosition}>
@@ -135,7 +153,7 @@ const ExpenseAdminActions = ({
             {...buttonProps}
           />
           {hasDeleteConfirm && (
-            <Mutation mutation={deleteExpenseMutation} context={API_V2_CONTEXT}>
+            <Mutation mutation={deleteExpenseMutation} context={API_V2_CONTEXT} update={removeExpenseFromCache}>
               {deleteExpense => (
                 <ConfirmationModal
                   isDanger

--- a/components/expenses/ExpenseModal.js
+++ b/components/expenses/ExpenseModal.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/client';
 import { pick } from 'lodash';
-import { useIntl } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import { formatErrorMessage } from '../../lib/errors';
 import { API_V2_CONTEXT, gqlV2 } from '../../lib/graphql/helpers';
@@ -46,15 +46,21 @@ const ExpenseModal = ({ expense, onDelete, onProcess, onClose, show }) => {
       trapFocus={!loading}
     >
       <ModalBody maxHeight="calc(80vh - 80px)" overflowY="auto" mb={80} p={20}>
-        <ExpenseSummary
-          isLoading={loading || !data}
-          expense={!loading ? data?.expense : null}
-          host={!loading ? data?.expense?.account?.host : null}
-          collective={!loading ? data?.expense?.account : null}
-          onDelete={onDelete}
-          onClose={onClose}
-          borderless
-        />
+        {loading || data?.expense ? (
+          <ExpenseSummary
+            isLoading={loading || !data}
+            expense={!loading ? data?.expense : null}
+            host={!loading ? data?.expense?.account?.host : null}
+            collective={!loading ? data?.expense?.account : null}
+            onDelete={onDelete}
+            onClose={onClose}
+            borderless
+          />
+        ) : (
+          <MessageBox type="warning" withIcon>
+            <FormattedMessage id="Expense.NotFound" defaultMessage="This expense doesn't exist or has been removed" />
+          </MessageBox>
+        )}
       </ModalBody>
       <ModalFooter
         position="absolute"

--- a/components/expenses/ExpensesList.js
+++ b/components/expenses/ExpensesList.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { sumBy } from 'lodash';
+import FlipMove from 'react-flip-move';
 import { FormattedMessage } from 'react-intl';
 import styled, { css } from 'styled-components';
 
@@ -41,32 +42,39 @@ const ExpensesList = ({
   onDelete,
   onProcess,
 }) => {
-  expenses = !isLoading ? expenses : [...new Array(nbPlaceholders)];
-
-  if (!expenses?.length) {
+  if (!expenses?.length && !isLoading) {
     return null;
   }
 
   const totalAmount = sumBy(expenses, 'amount');
-
   return (
     <StyledCard>
-      {expenses.map((expense, idx) => (
-        <ExpenseContainer key={expense?.id || idx} isFirst={!idx} data-cy={`expense-${expense?.status}`}>
-          <ExpenseBudgetItem
-            isLoading={isLoading}
-            isInverted={isInverted}
-            collective={collective || expense?.account}
-            expense={expense}
-            host={host}
-            showProcessActions
-            view={view}
-            usePreviewModal={usePreviewModal}
-            onDelete={onDelete}
-            onProcess={onProcess}
-          />
-        </ExpenseContainer>
-      ))}
+      {isLoading ? (
+        [...new Array(nbPlaceholders)].map((_, idx) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <ExpenseContainer key={idx} isFirst={!idx}>
+            <ExpenseBudgetItem isLoading />
+          </ExpenseContainer>
+        ))
+      ) : (
+        <FlipMove enterAnimation="fade" leaveAnimation="fade">
+          {expenses.map((expense, idx) => (
+            <ExpenseContainer key={expense.id} isFirst={!idx} data-cy={`expense-${expense.status}`}>
+              <ExpenseBudgetItem
+                isInverted={isInverted}
+                collective={collective || expense.account}
+                expense={expense}
+                host={host}
+                showProcessActions
+                view={view}
+                usePreviewModal={usePreviewModal}
+                onDelete={onDelete}
+                onProcess={onProcess}
+              />
+            </ExpenseContainer>
+          ))}
+        </FlipMove>
+      )}
       {!isLoading && (
         <FooterContainer>
           <Flex flexDirection={['row', 'column']} mt={[3, 0]} flexWrap="wrap" alignItems={['center', 'flex-end']}>

--- a/components/expenses/ProcessExpenseButtons.js
+++ b/components/expenses/ProcessExpenseButtons.js
@@ -66,7 +66,8 @@ const ProcessExpenseButtons = ({
   onSuccess,
 }) => {
   const [selectedAction, setSelectedAction] = React.useState(null);
-  const mutationOptions = { context: API_V2_CONTEXT };
+  const onUpdate = (cache, response) => onSuccess?.(response.data.processExpense, cache);
+  const mutationOptions = { context: API_V2_CONTEXT, update: onUpdate };
   const [processExpense, { loading }] = useMutation(processExpenseMutation, mutationOptions);
   const [error, setError] = React.useState(null);
 
@@ -80,12 +81,7 @@ const ProcessExpenseButtons = ({
 
     try {
       const variables = { id: expense.id, legacyId: expense.legacyId, action, paymentParams };
-      const processedExpense = await processExpense({ variables });
-      if (onSuccess) {
-        await onSuccess(processedExpense, action, paymentParams);
-      }
-
-      return processedExpense;
+      return processExpense({ variables });
     } catch (e) {
       setError(e);
       if (onError && selectedAction !== 'PAY') {

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -810,6 +810,7 @@
   "expense.markAsUnpaid.btn": "Marca com a pendent de pagar",
   "Expense.markAsUnpaid.details": "The amount will be credited back to the Collective balance.",
   "expense.notes": "Notes",
+  "Expense.NotFound": "This expense doesn't exist or has been removed",
   "expense.page.description": "Payment processor fees may apply.",
   "expense.page.total": "Page Total",
   "expense.paid": "Paid",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -810,6 +810,7 @@
   "expense.markAsUnpaid.btn": "Mark as unpaid",
   "Expense.markAsUnpaid.details": "The amount will be credited back to the Collective balance.",
   "expense.notes": "Poznámky",
+  "Expense.NotFound": "This expense doesn't exist or has been removed",
   "expense.page.description": "Payment processor fees may apply.",
   "expense.page.total": "Page Total",
   "expense.paid": "Paid",

--- a/lang/de.json
+++ b/lang/de.json
@@ -810,6 +810,7 @@
   "expense.markAsUnpaid.btn": "Als unbezahlt markieren",
   "Expense.markAsUnpaid.details": "The amount will be credited back to the Collective balance.",
   "expense.notes": "Notes",
+  "Expense.NotFound": "This expense doesn't exist or has been removed",
   "expense.page.description": "Payment processor fees may apply.",
   "expense.page.total": "Page Total",
   "expense.paid": "Ausgezahlt",

--- a/lang/en.json
+++ b/lang/en.json
@@ -810,6 +810,7 @@
   "expense.markAsUnpaid.btn": "Mark as unpaid",
   "Expense.markAsUnpaid.details": "The amount will be credited back to the Collective balance.",
   "expense.notes": "Notes",
+  "Expense.NotFound": "This expense doesn't exist or has been removed",
   "expense.page.description": "Payment processor fees may apply.",
   "expense.page.total": "Page Total",
   "expense.paid": "Paid",

--- a/lang/es.json
+++ b/lang/es.json
@@ -810,6 +810,7 @@
   "expense.markAsUnpaid.btn": "Marcar como impagado",
   "Expense.markAsUnpaid.details": "The amount will be credited back to the Collective balance.",
   "expense.notes": "Notas",
+  "Expense.NotFound": "This expense doesn't exist or has been removed",
   "expense.page.description": "Payment processor fees may apply.",
   "expense.page.total": "Page Total",
   "expense.paid": "Paid",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -810,6 +810,7 @@
   "expense.markAsUnpaid.btn": "Marquer comme impayé",
   "Expense.markAsUnpaid.details": "The amount will be credited back to the Collective balance.",
   "expense.notes": "Notes",
+  "Expense.NotFound": "This expense doesn't exist or has been removed",
   "expense.page.description": "Payment processor fees may apply.",
   "expense.page.total": "Page Total",
   "expense.paid": "Payée",

--- a/lang/it.json
+++ b/lang/it.json
@@ -810,6 +810,7 @@
   "expense.markAsUnpaid.btn": "Contrassegna come non pagato",
   "Expense.markAsUnpaid.details": "The amount will be credited back to the Collective balance.",
   "expense.notes": "Note",
+  "Expense.NotFound": "This expense doesn't exist or has been removed",
   "expense.page.description": "Payment processor fees may apply.",
   "expense.page.total": "Page Total",
   "expense.paid": "Pagato",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -810,6 +810,7 @@
   "expense.markAsUnpaid.btn": "未支払いにする",
   "Expense.markAsUnpaid.details": "The amount will be credited back to the Collective balance.",
   "expense.notes": "注",
+  "Expense.NotFound": "This expense doesn't exist or has been removed",
   "expense.page.description": "Payment processor fees may apply.",
   "expense.page.total": "Page Total",
   "expense.paid": "Paid",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -810,6 +810,7 @@
   "expense.markAsUnpaid.btn": "Mark as unpaid",
   "Expense.markAsUnpaid.details": "The amount will be credited back to the Collective balance.",
   "expense.notes": "메모",
+  "Expense.NotFound": "This expense doesn't exist or has been removed",
   "expense.page.description": "Payment processor fees may apply.",
   "expense.page.total": "Page Total",
   "expense.paid": "지불됨",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -810,6 +810,7 @@
   "expense.markAsUnpaid.btn": "Mark as unpaid",
   "Expense.markAsUnpaid.details": "The amount will be credited back to the Collective balance.",
   "expense.notes": "Notes",
+  "Expense.NotFound": "This expense doesn't exist or has been removed",
   "expense.page.description": "Payment processor fees may apply.",
   "expense.page.total": "Page Total",
   "expense.paid": "Paid",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -810,6 +810,7 @@
   "expense.markAsUnpaid.btn": "Marcar como não paga",
   "Expense.markAsUnpaid.details": "O valor será creditado de volta ao saldo do coletivo.",
   "expense.notes": "Anotações",
+  "Expense.NotFound": "This expense doesn't exist or has been removed",
   "expense.page.description": "Tarifas do processador de pagamento podem ser aplicadas.",
   "expense.page.total": "Total de páginas",
   "expense.paid": "Paga",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -810,6 +810,7 @@
   "expense.markAsUnpaid.btn": "Marcar como não pago",
   "Expense.markAsUnpaid.details": "The amount will be credited back to the Collective balance.",
   "expense.notes": "Notas",
+  "Expense.NotFound": "This expense doesn't exist or has been removed",
   "expense.page.description": "Payment processor fees may apply.",
   "expense.page.total": "Page Total",
   "expense.paid": "Paid",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -810,6 +810,7 @@
   "expense.markAsUnpaid.btn": "Отметить как невыплаченное",
   "Expense.markAsUnpaid.details": "The amount will be credited back to the Collective balance.",
   "expense.notes": "Комментарии",
+  "Expense.NotFound": "This expense doesn't exist or has been removed",
   "expense.page.description": "Payment processor fees may apply.",
   "expense.page.total": "Page Total",
   "expense.paid": "Выплачено",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -810,6 +810,7 @@
   "expense.markAsUnpaid.btn": "Mark as unpaid",
   "Expense.markAsUnpaid.details": "The amount will be credited back to the Collective balance.",
   "expense.notes": "Примітки",
+  "Expense.NotFound": "This expense doesn't exist or has been removed",
   "expense.page.description": "Payment processor fees may apply.",
   "expense.page.total": "Page Total",
   "expense.paid": "Paid",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -810,6 +810,7 @@
   "expense.markAsUnpaid.btn": "标记为未支付",
   "Expense.markAsUnpaid.details": "The amount will be credited back to the Collective balance.",
   "expense.notes": "笔记",
+  "Expense.NotFound": "This expense doesn't exist or has been removed",
   "expense.page.description": "Payment processor fees may apply.",
   "expense.page.total": "Page Total",
   "expense.paid": "已支付",

--- a/lib/hooks/useLazyGraphQLPaginatedResults.js
+++ b/lib/hooks/useLazyGraphQLPaginatedResults.js
@@ -1,0 +1,41 @@
+import React from 'react';
+
+const DEFAULT_OPTIONS = {
+  /** Defines the percentage of items actually displayed */
+  percentageDisplayed: 0.5,
+};
+
+/**
+ * An helper to work with dynamic paginated lists coming from GraphQL, intended to reduce
+ * the load on server by loading a bigger batches at the start and updating the list in cache manually.
+ */
+export const useLazyGraphQLPaginatedResults = (query, key, options = DEFAULT_OPTIONS) => {
+  const allOptions = { ...DEFAULT_OPTIONS, ...options };
+  const limit = query?.variables?.limit || 0;
+  const results = query?.data?.[key];
+  const nbItemsDisplayed = limit * allOptions.percentageDisplayed;
+  const resultsCount = results?.nodes?.length || 0;
+
+  // Refetch when the number of items go below the threshold
+  React.useEffect(() => {
+    if (results && !query.loading && resultsCount <= nbItemsDisplayed && resultsCount < results.totalCount) {
+      query.refetch();
+    }
+  }, [query?.loading, resultsCount, nbItemsDisplayed]);
+
+  if (!results) {
+    return {
+      nodes: [],
+      totalCount: 0,
+      offset: 0,
+      limit: nbItemsDisplayed,
+    };
+  }
+
+  return {
+    offset: query.variables.offset,
+    limit: nbItemsDisplayed,
+    totalCount: results.totalCount,
+    nodes: results.nodes.slice(0, nbItemsDisplayed),
+  };
+};


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/3583

Triggers one `refetch` request every 10 processed expenses (versus one every processed expense previously) by relying on Apollo's cache and updating it manually. Also adds a small animations for list items.

**Todo**
- [x] Load bigger batches, update cache manually to reduce the number of fetches (when filtering is enabled)
- [x] Animate the list when removing elements
- [x] Cleanup the code

![Peek 2021-01-07 17-18](https://user-images.githubusercontent.com/1556356/103916143-5dcb6400-510c-11eb-8439-42bc297a1a5e.gif)
