### PR TITLE
Remove useAlgolia parameter from search

### DIFF
--- a/components/CollectivePickerAsync.js
+++ b/components/CollectivePickerAsync.js
@@ -16,7 +16,7 @@ const collectivePickerSearchQuery = gql`
     $limit: Int
     $hostCollectiveIds: [Int]
   ) {
-    search(term: $term, types: $types, limit: $limit, hostCollectiveIds: $hostCollectiveIds, useAlgolia: false) {
+    search(term: $term, types: $types, limit: $limit, hostCollectiveIds: $hostCollectiveIds) {
       id
       collectives {
         id


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective-api/pull/5018

`false` is now the default value for this