### PR TITLE
Adjust card margins for both organizations and collectives

### DIFF
--- a/components/Member.js
+++ b/components/Member.js
@@ -31,7 +31,8 @@ const MemberContainer = styled.div`
     margin: 0;
   }
 
-  .ORGANIZATION {
+  .ORGANIZATION,
+  .COLLECTIVE {
     width: 200px;
     margin: 1rem;
   }


### PR DESCRIPTION
This fixes the card margin alignment issue when there's collectives present in the `banner.html` page.

Fixes https://github.com/opencollective/opencollective/issues/3909

# Screenshots

<details>
<summary>Desktop</summary>

![image](https://user-images.githubusercontent.com/12435965/105751322-b23b5580-5efa-11eb-8646-e7a0bf5d3f3a.png)
</details>


<details>
<summary>Mobile</summary>

![Screen Shot 2021-01-25 at 10 47 38](https://user-images.githubusercontent.com/12435965/105751384-c8491600-5efa-11eb-9f86-8b5d69005c47.png)
</details>
