### PR TITLE
fix(homepage): fix open finance dead link

### DIFF
--- a/components/home/sections/LearnMore.js
+++ b/components/home/sections/LearnMore.js
@@ -88,7 +88,7 @@ const learningChannels = [
   {
     id: 'openFinances',
     name: 'Open Finances',
-    link: 'https://opencollective.com/opencollectiveinc',
+    link: 'https://opencollective.com/opencollective',
     desktopItemOrder: 5,
   },
   {


### PR DESCRIPTION
Fixes "Open Finance" dead link on the home page. 