### PR TITLE
BannerIframe: Fix cards size

### DIFF
--- a/components/Member.js
+++ b/components/Member.js
@@ -19,11 +19,6 @@ const MemberContainer = styled.div`
   float: left;
   position: relative;
 
-  .ORGANIZATION {
-    width: 200px;
-    margin: 1rem;
-  }
-
   .USER {
     margin: 0.5rem 0.25rem;
   }
@@ -34,6 +29,11 @@ const MemberContainer = styled.div`
 
   .small .avatar {
     margin: 0;
+  }
+
+  .ORGANIZATION {
+    width: 200px;
+    margin: 1rem;
   }
 `;
 


### PR DESCRIPTION
Fix a layout issue that only impacted collectives with 50+ member organizations. Before https://github.com/opencollective/opencollective-frontend/pull/5486, the `.ORGANIZATION` class had priority over `.small`. The PR inverted that.

## Before

![image](https://user-images.githubusercontent.com/1556356/102463684-b5196f80-404b-11eb-987f-c6e2566ee7ab.png)

## After

![image](https://user-images.githubusercontent.com/1556356/102463908-fd389200-404b-11eb-8872-ad93f75e0024.png)
