### PR TITLE
Navigation v2: responsive tablet menu + URL-based feature flag

### DIFF
--- a/components/collective-navbar/ActionsMenu.js
+++ b/components/collective-navbar/ActionsMenu.js
@@ -71,7 +71,7 @@ const ActionsDropdown = styled(Dropdown)`
       position: relative;
       box-shadow: none;
       border: none;
-      padding-left: 28px;
+      padding-left: 14px;
     }
   }
 `;
@@ -80,6 +80,12 @@ const StyledActionButton = styled(StyledButton)`
   @media (max-width: 40em) {
     cursor: none;
     pointer-events: none;
+  }
+`;
+
+const StyledChevronDown = styled(ChevronDown)`
+  @media (max-width: 40em) {
+    display: none;
   }
 `;
 
@@ -123,7 +129,7 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction }) => {
       <Box px={1}>
         <ActionsDropdown trigger="click">
           <Flex alignItems="center">
-            <Box display={['block', 'none']} width={'33px'} ml={2}>
+            <Box display={['block', 'none']} width={'32px'} ml={2}>
               <StyledHr borderStyle="solid" borderColor="#304CDC" />
             </Box>
             <StyledActionButton
@@ -142,7 +148,7 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction }) => {
               <Span css={{ verticalAlign: 'middle', marginRight: '4px' }}>
                 <FormattedMessage id="CollectivePage.NavBar.ActionMenu.Actions" defaultMessage="Actions" />
               </Span>
-              <ChevronDown size="14px" />
+              <StyledChevronDown size="14px" />
             </StyledActionButton>
           </Flex>
           <DropdownArrow />

--- a/components/collective-navbar/ActionsMenu.js
+++ b/components/collective-navbar/ActionsMenu.js
@@ -4,6 +4,7 @@ import { Envelope } from '@styled-icons/boxicons-regular/Envelope';
 import { Planet } from '@styled-icons/boxicons-regular/Planet';
 import { Receipt } from '@styled-icons/boxicons-regular/Receipt';
 import { MoneyCheckAlt } from '@styled-icons/fa-solid/MoneyCheckAlt';
+import { ChevronDown } from '@styled-icons/feather/ChevronDown/ChevronDown';
 import { AttachMoney } from '@styled-icons/material/AttachMoney';
 import { Dashboard } from '@styled-icons/material/Dashboard';
 import { Stack } from '@styled-icons/remix-line/Stack';
@@ -138,9 +139,10 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction }) => {
               tabIndex="-1"
               data-cy="collective-navbar-actions-btn"
             >
-              <Span css={{ verticalAlign: 'middle' }}>
+              <Span css={{ verticalAlign: 'middle', marginRight: '4px' }}>
                 <FormattedMessage id="CollectivePage.NavBar.ActionMenu.Actions" defaultMessage="Actions" />
               </Span>
+              <ChevronDown size="14px" />
             </StyledActionButton>
           </Flex>
           <DropdownArrow />

--- a/components/collective-navbar/NavBarCategoryDropdown.js
+++ b/components/collective-navbar/NavBarCategoryDropdown.js
@@ -31,7 +31,7 @@ const IconIllustration = styled.img.attrs({ alt: '' })`
   height: 32px;
 `;
 
-const CategoryContainer = styled(StyledLink).attrs({ px: [1, null, 0] })`
+const CategoryContainer = styled(StyledLink).attrs({ px: [1, 3, 0] })`
   display: block;
   font-size: 14px;
   line-height: 16px;
@@ -85,7 +85,7 @@ const CategoryContainer = styled(StyledLink).attrs({ px: [1, null, 0] })`
       }
     `}
 
-  @media (max-width: 40em) {
+  @media (max-width: 52em) {
     border-top: 1px solid #e1e1e1;
     &::after {
       display: none;
@@ -123,7 +123,7 @@ const MenuItem = styled('li')`
 `;
 
 const CategoryDropdown = styled(Dropdown)`
-  @media (max-width: 40em) {
+  @media (max-width: 52em) {
     ${DropdownArrow} {
       display: none !important;
     }
@@ -152,7 +152,7 @@ const NavBarCategoryDropdown = ({ useAnchor, collective, category, isSelected, l
   return (
     <CategoryDropdown trigger="hover" tabIndex="-1">
       <CategoryContainer
-        mr={[0, 3]}
+        mr={[0, null, 3]}
         isSelected={isSelected}
         {...getLinkProps(useAnchor, collective, category)}
         onClick={e => {

--- a/components/collective-navbar/index.js
+++ b/components/collective-navbar/index.js
@@ -1,6 +1,7 @@
 import React, { Fragment, useRef } from 'react';
 import { PropTypes } from 'prop-types';
 import { DotsVerticalRounded } from '@styled-icons/boxicons-regular/DotsVerticalRounded';
+import { XCircle } from '@styled-icons/boxicons-regular/XCircle';
 import { Settings } from '@styled-icons/feather/Settings';
 import themeGet from '@styled-system/theme-get';
 import { get } from 'lodash';
@@ -84,6 +85,29 @@ const CollectiveNameV2 = styled(H1)`
 
   a:not(:hover) {
     color: #313233;
+  }
+`;
+
+const CategoriesContainer = styled(Container)`
+  @media screen and (min-width: 40em) and (max-width: 64em) {
+    border: 1px solid rgba(214, 214, 214, 0.3);
+    border-radius: 0px 0px 0px 8px;
+    box-shadow: 0px 6px 10px -5px rgba(214, 214, 214, 0.5);
+    position: absolute;
+    right: 0;
+    top: 52px;
+    width: 0;
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 0.4s ease-out, visibility 0.4s ease-out, width 0.2s ease-out;
+
+    ${props =>
+      props.isExpanded &&
+      css`
+        width: 400px;
+        visibility: visible;
+        opacity: 1;
+      `}
   }
 `;
 
@@ -198,12 +222,23 @@ const InfosContainer = styled(Container)`
     `}
 `;
 
-/** Displayed on mobile to toggle the menu */
+/** Displayed on mobile & tablet to toggle the menu */
 const ExpandMenuIcon = styled(DotsVerticalRounded).attrs({ size: 28 })`
   cursor: pointer;
   margin-right: 4px;
   flex: 0 0 28px;
-  color: ${themeGet('colors.black.500')};
+  color: #304cdc;
+
+  @media (min-width: 52em) {
+    display: none;
+  }
+`;
+
+const CloseMenuIcon = styled(XCircle).attrs({ size: 28 })`
+  cursor: pointer;
+  margin-right: 4px;
+  flex: 0 0 28px;
+  color: #304cdc;
 
   @media (min-width: 52em) {
     display: none;
@@ -353,7 +388,11 @@ const CollectiveNavbar = ({
         </Box>
         {!onlyInfos && (
           <Box display={['block', 'none']} marginLeft="auto">
-            <ExpandMenuIcon onClick={() => setExpanded(!isExpanded)} />
+            {isExpanded ? (
+              <CloseMenuIcon onClick={() => setExpanded(!isExpanded)} />
+            ) : (
+              <ExpandMenuIcon onClick={() => setExpanded(!isExpanded)} />
+            )}
           </Box>
         )}
       </InfosContainerV2>
@@ -361,18 +400,17 @@ const CollectiveNavbar = ({
 
       {!onlyInfos && (
         <Fragment>
-          <Container
+          <CategoriesContainer
             ref={navbarRef}
             backgroundColor="#fff"
             display={isExpanded ? 'flex' : ['none', 'flex']}
-            flexDirection={['column', 'row']}
+            flexDirection={['column', null, 'row']}
             flexShrink={2}
             flexGrow={1}
             justifyContent={['space-between', null, 'flex-start']}
-            minWidth={0}
             order={[0, 3, 0]}
-            borderTop={['none', '1px solid #e1e1e1', 'none']}
             overflowX="auto"
+            isExpanded={isExpanded}
           >
             {isLoading ? (
               <LoadingPlaceholder height={43} minWidth={150} mb={2} />
@@ -388,7 +426,7 @@ const CollectiveNavbar = ({
                 />
               ))
             )}
-          </Container>
+          </CategoriesContainer>
 
           {/* CTAs for v2 navbar & admin panel */}
           <Container
@@ -441,6 +479,15 @@ const CollectiveNavbar = ({
                 callsToAction={callsToAction}
                 createNotification={createNotification}
               />
+            )}
+            {!onlyInfos && (
+              <Container display={['none', 'flex', 'none']} alignItems="center">
+                {isExpanded ? (
+                  <CloseMenuIcon onClick={() => setExpanded(!isExpanded)} />
+                ) : (
+                  <ExpandMenuIcon onClick={() => setExpanded(!isExpanded)} />
+                )}
+              </Container>
             )}
           </Container>
         </Fragment>

--- a/components/collective-navbar/index.js
+++ b/components/collective-navbar/index.js
@@ -5,7 +5,7 @@ import { Settings } from '@styled-icons/feather/Settings';
 import { Close } from '@styled-icons/material/Close';
 import themeGet from '@styled-system/theme-get';
 import { get } from 'lodash';
-import { withRouter } from 'next/router';
+import { useRouter } from 'next/router';
 import { FormattedMessage, useIntl } from 'react-intl';
 import styled, { css } from 'styled-components';
 
@@ -317,9 +317,9 @@ const CollectiveNavbar = ({
   showBackButton,
   withShadow,
   useAnchorsForCategories,
-  router,
 }) => {
-  const newNavbarFeatureFlag = get(router, 'query.version') === 'v2';
+  const router = useRouter();
+  const newNavbarFeatureFlag = get(router, 'query.navbarVersion') === 'v2';
   const intl = useIntl();
   const [isExpanded, setExpanded] = React.useState(false);
   sections = sections || getFilteredSectionsForCollective(collective, isAdmin, null, newNavbarFeatureFlag);
@@ -666,8 +666,6 @@ CollectiveNavbar.propTypes = {
   withShadow: PropTypes.bool,
   /** To use on the collective page. Sets links to anchors rather than full URLs for faster navigation */
   useAnchorsForCategories: PropTypes.bool,
-  /** From withRouter */
-  router: PropTypes.object,
 };
 
 CollectiveNavbar.defaultProps = {
@@ -688,4 +686,4 @@ CollectiveNavbar.defaultProps = {
   },
 };
 
-export default React.memo(withRouter(CollectiveNavbar));
+export default React.memo(CollectiveNavbar);

--- a/components/collective-page/graphql/preload.js
+++ b/components/collective-page/graphql/preload.js
@@ -16,14 +16,14 @@ import { getUpdatesSectionQueryVariables, updatesSectionQuery } from '../section
 
 import { collectivePageQuery, getCollectivePageQueryVariables } from './queries';
 
-export const preloadCollectivePageGraphlQueries = async (slug, client) => {
+export const preloadCollectivePageGraphlQueries = async (slug, client, hasNewCollectiveNavbar) => {
   const result = await client.query({
     query: collectivePageQuery,
     variables: getCollectivePageQueryVariables(slug),
   });
   const collective = result?.data?.Collective;
   if (collective) {
-    const sections = getFilteredSectionsForCollective(collective);
+    const sections = getFilteredSectionsForCollective(collective, null, null, hasNewCollectiveNavbar);
     const queries = [];
     if (sections.includes('budget')) {
       queries.push(

--- a/components/collective-page/index.js
+++ b/components/collective-page/index.js
@@ -110,7 +110,7 @@ class CollectivePage extends Component {
   }
 
   getSections = memoizeOne((collective, isAdmin, isHostAdmin) => {
-    const hasNewCollectiveNavbar = get(this.props.router, 'query.version') === 'v2';
+    const hasNewCollectiveNavbar = get(this.props.router, 'query.navbarVersion') === 'v2';
     return getFilteredSectionsForCollective(collective, isAdmin, isHostAdmin, hasNewCollectiveNavbar);
   });
 
@@ -135,9 +135,10 @@ class CollectivePage extends Component {
     const sections = this.getSections(this.props.collective, this.props.isAdmin, this.props.isHostAdmin);
 
     if (
-      get(this.props.router, 'query.version') === 'v2' &&
+      get(this.props.router, 'query.navbarVersion') === 'v2' &&
       get(this.props.collective, 'settings.collectivePage.useNewSections')
     ) {
+      console.log('collective-page/index using new v2');
       for (let i = sections.length - 1; i >= 0; i--) {
         if (sections[i].type !== 'CATEGORY') {
           continue;
@@ -190,7 +191,7 @@ class CollectivePage extends Component {
       const isEvent = type === CollectiveType.EVENT;
       const isProject = type === CollectiveType.PROJECT;
 
-      if (get(this.props.router.query.version) === 'v2') {
+      if (get(this.props.router, 'query.navbarVersion') === 'v2') {
         // The "too many calls to action" issue doesn't stand anymore with the new navbar, so
         // we can let the CollectiveNavbar component in charge of most of the flags, to make sure
         // we display the same thing everywhere. The two flags below should be migrated and this
@@ -357,7 +358,7 @@ class CollectivePage extends Component {
 
   render() {
     const { collective, host, isAdmin, isRoot, onPrimaryColorChange, LoggedInUser, router } = this.props;
-    const newNavbarFeatureFlag = router?.query?.version === 'v2';
+    const newNavbarFeatureFlag = router?.query?.navbarVersion === 'v2';
     const { type, isHost, canApply, canContact, isActive, settings } = collective;
     const { isFixed, selectedSection, selectedCategory, notification } = this.state;
     const sections = this.getSections(this.props.collective, this.props.isAdmin, this.props.isHostAdmin);

--- a/components/collective-page/sections/About.js
+++ b/components/collective-page/sections/About.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import dynamic from 'next/dynamic';
-import { withRouter } from 'next/router';
+import { useRouter } from 'next/router';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 
 import { CollectiveType } from '../../../lib/constants/collectives';
@@ -39,12 +39,13 @@ const messages = defineMessages({
 /**
  * About section category with editable description
  */
-const SectionAbout = ({ collective, canEdit, intl, router }) => {
+const SectionAbout = ({ collective, canEdit, intl }) => {
   const isEmptyDescription = isEmptyValue(collective.longDescription);
   const isCollective = collective.type === CollectiveType.COLLECTIVE;
   const isFund = collective.type === CollectiveType.FUND;
   canEdit = collective.isArchived ? false : canEdit;
-  const newNavbarFeatureFlag = get(router, 'query.version') === 'v2';
+  const router = useRouter();
+  const newNavbarFeatureFlag = get(router, 'query.navbarVersion') === 'v2';
 
   return (
     <ContainerSectionContent px={2} py={[4, 5]}>
@@ -132,9 +133,6 @@ SectionAbout.propTypes = {
 
   /** @ignore from injectIntl */
   intl: PropTypes.object,
-
-  /** @ignore from withRouter */
-  router: PropTypes.object,
 };
 
-export default React.memo(withRouter(injectIntl(SectionAbout)));
+export default React.memo(injectIntl(SectionAbout));

--- a/components/collective-page/sections/About.js
+++ b/components/collective-page/sections/About.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { get } from 'lodash';
 import dynamic from 'next/dynamic';
+import { withRouter } from 'next/router';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 
-import { hasNewNavBar } from '../../../lib/collective-sections';
 import { CollectiveType } from '../../../lib/constants/collectives';
 
 import Container from '../../Container';
@@ -38,15 +39,16 @@ const messages = defineMessages({
 /**
  * About section category with editable description
  */
-const SectionAbout = ({ collective, canEdit, intl }) => {
+const SectionAbout = ({ collective, canEdit, intl, router }) => {
   const isEmptyDescription = isEmptyValue(collective.longDescription);
   const isCollective = collective.type === CollectiveType.COLLECTIVE;
   const isFund = collective.type === CollectiveType.FUND;
   canEdit = collective.isArchived ? false : canEdit;
+  const newNavbarFeatureFlag = get(router, 'query.version') === 'v2';
 
   return (
     <ContainerSectionContent px={2} py={[4, 5]}>
-      {!hasNewNavBar(collective) && <SectionHeader title={Sections.ABOUT} illustrationSrc={aboutSectionHeaderIcon} />}
+      {!newNavbarFeatureFlag && <SectionHeader title={Sections.ABOUT} illustrationSrc={aboutSectionHeaderIcon} />}
 
       <Container width="100%" maxWidth={700} margin="0 auto" mt={4}>
         <InlineEditField
@@ -130,6 +132,9 @@ SectionAbout.propTypes = {
 
   /** @ignore from injectIntl */
   intl: PropTypes.object,
+
+  /** @ignore from withRouter */
+  router: PropTypes.object,
 };
 
-export default React.memo(injectIntl(SectionAbout));
+export default React.memo(withRouter(injectIntl(SectionAbout)));

--- a/components/collective-page/sections/Budget.js
+++ b/components/collective-page/sections/Budget.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/client';
-import { isEmpty } from 'lodash';
+import { get, isEmpty } from 'lodash';
+import { withRouter } from 'next/router';
 import { FormattedMessage, injectIntl } from 'react-intl';
 
-import { hasNewNavBar } from '../../../lib/collective-sections';
 import { CollectiveType } from '../../../lib/constants/collectives';
 import { formatCurrency } from '../../../lib/currency-utils';
 import { GraphQLContext } from '../../../lib/graphql/context';
@@ -44,7 +44,7 @@ export const getBudgetSectionQueryVariables = slug => {
  * The budget section. Shows the expenses, the latests transactions and some statistics
  * abut the global budget of the collective.
  */
-const SectionBudget = ({ collective, stats, LoggedInUser }) => {
+const SectionBudget = ({ collective, stats, LoggedInUser, router }) => {
   const budgetQueryResult = useQuery(budgetSectionQuery, {
     variables: getBudgetSectionQueryVariables(collective.slug),
     context: API_V2_CONTEXT,
@@ -54,6 +54,7 @@ const SectionBudget = ({ collective, stats, LoggedInUser }) => {
     (stats.activeRecurringContributions?.monthly || 0) + (stats.activeRecurringContributions?.yearly || 0) / 12;
   const isFund = collective.type === CollectiveType.FUND;
   const isProject = collective.type === CollectiveType.PROJECT;
+  const newNavbarFeatureFlag = get(router, 'query.version') === 'v2';
 
   React.useEffect(() => {
     refetch();
@@ -61,7 +62,7 @@ const SectionBudget = ({ collective, stats, LoggedInUser }) => {
 
   return (
     <ContainerSectionContent pt={[4, 5]} pb={3}>
-      {!hasNewNavBar(collective) && (
+      {!newNavbarFeatureFlag && (
         <SectionHeader
           title={Sections.BUDGET}
           subtitle={
@@ -211,6 +212,9 @@ SectionBudget.propTypes = {
 
   /** @ignore from injectIntl */
   intl: PropTypes.object,
+
+  /** @ignore from withRouter */
+  router: PropTypes.object,
 };
 
-export default React.memo(withUser(injectIntl(SectionBudget)));
+export default React.memo(withRouter(withUser(injectIntl(SectionBudget))));

--- a/components/collective-page/sections/Budget.js
+++ b/components/collective-page/sections/Budget.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/client';
 import { get, isEmpty } from 'lodash';
-import { withRouter } from 'next/router';
+import { useRouter } from 'next/router';
 import { FormattedMessage, injectIntl } from 'react-intl';
 
 import { CollectiveType } from '../../../lib/constants/collectives';
@@ -44,7 +44,7 @@ export const getBudgetSectionQueryVariables = slug => {
  * The budget section. Shows the expenses, the latests transactions and some statistics
  * abut the global budget of the collective.
  */
-const SectionBudget = ({ collective, stats, LoggedInUser, router }) => {
+const SectionBudget = ({ collective, stats, LoggedInUser }) => {
   const budgetQueryResult = useQuery(budgetSectionQuery, {
     variables: getBudgetSectionQueryVariables(collective.slug),
     context: API_V2_CONTEXT,
@@ -54,7 +54,8 @@ const SectionBudget = ({ collective, stats, LoggedInUser, router }) => {
     (stats.activeRecurringContributions?.monthly || 0) + (stats.activeRecurringContributions?.yearly || 0) / 12;
   const isFund = collective.type === CollectiveType.FUND;
   const isProject = collective.type === CollectiveType.PROJECT;
-  const newNavbarFeatureFlag = get(router, 'query.version') === 'v2';
+  const router = useRouter();
+  const newNavbarFeatureFlag = get(router, 'query.navbarVersion') === 'v2';
 
   React.useEffect(() => {
     refetch();
@@ -212,9 +213,6 @@ SectionBudget.propTypes = {
 
   /** @ignore from injectIntl */
   intl: PropTypes.object,
-
-  /** @ignore from withRouter */
-  router: PropTypes.object,
 };
 
-export default React.memo(withRouter(withUser(injectIntl(SectionBudget))));
+export default React.memo(withUser(injectIntl(SectionBudget)));

--- a/components/collective-page/sections/Contribute.js
+++ b/components/collective-page/sections/Contribute.js
@@ -261,7 +261,7 @@ class SectionContribute extends React.PureComponent {
     const sortedTicketTiers = this.sortTicketTiers(this.filterTickets(tiers));
     const hideTicketsFromNonAdmins = (sortedTicketTiers.length === 0 || !collective.isActive) && !isAdmin;
     const cannotOrderTickets = (!hasContribute && !isAdmin) || (!canOrderTicketsFromEvent(collective) && !isAdmin);
-    const newNavbarFeatureFlag = get(router, 'query.version') === 'v2';
+    const newNavbarFeatureFlag = get(router, 'query.navbarVersion') === 'v2';
 
     /*
     cases

--- a/components/collective-page/sections/Contributions.js
+++ b/components/collective-page/sections/Contributions.js
@@ -222,7 +222,7 @@ class SectionContributions extends React.PureComponent {
   render() {
     const { collective, data, intl, LoggedInUser, router } = this.props;
     const { nbMemberships, selectedFilter } = this.state;
-    const newNavbarFeatureFlag = get(router, 'query.version') === 'v2';
+    const newNavbarFeatureFlag = get(router, 'query.navbarVersion') === 'v2';
 
     if (data.loading) {
       return <LoadingPlaceholder height={600} borderRadius={0} />;

--- a/components/collective-page/sections/Contributions.js
+++ b/components/collective-page/sections/Contributions.js
@@ -2,15 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { gql } from '@apollo/client';
 import { graphql } from '@apollo/client/react/hoc';
+import { get } from 'lodash';
 import memoizeOne from 'memoize-one';
+import { withRouter } from 'next/router';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import styled from 'styled-components';
 
-import { hasNewNavBar } from '../../../lib/collective-sections';
 import { CollectiveType } from '../../../lib/constants/collectives';
 import roles from '../../../lib/constants/roles';
-import { getEnvVar } from '../../../lib/env-utils';
-import { parseToBoolean } from '../../../lib/utils';
 
 import Container from '../../Container';
 import { Box, Flex, Grid } from '../../Grid';
@@ -142,6 +141,9 @@ class SectionContributions extends React.PureComponent {
 
     /** @ignore from withIntl */
     intl: PropTypes.object,
+
+    /** @ignore from withRouter */
+    router: PropTypes.object,
   };
 
   state = {
@@ -218,8 +220,9 @@ class SectionContributions extends React.PureComponent {
   };
 
   render() {
-    const { collective, data, intl, LoggedInUser } = this.props;
+    const { collective, data, intl, LoggedInUser, router } = this.props;
     const { nbMemberships, selectedFilter } = this.state;
+    const newNavbarFeatureFlag = get(router, 'query.version') === 'v2';
 
     if (data.loading) {
       return <LoadingPlaceholder height={600} borderRadius={0} />;
@@ -250,7 +253,7 @@ class SectionContributions extends React.PureComponent {
         {memberOf.length > 0 && (
           <React.Fragment>
             <ContainerSectionContent>
-              {!hasNewNavBar(collective) && (
+              {!newNavbarFeatureFlag && (
                 <SectionHeader
                   title={Sections.CONTRIBUTIONS}
                   subtitle={
@@ -315,9 +318,7 @@ class SectionContributions extends React.PureComponent {
           </React.Fragment>
         )}
 
-        {parseToBoolean(getEnvVar('NEW_COLLECTIVE_NAVBAR')) && (
-          <SectionRecurringContributions slug={collective.slug} LoggedInUser={LoggedInUser} />
-        )}
+        {newNavbarFeatureFlag && <SectionRecurringContributions slug={collective.slug} LoggedInUser={LoggedInUser} />}
 
         {connectedCollectives.length > 0 && (
           <Box mt={5}>
@@ -448,4 +449,4 @@ const addContributionsSectionData = graphql(contributionsSectionQuery, {
   }),
 });
 
-export default React.memo(injectIntl(addContributionsSectionData(SectionContributions)));
+export default React.memo(withRouter(injectIntl(addContributionsSectionData(SectionContributions))));

--- a/components/collective-page/sections/Events.js
+++ b/components/collective-page/sections/Events.js
@@ -70,7 +70,7 @@ class SectionEvents extends React.PureComponent {
     const { collective, events, connectedCollectives, isAdmin, router } = this.props;
     const hasNoContributorForEvents = !events.find(event => event.contributors.length > 0);
     const [pastEvents, upcomingEvents] = this.triageEvents(events);
-    const newNavbarFeatureFlag = get(router, 'query.version') === 'v2';
+    const newNavbarFeatureFlag = get(router, 'query.navbarVersion') === 'v2';
 
     return (
       <Fragment>

--- a/components/collective-page/sections/Events.js
+++ b/components/collective-page/sections/Events.js
@@ -1,10 +1,10 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { partition } from 'lodash';
+import { get, partition } from 'lodash';
 import memoizeOne from 'memoize-one';
+import { withRouter } from 'next/router';
 import { FormattedMessage, injectIntl } from 'react-intl';
 
-import { hasNewNavBar } from '../../../lib/collective-sections';
 import { isPastEvent } from '../../../lib/events';
 
 import { CONTRIBUTE_CARD_WIDTH } from '../../contribute-cards/Contribute';
@@ -47,6 +47,8 @@ class SectionEvents extends React.PureComponent {
     ),
 
     isAdmin: PropTypes.bool.isRequired,
+    /** @ignore from withRouter */
+    router: PropTypes.object,
   };
 
   triageEvents = memoizeOne(events => {
@@ -65,13 +67,14 @@ class SectionEvents extends React.PureComponent {
   };
 
   render() {
-    const { collective, events, connectedCollectives, isAdmin } = this.props;
+    const { collective, events, connectedCollectives, isAdmin, router } = this.props;
     const hasNoContributorForEvents = !events.find(event => event.contributors.length > 0);
     const [pastEvents, upcomingEvents] = this.triageEvents(events);
+    const newNavbarFeatureFlag = get(router, 'query.version') === 'v2';
 
     return (
       <Fragment>
-        {!hasNewNavBar(collective) && (
+        {!newNavbarFeatureFlag && (
           <ContainerSectionContent pt={5}>
             <SectionHeader
               title={Sections.EVENTS}
@@ -147,4 +150,4 @@ class SectionEvents extends React.PureComponent {
   }
 }
 
-export default injectIntl(SectionEvents);
+export default withRouter(injectIntl(SectionEvents));

--- a/components/collective-page/sections/Transactions.js
+++ b/components/collective-page/sections/Transactions.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/client';
 import { get } from 'lodash';
-import { withRouter } from 'next/router';
+import { useRouter } from 'next/router';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import styled from 'styled-components';
 
@@ -77,9 +77,10 @@ const SectionTransactions = props => {
     refetch({ slug: props.collective.slug, limit: NB_DISPLAYED, hasExpense, hasOrder });
   }, [filter, props.collective.slug, refetch]);
 
-  const { intl, collective, router } = props;
+  const { intl, collective } = props;
   const collectiveHasNoTransactions = !loading && data?.transactions?.totalCount === 0 && filter === FILTERS.ALL;
-  const newNavbarFeatureFlag = get(router, 'query.version') === 'v2';
+  const router = useRouter();
+  const newNavbarFeatureFlag = get(router, 'query.navbarVersion') === 'v2';
 
   return (
     <Box py={5}>
@@ -164,9 +165,6 @@ SectionTransactions.propTypes = {
 
   /** @ignore from injectIntl */
   intl: PropTypes.object,
-
-  /** @ignore from withRouter */
-  router: PropTypes.object,
 };
 
-export default React.memo(withRouter(injectIntl(SectionTransactions)));
+export default React.memo(injectIntl(SectionTransactions));

--- a/components/collective-page/sections/Transactions.js
+++ b/components/collective-page/sections/Transactions.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/client';
+import { get } from 'lodash';
+import { withRouter } from 'next/router';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import styled from 'styled-components';
 
-import { hasNewNavBar } from '../../../lib/collective-sections';
 import { GraphQLContext } from '../../../lib/graphql/context';
 import { API_V2_CONTEXT, gqlV2 } from '../../../lib/graphql/helpers';
 
@@ -76,13 +77,14 @@ const SectionTransactions = props => {
     refetch({ slug: props.collective.slug, limit: NB_DISPLAYED, hasExpense, hasOrder });
   }, [filter, props.collective.slug, refetch]);
 
-  const { intl, collective } = props;
+  const { intl, collective, router } = props;
   const collectiveHasNoTransactions = !loading && data?.transactions?.totalCount === 0 && filter === FILTERS.ALL;
+  const newNavbarFeatureFlag = get(router, 'query.version') === 'v2';
 
   return (
     <Box py={5}>
       <ContainerSectionContent>
-        {!hasNewNavBar(collective) && (
+        {!newNavbarFeatureFlag && (
           <SectionHeader title={Sections.TRANSACTIONS} illustrationSrc={budgetSectionHeaderIcon} />
         )}
         {collectiveHasNoTransactions && (
@@ -162,6 +164,9 @@ SectionTransactions.propTypes = {
 
   /** @ignore from injectIntl */
   intl: PropTypes.object,
+
+  /** @ignore from withRouter */
+  router: PropTypes.object,
 };
 
-export default React.memo(injectIntl(SectionTransactions));
+export default React.memo(withRouter(injectIntl(SectionTransactions)));

--- a/components/edit-collective/sections/EditCollectivePage.js
+++ b/components/edit-collective/sections/EditCollectivePage.js
@@ -5,7 +5,7 @@ import { InfoCircle } from '@styled-icons/fa-solid/InfoCircle';
 import { DragIndicator } from '@styled-icons/material/DragIndicator';
 import { cloneDeep, flatten, get, isEqual, set, uniqBy } from 'lodash';
 import memoizeOne from 'memoize-one';
-import { withRouter } from 'next/router';
+import { useRouter } from 'next/router';
 import { useDrag, useDrop } from 'react-dnd';
 import { FormattedMessage, useIntl } from 'react-intl';
 import styled, { css } from 'styled-components';
@@ -333,9 +333,10 @@ MenuCategory.propTypes = {
   onSectionToggle: PropTypes.func,
 };
 
-const EditCollectivePage = ({ collective, router }) => {
+const EditCollectivePage = ({ collective }) => {
   const intl = useIntl();
-  const HAS_NEW_NAVBAR = get(router, 'query.version') === 'v2';
+  const router = useRouter();
+  const HAS_NEW_NAVBAR = get(router, 'query.navbarVersion') === 'v2';
   const [isDirty, setDirty] = React.useState(false);
   const [sections, setSections] = React.useState(null);
   const [tmpSections, setTmpSections] = React.useState(null);
@@ -518,7 +519,6 @@ EditCollectivePage.propTypes = {
     slug: PropTypes.string,
     type: PropTypes.string,
   }),
-  router: PropTypes.object,
 };
 
-export default withRouter(EditCollectivePage);
+export default EditCollectivePage;

--- a/lib/collective-sections.js
+++ b/lib/collective-sections.js
@@ -330,7 +330,6 @@ export const getFilteredSectionsForCollective = (collective, isAdmin, isHostAdmi
       get(collective, 'settings.collectivePage.sections')
     ) {
       sections = cloneDeep(get(collective, 'settings.collectivePage.sections'));
-
       // Filter sections
       const toRemove = getSectionsToRemoveForUser(collective, isAdmin, isHostAdmin, hasNewCollectiveNavbar);
       sections = sections.filter(e => e.type !== 'SECTION' || !toRemove.has(e.name));

--- a/lib/collective-sections.js
+++ b/lib/collective-sections.js
@@ -12,9 +12,7 @@ import { Sections } from '../components/collective-page/_constants';
 
 import { CollectiveType } from './constants/collectives';
 import hasFeature, { FEATURES } from './allowed-features';
-import { getEnvVar } from './env-utils';
 import { canOrderTicketsFromEvent, isPastEvent } from './events';
-import { parseToBoolean } from './utils';
 
 // Define default sections based on collective type
 const DEFAULT_SECTIONS = {
@@ -90,12 +88,10 @@ const DEFAULT_SECTIONS_V2 = {
   [CollectiveType.PROJECT]: [Sections.ABOUT, Sections.CONTRIBUTE, Sections.BUDGET],
 };
 
-const hasNewCollectiveNavbar = parseToBoolean(getEnvVar('NEW_COLLECTIVE_NAVBAR'));
-
 /**
  * 1. Returns all the sections than can be used for this collective
  */
-export const getDefaultSectionsForCollective = (type, isActive) => {
+export const getDefaultSectionsForCollective = (type, isActive, hasNewCollectiveNavbar) => {
   // Layer of compatibility with GQLV2
   const typeKey = type === 'INDIVIDUAL' ? 'USER' : type;
   // TODO: Keeping two versions of `DEFAULT_SECTIONS` is dangerous, we should have only one
@@ -139,7 +135,7 @@ export const filterSectionsForUser = (collectiveSections, isAdmin, isHostAdmin) 
 /**
  * 3. Filter the sections based on the data available
  */
-export const filterSectionsByData = (sections, collective, isAdmin, isHostAdmin) => {
+export const filterSectionsByData = (sections, collective, isAdmin, isHostAdmin, hasNewCollectiveNavbar) => {
   const toRemove = new Set();
   collective = collective || {};
   const isEvent = collective.type === CollectiveType.EVENT;
@@ -230,7 +226,7 @@ export const filterSectionsByData = (sections, collective, isAdmin, isHostAdmin)
   return sections.filter(section => !toRemove.has(section));
 };
 
-const getSectionsToRemoveForUser = (collective, isAdmin, isHostAdmin) => {
+const getSectionsToRemoveForUser = (collective, isAdmin, isHostAdmin, hasNewCollectiveNavbar) => {
   const toRemove = new Set();
   collective = collective || {};
 
@@ -318,7 +314,7 @@ const getSectionsToRemoveForUser = (collective, isAdmin, isHostAdmin) => {
 
 // Navigation v2
 export const filterSectionsByDataV2 = (sections, collective, isAdmin, isHostAdmin) => {
-  const toRemove = getSectionsToRemoveForUser(collective, isAdmin, isHostAdmin);
+  const toRemove = getSectionsToRemoveForUser(collective, isAdmin, isHostAdmin, true);
   return sections.filter(section => !toRemove.has(section));
 };
 
@@ -326,7 +322,7 @@ export const filterSectionsByDataV2 = (sections, collective, isAdmin, isHostAdmi
  * Combine all the previous steps to directly get the sections that should be
  * displayed for the user.
  */
-export const getFilteredSectionsForCollective = (collective, isAdmin, isHostAdmin) => {
+export const getFilteredSectionsForCollective = (collective, isAdmin, isHostAdmin, hasNewCollectiveNavbar) => {
   let sections;
   if (hasNewCollectiveNavbar) {
     if (
@@ -336,7 +332,7 @@ export const getFilteredSectionsForCollective = (collective, isAdmin, isHostAdmi
       sections = cloneDeep(get(collective, 'settings.collectivePage.sections'));
 
       // Filter sections
-      const toRemove = getSectionsToRemoveForUser(collective, isAdmin, isHostAdmin);
+      const toRemove = getSectionsToRemoveForUser(collective, isAdmin, isHostAdmin, hasNewCollectiveNavbar);
       sections = sections.filter(e => e.type !== 'SECTION' || !toRemove.has(e.name));
       sections.forEach(e => {
         if (e.type === 'CATEGORY') {
@@ -356,7 +352,7 @@ export const getFilteredSectionsForCollective = (collective, isAdmin, isHostAdmi
       get(collective, 'settings.collectivePage.sections') ||
       getDefaultSectionsForCollective(collective?.type, collective?.isActive);
     sections = filterSectionsForUser(sections, isAdmin, isHostAdmin);
-    return filterSectionsByData(sections, collective, isAdmin, isHostAdmin);
+    return filterSectionsByData(sections, collective, isAdmin, isHostAdmin, hasNewCollectiveNavbar);
   }
 };
 
@@ -511,8 +507,4 @@ export const addDefaultSections = (collective, sections) => {
   });
 
   return newSections;
-};
-
-export const hasNewNavBar = () => {
-  return hasNewCollectiveNavbar;
 };

--- a/pages/collective-page.js
+++ b/pages/collective-page.js
@@ -52,7 +52,7 @@ const GlobalStyles = createGlobalStyle`
  * to render `components/collective-page` with everything needed.
  */
 class CollectivePage extends React.Component {
-  static async getInitialProps({ client, req, res, query: { slug, status, step, mode, version } }) {
+  static async getInitialProps({ client, req, res, query: { slug, status, step, mode, navbarVersion } }) {
     if (res && req && (req.language || req.locale === 'en')) {
       res.set('Cache-Control', 'public, s-maxage=300');
     }
@@ -62,7 +62,7 @@ class CollectivePage extends React.Component {
     // If on server side
     if (req) {
       req.noStyledJsx = true;
-      const hasNewCollectiveNavbar = version === 'v2';
+      const hasNewCollectiveNavbar = navbarVersion === 'v2';
       await preloadCollectivePageGraphlQueries(slug, client, hasNewCollectiveNavbar);
       skipDataFromTree = true;
     }

--- a/pages/collective-page.js
+++ b/pages/collective-page.js
@@ -52,7 +52,7 @@ const GlobalStyles = createGlobalStyle`
  * to render `components/collective-page` with everything needed.
  */
 class CollectivePage extends React.Component {
-  static async getInitialProps({ client, req, res, query: { slug, status, step, mode } }) {
+  static async getInitialProps({ client, req, res, query: { slug, status, step, mode, version } }) {
     if (res && req && (req.language || req.locale === 'en')) {
       res.set('Cache-Control', 'public, s-maxage=300');
     }
@@ -62,7 +62,8 @@ class CollectivePage extends React.Component {
     // If on server side
     if (req) {
       req.noStyledJsx = true;
-      await preloadCollectivePageGraphlQueries(slug, client);
+      const hasNewCollectiveNavbar = version === 'v2';
+      await preloadCollectivePageGraphlQueries(slug, client, hasNewCollectiveNavbar);
       skipDataFromTree = true;
     }
 

--- a/server/pages.js
+++ b/server/pages.js
@@ -35,7 +35,7 @@ const pages = routes()
   .add('collectives-iframe', '/:collectiveSlug/(collectives|widget).html')
   .add('banner-iframe', '/:collectiveSlug/banner.html')
   .add('editEvent', '/:parentCollectiveSlug/events/:eventSlug/edit/:section?')
-  .add('editCollective', '/:slug/edit/:section?/:version(v2)?')
+  .add('editCollective', '/:slug/edit/:section?')
   .add('collective-contact', '/:parentCollectiveSlug?/:collectiveType(events|projects)?/:collectiveSlug/contact')
   .add('host.expenses', '/:hostCollectiveSlug/collectives/expenses', 'host.dashboard')
   .add(
@@ -156,7 +156,7 @@ pages.add('marketing', '/:pageSlug(how-it-works|gift-of-giving|gift-cards|pricin
 // ----------
 
 // Collective page
-pages.add('collective', '/:slug/:version(v2)?', 'collective-page');
+pages.add('collective', '/:slug', 'collective-page');
 pages.add(
   'collective-with-onboarding',
   '/:slug/:mode(onboarding)?/:step(administrators|contact|success)?',

--- a/server/pages.js
+++ b/server/pages.js
@@ -35,7 +35,7 @@ const pages = routes()
   .add('collectives-iframe', '/:collectiveSlug/(collectives|widget).html')
   .add('banner-iframe', '/:collectiveSlug/banner.html')
   .add('editEvent', '/:parentCollectiveSlug/events/:eventSlug/edit/:section?')
-  .add('editCollective', '/:slug/edit/:section?')
+  .add('editCollective', '/:slug/edit/:section?/:version(v2)?')
   .add('collective-contact', '/:parentCollectiveSlug?/:collectiveType(events|projects)?/:collectiveSlug/contact')
   .add('host.expenses', '/:hostCollectiveSlug/collectives/expenses', 'host.dashboard')
   .add(
@@ -156,7 +156,7 @@ pages.add('marketing', '/:pageSlug(how-it-works|gift-of-giving|gift-cards|pricin
 // ----------
 
 // Collective page
-pages.add('collective', '/:slug', 'collective-page');
+pages.add('collective', '/:slug/:version(v2)?', 'collective-page');
 pages.add(
   'collective-with-onboarding',
   '/:slug/:mode(onboarding)?/:step(administrators|contact|success)?',


### PR DESCRIPTION
* Adds tablet version of navbar menu (see below)
* Changes v2 feature flag to be URL-based (add `/v2` to the end of the URL to switch to new version)

![tablet-menu](https://user-images.githubusercontent.com/37520401/102255326-d8d09e80-3f01-11eb-8104-b72df123d0df.gif)
