### PR TITLE
CollectivePage: Add connected collectives section

### DIFF
--- a/lib/collective-sections.js
+++ b/lib/collective-sections.js
@@ -73,6 +73,7 @@ const DEFAULT_SECTIONS = {
 const DEFAULT_SECTIONS_V2 = {
   [CollectiveType.ORGANIZATION]: [
     Sections.CONTRIBUTE,
+    Sections.CONNECTED_COLLECTIVES,
     Sections.RECURRING_CONTRIBUTIONS,
     Sections.TOP_FINANCIAL_CONTRIBUTORS,
     Sections.EVENTS,
@@ -85,10 +86,11 @@ const DEFAULT_SECTIONS_V2 = {
   [CollectiveType.COLLECTIVE]: [
     Sections.GOALS,
     Sections.CONTRIBUTE,
+    Sections.EVENTS,
+    Sections.CONNECTED_COLLECTIVES,
     Sections.RECURRING_CONTRIBUTIONS,
     Sections.CONTRIBUTORS,
     Sections.TOP_FINANCIAL_CONTRIBUTORS,
-    Sections.EVENTS,
     Sections.BUDGET,
     Sections.UPDATES,
     Sections.CONVERSATIONS,
@@ -315,7 +317,8 @@ const getSectionsToRemoveForUser = (collective, isAdmin, isHostAdmin, hasNewColl
     if (!hasAccessToFeature(FEATURES.CONVERSATIONS)) {
       toRemove.add(Sections.CONVERSATIONS);
     }
-    if (!hasAccessToFeature(FEATURES.CONNECTED_ACCOUNTS)) {
+    if (collective.features[FEATURES.CONNECTED_ACCOUNTS] !== 'ACTIVE') {
+      // If there's no connected accounts, there's no benefit in enabling the section as it will return null anyway
       toRemove.add(Sections.CONNECTED_COLLECTIVES);
     }
     if (!collective.hasLongDescription && !collective.longDescription && !isAdmin && !isHostAdmin) {


### PR DESCRIPTION
Reported in https://opencollective.slack.com/archives/C6JTTA4SK/p1610466435188700

Section needs to be enabled by default for it to appear