### PR TITLE
EditCollectivePage: Fix drop behavior

### DIFF
--- a/components/edit-collective/sections/EditCollectivePage.js
+++ b/components/edit-collective/sections/EditCollectivePage.js
@@ -109,12 +109,12 @@ const CollectiveSectionEntry = ({
   const [, drop] = useDrop({
     accept: getItemType(parentItem),
     hover: item => onMove(item, index),
-    drop: item => onDrop(item, index),
   });
 
   const [{ isDragging }, drag, preview] = useDrag({
     item: { type: getItemType(parentItem), index, parentItem },
     collect: monitor => ({ isDragging: monitor.isDragging() }),
+    end: onDrop,
   });
 
   drag(drop(ref));
@@ -278,12 +278,12 @@ const MenuCategory = ({ item, index, collective, onMove, onDrop, onSectionToggle
   const [, drop] = useDrop({
     accept: getItemType(),
     hover: item => onMove(item, index),
-    drop: item => onDrop(item, index),
   });
 
   const [{ isDragging }, drag, preview] = useDrag({
     item: { type: getItemType(), index },
     collect: monitor => ({ isDragging: monitor.isDragging() }),
+    end: onDrop,
   });
 
   drag(drop(ref));
@@ -372,9 +372,9 @@ const EditCollectivePage = ({ collective }) => {
     }
   };
 
-  const onDrop = (item, hoverIndex) => {
+  const onDrop = () => {
+    setSections(tmpSections);
     setTmpSections(null);
-    setSections(getNewSections(sections, item, hoverIndex, useNewSections));
     setDirty(true);
   };
 


### PR DESCRIPTION
The `drop` event is not triggered when it's too far, so we ended up with a messed up list when the item was not dropped close enough to its expected position. We now use the `end` behavior which is always triggered, and just save the temporary sections as the result. 