### PR TITLE
Fix Typo in Pledges Page

### DIFF
--- a/lang/ar.json
+++ b/lang/ar.json
@@ -552,7 +552,7 @@
   "CreateOrder.TitleForEvent": "Order tickets for {event}",
   "createPledge.collectiveDetails": "Details of the new collective:",
   "createPledge.conditions": "At the moment, you can only pledge for Open Source projects with a GitHub repository or organization. We\n                request the project to have a least 100 stars on GitHub!",
-  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to proove that you are an admin of this project.",
+  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to prove that you are an admin of this project.",
   "createPledge.faq.howToClaimSummary": "How do I claim a pledged collective?",
   "createPledge.faq.pay": "Once that pledged collective is claimed, we will email you to fulfill your pledge.",
   "createPledge.faq.paySummary": "When do I pay?",

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -554,7 +554,7 @@
   "CreateOrder.TitleForEvent": "Order tickets for {event}",
   "createPledge.collectiveDetails": "Details of the new collective:",
   "createPledge.conditions": "At the moment, you can only pledge for Open Source projects with a GitHub repository or organization. We\n                request the project to have a least 100 stars on GitHub!",
-  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to proove that you are an admin of this project.",
+  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to prove that you are an admin of this project.",
   "createPledge.faq.howToClaimSummary": "How do I claim a pledged collective?",
   "createPledge.faq.pay": "Once that pledged collective is claimed, we will email you to fulfill your pledge.",
   "createPledge.faq.paySummary": "When do I pay?",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -554,7 +554,7 @@
   "CreateOrder.TitleForEvent": "Order tickets for {event}",
   "createPledge.collectiveDetails": "Podrobnosti o novém kolektivu:",
   "createPledge.conditions": "At the moment, you can only pledge for Open Source projects with a GitHub repository or organization. We\n                request the project to have a least 100 stars on GitHub!",
-  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to proove that you are an admin of this project.",
+  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to prove that you are an admin of this project.",
   "createPledge.faq.howToClaimSummary": "How do I claim a pledged collective?",
   "createPledge.faq.pay": "Once that pledged collective is claimed, we will email you to fulfill your pledge.",
   "createPledge.faq.paySummary": "Kdy platím?",

--- a/lang/cy.json
+++ b/lang/cy.json
@@ -552,7 +552,7 @@
   "CreateOrder.TitleForEvent": "Order tickets for {event}",
   "createPledge.collectiveDetails": "Details of the new collective:",
   "createPledge.conditions": "At the moment, you can only pledge for Open Source projects with a GitHub repository or organization. We\n                request the project to have a least 100 stars on GitHub!",
-  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to proove that you are an admin of this project.",
+  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to prove that you are an admin of this project.",
   "createPledge.faq.howToClaimSummary": "How do I claim a pledged collective?",
   "createPledge.faq.pay": "Once that pledged collective is claimed, we will email you to fulfill your pledge.",
   "createPledge.faq.paySummary": "When do I pay?",

--- a/lang/de.json
+++ b/lang/de.json
@@ -554,7 +554,7 @@
   "CreateOrder.TitleForEvent": "Tickets für {event} bestellen",
   "createPledge.collectiveDetails": "Details des neuen Kollektivs:",
   "createPledge.conditions": "At the moment, you can only pledge for Open Source projects with a GitHub repository or organization. We\n                request the project to have a least 100 stars on GitHub!",
-  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to proove that you are an admin of this project.",
+  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to prove that you are an admin of this project.",
   "createPledge.faq.howToClaimSummary": "How do I claim a pledged collective?",
   "createPledge.faq.pay": "Once that pledged collective is claimed, we will email you to fulfill your pledge.",
   "createPledge.faq.paySummary": "Wann bezahle ich?",

--- a/lang/en.json
+++ b/lang/en.json
@@ -554,7 +554,7 @@
   "CreateOrder.TitleForEvent": "Order tickets for {event}",
   "createPledge.collectiveDetails": "Details of the new collective:",
   "createPledge.conditions": "At the moment, you can only pledge for Open Source projects with a GitHub repository or organization. We\n                request the project to have a least 100 stars on GitHub!",
-  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to proove that you are an admin of this project.",
+  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to prove that you are an admin of this project.",
   "createPledge.faq.howToClaimSummary": "How do I claim a pledged collective?",
   "createPledge.faq.pay": "Once that pledged collective is claimed, we will email you to fulfill your pledge.",
   "createPledge.faq.paySummary": "When do I pay?",

--- a/lang/es.json
+++ b/lang/es.json
@@ -554,7 +554,7 @@
   "CreateOrder.TitleForEvent": "Solicitar billetes para {event}",
   "createPledge.collectiveDetails": "Detalles del nuevo colectivo:",
   "createPledge.conditions": "Por el momento, solo puedes prometer proyectos de Código Abierto con un repositorio u organización de GitHub. ¡Nosotros\n                pedimos al proyecto que tenga al menos 100 estrellas en GitHub!",
-  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to proove that you are an admin of this project.",
+  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to prove that you are an admin of this project.",
   "createPledge.faq.howToClaimSummary": "How do I claim a pledged collective?",
   "createPledge.faq.pay": "Once that pledged collective is claimed, we will email you to fulfill your pledge.",
   "createPledge.faq.paySummary": "¿Cuando pago?",

--- a/lang/fa.json
+++ b/lang/fa.json
@@ -552,7 +552,7 @@
   "CreateOrder.TitleForEvent": "Order tickets for {event}",
   "createPledge.collectiveDetails": "Details of the new collective:",
   "createPledge.conditions": "At the moment, you can only pledge for Open Source projects with a GitHub repository or organization. We\n                request the project to have a least 100 stars on GitHub!",
-  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to proove that you are an admin of this project.",
+  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to prove that you are an admin of this project.",
   "createPledge.faq.howToClaimSummary": "How do I claim a pledged collective?",
   "createPledge.faq.pay": "Once that pledged collective is claimed, we will email you to fulfill your pledge.",
   "createPledge.faq.paySummary": "When do I pay?",

--- a/lang/hu.json
+++ b/lang/hu.json
@@ -552,7 +552,7 @@
   "CreateOrder.TitleForEvent": "Order tickets for {event}",
   "createPledge.collectiveDetails": "Details of the new collective:",
   "createPledge.conditions": "At the moment, you can only pledge for Open Source projects with a GitHub repository or organization. We\n                request the project to have a least 100 stars on GitHub!",
-  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to proove that you are an admin of this project.",
+  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to prove that you are an admin of this project.",
   "createPledge.faq.howToClaimSummary": "How do I claim a pledged collective?",
   "createPledge.faq.pay": "Once that pledged collective is claimed, we will email you to fulfill your pledge.",
   "createPledge.faq.paySummary": "When do I pay?",

--- a/lang/it.json
+++ b/lang/it.json
@@ -554,7 +554,7 @@
   "CreateOrder.TitleForEvent": "Ordina biglietti per {event}",
   "createPledge.collectiveDetails": "Dettagli del nuovo collettivo:",
   "createPledge.conditions": "At the moment, you can only pledge for Open Source projects with a GitHub repository or organization. We\n                request the project to have a least 100 stars on GitHub!",
-  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to proove that you are an admin of this project.",
+  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to prove that you are an admin of this project.",
   "createPledge.faq.howToClaimSummary": "How do I claim a pledged collective?",
   "createPledge.faq.pay": "Once that pledged collective is claimed, we will email you to fulfill your pledge.",
   "createPledge.faq.paySummary": "Quando pagherò?",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -554,7 +554,7 @@
   "CreateOrder.TitleForEvent": "Order tickets for {event}",
   "createPledge.collectiveDetails": "新しいコレクティブの詳細",
   "createPledge.conditions": "At the moment, you can only pledge for Open Source projects with a GitHub repository or organization. We\n                request the project to have a least 100 stars on GitHub!",
-  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to proove that you are an admin of this project.",
+  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to prove that you are an admin of this project.",
   "createPledge.faq.howToClaimSummary": "How do I claim a pledged collective?",
   "createPledge.faq.pay": "Once that pledged collective is claimed, we will email you to fulfill your pledge.",
   "createPledge.faq.paySummary": "支払いはいつですか?",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -554,7 +554,7 @@
   "CreateOrder.TitleForEvent": "Order tickets for {event}",
   "createPledge.collectiveDetails": "Details of the new collective:",
   "createPledge.conditions": "At the moment, you can only pledge for Open Source projects with a GitHub repository or organization. We\n                request the project to have a least 100 stars on GitHub!",
-  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to proove that you are an admin of this project.",
+  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to prove that you are an admin of this project.",
   "createPledge.faq.howToClaimSummary": "How do I claim a pledged collective?",
   "createPledge.faq.pay": "Once that pledged collective is claimed, we will email you to fulfill your pledge.",
   "createPledge.faq.paySummary": "When do I pay?",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -554,7 +554,7 @@
   "CreateOrder.TitleForEvent": "Order tickets for {event}",
   "createPledge.collectiveDetails": "Details of the new collective:",
   "createPledge.conditions": "At the moment, you can only pledge for Open Source projects with a GitHub repository or organization. We\n                request the project to have a least 100 stars on GitHub!",
-  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to proove that you are an admin of this project.",
+  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to prove that you are an admin of this project.",
   "createPledge.faq.howToClaimSummary": "How do I claim a pledged collective?",
   "createPledge.faq.pay": "Once that pledged collective is claimed, we will email you to fulfill your pledge.",
   "createPledge.faq.paySummary": "When do I pay?",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -554,7 +554,7 @@
   "CreateOrder.TitleForEvent": "Order tickets for {event}",
   "createPledge.collectiveDetails": "Details of the new collective:",
   "createPledge.conditions": "At the moment, you can only pledge for Open Source projects with a GitHub repository or organization. We\n                request the project to have a least 100 stars on GitHub!",
-  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to proove that you are an admin of this project.",
+  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to prove that you are an admin of this project.",
   "createPledge.faq.howToClaimSummary": "How do I claim a pledged collective?",
   "createPledge.faq.pay": "Once that pledged collective is claimed, we will email you to fulfill your pledge.",
   "createPledge.faq.paySummary": "When do I pay?",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -554,7 +554,7 @@
   "CreateOrder.TitleForEvent": "Заказать билеты на {event}",
   "createPledge.collectiveDetails": "Детали нового коллектива:",
   "createPledge.conditions": "At the moment, you can only pledge for Open Source projects with a GitHub repository or organization. We\n                request the project to have a least 100 stars on GitHub!",
-  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to proove that you are an admin of this project.",
+  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to prove that you are an admin of this project.",
   "createPledge.faq.howToClaimSummary": "How do I claim a pledged collective?",
   "createPledge.faq.pay": "Once that pledged collective is claimed, we will email you to fulfill your pledge.",
   "createPledge.faq.paySummary": "Когда нужно оплатить?",

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -552,7 +552,7 @@
   "CreateOrder.TitleForEvent": "Order tickets for {event}",
   "createPledge.collectiveDetails": "Details of the new collective:",
   "createPledge.conditions": "At the moment, you can only pledge for Open Source projects with a GitHub repository or organization. We\n                request the project to have a least 100 stars on GitHub!",
-  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to proove that you are an admin of this project.",
+  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to prove that you are an admin of this project.",
   "createPledge.faq.howToClaimSummary": "How do I claim a pledged collective?",
   "createPledge.faq.pay": "Once that pledged collective is claimed, we will email you to fulfill your pledge.",
   "createPledge.faq.paySummary": "When do I pay?",

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -552,7 +552,7 @@
   "CreateOrder.TitleForEvent": "Order tickets for {event}",
   "createPledge.collectiveDetails": "Details of the new collective:",
   "createPledge.conditions": "At the moment, you can only pledge for Open Source projects with a GitHub repository or organization. We\n                request the project to have a least 100 stars on GitHub!",
-  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to proove that you are an admin of this project.",
+  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to prove that you are an admin of this project.",
   "createPledge.faq.howToClaimSummary": "How do I claim a pledged collective?",
   "createPledge.faq.pay": "Once that pledged collective is claimed, we will email you to fulfill your pledge.",
   "createPledge.faq.paySummary": "When do I pay?",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -552,7 +552,7 @@
   "CreateOrder.TitleForEvent": "Order tickets for {event}",
   "createPledge.collectiveDetails": "Подробиці про новий колектив:",
   "createPledge.conditions": "At the moment, you can only pledge for Open Source projects with a GitHub repository or organization. We\n                request the project to have a least 100 stars on GitHub!",
-  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to proove that you are an admin of this project.",
+  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to prove that you are an admin of this project.",
   "createPledge.faq.howToClaimSummary": "How do I claim a pledged collective?",
   "createPledge.faq.pay": "Once that pledged collective is claimed, we will email you to fulfill your pledge.",
   "createPledge.faq.paySummary": "When do I pay?",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -554,7 +554,7 @@
   "CreateOrder.TitleForEvent": "Order tickets for {event}",
   "createPledge.collectiveDetails": "新集体的细节：",
   "createPledge.conditions": "目前, 您只能使用 GitHub 存储库或组织为开源项目认捐。我们要求至少有一个Github储存库有100星!",
-  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to proove that you are an admin of this project.",
+  "createPledge.faq.howToClaim": "You’ll need to contact <SupportLink></SupportLink> to prove that you are an admin of this project.",
   "createPledge.faq.howToClaimSummary": "How do I claim a pledged collective?",
   "createPledge.faq.pay": "Once that pledged collective is claimed, we will email you to fulfill your pledge.",
   "createPledge.faq.paySummary": "When do I pay?",

--- a/pages/createPledge.js
+++ b/pages/createPledge.js
@@ -652,7 +652,7 @@ class CreatePledgePage extends React.Component {
                 </summary>
                 <FormattedMessage
                   id="createPledge.faq.howToClaim"
-                  defaultMessage="You’ll need to contact <SupportLink></SupportLink> to proove that you are an admin of this project."
+                  defaultMessage="You’ll need to contact <SupportLink></SupportLink> to prove that you are an admin of this project."
                   values={I18nFormatters}
                 />
               </Details>

--- a/test/cypress/integration/36-pledges.test.js
+++ b/test/cypress/integration/36-pledges.test.js
@@ -91,7 +91,7 @@ describe('check FAQ context in each pledge is valid or not', () => {
 
   it('verify how do i claim a pledge ?', () => {
     cy.get('[data-cy="howDoIClaimPledge"]').click();
-    cy.get('[data-cy="howDoIClaimPledge"]').should('contain', 'to proove that you are an admin of this project');
+    cy.get('[data-cy="howDoIClaimPledge"]').should('contain', 'to prove that you are an admin of this project');
   });
 });
 


### PR DESCRIPTION
This fixes the typo that was noticed in the pledges page where the word prove was mistakenly typed as proove.