### PR TITLE
Navbar: Compatibility with old sections format

### DIFF
--- a/lib/collective-sections.js
+++ b/lib/collective-sections.js
@@ -262,10 +262,10 @@ export const filterSectionsByData = (sections, collective, isAdmin, isHostAdmin)
 export const filterSectionsByDataV2 = (sections, collective, isAdmin, isHostAdmin) => {
   const toRemove = getSectionsToRemoveForUser(collective, isAdmin, isHostAdmin, true);
 
-  sections = sections.filter(e => e.type !== 'SECTION' || !toRemove.has(e.name));
+  sections = sections.filter(e => e.type !== 'SECTION' || (!toRemove.has(e.name) && e.isEnabled));
   sections.forEach(e => {
     if (e.type === 'CATEGORY') {
-      e.sections = e.sections.filter(e => !toRemove.has(e.name));
+      e.sections = e.sections.filter(e => !toRemove.has(e.name) && e.isEnabled);
     }
   });
 
@@ -380,8 +380,9 @@ const getSectionsToRemoveForUser = (collective, isAdmin, isHostAdmin, hasNewColl
 export const getFilteredSectionsForCollective = (collective, isAdmin, isHostAdmin, hasNewCollectiveNavbar) => {
   let sections;
   const hasNewSectionsFormat = get(collective, 'settings.collectivePage.useNewSections');
-  if (hasNewCollectiveNavbar && hasNewSectionsFormat && get(collective, 'settings.collectivePage.sections')) {
-    sections = cloneDeep(get(collective, 'settings.collectivePage.sections'));
+  const collectiveSections = get(collective, 'settings.collectivePage.sections');
+  if (hasNewCollectiveNavbar && hasNewSectionsFormat && collectiveSections) {
+    sections = cloneDeep(collectiveSections);
     // Filter sections
     const toRemove = getSectionsToRemoveForUser(collective, isAdmin, isHostAdmin, hasNewCollectiveNavbar);
     sections = sections.filter(e => e.type !== 'SECTION' || (e.isEnabled && !toRemove.has(e.name)));
@@ -395,13 +396,12 @@ export const getFilteredSectionsForCollective = (collective, isAdmin, isHostAdmi
     return sections.filter(e => e.type !== 'CATEGORY' || e.sections.length > 0);
   }
 
-  sections =
-    get(collective, 'settings.collectivePage.sections') ||
-    getDefaultSectionsForCollective(collective?.type, collective?.isActive);
+  sections = collectiveSections || getDefaultSectionsForCollective(collective?.type, collective?.isActive);
 
   if (hasNewCollectiveNavbar) {
+    const hasStringFormat = typeof collectiveSections?.[0] === 'string';
     sections = convertSectionsToNewFormat(sections, collective?.type);
-    sections = addDefaultSections(collective, sections);
+    sections = addDefaultSections(collective, sections, !hasStringFormat);
     return filterSectionsByDataV2(sections, collective, isAdmin, isHostAdmin);
   } else {
     if (hasNewSectionsFormat) {
@@ -621,7 +621,7 @@ export const hasSection = (sections, sectionName) => {
  * Adds the default sections that are not yet defined in `sections`, with `isEnabled` to false.
  * Useful to make sure newly added sections/categories are added on legacy collectives.
  */
-export const addDefaultSections = (collective, sections) => {
+export const addDefaultSections = (collective, sections, defaultIsEnabled = true) => {
   const defaultSections = getDefaultSectionsForCollective(collective.type, collective.isActive, true);
   const newSections = cloneDeep(sections);
 
@@ -635,9 +635,9 @@ export const addDefaultSections = (collective, sections) => {
           category = { type: 'CATEGORY', name: categoryName, sections: [] };
           newSections.push(category);
         }
-        category.sections.push({ type: 'SECTION', name: section, isEnabled: true });
+        category.sections.push({ type: 'SECTION', name: section, isEnabled: defaultIsEnabled });
       } else {
-        newSections.push({ type: 'SECTION', name: section, isEnabled: true });
+        newSections.push({ type: 'SECTION', name: section, isEnabled: defaultIsEnabled });
       }
     }
   });


### PR DESCRIPTION
A layer of compatibility for new navbar and (really) old sections format, when they were stored as an array of string