### PR TITLE
Updated expense form to use host address as default address

### DIFF
--- a/components/expenses/ExpenseFormPayeeStep.js
+++ b/components/expenses/ExpenseFormPayeeStep.js
@@ -139,12 +139,12 @@ const ExpenseFormPayeeStep = ({
   const setDefaultHostAddress = () => {
     formik.setFieldValue('payeeLocation.country', loggedInAccount.location.country);
     formik.setFieldValue('payeeLocation.address', loggedInAccount.location.address);
-  }
+  };
 
   useEffect(() => {
-    loggedInAccount && setDefaultHostAddress()
+    loggedInAccount && setDefaultHostAddress();
 
-    return () => loggedInAccount && setDefaultHostAddress()
+    return () => loggedInAccount && setDefaultHostAddress();
   }, [loggedInAccount]);
 
   const collectivePick = canInvite

--- a/components/expenses/ExpenseFormPayeeStep.js
+++ b/components/expenses/ExpenseFormPayeeStep.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { FastField, Field } from 'formik';
 import { first, get, omit, partition, pick } from 'lodash';
@@ -135,6 +135,17 @@ const ExpenseFormPayeeStep = ({
     types: [CollectiveType.ORGANIZATION],
     __background__: 'white',
   });
+
+  const setDefaultHostAddress = () => {
+    formik.setFieldValue('payeeLocation.country', loggedInAccount.location.country);
+    formik.setFieldValue('payeeLocation.address', loggedInAccount.location.address);
+  }
+
+  useEffect(() => {
+    loggedInAccount && setDefaultHostAddress()
+
+    return () => loggedInAccount && setDefaultHostAddress()
+  }, [loggedInAccount]);
 
   const collectivePick = canInvite
     ? ({ id }) => (

--- a/components/expenses/ExpenseFormPayeeStep.js
+++ b/components/expenses/ExpenseFormPayeeStep.js
@@ -136,16 +136,11 @@ const ExpenseFormPayeeStep = ({
     __background__: 'white',
   });
 
-  const setDefaultHostAddress = () => {
-    formik.setFieldValue('payeeLocation.country', loggedInAccount.location.country);
-    formik.setFieldValue('payeeLocation.address', loggedInAccount.location.address);
-  };
-
   useEffect(() => {
-    loggedInAccount && setDefaultHostAddress();
+    setLocationFromPayee(formik, collective.host);
 
-    return () => loggedInAccount && setDefaultHostAddress();
-  }, [loggedInAccount]);
+    return () => setLocationFromPayee(formik, collective.host);
+  }, []);
 
   const collectivePick = canInvite
     ? ({ id }) => (


### PR DESCRIPTION
This resolves [#3765](https://github.com/opencollective/opencollective/issues/3765)

# Description
This PR modifies the `ExpensePayeeFormStep` component to use the `loggedInUser`'s ( host ) address as the default address which can later be changed using the `CollectivePicker` dropdown.
