### PR TITLE
CollectivePage: GraphQL crash

### DIFF
--- a/components/collective-page/graphql/queries.js
+++ b/components/collective-page/graphql/queries.js
@@ -98,7 +98,6 @@ export const collectivePageQuery = gql`
         name
         slug
         description
-        useStandalonePage
         goal
         interval
         currency


### PR DESCRIPTION
GraphQL is failing to reconciliate the cache, somehow removing this field helps. Still investigating.