### PR TITLE
SignIn: Try to prevent Outlook robots from signing in

### DIFF
--- a/lang/ca.json
+++ b/lang/ca.json
@@ -130,6 +130,7 @@
   "CancelEdit": "Cancel·la la modificació",
   "cancelOrder.modal.body": "Esteu segur que voleu cancel·lar aquesta ordre?",
   "cancelOrder.modal.header": "Cancel·la l'ordre",
+  "checkingBrowser": "Your browser is being verified. If this message doesn't disappear, try to move your mouse or to touch your screen for mobile.",
   "clickHere": "Clica aquí",
   "Clipboard.Copied": "S'ha copiat!",
   "Clipboard.Copy": "Copia al porta-retalls",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -130,6 +130,7 @@
   "CancelEdit": "Zrušit úpravu",
   "cancelOrder.modal.body": "Opravdu chcete zrušit tuto objednávku?",
   "cancelOrder.modal.header": "Zrušit objednávku",
+  "checkingBrowser": "Your browser is being verified. If this message doesn't disappear, try to move your mouse or to touch your screen for mobile.",
   "clickHere": "Klikněte zde",
   "Clipboard.Copied": "Zkopírováno!",
   "Clipboard.Copy": "Kopírovat do schránky",

--- a/lang/de.json
+++ b/lang/de.json
@@ -130,6 +130,7 @@
   "CancelEdit": "Bearbeitung abbrechen",
   "cancelOrder.modal.body": "Sind Sie sicher, dass Sie diese Bestellung stornieren möchten?",
   "cancelOrder.modal.header": "Bestellung abbrechen",
+  "checkingBrowser": "Your browser is being verified. If this message doesn't disappear, try to move your mouse or to touch your screen for mobile.",
   "clickHere": "Klick hier",
   "Clipboard.Copied": "Kopiert!",
   "Clipboard.Copy": "In die Zwischenablage kopieren",

--- a/lang/en.json
+++ b/lang/en.json
@@ -130,6 +130,7 @@
   "CancelEdit": "Cancel edit",
   "cancelOrder.modal.body": "Are you sure you want to cancel this order?",
   "cancelOrder.modal.header": "Cancel Order",
+  "checkingBrowser": "Your browser is being verified. If this message doesn't disappear, try to move your mouse or to touch your screen for mobile.",
   "clickHere": "Click here",
   "Clipboard.Copied": "Copied!",
   "Clipboard.Copy": "Copy to clipboard",

--- a/lang/es.json
+++ b/lang/es.json
@@ -130,6 +130,7 @@
   "CancelEdit": "Cancelar edición",
   "cancelOrder.modal.body": "¿Está seguro de que quiere cancelar este pedido?",
   "cancelOrder.modal.header": "Cancelar pedido",
+  "checkingBrowser": "Your browser is being verified. If this message doesn't disappear, try to move your mouse or to touch your screen for mobile.",
   "clickHere": "Haga clic aquí",
   "Clipboard.Copied": "¡Copiado!",
   "Clipboard.Copy": "Copiar al portapapeles",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -130,6 +130,7 @@
   "CancelEdit": "Annuler l'édition",
   "cancelOrder.modal.body": "Êtes-vous sûr de vouloir annuler cette commande ?",
   "cancelOrder.modal.header": "Annuler la commande",
+  "checkingBrowser": "Your browser is being verified. If this message doesn't disappear, try to move your mouse or to touch your screen for mobile.",
   "clickHere": "Cliquez ici",
   "Clipboard.Copied": "Copié",
   "Clipboard.Copy": "Copier",

--- a/lang/it.json
+++ b/lang/it.json
@@ -130,6 +130,7 @@
   "CancelEdit": "Annulla modifica",
   "cancelOrder.modal.body": "Sei sicuro di voler annullare questo ordine?",
   "cancelOrder.modal.header": "Annulla Ordine",
+  "checkingBrowser": "Your browser is being verified. If this message doesn't disappear, try to move your mouse or to touch your screen for mobile.",
   "clickHere": "Clicca qui",
   "Clipboard.Copied": "Copiato!",
   "Clipboard.Copy": "Copia nella clipboard",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -130,6 +130,7 @@
   "CancelEdit": "編集をキャンセル",
   "cancelOrder.modal.body": "ご注文をキャンセルしてもよろしいですか？",
   "cancelOrder.modal.header": "注文をキャンセル",
+  "checkingBrowser": "Your browser is being verified. If this message doesn't disappear, try to move your mouse or to touch your screen for mobile.",
   "clickHere": "こちらからどうぞ",
   "Clipboard.Copied": "コピーしました!",
   "Clipboard.Copy": "クリップボードにコピー",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -130,6 +130,7 @@
   "CancelEdit": "변경 취소",
   "cancelOrder.modal.body": "정말 이 주문을 취소하시겠습니까?",
   "cancelOrder.modal.header": "주문 취소",
+  "checkingBrowser": "Your browser is being verified. If this message doesn't disappear, try to move your mouse or to touch your screen for mobile.",
   "clickHere": "더 알아보기",
   "Clipboard.Copied": "복사되었습니다!",
   "Clipboard.Copy": "클립보드에 복사",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -130,6 +130,7 @@
   "CancelEdit": "Bewerking annuleren",
   "cancelOrder.modal.body": "Weet u zeker dat u deze bestelling wilt annuleren?",
   "cancelOrder.modal.header": "Bestelling annuleren",
+  "checkingBrowser": "Your browser is being verified. If this message doesn't disappear, try to move your mouse or to touch your screen for mobile.",
   "clickHere": "Hier klikken",
   "Clipboard.Copied": "Gekopieerd!",
   "Clipboard.Copy": "Kopieer naar klembord",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -130,6 +130,7 @@
   "CancelEdit": "Cancelar edição",
   "cancelOrder.modal.body": "Você tem certeza que deseja cancelar este pedido?",
   "cancelOrder.modal.header": "Cancelar pedido",
+  "checkingBrowser": "Your browser is being verified. If this message doesn't disappear, try to move your mouse or to touch your screen for mobile.",
   "clickHere": "Clique aqui",
   "Clipboard.Copied": "Copiado!",
   "Clipboard.Copy": "Copiar para a área de transferência",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -130,6 +130,7 @@
   "CancelEdit": "Отменить изменения",
   "cancelOrder.modal.body": "Вы уверены, что хотите отменить этот заказ?",
   "cancelOrder.modal.header": "Отменить Заказ",
+  "checkingBrowser": "Your browser is being verified. If this message doesn't disappear, try to move your mouse or to touch your screen for mobile.",
   "clickHere": "Нажмите здесь",
   "Clipboard.Copied": "Скопировано!",
   "Clipboard.Copy": "Скопировать в буфер обмена",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -130,6 +130,7 @@
   "CancelEdit": "取消编辑",
   "cancelOrder.modal.body": "您确定要取消此订单吗？",
   "cancelOrder.modal.header": "取消订单",
+  "checkingBrowser": "Your browser is being verified. If this message doesn't disappear, try to move your mouse or to touch your screen for mobile.",
   "clickHere": "单击此处",
   "Clipboard.Copied": "已复制！",
   "Clipboard.Copy": "复制到剪贴板",

--- a/lib/__tests__/robots-tetector.test.js
+++ b/lib/__tests__/robots-tetector.test.js
@@ -1,0 +1,32 @@
+import { isSuspiciousUserAgent } from '../robots-detector';
+
+describe('Robots detector', () => {
+  describe('', () => {
+    it('Detects suspicious user agents', () => {
+      expect(
+        isSuspiciousUserAgent(
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.109 Safari/537.36',
+        ),
+      ).toBe(true);
+    });
+
+    it('Is fine with missing user agents', () => {
+      expect(isSuspiciousUserAgent()).toBe(false);
+      expect(isSuspiciousUserAgent(null)).toBe(false);
+      expect(isSuspiciousUserAgent('')).toBe(false);
+      expect(isSuspiciousUserAgent('      ')).toBe(false);
+    });
+
+    it('Returns ok for most browsers', () => {
+      expect(
+        isSuspiciousUserAgent(
+          'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.66 Safari/537.36',
+        ),
+      ).toBe(false);
+
+      expect(
+        isSuspiciousUserAgent('Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:83.0) Gecko/20100101 Firefox/83.0'),
+      ).toBe(false);
+    });
+  });
+});

--- a/lib/robots-detector.js
+++ b/lib/robots-detector.js
@@ -1,0 +1,64 @@
+import { throttle } from 'lodash';
+
+/**
+ * We don't have much information about the robots invalidating our sign in tokens yet,
+ * except that they use older versions of Chrome.
+ */
+export const isSuspiciousUserAgent = userAgent => {
+  if (!userAgent) {
+    return false;
+  }
+
+  const chromeVersionRegex = /Chrome\/(\d+)/;
+  const regexResult = userAgent.match(chromeVersionRegex);
+  if (!regexResult) {
+    // Not Chrome
+    return false;
+  }
+
+  const chromeVersion = parseInt(regexResult[1]);
+  return chromeVersion <= 72;
+};
+
+/**
+ * JS client-side robot detector
+ */
+export class RobotsDetector {
+  static WATCHED_EVENTS = ['mousemove', 'keydown', 'touchstart'];
+
+  constructor() {
+    this.isListening = false;
+    this.callback = null;
+  }
+
+  startListening(callback) {
+    this.callback = callback;
+    if (!this.isListening) {
+      this.isListening = true;
+      RobotsDetector.WATCHED_EVENTS.forEach(event => {
+        document.addEventListener(event, this.watchEvent);
+      });
+    }
+  }
+
+  stopListening() {
+    if (this.isListening) {
+      this.isListening = false;
+      RobotsDetector.WATCHED_EVENTS.forEach(event => {
+        document.removeEventListener(event, this.watchEvent);
+      });
+    }
+  }
+
+  /**
+   * Watch for human activity. As soon as something is detected, stop listening & call `callback`
+   */
+  watchEvent = throttle(
+    () => {
+      this.callback?.();
+      this.stopListening();
+    },
+    1000,
+    { trailing: false },
+  );
+}


### PR DESCRIPTION
Try to prevent Outlook issue https://github.com/opencollective/opencollective/issues/3656 where their ATP feature invalidates our sign in tokens. The current behavior is this:
- Check user agent: we noticed that they were using old chrome versions, so we're starting from this hypothesis
- If suspicious user agent is detected, show a javascript challenge and don't trigger any request, show a message for users to know that they should do something
- If a mouse move, a touch event or a key pressed event is detected, hide the message & send the sign in request

![Peek 2020-11-26 16-40](https://user-images.githubusercontent.com/1556356/100370319-5d688500-3006-11eb-833d-6555166ca99f.gif)
