### PR TITLE
security.txt: include in static folder

### DIFF
--- a/scripts/build_server.sh
+++ b/scripts/build_server.sh
@@ -10,7 +10,7 @@ cp -R $SRC/lang $DIST
 
 echo "> Copying static"
 shx mkdir -p $DIST/public/static
-cp -R $SRC/public/.well-known $DIST/static
+cp -R $SRC/public/.well-known $DIST/public/static
 cp -R $SRC/public/static/fonts $DIST/public/static
 cp -R $SRC/public/static/icons $DIST/public/static
 cp -R $SRC/public/static/images $DIST/public/static


### PR DESCRIPTION
For https://opencollective.com/.well-known/security.txt. We missed this when transitioning to the new NextJS `public` folder