### PR TITLE
Add Accessiblity Features to the Contribution Screen

### DIFF
--- a/components/ConfirmationModal.js
+++ b/components/ConfirmationModal.js
@@ -52,7 +52,7 @@ const ConfirmationModal = ({
   const { formatMessage } = useIntl();
 
   return (
-    <Modal width="570px" show={show} onClose={onClose} {...props}>
+    <Modal role="alertdialog" width="570px" show={show} onClose={onClose} {...props}>
       <ModalHeader onClose={onClose}>{header}</ModalHeader>
       <ModalBody pt={2}>{children || <P>{body}</P>}</ModalBody>
       <ModalFooter>
@@ -60,6 +60,7 @@ const ConfirmationModal = ({
           <StyledButton
             mx={20}
             my={1}
+            autoFocus
             minWidth={140}
             onClick={cancelHandler || onClose}
             disabled={submitting}

--- a/components/StyledAmountPicker.js
+++ b/components/StyledAmountPicker.js
@@ -71,6 +71,8 @@ const StyledAmountPicker = ({ presets, currency, value, otherAmountDisplay, onCh
         <StyledButtonSet
           id="amount"
           data-cy="amount-picker"
+          role="group"
+          aria-label="Contribution amount"
           width="100%"
           justifyContent="center"
           items={options}

--- a/components/StyledButtonSet.js
+++ b/components/StyledButtonSet.js
@@ -65,6 +65,7 @@ const StyledButtonSet = ({
         onClick={onChange && (() => onChange(item))}
         className={item === selected ? 'selected' : undefined}
         disabled={disabled}
+        aria-pressed={item === selected}
         type="button"
         py="8px"
         customBorderRadius={customBorderRadius}

--- a/components/StyledModal.js
+++ b/components/StyledModal.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Times } from '@styled-icons/fa-solid/Times';
 import themeGet from '@styled-system/theme-get';
+import FocusTrap from 'focus-trap-react';
 import { createPortal } from 'react-dom';
 import styled, { createGlobalStyle, css } from 'styled-components';
 import { background, margin, overflow, space } from 'styled-system';
@@ -183,14 +184,16 @@ const StyledModal = ({ children, show, onClose, usePortal, ...props }) => {
       <React.Fragment>
         <GlobalModalStyle />
         <Wrapper>
-          <Modal {...props}>
-            {React.Children.map(children, child => {
-              if (child.type.displayName === 'Header') {
-                return React.cloneElement(child, { onClose });
-              }
-              return child;
-            })}
-          </Modal>
+          <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }}>
+            <Modal {...props}>
+              {React.Children.map(children, child => {
+                if (child.type.displayName === 'Header') {
+                  return React.cloneElement(child, { onClose });
+                }
+                return child;
+              })}
+            </Modal>
+          </FocusTrap>
         </Wrapper>
       </React.Fragment>
     );
@@ -200,14 +203,16 @@ const StyledModal = ({ children, show, onClose, usePortal, ...props }) => {
       <React.Fragment>
         <GlobalModalStyle />
         <Wrapper>
-          <Modal {...props}>
-            {React.Children.map(children, child => {
-              if (child.type?.displayName === 'Header') {
-                return React.cloneElement(child, { onClose });
-              }
-              return child;
-            })}
-          </Modal>
+          <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }}>
+            <Modal {...props}>
+              {React.Children.map(children, child => {
+                if (child.type?.displayName === 'Header') {
+                  return React.cloneElement(child, { onClose });
+                }
+                return child;
+              })}
+            </Modal>
+          </FocusTrap>
           <ModalOverlay onClick={onClose} />
         </Wrapper>
       </React.Fragment>,

--- a/components/contribution-flow/FeesOnTopInput.js
+++ b/components/contribution-flow/FeesOnTopInput.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { isNil } from 'lodash';
-import { FormattedMessage } from 'react-intl';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import styled from 'styled-components';
 
 import INTERVALS from '../../lib/constants/intervals';
@@ -13,6 +13,17 @@ import StyledSelect from '../StyledSelect';
 import { P, Span } from '../Text';
 
 import illustration from './fees-on-top-illustration.png';
+
+const msg = defineMessages({
+  noThankYou: {
+    id: 'NoThankYou',
+    defaultMessage: 'No, thank you',
+  },
+  other: {
+    id: 'platformFee.Other',
+    defaultMessage: 'Other',
+  },
+});
 
 const Illustration = styled.img.attrs({ src: illustration })`
   width: 40px;
@@ -26,33 +37,44 @@ const getOptionFromPercentage = (amount, currency, percentage) => {
   return {
     // Value must be unique, so we set a special key if feeAmount is 0
     value: feeAmount || `${percentage}%`,
+    feeAmount,
     percentage,
-    label: (
-      <span>
-        {formatCurrency(feeAmount, currency)} <Span color="black.500">({percentage * 100}%)</Span>
-      </span>
-    ),
+    currency,
+    label: `${feeAmount / 100} ${currency} (${percentage * 100}%)`,
   };
 };
 
-const getOptions = (amount, currency) => {
+const getOptions = (amount, currency, intl) => {
   return [
     ...DEFAULT_PERCENTAGES.map(percentage => {
       return getOptionFromPercentage(amount, currency, percentage);
     }),
     {
-      label: <FormattedMessage id="NoThankYou" defaultMessage="No, thank you" />,
+      label: intl.formatMessage(msg.noThankYou),
       value: 0,
     },
     {
-      label: <FormattedMessage id="platformFee.Other" defaultMessage="Other" />,
+      label: intl.formatMessage(msg.other),
       value: 'CUSTOM',
     },
   ];
 };
 
 const FeesOnTopInput = ({ currency, amount, fees, onChange }) => {
-  const options = React.useMemo(() => getOptions(amount, currency), [amount, currency]);
+  const intl = useIntl();
+  const options = React.useMemo(() => getOptions(amount, currency, intl), [amount, currency]);
+  const formatOptionLabel = option => {
+    if (option.currency) {
+      return (
+        <span>
+          {formatCurrency(option.feeAmount, option.currency)}{' '}
+          <Span color="black.500">({option.percentage * 100}%)</Span>
+        </span>
+      );
+    } else {
+      return option.label;
+    }
+  };
   const [selectedOption, setSelectedOption] = React.useState(options[1]);
   const [isReady, setReady] = React.useState(false);
 
@@ -96,6 +118,7 @@ const FeesOnTopInput = ({ currency, amount, fees, onChange }) => {
           </P>
         </Flex>
         <StyledSelect
+          aria-label="Donation percentage"
           width="100%"
           maxWidth={['100%', 190]}
           mt={[2, 0]}
@@ -103,6 +126,7 @@ const FeesOnTopInput = ({ currency, amount, fees, onChange }) => {
           fontSize="15px"
           options={options}
           onChange={setSelectedOption}
+          formatOptionLabel={formatOptionLabel}
           value={selectedOption}
         />
       </Flex>

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -52,6 +52,8 @@ const StepDetails = ({ onChange, data, collective, tier, showFeesOnTop }) => {
           items={[null, INTERVALS.month, INTERVALS.year]}
           selected={data?.interval || null}
           buttonProps={{ px: 2, py: '5px' }}
+          role="group"
+          aria-label="Amount types"
           onChange={interval => {
             if (tier) {
               setTemporaryInterval(interval);
@@ -91,7 +93,6 @@ const StepDetails = ({ onChange, data, collective, tier, showFeesOnTop }) => {
                 type="number"
                 currency={collective.currency}
                 value={data?.amount || null}
-                placeholder="---"
                 width={1}
                 min={minAmount}
                 currencyDisplay="full"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12398,6 +12398,22 @@
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
+    "focus-trap": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.3.0.tgz",
+      "integrity": "sha512-BBzvFfkPg5PqrVVCdQ1YOIVNKGvqG9YNVkiAUQFuDM66N8J9uADhs6mlYKrd30ofDJIzEniBnBKM7GO45iCzKQ==",
+      "requires": {
+        "tabbable": "^5.1.5"
+      }
+    },
+    "focus-trap-react": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-8.4.0.tgz",
+      "integrity": "sha512-Qay+xBVQDq2AgYvQChE3zoG6+JSm424AbTCjRmGqO/blOLjUc7UhixUeyZR180HN8HZ05GzZ1LjHz0nfrE3YKA==",
+      "requires": {
+        "focus-trap": "^6.3.0"
+      }
+    },
     "follow-redirects": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
@@ -13050,7 +13066,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "gzip-size": {
       "version": "5.1.1",
@@ -19014,6 +19031,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -19028,6 +19046,7 @@
           "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
           "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-docker": "^2.0.0"
           }
@@ -19037,6 +19056,7 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -19046,6 +19066,7 @@
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -23032,7 +23053,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "shx": {
       "version": "0.3.3",
@@ -24247,6 +24269,11 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/syslog-parse/-/syslog-parse-1.3.1.tgz",
       "integrity": "sha1-pszo/ytxuCeWS7yXEFWAmcharkg="
+    },
+    "tabbable": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.1.5.tgz",
+      "integrity": "sha512-oVAPrWgLLqrbvQE8XqcU7CVBq6SQbaIbHkhOca3u7/jzuQvyZycrUKPCGr04qpEIUslmUlULbSeN+m3QrKEykA=="
     },
     "table": {
       "version": "6.0.7",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "express-winston": "4.0.5",
     "express-ws": "4.0.0",
     "file-saver": "2.0.5",
+    "focus-trap-react": "8.4.0",
     "formik": "2.2.6",
     "full-icu": "1.3.1",
     "glob": "7.1.6",


### PR DESCRIPTION
This PR provides the following basic features. I've tested this with [Orca](https://help.gnome.org/users/orca/stable/)

- Add group details to buttons
- Announce pressed state of the buttons
- Announce the message dialog
- Auto focus on the cancel button of the dialog
- Announce the percentage selection at the bottom of the form (the donation select input)

The following needs to be still completed.

~~- Ideally trap the focus within the dialog after it opens (i.e: we need to make sure the tabs don't flow out of the dialog; they should wrap)~~
~~- Need a better solution to the donation select input as we seem to be using react-select and that seems to have a lot of accessibility issues; https://github.com/JedWatson/react-select/issues?q=is%3Aissue+is%3Aopen+accessibility~~

Resolves https://github.com/opencollective/opencollective/issues/3790