### PR TITLE
Set custom fee radio button when you set a custom fee

### DIFF
--- a/components/host-dashboard/CollectiveFeesStructureModal.js
+++ b/components/host-dashboard/CollectiveFeesStructureModal.js
@@ -108,6 +108,7 @@ const CollectiveFeesStructureModal = ({ host, collective, ...props }) => {
                     fontWeight="normal"
                     value={isNaN(hostFeePercent) ? '' : hostFeePercent}
                     step="0.01"
+                    onClick={() => setSelectedOption(key)}
                     onChange={e => setHostFeePercent(parseFloat(e.target.value))}
                     onBlur={e => {
                       const newValue = clamp(round(parseFloat(e.target.value), 2), 0, 100);


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/3649

# Description

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->
Set the radio button for the custom fee option when a user clicks on the custom fee box

# Screenshots

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
![set-button-click-box](https://user-images.githubusercontent.com/24629960/99605229-478b0c80-29d5-11eb-97ea-1f3fcbb1631a.gif)
