### PR TITLE
Currency: Always display decimals for small amounts

### DIFF
--- a/components/Currency.js
+++ b/components/Currency.js
@@ -14,6 +14,9 @@ import { Span } from './Text';
 const Currency = ({ abbreviate, currency, precision, value, ...styles }) => {
   if (precision === 'auto') {
     precision = value % 100 === 0 ? 0 : 2;
+  } else if (precision < 2 && value < 100) {
+    // Force precision if number is < $1 to never display $0 for small amounts
+    precision = 2;
   }
 
   if (abbreviate) {


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/3384

This will make sure we never display `$0` for small amounts (< $1)