### PR TITLE
Add homepage missing french translation

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1064,7 +1064,7 @@
   "home.whatCanYouDoSection.subTitle": "Acceptez les dons et les sponsors, célébrez vos soutiens, payez les dépenses et tenez tout le monde à jour — tout cela au même endroit.",
   "home.whatCanYouDoSection.title": "Que pouvez-vous faire sur Open Collective ?",
   "home.whatIsGreatAboutOC": "Qu'est-ce qui rend Open Collective si génial ?",
-  "home.whatIsGreatAboutOC.description": "Money management made simple, plus great tools for community engagement, budget reporting, and fiscal sponsorship.",
+  "home.whatIsGreatAboutOC.description": "Gestion des finances rendu simple, plus des outils d'engagement de communautés, de rapport de budget, et de sponsoring fiscal.",
   "host.apply.create.btn": "Candidater",
   "host.applyTo": "Apply to {hostName}",
   "host.dashboard": "Tableau de bord",


### PR DESCRIPTION
# Description

There is a missing translation in the landing page for french users. This PR adds a translation.

# Screenshots

![image](https://user-images.githubusercontent.com/32022851/103140888-7428f700-46ec-11eb-916e-9b3e7eea9cbf.png)

