### PR TITLE
Fix bug to hide previously opt-in features (Conversations, Updates) that are now on by default

### DIFF
--- a/lib/allowed-features.js
+++ b/lib/allowed-features.js
@@ -72,6 +72,19 @@ const hasFeature = (collective, feature) => {
     return false;
   }
 
+  // *** Important: opt-in/opt-out checks need to be in front of features endpoint checks until we
+  // *** fully migrate to the features API endpoint and make sure every case is accounted for.
+  // Check opt-out flags
+  if (feature === FEATURES.UPDATES && collective.type === CollectiveType.COLLECTIVE) {
+    return Boolean(get(collective, FEATURE_FLAGS[FEATURES.UPDATES], true));
+  }
+
+  // Check opt-in flags - to be removed when all features using features endpoint?
+  const activationFlag = FEATURE_FLAGS[feature];
+  if (activationFlag) {
+    return Boolean(get(collective, activationFlag, false));
+  }
+
   if (collective.features) {
     const featureStatus = collective.features[feature];
 
@@ -82,12 +95,6 @@ const hasFeature = (collective, feature) => {
     if (featureStatus === 'DISABLED' || featureStatus === 'UNSUPPORTED') {
       return false;
     }
-  }
-
-  // Check optional flags - to be removed when all features using features endpoint?
-  const activationFlag = FEATURE_FLAGS[feature];
-  if (activationFlag) {
-    return Boolean(get(collective, activationFlag, false));
   }
 
   return true;


### PR DESCRIPTION
Fixes https://github.com/opencollective/opencollective/issues/3732

Conversations and Updates used to be opt-in. Now they are on by default. Collectives that are old enough to not have explicit flags set in `settings.features` or `settings.collectivePage` due to rearranging collective sections, might be displaying these sections even if they are not expecting to.

Please see context here: https://github.com/opencollective/opencollective/issues/3732#issuecomment-735749022