### PR TITLE
StyledDropzone: Show message when file type is rejected

### DIFF
--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1643,6 +1643,7 @@
   "startDateAndTime": "start date and time",
   "StepsProgress.mobile.next": "Next: {stepName}",
   "StepsProgress.mobile.status": "{from} of {to}",
+  "StyledDropzone.": "The following {count, plural, one {file is} other {files are}} not valid: {files}",
   "StyledDropzone.DropMsg": "Drop {count,plural, one {file} other {files}} here",
   "StyledInputTags.AddLabel": "Add Tags",
   "StyledInputTags.EditLabel": "Edit Tags",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1643,6 +1643,7 @@
   "startDateAndTime": "start date and time",
   "StepsProgress.mobile.next": "Next: {stepName}",
   "StepsProgress.mobile.status": "{from} of {to}",
+  "StyledDropzone.": "The following {count, plural, one {file is} other {files are}} not valid: {files}",
   "StyledDropzone.DropMsg": "Drop {count,plural, one {file} other {files}} here",
   "StyledInputTags.AddLabel": "Add Tags",
   "StyledInputTags.EditLabel": "Edit Tags",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1643,6 +1643,7 @@
   "startDateAndTime": "start date and time",
   "StepsProgress.mobile.next": "Next: {stepName}",
   "StepsProgress.mobile.status": "{from} of {to}",
+  "StyledDropzone.": "The following {count, plural, one {file is} other {files are}} not valid: {files}",
   "StyledDropzone.DropMsg": "Drop {count,plural, one {file} other {files}} here",
   "StyledInputTags.AddLabel": "Add Tags",
   "StyledInputTags.EditLabel": "Edit Tags",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1643,6 +1643,7 @@
   "startDateAndTime": "start date and time",
   "StepsProgress.mobile.next": "Next: {stepName}",
   "StepsProgress.mobile.status": "{from} of {to}",
+  "StyledDropzone.": "The following {count, plural, one {file is} other {files are}} not valid: {files}",
   "StyledDropzone.DropMsg": "Drop {count,plural, one {file} other {files}} here",
   "StyledInputTags.AddLabel": "Add Tags",
   "StyledInputTags.EditLabel": "Edit Tags",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1643,6 +1643,7 @@
   "startDateAndTime": "fecha y hora de inicio",
   "StepsProgress.mobile.next": "Siguiente: {stepName}",
   "StepsProgress.mobile.status": "{from} de {to}",
+  "StyledDropzone.": "The following {count, plural, one {file is} other {files are}} not valid: {files}",
   "StyledDropzone.DropMsg": "Drop {count,plural, one {file} other {files}} here",
   "StyledInputTags.AddLabel": "Añadir etiquetas",
   "StyledInputTags.EditLabel": "Editar las etiquetas",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1643,6 +1643,7 @@
   "startDateAndTime": "date et heure de début",
   "StepsProgress.mobile.next": "Suivant : {stepName}",
   "StepsProgress.mobile.status": "{from} sur {to}",
+  "StyledDropzone.": "The following {count, plural, one {file is} other {files are}} not valid: {files}",
   "StyledDropzone.DropMsg": "Déposez {count,plural, one {votre fichier} other {vos fichiers}} ici",
   "StyledInputTags.AddLabel": "Ajouter des Tags",
   "StyledInputTags.EditLabel": "Modifier les Tags",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1643,6 +1643,7 @@
   "startDateAndTime": "start date and time",
   "StepsProgress.mobile.next": "Next: {stepName}",
   "StepsProgress.mobile.status": "{from} of {to}",
+  "StyledDropzone.": "The following {count, plural, one {file is} other {files are}} not valid: {files}",
   "StyledDropzone.DropMsg": "Drop {count,plural, one {file} other {files}} here",
   "StyledInputTags.AddLabel": "Add Tags",
   "StyledInputTags.EditLabel": "Edit Tags",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1643,6 +1643,7 @@
   "startDateAndTime": "start date and time",
   "StepsProgress.mobile.next": "Next: {stepName}",
   "StepsProgress.mobile.status": "{from} of {to}",
+  "StyledDropzone.": "The following {count, plural, one {file is} other {files are}} not valid: {files}",
   "StyledDropzone.DropMsg": "Drop {count,plural, one {file} other {files}} here",
   "StyledInputTags.AddLabel": "Add Tags",
   "StyledInputTags.EditLabel": "Edit Tags",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1643,6 +1643,7 @@
   "startDateAndTime": "start date and time",
   "StepsProgress.mobile.next": "다음: {stepName}",
   "StepsProgress.mobile.status": "{from} of {to}",
+  "StyledDropzone.": "The following {count, plural, one {file is} other {files are}} not valid: {files}",
   "StyledDropzone.DropMsg": "Drop {count,plural, one {file} other {files}} here",
   "StyledInputTags.AddLabel": "Add Tags",
   "StyledInputTags.EditLabel": "Edit Tags",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1643,6 +1643,7 @@
   "startDateAndTime": "start date and time",
   "StepsProgress.mobile.next": "Next: {stepName}",
   "StepsProgress.mobile.status": "{from} of {to}",
+  "StyledDropzone.": "The following {count, plural, one {file is} other {files are}} not valid: {files}",
   "StyledDropzone.DropMsg": "Drop {count,plural, one {file} other {files}} here",
   "StyledInputTags.AddLabel": "Add Tags",
   "StyledInputTags.EditLabel": "Edit Tags",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1643,6 +1643,7 @@
   "startDateAndTime": "data e hora de início",
   "StepsProgress.mobile.next": "Próximo: {stepName}",
   "StepsProgress.mobile.status": "{from} de {to}",
+  "StyledDropzone.": "The following {count, plural, one {file is} other {files are}} not valid: {files}",
   "StyledDropzone.DropMsg": "Drop {count,plural, one {file} other {files}} here",
   "StyledInputTags.AddLabel": "Add Tags",
   "StyledInputTags.EditLabel": "Edit Tags",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1643,6 +1643,7 @@
   "startDateAndTime": "start date and time",
   "StepsProgress.mobile.next": "Далее: {stepName}",
   "StepsProgress.mobile.status": "{from} of {to}",
+  "StyledDropzone.": "The following {count, plural, one {file is} other {files are}} not valid: {files}",
   "StyledDropzone.DropMsg": "Drop {count,plural, one {file} other {files}} here",
   "StyledInputTags.AddLabel": "Добавить Теги",
   "StyledInputTags.EditLabel": "Изменить Теги",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -1643,6 +1643,7 @@
   "startDateAndTime": "start date and time",
   "StepsProgress.mobile.next": "Next: {stepName}",
   "StepsProgress.mobile.status": "{from} of {to}",
+  "StyledDropzone.": "The following {count, plural, one {file is} other {files are}} not valid: {files}",
   "StyledDropzone.DropMsg": "Drop {count,plural, one {file} other {files}} here",
   "StyledInputTags.AddLabel": "Додати мітки",
   "StyledInputTags.EditLabel": "Змінити мітки",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1643,6 +1643,7 @@
   "startDateAndTime": "start date and time",
   "StepsProgress.mobile.next": "下一步： {stepName}",
   "StepsProgress.mobile.status": "{from} of {to}",
+  "StyledDropzone.": "The following {count, plural, one {file is} other {files are}} not valid: {files}",
   "StyledDropzone.DropMsg": "Drop {count,plural, one {file} other {files}} here",
   "StyledInputTags.AddLabel": "添加标签",
   "StyledInputTags.EditLabel": "编辑标签",


### PR DESCRIPTION
The styled dropzone provided no feedback when a file was rejected, which apparently lead to people submitting expenses without the proper documentation (see https://opencollective.freshdesk.com/a/tickets/12645). This PR adds a toast error when one or multiple files is rejected.

![Peek 2021-01-26 17-20](https://user-images.githubusercontent.com/1556356/105872658-f01fa300-5ffa-11eb-83a3-28c9247334bc.gif)

