### PR TITLE
Pledges: don't crash when fromCollective is null

### DIFF
--- a/components/PledgedCollectivePage.js
+++ b/components/PledgedCollectivePage.js
@@ -66,7 +66,7 @@ const PledgedCollectivePage = ({ collective }) => {
     );
   }
 
-  const pledges = [...data.Collective.pledges].reverse();
+  const pledges = [...data.Collective.pledges].reverse().filter(pledge => pledge.fromCollective);
   const pledgeStats = pledges.reduce(
     (stats, { fromCollective, totalAmount }) => {
       stats[fromCollective.type]++;


### PR DESCRIPTION
also checked the database and it was the only occurrence

```
SELECT * FROM "Orders", "Collectives" WHERE "status" = 'PLEDGED' AND "Collectives"."id" = "Orders"."FromCollectiveId" AND "Collectives"."deletedAt" IS NOT NULL;
```