### PR TITLE
Redirect to the relevant page after accepting invitation

### DIFF
--- a/components/MemberInvitationsList.js
+++ b/components/MemberInvitationsList.js
@@ -33,7 +33,11 @@ const MemberInvitationsList = ({ invitations, selectedInvitationId }) => {
     <Flex flexDirection="column" alignItems="center">
       {invitations.map(invitation => (
         <Box key={invitation.id} mb={5}>
-          <ReplyToMemberInvitationCard invitation={invitation} isSelected={invitation.id === selectedInvitationId} />
+          <ReplyToMemberInvitationCard
+            invitation={invitation}
+            isSelected={invitation.id === selectedInvitationId}
+            redirectOnAccept={invitations.length === 1}
+          />
         </Box>
       ))}
     </Flex>

--- a/components/ReplyToMemberInvitationCard.js
+++ b/components/ReplyToMemberInvitationCard.js
@@ -6,6 +6,7 @@ import { defineMessages, useIntl } from 'react-intl';
 import roles from '../lib/constants/roles';
 import { getErrorFromGraphqlException } from '../lib/errors';
 import formatMemberRole from '../lib/i18n/member-role';
+import { Router } from '../server/pages';
 
 import Avatar from './Avatar';
 import { Flex } from './Grid';
@@ -52,7 +53,7 @@ const replyToMemberInvitationMutation = gql`
  * A card with actions for users to accept or decline an invitation to join the members
  * of a collective.
  */
-const ReplyToMemberInvitationCard = ({ invitation, isSelected, refetchLoggedInUser }) => {
+const ReplyToMemberInvitationCard = ({ invitation, isSelected, refetchLoggedInUser, redirectOnAccept }) => {
   const intl = useIntl();
   const { formatMessage } = intl;
   const [accepted, setAccepted] = React.useState();
@@ -66,6 +67,9 @@ const ReplyToMemberInvitationCard = ({ invitation, isSelected, refetchLoggedInUs
     setAccepted(accept);
     await sendReplyToInvitation({ variables: { id: invitation.id, accept } });
     await refetchLoggedInUser();
+    if (accept && redirectOnAccept) {
+      await Router.pushRoute(`/${invitation.collective.slug}`);
+    }
     setSubmitting(false);
   };
 
@@ -141,10 +145,12 @@ ReplyToMemberInvitationCard.propTypes = {
     role: PropTypes.oneOf(Object.values(roles)),
     collective: PropTypes.shape({
       name: PropTypes.string,
+      slug: PropTypes.string,
     }),
   }),
   /** @ignore form withUser */
   refetchLoggedInUser: PropTypes.func,
+  redirectOnAccept: PropTypes.bool,
 };
 
 export default withUser(ReplyToMemberInvitationCard);

--- a/test/cypress/integration/22-collective.edit.test.js
+++ b/test/cypress/integration/22-collective.edit.test.js
@@ -47,6 +47,7 @@ describe('edit collective', () => {
       cy.wrap($form).find('input[name="name"]').type('AmazingNewUser');
       cy.wrap($form).find('button[type="submit"]').click();
     });
+    cy.wait(200);
     cy.getByDataCy('create-collective-mini-form').should('not.exist'); // Wait for form to be submitted
     cy.getByDataCy('save-members-btn').click();
     cy.get('[data-cy="member-1"] [data-cy="member-pending-tag"]').should('exist');
@@ -59,7 +60,11 @@ describe('edit collective', () => {
     cy.login({ email: invitedUserEmail, redirect: `/member-invitations` });
     cy.getByDataCy('member-invitation-card').contains('CollectiveToEdit');
     cy.getByDataCy('member-invitation-accept-btn').click();
-    cy.getByDataCy('member-invitation-card').contains('Accepted');
+
+    // Should be redirected to the collective page and added to the team section
+    cy.url().should('eq', `${Cypress.config().baseUrl}/${collectiveSlug}`);
+    cy.contains('#section-our-team', 'AmazingNewUser');
+
     cy.visit(`/${collectiveSlug}/edit/members`);
     cy.get('[data-cy="member-1"]').find('[data-cy="member-pending-tag"]').should('not.exist');
   });


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Closes https://github.com/opencollective/opencollective/issues/3453

# Description

These changes make the accept button callback to redirect to the collective page.
As mentioned in the issue conversation, this only happens when there's a single pending invitation.

# Screenshots
I've recorded two gifs. 
In the first gif the user accepts a single pending invitation and the redirect does happen:

![single-invite](https://user-images.githubusercontent.com/43905913/104134358-ba8b8080-5391-11eb-99f7-82bd0217dcab.gif)

In the second gif the user accepts two pending invitations and the redirect doesn't happen:

![multiple-invites](https://user-images.githubusercontent.com/43905913/104134396-e4dd3e00-5391-11eb-853b-634beba2b274.gif)

Let me know if there's anything else that needs to be done :) 
<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
