### PR TITLE
Fix typerror bug and mobile/tablet early submit in onboarding modal

### DIFF
--- a/components/onboarding-modal/OnboardingContentBox.js
+++ b/components/onboarding-modal/OnboardingContentBox.js
@@ -47,9 +47,9 @@ class OnboardingContentBox extends React.Component {
   }
 
   componentDidMount() {
-    const member = this.props.LoggedInUser.memberOf.filter(member => member.collective.id === this.props.collective.id);
+    const member = this.props.LoggedInUser.memberOf.find(member => member.collective.id === this.props.collective.id);
     this.setState({
-      admins: [{ role: 'ADMIN', member: this.props.LoggedInUser.collective, id: member[0].id }],
+      admins: [{ role: 'ADMIN', member: this.props.LoggedInUser.collective, id: member.id }],
     });
   }
 

--- a/components/onboarding-modal/OnboardingNavButtons.js
+++ b/components/onboarding-modal/OnboardingNavButtons.js
@@ -83,7 +83,13 @@ class OnboardingNavButtons extends React.Component {
               </StyledRoundButton>
             )}
 
-            <StyledButton buttonStyle="primary" onClick={() => handleSubmit} loading={loading} data-cy="finish-button">
+            <StyledButton
+              type="submit"
+              buttonStyle="primary"
+              onClick={() => handleSubmit}
+              loading={loading}
+              data-cy="finish-button"
+            >
               <FormattedMessage id="Finish" defaultMessage="Finish" />
             </StyledButton>
           </Fragment>
@@ -130,7 +136,8 @@ class OnboardingNavButtons extends React.Component {
                 data-cy="step-forward-button"
                 mx={1}
                 buttonStyle="primary"
-                onClick={() => {
+                onClick={e => {
+                  e.preventDefault();
                   Router.pushRoute('collective-with-onboarding', {
                     slug,
                     mode,


### PR DESCRIPTION
Relates https://github.com/opencollective/opencollective/issues/3130

Finally (hopefully) fixes the onboarding modal bug. Finding the correct membership in the `LoggedInUser.memberOf` array was done using `array.filter` which returned an array of objects, hence needing to write `id: member[0].id`. New version uses `array.find` which returns an object of the membership info, so we can use `id: member.id` instead.

Also found a bug where on tablet/mobile view, clicking 'Next step' to go from administrators to contact caused the form to submit early. Have fixed that as well.