### PR TITLE
Collective navigation v2: primary colors and buttons for 2 CTAs

### DIFF
--- a/components/ApplyToHostBtn.js
+++ b/components/ApplyToHostBtn.js
@@ -39,7 +39,7 @@ class ApplyToHostBtn extends React.Component {
         ...buttonProps,
         children: (
           <React.Fragment>
-            {!withoutIcon && <CheckCircle size="1.2em" />}
+            {!withoutIcon && <CheckCircle size="1em" />}
             {!withoutIcon && ' '}
             <span>
               <FormattedMessage id="host.apply.create.btn" defaultMessage="Apply" />

--- a/components/collective-navbar/NavBarCategoryDropdown.js
+++ b/components/collective-navbar/NavBarCategoryDropdown.js
@@ -51,7 +51,6 @@ const CategoryContainer = styled(StyledLink).attrs({ px: [1, 3, 0] })`
   }
 
   &:hover {
-    color: ${themeGet('colors.primary.400')};
     text-decoration: none;
   }
 
@@ -119,6 +118,10 @@ const MenuItem = styled('li')`
     line-height: 16px;
     letter-spacing: -0.4px;
     outline: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
 
     &:not(:hover) {
       color: #313233;

--- a/components/collective-navbar/menu.js
+++ b/components/collective-navbar/menu.js
@@ -15,6 +15,7 @@ export const NAVBAR_ACTION_TYPE = {
   ADD_FUNDS: 'addFunds',
   CONTRIBUTE: 'hasContribute',
   MANAGE_SUBSCRIPTIONS: 'hasManageSubscriptions',
+  REQUEST_GRANT: 'hasRequestGrant',
 };
 
 const titles = defineMessages({

--- a/components/collective-page/CategoryHeader.js
+++ b/components/collective-page/CategoryHeader.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Info } from '@styled-icons/feather/Info';
+import themeGet from '@styled-system/theme-get';
 import { FormattedMessage, useIntl } from 'react-intl';
 import styled from 'styled-components';
 
@@ -16,10 +17,10 @@ import { P } from '../Text';
 import { Dimensions } from './_constants';
 import SectionTitle from './SectionTitle';
 
-import aboutSectionHeaderIcon from '../../public/static/images/collective-navigation/CollectiveSectionHeaderIconAbout.png';
-import budgetSectionHeaderIcon from '../../public/static/images/collective-navigation/CollectiveSectionHeaderIconBudget.png';
-import connectSectionHeaderIcon from '../../public/static/images/collective-navigation/CollectiveSectionHeaderIconConnect.png';
-import contributeSectionHeaderIcon from '../../public/static/images/collective-navigation/CollectiveSectionHeaderIconContribute.png';
+import aboutSectionHeaderIcon from '../../public/static/images/collective-navigation/CollectiveNavbarIconAbout.png';
+import budgetSectionHeaderIcon from '../../public/static/images/collective-navigation/CollectiveNavbarIconBudget.png';
+import connectSectionHeaderIcon from '../../public/static/images/collective-navigation/CollectiveNavbarIconConnect.png';
+import contributeSectionHeaderIcon from '../../public/static/images/collective-navigation/CollectiveNavbarIconContribute.png';
 
 const ContainerWithMaxWidth = styled(Container).attrs({
   maxWidth: Dimensions.MAX_SECTION_WIDTH,
@@ -32,8 +33,32 @@ const ContainerWithMaxWidth = styled(Container).attrs({
 `;
 
 const TypeIllustration = styled.img.attrs({ alt: '' })`
+  position: absolute;
   width: 48px;
   height: 48px;
+`;
+
+const TypeIllustrationCircle = styled(Flex)`
+  position: relative;
+  width: 48px;
+  height: 48px;
+
+  &::before {
+    content: '';
+    background: ${themeGet('colors.primary.100')};
+    border-radius: 50%;
+    height: 30px;
+    width: 30px;
+    position: absolute;
+    right: 0;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: auto;
+    margin-bottom: auto;
+  }
 `;
 
 const getCategoryData = (intl, collective, category) => {
@@ -117,9 +142,9 @@ const CategoryHeader = React.forwardRef(({ collective, category, isAdmin, ...pro
   return (
     <ContainerWithMaxWidth ref={ref} {...props}>
       <Flex alignItems="center" justifyContent="center">
-        <Flex alignItems="center" mr={2}>
+        <TypeIllustrationCircle alignItems="center" mr={2}>
           <TypeIllustration src={data.img} />
-        </Flex>
+        </TypeIllustrationCircle>
         <Flex alignItems="center" mr={3}>
           <SectionTitle mr={2} my={3} data-cy={`category-${category}-title`}>
             {data.title}


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/3764
Relates https://github.com/opencollective/opencollective/issues/3841

* Renders category header icons in primary color
* Addresses a lot of https://github.com/opencollective/opencollective/issues/3841 - hover and active states for CTAs, actions menu, dropdown menus, etc
* Renders 2 buttons if there are only 2 CTAs instead of 1 button and a dropdown menu for just 1 action
  * As requested, the function that was previously `getMainAction` has now been abstracted slightly to `getActions` and is used across both components
  * As mentioned in the code comments, we still need to add components for `hasRequestGrant` and `addPrepaidBudget` but perhaps as an interation after this PR
  * All CTA logic has been moved into one file (`collective-navbar/index.js`) instead of having it split across there and `ActionsMenu.js`

![hoverstates](https://user-images.githubusercontent.com/37520401/105518203-e5e66780-5ccf-11eb-816d-75ade400d3ea.gif)

