### PR TITLE
fix: Don't break expenses URL when selecting page number

### DIFF
--- a/components/Pagination.js
+++ b/components/Pagination.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';
 import { FormattedMessage } from 'react-intl';
 
+import { mapRouteToURL } from '../lib/routes-utils';
+
 import Container from './Container';
 import { Flex } from './Grid';
 import Link from './Link';
@@ -30,7 +32,8 @@ const Pagination = ({ route, limit, offset, total, scrollToTopOnChange, isDisabl
     }
 
     const { pathname, query } = router;
-    await router.push({ pathname, query: { ...query, offset: (value - 1) * limit } });
+    const pushedRoute = { pathname, query: { ...query, offset: (value - 1) * limit } };
+    await router.push(pushedRoute, mapRouteToURL(pushedRoute));
 
     if (scrollToTopOnChange) {
       window.scrollTo(0, 0);

--- a/lib/routes-utils.js
+++ b/lib/routes-utils.js
@@ -1,0 +1,12 @@
+export const mapRouteToURL = routeObj => {
+  if (routeObj.pathname === undefined) {
+    return null;
+  } else if (routeObj.pathname === '/expenses') {
+    const { collectiveSlug, ...queryURL } = routeObj.query;
+    const queryURLstr = new URLSearchParams(queryURL).toString();
+
+    return `${collectiveSlug}/expenses?${queryURLstr}`;
+  } else {
+    return null;
+  }
+};


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Fixes https://github.com/opencollective/opencollective/issues/3914

# Description
Noticed that `Router.pushRoute()` has exactly the behaviour needed here so I've used that instead of `router.push()`.
From what I could tell this fixes the issue without breaking anything. 

Let me know if there's anything else that needs to be done. 
