### PR TITLE
Add receiving variant to EditPayPalAccount

### DIFF
--- a/components/edit-collective/EditConnectedAccount.js
+++ b/components/edit-collective/EditConnectedAccount.js
@@ -23,6 +23,7 @@ class EditConnectedAccount extends React.Component {
     intl: PropTypes.object.isRequired,
     service: PropTypes.string,
     connectedAccount: PropTypes.object,
+    variation: PropTypes.bool,
   };
 
   constructor(props) {
@@ -127,7 +128,7 @@ class EditConnectedAccount extends React.Component {
   }
 
   render() {
-    const { intl, service, collective } = this.props;
+    const { intl, service, collective, variation } = this.props;
     const { connectedAccount } = this.state;
 
     let vars = {};
@@ -146,7 +147,14 @@ class EditConnectedAccount extends React.Component {
         <EditTransferWiseAccount collective={collective} connectedAccount={this.props.connectedAccount} intl={intl} />
       );
     } else if (service === 'paypal') {
-      return <EditPayPalAccount collective={collective} connectedAccount={this.props.connectedAccount} intl={intl} />;
+      return (
+        <EditPayPalAccount
+          collective={collective}
+          connectedAccount={this.props.connectedAccount}
+          variation={variation}
+          intl={intl}
+        />
+      );
     }
 
     return (

--- a/components/edit-collective/EditPayPalAccount.js
+++ b/components/edit-collective/EditPayPalAccount.js
@@ -35,6 +35,7 @@ const deleteConnectedAccountMutation = gqlV2/* GraphQL */ `
 `;
 
 const EditPayPalAccount = props => {
+  const isReceiving = props.variation == 'RECEIVING';
   const mutationOptions = {
     context: API_V2_CONTEXT,
     refetchQueries: [{ query: editCollectivePageQuery, variables: { slug: props.collective.slug } }],
@@ -92,16 +93,18 @@ const EditPayPalAccount = props => {
     return (
       <form onSubmit={formik.handleSubmit}>
         <P fontSize="12px" color="black.600" fontWeight="normal">
-          <FormattedMessage
-            id="collective.create.connectedAccounts.paypal.description"
-            defaultMessage="Connect a PayPal account to pay expenses with one click. For instructions on how to connect to PayPal, please, <a>read our documentation</a>."
-            values={{
-              a: getI18nLink({
-                href: 'https://docs.opencollective.com/help/fiscal-hosts/payouts/payouts-with-paypal',
-                openInNewTab: true,
-              }),
-            }}
-          />
+          {isReceiving ? null : (
+            <FormattedMessage
+              id="collective.create.connectedAccounts.paypal.description"
+              defaultMessage="Connect a PayPal account to pay expenses with one click. For instructions on how to connect to PayPal, please, <a>read our documentation</a>."
+              values={{
+                a: getI18nLink({
+                  href: 'https://docs.opencollective.com/help/fiscal-hosts/payouts/payouts-with-paypal',
+                  openInNewTab: true,
+                }),
+              }}
+            />
+          )}
         </P>
         <StyledInputField
           name="clientId"
@@ -124,11 +127,14 @@ const EditPayPalAccount = props => {
             <StyledInput type="text" {...inputProps} onChange={formik.handleChange} value={formik.values.token} />
           )}
         </StyledInputField>
-        <StyledInputField mt={2} name="webhookId" label="Webhook ID" disabled={isCreating}>
-          {inputProps => (
-            <StyledInput type="text" {...inputProps} onChange={formik.handleChange} value={formik.values.webhookId} />
-          )}
-        </StyledInputField>
+
+        {isReceiving ? null : (
+          <StyledInputField mt={2} name="webhookId" label="Webhook ID" disabled={isCreating}>
+            {inputProps => (
+              <StyledInput type="text" {...inputProps} onChange={formik.handleChange} value={formik.values.webhookId} />
+            )}
+          </StyledInputField>
+        )}
         <StyledButton mt={10} type="submit" buttonSize="tiny" loading={isCreating}>
           <FormattedMessage id="collective.connectedAccounts.paypal.button" defaultMessage="Connect PayPal" />
         </StyledButton>
@@ -160,6 +166,7 @@ EditPayPalAccount.propTypes = {
   connectedAccount: PropTypes.object,
   collective: PropTypes.object,
   intl: PropTypes.object.isRequired,
+  variation: PropTypes.string,
 };
 
 export default EditPayPalAccount;

--- a/components/edit-collective/sections/ConnectedAccounts.js
+++ b/components/edit-collective/sections/ConnectedAccounts.js
@@ -30,6 +30,7 @@ const ConnectedAccounts = props => {
             collective={props.collective}
             service={service}
             connectedAccount={connectedAccountsByService[service] && connectedAccountsByService[service][0]}
+            variation={props.variation}
           />
         </Box>
       ))}
@@ -42,6 +43,7 @@ ConnectedAccounts.propTypes = {
   connectedAccounts: PropTypes.arrayOf(PropTypes.object),
   editMode: PropTypes.bool,
   services: PropTypes.arrayOf(PropTypes.string),
+  variation: PropTypes.oneOf(['SENDING', 'RECEIVING']),
 };
 
 export default ConnectedAccounts;

--- a/components/edit-collective/sections/ReceivingMoney.js
+++ b/components/edit-collective/sections/ReceivingMoney.js
@@ -44,6 +44,7 @@ class ReceivingMoney extends React.Component {
               collective={this.props.collective}
               connectedAccounts={this.props.collective.connectedAccounts}
               services={services}
+              variation="RECEIVING"
             />
           </React.Fragment>
         )}


### PR DESCRIPTION
Adding a variant when connecting to PayPal to receive donations so we don't just reuse the PayPal Payouts form.