### PR TITLE
enhancement(Update): use uppercase text for the 'ADMIN' tag

### DIFF
--- a/components/StyledUpdate.js
+++ b/components/StyledUpdate.js
@@ -180,7 +180,7 @@ class StyledUpdate extends Component {
             />
           </Box>
         )}
-        <StyledTag fontSize="10px" py={1}>
+        <StyledTag textTransform="uppercase" fontSize="10px" py={1}>
           <FormattedMessage id="Member.Role.ADMIN" defaultMessage="Admin" />
         </StyledTag>
         {editable && (


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/3900

# Description

use uppercase text for the 'ADMIN' tag

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots

![Screenshot at 2021-01-25 14-13-22](https://user-images.githubusercontent.com/46647141/105681730-85e20200-5f17-11eb-9460-ba0f1bc5c93a.png)

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
