### PR TITLE
Dashboard: Bring back all orders (not just the pending ones)

### DIFF
--- a/components/budget/OrderBudgetItem.js
+++ b/components/budget/OrderBudgetItem.js
@@ -15,6 +15,7 @@ import LinkCollective from '../LinkCollective';
 import LoadingPlaceholder from '../LoadingPlaceholder';
 import OrderStatusTag from '../orders/OrderStatusTag';
 import ProcessOrderButtons from '../orders/ProcessOrderButtons';
+import StyledTag from '../StyledTag';
 import { H3, P, Span } from '../Text';
 import TransactionSign from '../TransactionSign';
 
@@ -88,7 +89,6 @@ const OrderBudgetItem = ({ isLoading, order }) => {
                     textDecoration="none"
                     color="black.900"
                     fontSize={`${fontSize}px`}
-                    title={`#${order.legacyId}`}
                     data-cy="expense-title"
                   >
                     {value}
@@ -120,12 +120,25 @@ const OrderBudgetItem = ({ isLoading, order }) => {
               <Flex alignItems="center">
                 <TransactionSign isCredit />
                 <Span color="black.500" fontSize="15px">
-                  <FormattedMoneyAmount amount={order.amount.valueInCents} currency={order.currency} precision={2} />
+                  <FormattedMoneyAmount
+                    amount={order.amount.valueInCents}
+                    currency={order.amount.currency}
+                    precision={2}
+                  />
                 </Span>
               </Flex>
             )}
           </Flex>
-          {isLoading ? <LoadingPlaceholder height={20} width={140} /> : <OrderStatusTag status={order.status} />}
+          {isLoading ? (
+            <LoadingPlaceholder height={20} width={140} />
+          ) : (
+            <Flex>
+              <StyledTag variant="rounded-left" fontSize="10px" fontWeight="500" mr={1}>
+                <FormattedMessage id="Order" defaultMessage="Order" /> #{order.legacyId}
+              </StyledTag>
+              <OrderStatusTag status={order.status} />
+            </Flex>
+          )}
         </Flex>
       </Flex>
       <Flex flexWrap="wrap" justifyContent="space-between" alignItems="center" mt={2}>
@@ -188,8 +201,7 @@ OrderBudgetItem.propTypes = {
     description: PropTypes.string.isRequired,
     status: PropTypes.oneOf(Object.values(ORDER_STATUS)).isRequired,
     createdAt: PropTypes.string.isRequired,
-    amount: PropTypes.number.isRequired,
-    currency: PropTypes.string.isRequired,
+    amount: PropTypes.object.isRequired,
     permissions: PropTypes.shape({
       canReject: PropTypes.bool,
       canMarkAsPaid: PropTypes.bool,

--- a/components/orders/OrdersWithData.js
+++ b/components/orders/OrdersWithData.js
@@ -63,6 +63,7 @@ const accountOrdersQuery = gqlV2/* GraphQL */ `
         status
         amount {
           valueInCents
+          currency
         }
         paymentMethod {
           id

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1203,6 +1203,7 @@
   "OpenInbox": "Open {providerName}",
   "openSourceApply.GithubRepositories.title": "Pick a repository",
   "OptionalFieldLabel": "{field} (optional)",
+  "Order": "Order",
   "order.active": "Active",
   "order.cancelled": "Cancelled",
   "Order.Confirm.Processing": "Confirming your payment method…",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1203,6 +1203,7 @@
   "OpenInbox": "Open {providerName}",
   "openSourceApply.GithubRepositories.title": "Pick a repository",
   "OptionalFieldLabel": "{field} (optional)",
+  "Order": "Order",
   "order.active": "Active",
   "order.cancelled": "Cancelled",
   "Order.Confirm.Processing": "Confirming your payment method…",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1203,6 +1203,7 @@
   "OpenInbox": "Öffne {providerName}",
   "openSourceApply.GithubRepositories.title": "Pick a repository",
   "OptionalFieldLabel": "{field} (optional)",
+  "Order": "Order",
   "order.active": "Active",
   "order.cancelled": "Cancelled",
   "Order.Confirm.Processing": "Confirming your payment method…",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1203,6 +1203,7 @@
   "OpenInbox": "Open {providerName}",
   "openSourceApply.GithubRepositories.title": "Pick a repository",
   "OptionalFieldLabel": "{field} (optional)",
+  "Order": "Order",
   "order.active": "Active",
   "order.cancelled": "Cancelled",
   "Order.Confirm.Processing": "Confirming your payment method…",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1203,6 +1203,7 @@
   "OpenInbox": "Abrir {providerName}",
   "openSourceApply.GithubRepositories.title": "Seleccione un repositorio",
   "OptionalFieldLabel": "{field} (opcional)",
+  "Order": "Order",
   "order.active": "Active",
   "order.cancelled": "Cancelled",
   "Order.Confirm.Processing": "Confirmando tu método de pago…",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1203,6 +1203,7 @@
   "OpenInbox": "Ouvrir {providerName}",
   "openSourceApply.GithubRepositories.title": "Choisissez un dépôt",
   "OptionalFieldLabel": "{field} (optionnel)",
+  "Order": "Order",
   "order.active": "Active",
   "order.cancelled": "Cancelled",
   "Order.Confirm.Processing": "Confirmation du moyen de paiement…",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1203,6 +1203,7 @@
   "OpenInbox": "Open {providerName}",
   "openSourceApply.GithubRepositories.title": "Pick a repository",
   "OptionalFieldLabel": "{field} (optional)",
+  "Order": "Order",
   "order.active": "Active",
   "order.cancelled": "Cancelled",
   "Order.Confirm.Processing": "Confirming your payment method…",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1203,6 +1203,7 @@
   "OpenInbox": "{providerName} を開く",
   "openSourceApply.GithubRepositories.title": "リポジトリを選ぶ",
   "OptionalFieldLabel": "{field} (optional)",
+  "Order": "Order",
   "order.active": "Active",
   "order.cancelled": "Cancelled",
   "Order.Confirm.Processing": "Confirming your payment method…",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1203,6 +1203,7 @@
   "OpenInbox": "Open {providerName}",
   "openSourceApply.GithubRepositories.title": "Pick a repository",
   "OptionalFieldLabel": "{field} (optional)",
+  "Order": "Order",
   "order.active": "Active",
   "order.cancelled": "Cancelled",
   "Order.Confirm.Processing": "Confirming your payment method…",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1203,6 +1203,7 @@
   "OpenInbox": "Open {providerName}",
   "openSourceApply.GithubRepositories.title": "Pick a repository",
   "OptionalFieldLabel": "{field} (optional)",
+  "Order": "Order",
   "order.active": "Active",
   "order.cancelled": "Cancelled",
   "Order.Confirm.Processing": "Confirming your payment method…",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1203,6 +1203,7 @@
   "OpenInbox": "Abrir {providerName}",
   "openSourceApply.GithubRepositories.title": "Selecione um repositório",
   "OptionalFieldLabel": "{field} (opcional)",
+  "Order": "Order",
   "order.active": "Active",
   "order.cancelled": "Cancelled",
   "Order.Confirm.Processing": "Confirmando seu método de pagamento…",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1203,6 +1203,7 @@
   "OpenInbox": "Открыть {providerName}",
   "openSourceApply.GithubRepositories.title": "Pick a repository",
   "OptionalFieldLabel": "{field} (optional)",
+  "Order": "Order",
   "order.active": "Active",
   "order.cancelled": "Cancelled",
   "Order.Confirm.Processing": "Confirming your payment method…",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1203,6 +1203,7 @@
   "OpenInbox": "Open {providerName}",
   "openSourceApply.GithubRepositories.title": "Pick a repository",
   "OptionalFieldLabel": "{field} (optional)",
+  "Order": "Order",
   "order.active": "Active",
   "order.cancelled": "Cancelled",
   "Order.Confirm.Processing": "Confirming your payment method…",

--- a/pages/host.dashboard.js
+++ b/pages/host.dashboard.js
@@ -8,7 +8,6 @@ import { omit } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import styled, { css } from 'styled-components';
 
-import { ORDER_STATUS } from '../lib/constants/order-status';
 import { addCollectiveCoverData } from '../lib/graphql/queries';
 
 import CollectiveNavbar from '../components/CollectiveNavbar';
@@ -129,11 +128,7 @@ class HostDashboardPage extends React.Component {
       case 'donations':
         return (
           <Box py={4}>
-            <OrdersWithData
-              accountSlug={host.slug}
-              status={ORDER_STATUS.PENDING}
-              title={<FormattedMessage id="PendingBankTransfers" defaultMessage="Pending bank transfers" />}
-            />
+            <OrdersWithData accountSlug={host.slug} />
           </Box>
         );
       case HOST_SECTIONS.HOSTED_COLLECTIVES:
@@ -188,7 +183,7 @@ class HostDashboardPage extends React.Component {
                 isActive={view === 'donations'}
               >
                 <DonateIcon size="1em" />
-                <FormattedMessage id="PendingBankTransfers" defaultMessage="Pending bank transfers" />
+                <FormattedMessage id="FinancialContributions" defaultMessage="Financial Contributions" />
               </MenuLink>
               <MenuLink
                 route="host.dashboard"


### PR DESCRIPTION
- Display all orders (with `status` filter)
- Fix wrong currency being displayed
- Surface Order ID

![image](https://user-images.githubusercontent.com/1556356/100222816-eefac880-2f1a-11eb-8c99-49ef5d2c6d03.png)

Based on this feedback we received from the Social Change Nest:

> We noticed this morning when we went in to make our payments that the
> Financial Contribution tab, which used to be under Dashboard, is gone.
> We can see there's a Pending Bank Transfer tab, although it's really
> just for pending transactions and we can't see anything else on there.
> 
> Is it possible to bring back the financial contribution tab, or what
> was the thinking behind this and is there another way we can access
> the information that was there? That was one of the main features our
> team used on a daily basis to check payments. We used it to make
> contributions to collective pages and to search for contributions that
> the public had made.
> 
> It also had reference numbers for transactions which was the main way
> that we used to search for things, and now that's gone it means we
> can't search with references and consolidate our payments. It's really
> restricting what we can do as hosts without that feature.
> 
> Also, our transactions are now appearing in USD instead of GBP, would
> you also be able to change this over?