### PR TITLE
Fix: Added keyboard shortcut to dismiss modals. 

### DIFF
--- a/components/AddFundsModal.js
+++ b/components/AddFundsModal.js
@@ -7,7 +7,6 @@ import { Col, Modal, Row } from 'react-bootstrap';
 import { FormattedMessage } from 'react-intl';
 
 import { CollectiveType } from '../lib/constants/collectives';
-import useKeyboardShortcut from '../lib/hooks/useKeyboardKey';
 
 import AddFundsForm from './AddFundsForm';
 import Button from './Button';
@@ -60,8 +59,6 @@ const AddFundsModal = ({ LoggedInUser, show, setShow, collective, host }) => {
   if (!LoggedInUser) {
     return null;
   }
-
-  useKeyboardShortcut({ callback: () => close(), keyName: 'Escape', keyCode: 27, keyAbb: 'Esc' });
 
   return (
     <Modal show={show} onHide={close}>

--- a/components/AddFundsModal.js
+++ b/components/AddFundsModal.js
@@ -7,7 +7,7 @@ import { Col, Modal, Row } from 'react-bootstrap';
 import { FormattedMessage } from 'react-intl';
 
 import { CollectiveType } from '../lib/constants/collectives';
-import useKeyboardShortcut from '../lib/hooks/useEscapeKey'
+import useKeyboardShortcut from '../lib/hooks/useKeyboardKey';
 
 import AddFundsForm from './AddFundsForm';
 import Button from './Button';
@@ -61,7 +61,7 @@ const AddFundsModal = ({ LoggedInUser, show, setShow, collective, host }) => {
     return null;
   }
 
-  useKeyboardShortcut(() => close())
+  useKeyboardShortcut({ callback: () => close(), keyName: 'Escape', keyCode: 27, keyAbb: 'Esc' });
 
   return (
     <Modal show={show} onHide={close}>

--- a/components/AddFundsModal.js
+++ b/components/AddFundsModal.js
@@ -7,6 +7,7 @@ import { Col, Modal, Row } from 'react-bootstrap';
 import { FormattedMessage } from 'react-intl';
 
 import { CollectiveType } from '../lib/constants/collectives';
+import useKeyboardShortcut from '../lib/hooks/useEscapeKey'
 
 import AddFundsForm from './AddFundsForm';
 import Button from './Button';
@@ -59,6 +60,8 @@ const AddFundsModal = ({ LoggedInUser, show, setShow, collective, host }) => {
   if (!LoggedInUser) {
     return null;
   }
+
+  useKeyboardShortcut(() => close())
 
   return (
     <Modal show={show} onHide={close}>

--- a/components/MenuPopover.js
+++ b/components/MenuPopover.js
@@ -5,8 +5,8 @@ import { Manager, Popper, Reference } from 'react-popper';
 import styled from 'styled-components';
 import { v4 as uuid } from 'uuid';
 
-import useEscapeKey from '../lib/hooks/useKeyboardKey';
 import useGlobalBlur from '../lib/hooks/useGlobalBlur';
+import useEscapeKey, { ESCAPE_KEY } from '../lib/hooks/useKeyboardKey';
 
 const StyledMenuPopoverContainer = styled(`div`)`
   max-width: 320px;
@@ -105,7 +105,7 @@ const TooltipContent = ({ place, content, onClose }) => {
   });
 
   // Close when Escape is pressed
-  useEscapeKey({ callback: onClose, keyName: 'Escape', keyAbb: 'Esc', keyCode: 27 });
+  useEscapeKey({ callback: onClose, keyMatch: ESCAPE_KEY });
 
   // Focus menu when opening
   React.useEffect(() => {

--- a/components/MenuPopover.js
+++ b/components/MenuPopover.js
@@ -5,7 +5,7 @@ import { Manager, Popper, Reference } from 'react-popper';
 import styled from 'styled-components';
 import { v4 as uuid } from 'uuid';
 
-import useEscapeKey from '../lib/hooks/useEscapeKey';
+import useEscapeKey from '../lib/hooks/useKeyboardKey';
 import useGlobalBlur from '../lib/hooks/useGlobalBlur';
 
 const StyledMenuPopoverContainer = styled(`div`)`
@@ -105,7 +105,7 @@ const TooltipContent = ({ place, content, onClose }) => {
   });
 
   // Close when Escape is pressed
-  useEscapeKey(onClose);
+  useEscapeKey({ callback: onClose, keyName: 'Escape', keyAbb: 'Esc', keyCode: 27 });
 
   // Focus menu when opening
   React.useEffect(() => {

--- a/components/StyledModal.js
+++ b/components/StyledModal.js
@@ -12,7 +12,7 @@ import { Flex } from './Grid';
 import { fadeIn } from './StyledKeyframes';
 import { P } from './Text';
 
-import useKeyBoardShortcut from '../lib/hooks/useEscapeKey'
+import useKeyBoardShortcut from '../lib/hooks/useKeyboardKey';
 
 const Wrapper = styled(Flex)`
   position: fixed;
@@ -176,8 +176,8 @@ ModalFooter.defaultProps = {
  */
 const StyledModal = ({ children, show, onClose, usePortal, ...props }) => {
   // Closes the modal upon the `ESC` key press.
-  useKeyBoardShortcut(() =>  onClose())
-  
+  useKeyBoardShortcut({ callback: () => onClose(), keyName: 'Escape', keyAbb: 'Esc', keyCode: 27 });
+
   if (show && usePortal === false) {
     return (
       <React.Fragment>

--- a/components/StyledModal.js
+++ b/components/StyledModal.js
@@ -6,13 +6,13 @@ import { createPortal } from 'react-dom';
 import styled, { createGlobalStyle, css } from 'styled-components';
 import { background, margin, overflow, space } from 'styled-system';
 
+import useKeyBoardShortcut, { ESCAPE_KEY } from '../lib/hooks/useKeyboardKey';
+
 import Avatar from './Avatar';
 import Container from './Container';
 import { Flex } from './Grid';
 import { fadeIn } from './StyledKeyframes';
 import { P } from './Text';
-
-import useKeyBoardShortcut from '../lib/hooks/useKeyboardKey';
 
 const Wrapper = styled(Flex)`
   position: fixed;
@@ -176,7 +176,7 @@ ModalFooter.defaultProps = {
  */
 const StyledModal = ({ children, show, onClose, usePortal, ...props }) => {
   // Closes the modal upon the `ESC` key press.
-  useKeyBoardShortcut({ callback: () => onClose(), keyName: 'Escape', keyAbb: 'Esc', keyCode: 27 });
+  useKeyBoardShortcut({ callback: () => onClose(), keyMatch: ESCAPE_KEY });
 
   if (show && usePortal === false) {
     return (

--- a/components/StyledModal.js
+++ b/components/StyledModal.js
@@ -12,6 +12,8 @@ import { Flex } from './Grid';
 import { fadeIn } from './StyledKeyframes';
 import { P } from './Text';
 
+import useKeyBoardShortcut from '../lib/hooks/useEscapeKey'
+
 const Wrapper = styled(Flex)`
   position: fixed;
   top: 0;
@@ -173,6 +175,9 @@ ModalFooter.defaultProps = {
  * a styled `Container`.
  */
 const StyledModal = ({ children, show, onClose, usePortal, ...props }) => {
+  // Closes the modal upon the `ESC` key press.
+  useKeyBoardShortcut(() =>  onClose())
+  
   if (show && usePortal === false) {
     return (
       <React.Fragment>

--- a/components/TopBarProfileMenu.js
+++ b/components/TopBarProfileMenu.js
@@ -29,6 +29,8 @@ import StyledRoundButton from './StyledRoundButton';
 import { P } from './Text';
 import { withUser } from './UserProvider';
 
+import useKeyBoardShortcut from '../lib/hooks/useEscapeKey';
+
 const memberInvitationsCountQuery = gql`
   query MemberInvitationsCount($memberCollectiveId: Int!) {
     memberInvitations(MemberCollectiveId: $memberCollectiveId) {
@@ -94,6 +96,7 @@ class TopBarProfileMenu extends React.Component {
   }
 
   componentDidMount() {
+    document.addEventListener('keydown', this.handleEscKey);
     document.addEventListener('click', this.onClickOutside);
     if (!getFromLocalStorage(LOCAL_STORAGE_KEYS.ACCESS_TOKEN)) {
       this.setState({ loading: false });
@@ -102,7 +105,17 @@ class TopBarProfileMenu extends React.Component {
 
   componentWillUnmount() {
     document.removeEventListener('click', this.onClickOutside);
+    document.removeEventListener('keydown', this.handleEscKey);
   }
+
+  handleEscKey = event => {
+    const { key, keyCode } = event;
+    if (key === 'Escape' || key === 'Esc' || keyCode === 27) {
+      this.setState({
+        showProfileMenu: false,
+      });
+    }
+  };
 
   logout = () => {
     this.setState({ showProfileMenu: false, status: 'loggingout' });

--- a/components/TopBarProfileMenu.js
+++ b/components/TopBarProfileMenu.js
@@ -29,8 +29,6 @@ import StyledRoundButton from './StyledRoundButton';
 import { P } from './Text';
 import { withUser } from './UserProvider';
 
-import useKeyBoardShortcut from '../lib/hooks/useEscapeKey';
-
 const memberInvitationsCountQuery = gql`
   query MemberInvitationsCount($memberCollectiveId: Int!) {
     memberInvitations(MemberCollectiveId: $memberCollectiveId) {
@@ -96,7 +94,7 @@ class TopBarProfileMenu extends React.Component {
   }
 
   componentDidMount() {
-    document.addEventListener('keydown', this.handleEscKey);
+    document.addEventListener('keydown', this.handleKeyPress);
     document.addEventListener('click', this.onClickOutside);
     if (!getFromLocalStorage(LOCAL_STORAGE_KEYS.ACCESS_TOKEN)) {
       this.setState({ loading: false });
@@ -108,7 +106,7 @@ class TopBarProfileMenu extends React.Component {
     document.removeEventListener('keydown', this.handleEscKey);
   }
 
-  handleEscKey = event => {
+  handleKeyPress = event => {
     const { key, keyCode } = event;
     if (key === 'Escape' || key === 'Esc' || keyCode === 27) {
       this.setState({

--- a/components/edit-collective/sections/FiscalHosting.js
+++ b/components/edit-collective/sections/FiscalHosting.js
@@ -4,8 +4,8 @@ import { gql, useMutation } from '@apollo/client';
 import { FormattedMessage } from 'react-intl';
 
 import { getErrorFromGraphqlException } from '../../../lib/errors';
+import useKeyboardShortcut, { ENTER_KEY } from '../../../lib/hooks/useKeyboardKey';
 
-import useKeyboardShortcut from '../../../lib/hooks/useKeyboardKey';
 import Container from '../../Container';
 import StyledButton from '../../StyledButton';
 import Modal, { ModalBody, ModalFooter, ModalHeader } from '../../StyledModal';
@@ -159,7 +159,7 @@ const FiscalHosting = ({ collective }) => {
     }
   };
 
-  useKeyboardShortcut({ callback: handlePrimaryBtnClick, keyAbb: 'Enter', keyName: 'Enter', keyCode: 13 });
+  useKeyboardShortcut({ callback: handlePrimaryBtnClick, keyMatch: ENTER_KEY });
 
   return (
     <Container display="flex" flexDirection="column" width={1} alignItems="flex-start">

--- a/components/edit-collective/sections/FiscalHosting.js
+++ b/components/edit-collective/sections/FiscalHosting.js
@@ -5,6 +5,7 @@ import { FormattedMessage } from 'react-intl';
 
 import { getErrorFromGraphqlException } from '../../../lib/errors';
 
+import useKeyboardShortcut from '../../../lib/hooks/useKeyboardKey';
 import Container from '../../Container';
 import StyledButton from '../../StyledButton';
 import Modal, { ModalBody, ModalFooter, ModalHeader } from '../../StyledModal';
@@ -149,6 +150,16 @@ const FiscalHosting = ({ collective }) => {
   };
 
   const closeActivateBudget = () => setActivateBudgetModal({ ...activateBudgetModal, show: false });
+
+  const handlePrimaryBtnClick = () => {
+    if (activateBudgetModal.type === 'Deactivate') {
+      handleDeactivateBudget({ id: collective.id });
+    } else {
+      handleActivateBudget({ id: collective.id });
+    }
+  };
+
+  useKeyboardShortcut({ callback: handlePrimaryBtnClick, keyAbb: 'Enter', keyName: 'Enter', keyCode: 13 });
 
   return (
     <Container display="flex" flexDirection="column" width={1} alignItems="flex-start">
@@ -347,17 +358,7 @@ const FiscalHosting = ({ collective }) => {
             <StyledButton mx={20} onClick={() => setActivateBudgetModal({ ...activateBudgetModal, show: false })}>
               <FormattedMessage id="actions.cancel" defaultMessage={'Cancel'} />
             </StyledButton>
-            <StyledButton
-              buttonStyle="primary"
-              data-cy="action"
-              onClick={() => {
-                if (activateBudgetModal.type === 'Deactivate') {
-                  handleDeactivateBudget({ id: collective.id });
-                } else {
-                  handleActivateBudget({ id: collective.id });
-                }
-              }}
-            >
+            <StyledButton buttonStyle="primary" data-cy="action" onClick={() => handlePrimaryBtnClick()}>
               {activateBudgetModal.type === 'Activate' && (
                 <FormattedMessage id="FiscalHosting.budget.activate" defaultMessage={'Activate Host Budget'} />
               )}

--- a/lib/hooks/useKeyboardKey.js
+++ b/lib/hooks/useKeyboardKey.js
@@ -1,16 +1,17 @@
 import React from 'react';
 
-const useEscapeKey = callback => {
+const useKeyboardKey = ({ callback, keyName, keyAbb, keyCode }) => {
   React.useEffect(() => {
     const eventListener = event => {
-      let isEscape = false;
+      console.log(event);
+      let isRecognizedKey = false;
       if ('key' in event) {
-        isEscape = event.key === 'Escape' || event.key === 'Esc';
+        isRecognizedKey = event.key === keyName || event.key === keyAbb;
       } else {
-        isEscape = event.keyCode === 27;
+        isRecognizedKey = event.keyCode === keyCode;
       }
 
-      if (isEscape) {
+      if (isRecognizedKey) {
         callback();
       }
     };
@@ -22,4 +23,4 @@ const useEscapeKey = callback => {
   }, []);
 };
 
-export default useEscapeKey;
+export default useKeyboardKey;

--- a/lib/hooks/useKeyboardKey.js
+++ b/lib/hooks/useKeyboardKey.js
@@ -1,14 +1,13 @@
 import React from 'react';
 
-const useKeyboardKey = ({ callback, keyName, keyAbb, keyCode }) => {
+const useKeyboardKey = ({ callback, keyMatch }) => {
   React.useEffect(() => {
     const eventListener = event => {
-      console.log(event);
       let isRecognizedKey = false;
       if ('key' in event) {
-        isRecognizedKey = event.key === keyName || event.key === keyAbb;
+        isRecognizedKey = event.key === keyMatch.key || event.key === keyMatch.keyName;
       } else {
-        isRecognizedKey = event.keyCode === keyCode;
+        isRecognizedKey = event.keyCode === keyMatch.keyCode;
       }
 
       if (isRecognizedKey) {
@@ -24,3 +23,15 @@ const useKeyboardKey = ({ callback, keyName, keyAbb, keyCode }) => {
 };
 
 export default useKeyboardKey;
+
+export const ESCAPE_KEY = {
+  key: 'Escape',
+  keyName: 'Esc',
+  keyCode: 27,
+};
+
+export const ENTER_KEY = {
+  key: 'Enter',
+  keyName: 'Enter',
+  keyCode: 13,
+};


### PR DESCRIPTION
This PR would resolve [#3701 ](https://github.com/opencollective/opencollective/issues/3701)

# Description
This Pull Request adds the ability of a user to dismiss a modal by tapping the `ESC` key using event listeners.

This PR adds event listeners to the following modal components: 
- TopBarProfileMenu
- StyledModal 

Pending : 
-  `Enter` should confirm the modal (only when not dangerous, ie. not for "Delete account") 