### PR TITLE
Remove styled-jsx completely

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13050,7 +13050,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "gzip-size": {
       "version": "5.1.1",
@@ -19014,6 +19015,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -19028,6 +19030,7 @@
           "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
           "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-docker": "^2.0.0"
           }
@@ -19037,6 +19040,7 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -19046,6 +19050,7 @@
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -23032,7 +23037,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "shx": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "slugify": "1.4.6",
     "speakeasy": "2.0.0",
     "styled-components": "5.2.1",
-    "styled-jsx": "3.3.2",
     "styled-system": "5.1.5",
     "throng": "5.0.0",
     "trix": "1.3.1",

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -4,7 +4,6 @@ import React from 'react';
 import { pick } from 'lodash';
 import Document, { Head, Html, Main, NextScript } from 'next/document';
 import { ServerStyleSheet } from 'styled-components';
-import flush from 'styled-jsx/server';
 
 import { parseToBoolean } from '../lib/utils';
 
@@ -12,7 +11,7 @@ import { parseToBoolean } from '../lib/utils';
 // data for the user's locale for React Intl to work in the browser.
 export default class IntlDocument extends Document {
   static async getInitialProps(ctx) {
-    const { locale, localeDataScript, url, noStyledJsx } = ctx.req;
+    const { locale, localeDataScript, url } = ctx.req;
 
     const sheet = new ServerStyleSheet();
     const originalRenderPage = ctx.renderPage;
@@ -47,7 +46,6 @@ export default class IntlDocument extends Document {
         styles: (
           <React.Fragment>
             {initialProps.styles}
-            {noStyledJsx ? null : flush()}
             {sheet.getStyleElement()}
           </React.Fragment>
         ),

--- a/pages/collective-page.js
+++ b/pages/collective-page.js
@@ -62,7 +62,6 @@ class CollectivePage extends React.Component {
 
     // If on server side
     if (req) {
-      req.noStyledJsx = true;
       const hasNewCollectiveNavbar = hasNewNavbar(navbarVersion);
       await preloadCollectivePageGraphlQueries(slug, client, hasNewCollectiveNavbar);
       skipDataFromTree = true;

--- a/pages/index.js
+++ b/pages/index.js
@@ -47,7 +47,6 @@ HomePage.getInitialProps = ({ req, res }) => {
 
   // If on server side
   if (req) {
-    req.noStyledJsx = true;
     skipDataFromTree = true;
   }
 

--- a/server/content-security-policy.js
+++ b/server/content-security-policy.js
@@ -23,7 +23,7 @@ const COMMON_DIRECTIVES = {
   ],
   styleSrc: [
     SELF,
-    UNSAFE_INLINE, // For styled-components/styled-jsx. TODO: Limit for nonce
+    UNSAFE_INLINE, // For styled-components. TODO: Limit for nonce
   ],
   connectSrc: [
     SELF,


### PR DESCRIPTION
This removes the `styled-jsx` dependency from `package.json` and `_document.js`.

**Note:** Should be merged only after merging, https://github.com/opencollective/opencollective-frontend/pull/5743, https://github.com/opencollective/opencollective-frontend/pull/5744 and https://github.com/opencollective/opencollective/issues/3468.

Resolve https://github.com/opencollective/opencollective/issues/3289
