### PR TITLE
feat(StyledInputTags) - Add/remove/Navigate tags using keyboard

### DIFF
--- a/components/StyledInputTags.js
+++ b/components/StyledInputTags.js
@@ -27,12 +27,16 @@ const EditTag = styled(StyledTag)`
   border-color: ${props => props.theme.colors.black[200]};
   color: ${props => props.theme.colors.black[700]};
 
-  &:hover {
+  &:hover,
+  &:focus {
     background-color: ${props => props.theme.colors.white.full};
     border-color: ${props => props.theme.colors.blue[500]};
     svg {
       color: ${props => props.theme.colors.blue[500]};
     }
+  }
+  &:focus {
+    outline: 0;
   }
 
   ${props =>
@@ -84,12 +88,12 @@ const TagActionButton = styled.button`
   border: none;
   padding: 5px;
   line-height: inherit;
-  outline: none;
 `;
 
 const AddTagButton = styled(TagActionButton)`
   color: ${props => props.theme.colors.blue[400]};
-  &:hover {
+  &:hover,
+  &:focus {
     color: ${props => props.theme.colors.blue[600]};
   }
 `;
@@ -192,6 +196,13 @@ const StyledInputTags = ({ suggestedTags, value, onChange, renderUpdatedTags, de
                 mb="4px"
                 active={isOpen}
                 onClick={handleToggleInput}
+                tabIndex={0}
+                onKeyDown={e => {
+                  if (e.key === ' ') {
+                    e.preventDefault();
+                    handleToggleInput();
+                  }
+                }}
               >
                 <TagIcon size="14px" />{' '}
                 {tags?.length > 0 ? formatMessage(messages.editLabel) : formatMessage(messages.addLabel)}
@@ -210,7 +221,14 @@ const StyledInputTags = ({ suggestedTags, value, onChange, renderUpdatedTags, de
                   zIndex: 9999,
                 }}
               >
-                <StyledCard m={1} overflow="auto" {...props} ref={scrollerRef} boxShadow="0px 4px 10px #C4C7CC">
+                <StyledCard
+                  m={1}
+                  overflow="auto"
+                  overflowY="scroll"
+                  {...props}
+                  ref={scrollerRef}
+                  boxShadow="0px 4px 10px #C4C7CC"
+                >
                   <InputWrapper color="black.400">
                     <TagIcon size="16px" />
                     <Input
@@ -236,6 +254,12 @@ const StyledInputTags = ({ suggestedTags, value, onChange, renderUpdatedTags, de
                               onClick={() => {
                                 addTag(st);
                               }}
+                              onBlur={() => {
+                                if (st === suggestedTags[suggestedTags.length - 1]) {
+                                  handleToggleInput();
+                                }
+                              }}
+                              tabindex="0"
                             >
                               <Plus size="10px" />
                             </AddTagButton>

--- a/components/StyledTag.js
+++ b/components/StyledTag.js
@@ -116,7 +116,6 @@ const CloseButton = styled.button.attrs({
   border: none;
   padding: 0;
   line-height: inherit;
-  outline: none;
 `;
 
 /** Simple tag to display a short string */


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolves opencollective/opencollective#3078

# Description
Improve accessible functionality of `StyledInputTags` by being able to add/remove and navigate suggestions using keyboard (Tab key & spacebar) 

# Screenshots

https://user-images.githubusercontent.com/14836056/106004158-faf23a80-60c3-11eb-9a27-e26be95a5b9b.mov



