### PR TITLE
Fix: Display Platform tips when donating to Self-Hosted Organizations

### DIFF
--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -7,7 +7,6 @@ import memoizeOne from 'memoize-one';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import styled from 'styled-components';
 
-import { CollectiveType } from '../../lib/constants/collectives';
 import { getGQLV2FrequencyFromInterval } from '../../lib/constants/intervals';
 import { MODERATION_CATEGORIES_ALIASES } from '../../lib/constants/moderation-categories';
 import { GQLV2_PAYMENT_METHOD_TYPES } from '../../lib/constants/payment-methods';
@@ -446,8 +445,6 @@ class ContributionFlow extends React.Component {
       return false;
     } else if (this.props.tier?.type === TierTypes.TICKET) {
       return false;
-    } else if (this.state.stepProfile?.type === CollectiveType.COLLECTIVE) {
-      return this.state.stepProfile.host?.id && this.state.stepProfile.host.id === this.props.host?.id;
     } else {
       return true;
     }

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -5489,7 +5489,7 @@ type OrderWithPayment {
 """
 This represents an Organization account
 """
-type Organization implements Account {
+type Organization implements Account & AccountWithContributions {
   id: String
   legacyId: Int
 
@@ -5678,9 +5678,47 @@ type Organization implements Account {
   features: CollectiveFeatures!
 
   """
+  Number of unique financial contributors.
+  """
+  totalFinancialContributors(
+    """
+    Type of account (COLLECTIVE/EVENT/ORGANIZATION/INDIVIDUAL)
+    """
+    accountType: AccountType
+  ): Int!
+  tiers: TierCollection!
+
+  """
+  All the persons and entities that contribute to this account
+  """
+  contributors(
+    """
+    The number of results to fetch (default 10, max 1000)
+    """
+    limit: Int = 10
+
+    """
+    The offset to use to fetch
+    """
+    offset: Int = 0
+    roles: [MemberRole]
+  ): ContributorCollection!
+
+  """
+  How much platform fees are charged for this account
+  """
+  platformFeePercent: Int!
+
+  """
+  Returns true if a custom contribution to Open Collective can be submitted for contributions made to this account
+  """
+  platformContributionAvailable: Boolean!
+
+  """
   Amount of money in cents in the currency of the collective currently available to spend
   """
   balance: Int @deprecated(reason: "2020/04/09 - Should not have been introduced. Use stats.balance.value")
+  contributionPolicy: String
   email: String
 
   """

--- a/pages/contribution-flow.js
+++ b/pages/contribution-flow.js
@@ -323,6 +323,8 @@ const accountFieldsFragment = gqlV2/* GraphQL */ `
       country
     }
     ... on Organization {
+      platformFeePercent
+      platformContributionAvailable
       host {
         ...ContributionFlowHostFields
       }


### PR DESCRIPTION
Requires https://github.com/opencollective/opencollective-api/pull/4886
Not a widespread problem because donating to hosts is still only accessible through the `/donate` URL, but...