### PR TITLE
DateTime: add moment dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13686,13 +13686,13 @@
       "dependencies": {
         "colors": {
           "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "resolved": "http://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
           "dev": true
         },
         "commander": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
           "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
           "dev": true
         }
@@ -13965,7 +13965,7 @@
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
       "requires": {
-        "icu4c-data": "^0.65.2"
+        "icu4c-data": "^0.64.2"
       },
       "dependencies": {
         "icu4c-data": {
@@ -15025,7 +15025,7 @@
     },
     "immutable": {
       "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+      "resolved": "http://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
       "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
     },
     "import-fresh": {
@@ -19578,8 +19578,7 @@
     "moment": {
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-      "dev": true
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "moo": {
       "version": "0.5.1",
@@ -25785,7 +25784,7 @@
       "dependencies": {
         "ast-types": {
           "version": "0.7.8",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
+          "resolved": "http://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
           "integrity": "sha1-kC0uDWDQcb3NRtwRXhgJ7RHBOKk=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "load-script": "1.0.0",
     "lodash": "4.17.20",
     "memoize-one": "5.1.1",
+    "moment": "2.29.1",
     "next": "9.5.4",
     "next-routes": "1.4.2",
     "node-fetch": "2.6.1",


### PR DESCRIPTION
While removing `moment` in https://github.com/opencollective/opencollective-frontend/pull/5108, we missed the fact that it's a peer dependency of https://www.npmjs.com/package/react-datetime.