### PR TITLE
Navbar: Re-introduce global feature flag

### DIFF
--- a/components/collective-navbar/index.js
+++ b/components/collective-navbar/index.js
@@ -14,7 +14,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import styled, { createGlobalStyle, css } from 'styled-components';
 import { maxWidth } from 'styled-system';
 
-import { getFilteredSectionsForCollective, NAVBAR_CATEGORIES } from '../../lib/collective-sections';
+import { getFilteredSectionsForCollective, hasNewNavbar, NAVBAR_CATEGORIES } from '../../lib/collective-sections';
 import { CollectiveType } from '../../lib/constants/collectives';
 import useGlobalBlur from '../../lib/hooks/useGlobalBlur';
 import i18nCollectivePageSection from '../../lib/i18n-collective-page-section';
@@ -467,7 +467,7 @@ const CollectiveNavbar = ({
   useAnchorsForCategories,
 }) => {
   const router = useRouter();
-  const newNavbarFeatureFlag = get(router, 'query.navbarVersion') === 'v2';
+  const newNavbarFeatureFlag = hasNewNavbar(get(router, 'query.navbarVersion'));
   const intl = useIntl();
   const [isExpanded, setExpanded] = React.useState(false);
   sections = sections || getFilteredSectionsForCollective(collective, isAdmin, null, newNavbarFeatureFlag);

--- a/components/collective-page/index.js
+++ b/components/collective-page/index.js
@@ -6,7 +6,7 @@ import { withRouter } from 'next/router';
 import styled from 'styled-components';
 import { space } from 'styled-system';
 
-import { getFilteredSectionsForCollective } from '../../lib/collective-sections';
+import { getFilteredSectionsForCollective, hasNewNavbar } from '../../lib/collective-sections';
 import { CollectiveType } from '../../lib/constants/collectives';
 
 import CollectiveNavbar from '../collective-navbar';
@@ -103,7 +103,7 @@ class CollectivePage extends Component {
   }
 
   getSections = memoizeOne((collective, isAdmin, isHostAdmin) => {
-    const hasNewCollectiveNavbar = get(this.props.router, 'query.navbarVersion') === 'v2';
+    const hasNewCollectiveNavbar = hasNewNavbar(get(this.props.router, 'query.navbarVersion'));
     return getFilteredSectionsForCollective(collective, isAdmin, isHostAdmin, hasNewCollectiveNavbar);
   });
 
@@ -127,7 +127,7 @@ class CollectivePage extends Component {
     const breakpoint = window.scrollY + distanceThreshold;
     const sections = this.getSections(this.props.collective, this.props.isAdmin, this.props.isHostAdmin);
 
-    if (get(this.props.router, 'query.navbarVersion') === 'v2') {
+    if (hasNewNavbar(get(this.props.router, 'query.navbarVersion'))) {
       for (let i = sections.length - 1; i >= 0; i--) {
         if (sections[i].type !== 'CATEGORY') {
           continue;
@@ -192,7 +192,7 @@ class CollectivePage extends Component {
       const isEvent = type === CollectiveType.EVENT;
       const isProject = type === CollectiveType.PROJECT;
 
-      if (get(this.props.router, 'query.navbarVersion') === 'v2') {
+      if (hasNewNavbar(get(this.props.router, 'query.navbarVersion'))) {
         // The "too many calls to action" issue doesn't stand anymore with the new navbar, so
         // we can let the CollectiveNavbar component in charge of most of the flags, to make sure
         // we display the same thing everywhere. The two flags below should be migrated and this
@@ -223,7 +223,7 @@ class CollectivePage extends Component {
   };
 
   renderSection(section) {
-    const hasNewCollectiveNavbar = get(this.props.router, 'query.navbarVersion') === 'v2';
+    const hasNewCollectiveNavbar = hasNewNavbar(get(this.props.router, 'query.navbarVersion'));
     switch (section) {
       case Sections.UPDATES:
         return (
@@ -348,7 +348,7 @@ class CollectivePage extends Component {
 
   render() {
     const { collective, host, isAdmin, isHostAdmin, isRoot, onPrimaryColorChange, LoggedInUser, router } = this.props;
-    const newNavbarFeatureFlag = router?.query?.navbarVersion === 'v2';
+    const newNavbarFeatureFlag = hasNewNavbar(get(router, 'query.navbarVersion'));
     const { type, isHost, canApply, canContact, isActive, settings } = collective;
     const { isFixed, selectedSection, selectedCategory } = this.state;
     const sections = this.getSections(collective, isAdmin, isHostAdmin);

--- a/components/collective-page/sections/About.js
+++ b/components/collective-page/sections/About.js
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 
+import { hasNewNavbar } from '../../../lib/collective-sections';
 import { CollectiveType } from '../../../lib/constants/collectives';
 
 import Container from '../../Container';
@@ -45,7 +46,7 @@ const SectionAbout = ({ collective, canEdit, intl }) => {
   const isFund = collective.type === CollectiveType.FUND;
   canEdit = collective.isArchived ? false : canEdit;
   const router = useRouter();
-  const newNavbarFeatureFlag = get(router, 'query.navbarVersion') === 'v2';
+  const newNavbarFeatureFlag = hasNewNavbar(get(router, 'query.navbarVersion'));
 
   return (
     <ContainerSectionContent px={2} py={[4, 5]}>

--- a/components/collective-page/sections/Budget.js
+++ b/components/collective-page/sections/Budget.js
@@ -5,6 +5,7 @@ import { get, isEmpty } from 'lodash';
 import { useRouter } from 'next/router';
 import { FormattedMessage, injectIntl } from 'react-intl';
 
+import { hasNewNavbar } from '../../../lib/collective-sections';
 import { CollectiveType } from '../../../lib/constants/collectives';
 import { formatCurrency } from '../../../lib/currency-utils';
 import { GraphQLContext } from '../../../lib/graphql/context';
@@ -55,7 +56,7 @@ const SectionBudget = ({ collective, stats, LoggedInUser }) => {
   const isFund = collective.type === CollectiveType.FUND;
   const isProject = collective.type === CollectiveType.PROJECT;
   const router = useRouter();
-  const newNavbarFeatureFlag = get(router, 'query.navbarVersion') === 'v2';
+  const newNavbarFeatureFlag = hasNewNavbar(get(router, 'query.navbarVersion'));
 
   React.useEffect(() => {
     refetch();

--- a/components/collective-page/sections/Contribute.js
+++ b/components/collective-page/sections/Contribute.js
@@ -9,6 +9,7 @@ import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 
 import { getTopContributors } from '../../../lib/collective.lib';
+import { hasNewNavbar } from '../../../lib/collective-sections';
 import { CollectiveType } from '../../../lib/constants/collectives';
 import { TierTypes } from '../../../lib/constants/tiers-types';
 import { getErrorFromGraphqlException } from '../../../lib/errors';
@@ -261,7 +262,7 @@ class SectionContribute extends React.PureComponent {
     const sortedTicketTiers = this.sortTicketTiers(this.filterTickets(tiers));
     const hideTicketsFromNonAdmins = (sortedTicketTiers.length === 0 || !collective.isActive) && !isAdmin;
     const cannotOrderTickets = (!hasContribute && !isAdmin) || (!canOrderTicketsFromEvent(collective) && !isAdmin);
-    const newNavbarFeatureFlag = get(router, 'query.navbarVersion') === 'v2';
+    const newNavbarFeatureFlag = hasNewNavbar(get(router, 'query.navbarVersion'));
 
     /*
     cases

--- a/components/collective-page/sections/Contributions.js
+++ b/components/collective-page/sections/Contributions.js
@@ -8,6 +8,7 @@ import { withRouter } from 'next/router';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import styled from 'styled-components';
 
+import { hasNewNavbar } from '../../../lib/collective-sections';
 import { CollectiveType } from '../../../lib/constants/collectives';
 import roles from '../../../lib/constants/roles';
 
@@ -218,7 +219,7 @@ class SectionContributions extends React.PureComponent {
   render() {
     const { collective, data, intl, router } = this.props;
     const { nbMemberships, selectedFilter } = this.state;
-    const newNavbarFeatureFlag = get(router, 'query.navbarVersion') === 'v2';
+    const newNavbarFeatureFlag = hasNewNavbar(get(router, 'query.navbarVersion'));
 
     if (data.loading) {
       return <LoadingPlaceholder height={600} borderRadius={0} />;

--- a/components/edit-collective/sections/EditCollectivePage.js
+++ b/components/edit-collective/sections/EditCollectivePage.js
@@ -16,6 +16,7 @@ import {
   convertSectionsToNewFormat,
   getDefaultSectionsForCollective,
   getSectionPath,
+  hasNewNavbar,
 } from '../../../lib/collective-sections';
 import { CollectiveType } from '../../../lib/constants/collectives';
 import DRAG_AND_DROP_TYPES from '../../../lib/constants/drag-and-drop';
@@ -364,7 +365,7 @@ const loadSectionsForCollectiveV1 = collective => {
 const EditCollectivePage = ({ collective }) => {
   const intl = useIntl();
   const router = useRouter();
-  const useNewSections = get(router, 'query.navbarVersion') === 'v2';
+  const useNewSections = hasNewNavbar(get(router, 'query.navbarVersion'));
   const [isDirty, setDirty] = React.useState(false);
   const [sections, setSections] = React.useState(null);
   const [tmpSections, setTmpSections] = React.useState(null);

--- a/lib/collective-sections.js
+++ b/lib/collective-sections.js
@@ -15,7 +15,9 @@ import { Sections } from '../components/collective-page/_constants';
 
 import { CollectiveType } from './constants/collectives';
 import hasFeature, { FEATURES } from './allowed-features';
+import { getEnvVar } from './env-utils';
 import { canOrderTicketsFromEvent, isPastEvent } from './events';
+import { parseToBoolean } from './utils';
 
 // Define default sections based on collective type
 const DEFAULT_SECTIONS = {
@@ -643,4 +645,16 @@ export const addDefaultSections = (collective, sections, defaultIsEnabled = true
   });
 
   return newSections;
+};
+
+const NAV_V2_FEATURE_FLAG = parseToBoolean(getEnvVar('NEW_COLLECTIVE_NAVBAR'));
+
+export const hasNewNavbar = versionFromPath => {
+  if (versionFromPath === 'v2') {
+    return true;
+  } else if (versionFromPath === 'v1') {
+    return false;
+  } else {
+    return NAV_V2_FEATURE_FLAG;
+  }
 };

--- a/pages/collective-page.js
+++ b/pages/collective-page.js
@@ -5,6 +5,7 @@ import { get } from 'lodash';
 import dynamic from 'next/dynamic';
 import { createGlobalStyle } from 'styled-components';
 
+import { hasNewNavbar } from '../lib/collective-sections';
 import { generateNotFoundError } from '../lib/errors';
 
 import CollectivePageContent from '../components/collective-page';
@@ -62,7 +63,7 @@ class CollectivePage extends React.Component {
     // If on server side
     if (req) {
       req.noStyledJsx = true;
-      const hasNewCollectiveNavbar = navbarVersion === 'v2';
+      const hasNewCollectiveNavbar = hasNewNavbar(navbarVersion);
       await preloadCollectivePageGraphlQueries(slug, client, hasNewCollectiveNavbar);
       skipDataFromTree = true;
     }


### PR DESCRIPTION
Re-introduce the global flag removed in https://github.com/opencollective/opencollective-frontend/pull/5575. It's good to be able to quickly change from the URL, but we still want to be able to set the global default.

Also introduces the revert ability of forcing V1's navbar by settings `navbarVersion=v1`.