### PR TITLE
Collective sections format retro-compatibility

### DIFF
--- a/components/collective-page/graphql/preload.js
+++ b/components/collective-page/graphql/preload.js
@@ -1,4 +1,4 @@
-import { getFilteredSectionsForCollective } from '../../../lib/collective-sections';
+import { getFilteredSectionsForCollective, getSectionsNames } from '../../../lib/collective-sections';
 import { CollectiveType } from '../../../lib/constants/collectives';
 import { API_V2_CONTEXT } from '../../../lib/graphql/helpers';
 
@@ -24,8 +24,9 @@ export const preloadCollectivePageGraphlQueries = async (slug, client, hasNewCol
   const collective = result?.data?.Collective;
   if (collective) {
     const sections = getFilteredSectionsForCollective(collective, null, null, hasNewCollectiveNavbar);
+    const sectionsNames = getSectionsNames(sections);
     const queries = [];
-    if (sections.includes('budget')) {
+    if (sectionsNames.includes('budget')) {
       queries.push(
         client.query({
           query: budgetSectionQuery,
@@ -34,7 +35,7 @@ export const preloadCollectivePageGraphlQueries = async (slug, client, hasNewCol
         }),
       );
     }
-    if (sections.includes('contributions')) {
+    if (sectionsNames.includes('contributions')) {
       queries.push(
         client.query({
           query: contributionsSectionQuery,
@@ -42,7 +43,7 @@ export const preloadCollectivePageGraphlQueries = async (slug, client, hasNewCol
         }),
       );
     }
-    if (sections.includes('transactions')) {
+    if (sectionsNames.includes('transactions')) {
       queries.push(
         client.query({
           query: transactionsSectionQuery,
@@ -51,7 +52,7 @@ export const preloadCollectivePageGraphlQueries = async (slug, client, hasNewCol
         }),
       );
     }
-    if (sections.includes('recurring-contributions')) {
+    if (sectionsNames.includes('recurring-contributions')) {
       queries.push(
         client.query({
           query: recurringContributionsQuery,
@@ -60,7 +61,7 @@ export const preloadCollectivePageGraphlQueries = async (slug, client, hasNewCol
         }),
       );
     }
-    if (sections.includes('updates')) {
+    if (sectionsNames.includes('updates')) {
       queries.push(
         client.query({
           query: updatesSectionQuery,
@@ -68,7 +69,7 @@ export const preloadCollectivePageGraphlQueries = async (slug, client, hasNewCol
         }),
       );
     }
-    if (sections.includes('conversations')) {
+    if (sectionsNames.includes('conversations')) {
       queries.push(
         client.query({
           query: conversationsSectionQuery,

--- a/lib/collective-sections.js
+++ b/lib/collective-sections.js
@@ -1,12 +1,15 @@
 /**
- * There are 3 levels of filtering to know if a section should appear or not.
+ * There are 3 levels of filtering to know if a section should appear or not:
  *
  * 1. Status of the collective: the `type`, `isActive`
  * 2. User's permissions: certain sections are displayed only to admins
  * 3. The data: we won't display a section if it's empty
+ *
+ * The logic for these checks is progressively moving to the API, relying on the "features"
+ * field to know which features user has access to.
  */
 
-import { cloneDeep, get, remove } from 'lodash';
+import { cloneDeep, flatten, get, remove } from 'lodash';
 
 import { Sections } from '../components/collective-page/_constants';
 
@@ -358,11 +361,9 @@ export const filterSectionsByDataV2 = (sections, collective, isAdmin, isHostAdmi
  */
 export const getFilteredSectionsForCollective = (collective, isAdmin, isHostAdmin, hasNewCollectiveNavbar) => {
   let sections;
+  const hasNewSectionsFormat = get(collective, 'settings.collectivePage.useNewSections');
   if (hasNewCollectiveNavbar) {
-    if (
-      get(collective, 'settings.collectivePage.useNewSections') &&
-      get(collective, 'settings.collectivePage.sections')
-    ) {
+    if (hasNewSectionsFormat && get(collective, 'settings.collectivePage.sections')) {
       sections = cloneDeep(get(collective, 'settings.collectivePage.sections'));
       // Filter sections
       const toRemove = getSectionsToRemoveForUser(collective, isAdmin, isHostAdmin, hasNewCollectiveNavbar);
@@ -384,6 +385,9 @@ export const getFilteredSectionsForCollective = (collective, isAdmin, isHostAdmi
     sections =
       get(collective, 'settings.collectivePage.sections') ||
       getDefaultSectionsForCollective(collective?.type, collective?.isActive);
+    if (hasNewSectionsFormat) {
+      sections = convertSectionsToLegacyFormat(sections);
+    }
     sections = filterSectionsForUser(sections, isAdmin, isHostAdmin);
     return filterSectionsByData(sections, collective, isAdmin, isHostAdmin, hasNewCollectiveNavbar);
   }
@@ -472,6 +476,45 @@ export const convertSectionsToNewFormat = sections => {
   } while (sectionsToConvert.length > 0);
 
   return convertedSections;
+};
+
+/**
+ * Converts sections back to legacy format ([{ section, isEnabled }]), without categories
+ */
+export const convertSectionsToLegacyFormat = sections => {
+  return flatten(
+    sections.map(e => {
+      if (typeof e === 'string') {
+        return { section: e, isEnabled: true };
+      } else if (e.section) {
+        // Already Legacy format
+        return e;
+      } else if (e.type === 'SECTION') {
+        return { section: e.name, isEnabled: e.isEnabled, restrictedTo: e.restrictedTo };
+      } else if (e.type === 'CATEGORY' && e.sections) {
+        return convertSectionsToLegacyFormat(e.sections);
+      }
+    }),
+  );
+};
+
+/**
+ * Return all section names as an array of string
+ */
+export const getSectionsNames = sections => {
+  return flatten(
+    sections.map(e => {
+      if (typeof e === 'string') {
+        return e;
+      } else if (e.section) {
+        return e.section;
+      } else if (e.type === 'SECTION') {
+        return e.name;
+      } else if (e.type === 'CATEGORY' && e.sections) {
+        return getSectionsNames(e.sections);
+      }
+    }),
+  );
 };
 
 /**


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-frontend/pull/5575
Requirement for https://github.com/opencollective/opencollective/issues/3773

- Adapted preload
- Made sure navbar still works if you're using a frontend with old navbar while the collective has new sections format