### PR TITLE
Do not reload legacy keys from old cached expense drafts

### DIFF
--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -242,7 +242,13 @@ const ExpenseFormBody = ({
         if (formValues.payoutMethod?.type === PayoutMethodType.BANK_ACCOUNT && !collective.host?.transferwise) {
           formValues.payoutMethod = undefined;
         }
-        setValues(formValues);
+        setValues(
+          omit(
+            formValues,
+            // Omit deprecated fields, otherwise it will prevent expense submission
+            ['location', 'privateInfo'],
+          ),
+        );
       }
     }
   }, [formPersister, dirty]);


### PR DESCRIPTION
This bug was caught by Pia earlier today, she basically had an incompatible data structure cached that would cause the GraphQL mutation request to fail, preventing her from creating the expense.