### PR TITLE
ContributionFlow: Fix bug when going prev with PayPal

### DIFF
--- a/components/contribution-flow/ContributionFlowButtons.js
+++ b/components/contribution-flow/ContributionFlowButtons.js
@@ -74,7 +74,7 @@ class NewContributionFlowButtons extends React.Component {
               {this.getStepLabel(prevStep) || <FormattedMessage id="Pagination.Prev" defaultMessage="Previous" />}
             </StyledButton>
           )}
-          {!paypalButtonProps ? (
+          {!paypalButtonProps || nextStep ? (
             <StyledButton
               ml={17}
               minWidth={!nextStep ? 185 : 125}

--- a/lib/payment_method_label.js
+++ b/lib/payment_method_label.js
@@ -83,6 +83,8 @@ export const getPaymentMethodName = ({ name, data, type }) => {
   } else if (type === 'creditcard') {
     const brand = data && data.brand && formatCreditCardBrand(data.brand);
     return `${brand || type} **** ${name}`;
+  } else if (type === 'PAYPAL') {
+    return 'PayPal';
   } else {
     return name;
   }


### PR DESCRIPTION
Fix an issue that kept the `Pay with Paypal` button displayed when going prev by clicking on the steps.
Also added the label to step.