### PR TITLE
apollo: rollback to 3.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -143,29 +143,29 @@
       }
     },
     "@apollo/client": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.6.tgz",
-      "integrity": "sha512-XSm/STyNS8aHdDigLLACKNMHwI0qaQmEHWHtTP+jHe/E1wZRnn66VZMMgwKLy2V4uHISHfmiZ4KpUKDPeJAKqg==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.2.7.tgz",
+      "integrity": "sha512-4G80jvBLqenCFUhwkHAAHi2ox6Ygq35BkE38yxammqykZm6KE3tVlcEKGOZi0jpiuGJPC6LIQ0d1gtI8ADPtmg==",
       "requires": {
         "@graphql-typed-document-node/core": "^3.0.0",
         "@types/zen-observable": "^0.8.0",
         "@wry/context": "^0.5.2",
-        "@wry/equality": "^0.3.0",
+        "@wry/equality": "^0.2.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graphql-tag": "^2.11.0",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.13.1",
+        "optimism": "^0.13.0",
         "prop-types": "^15.7.2",
         "symbol-observable": "^2.0.0",
-        "ts-invariant": "^0.6.0",
+        "ts-invariant": "^0.5.0",
         "tslib": "^1.10.0",
         "zen-observable": "^0.8.14"
       },
       "dependencies": {
         "@wry/equality": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.3.0.tgz",
-          "integrity": "sha512-DRDAu/e3oWBj826OWNV/GCmSdHD248mASXImgNoLE/3SDvpgb+k6G/+TAmdpIB35ju264+kB22Rx92eXg52DnA==",
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.2.0.tgz",
+          "integrity": "sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==",
           "requires": {
             "tslib": "^1.9.3"
           }
@@ -176,12 +176,10 @@
           "integrity": "sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA=="
         },
         "ts-invariant": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.6.0.tgz",
-          "integrity": "sha512-caoafsfgb8QxdrKzFfjKt627m4i8KTtfAiji0DYJfWI4A/S9ORNNpzYuD9br64kyKFgxn9UNaLLbSupam84mCA==",
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.5.1.tgz",
+          "integrity": "sha512-k3UpDNrBZpqJFnAAkAHNmSHtNuCxcU6xLiziPgalHRKZHme6T6jnKC8CcXDmk1zbHLQM8pc+rNC1Q6FvXMAl+g==",
           "requires": {
-            "@types/ungap__global-this": "^0.3.1",
-            "@ungap/global-this": "^0.4.2",
             "tslib": "^1.9.3"
           }
         }
@@ -5906,11 +5904,6 @@
         "source-map": "^0.6.1"
       }
     },
-    "@types/ungap__global-this": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@types/ungap__global-this/-/ungap__global-this-0.3.1.tgz",
-      "integrity": "sha512-+/DsiV4CxXl6ZWefwHZDXSe1Slitz21tom38qPCaG0DYCS1NnDPIQDTKcmQ/tvK/edJUKkmuIDBJbmKDiB0r/g=="
-    },
     "@types/unist": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
@@ -5969,11 +5962,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.1.tgz",
       "integrity": "sha512-wmk0xQI6Yy7Fs/il4EpOcflG4uonUpYGqvZARESLc2oy4u69fkatFLbJOeW4Q6awO15P4rduAe6xkwHevpXcUQ=="
-    },
-    "@ungap/global-this": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@ungap/global-this/-/global-this-0.4.3.tgz",
-      "integrity": "sha512-MuHEpDBurNVeD6mV9xBcAN2wfTwuaFQhHuhWkJuXmyVJ5P5sBCw+nnFpdfb0tAvgWkfefWCsAoAsh7MTUr3LPg=="
     },
     "@vxna/mini-html-webpack-template": {
       "version": "2.0.0",
@@ -6142,11 +6130,18 @@
       }
     },
     "@wry/context": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.5.2.tgz",
-      "integrity": "sha512-B/JLuRZ/vbEKHRUiGj6xiMojST1kHhu4WcreLfNN7q9DqQFrb97cWgf/kiYsPSUCAMVN0HzfFc8XjJdzgZzfjw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.5.3.tgz",
+      "integrity": "sha512-n0uKHiWpf2ArHhmcHcUsKA+Dj0gtye/h56VmsDcoMRuK/ZPFeHKi8ck5L/ftqtF12ZbQR9l8xMPV7y+xybaRDA==",
       "requires": {
-        "tslib": "^1.9.3"
+        "tslib": "^1.14.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@wry/equality": {
@@ -12348,13 +12343,13 @@
       "dependencies": {
         "colors": {
           "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "resolved": "http://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
           "dev": true
         },
         "commander": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
           "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
           "dev": true
         }
@@ -13696,7 +13691,7 @@
     },
     "immutable": {
       "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+      "resolved": "http://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
       "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
     },
     "import-fresh": {
@@ -19661,9 +19656,9 @@
       }
     },
     "optimism": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.13.1.tgz",
-      "integrity": "sha512-16RRVYZe8ODcUqpabpY7Gb91vCAbdhn8FHjlUb2Hqnjjow1j8Z1dlppds+yAsLbreNTVylLC+tNX6DuC2vt3Kw==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.13.2.tgz",
+      "integrity": "sha512-kJkpDUEs/Rp8HsAYYlDzyvQHlT6YZa95P+2GGNR8p/VvsIkt6NilAk7oeTvMRKCq7BeclB7+bmdIexog2859GQ==",
       "requires": {
         "@wry/context": "^0.5.2"
       }
@@ -24657,7 +24652,7 @@
       "dependencies": {
         "ast-types": {
           "version": "0.7.8",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
+          "resolved": "http://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
           "integrity": "sha1-kC0uDWDQcb3NRtwRXhgJ7RHBOKk=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "npm": "6.12.0"
   },
   "dependencies": {
-    "@apollo/client": "3.3.6",
+    "@apollo/client": "3.2.7",
     "@formatjs/intl-relativetimeformat": "8.0.1",
     "@hyperwatch/hyperwatch": "3.8.1",
     "@material-ui/core": "4.11.2",


### PR DESCRIPTION
Rollback https://github.com/opencollective/opencollective-frontend/pull/5587
Related to this issue: https://github.com/apollographql/apollo-client/issues/7478

Impact: all our pages with a `skip: true` have a loading `true` when accessed directly (frontend routing is not impacted).

For example https://opencollective.com/create has an infinite loading spinner