### PR TITLE
StyledModal: Don't use focus trap if nothing to focus

### DIFF
--- a/components/AddPrepaidBudgetModal.js
+++ b/components/AddPrepaidBudgetModal.js
@@ -39,7 +39,7 @@ const AddPrepaidBudgetModal = ({ LoggedInUser, show, setShow, collective, host }
   }
 
   return (
-    <StyledModal show={show} onClose={close}>
+    <StyledModal show={show} onClose={close} trapFocus>
       <ModalBody>
         <Flex flexDirection="column">
           <Box>

--- a/components/ConfirmationModal.js
+++ b/components/ConfirmationModal.js
@@ -52,7 +52,7 @@ const ConfirmationModal = ({
   const { formatMessage } = useIntl();
 
   return (
-    <Modal role="alertdialog" width="570px" show={show} onClose={onClose} {...props}>
+    <Modal role="alertdialog" width="570px" show={show} onClose={onClose} trapFocus {...props}>
       <ModalHeader onClose={onClose}>{header}</ModalHeader>
       <ModalBody pt={2}>{children || <P>{body}</P>}</ModalBody>
       <ModalFooter>

--- a/components/FilesPreviewModal.js
+++ b/components/FilesPreviewModal.js
@@ -93,7 +93,7 @@ export default class FilesPreviewModal extends React.Component {
     const hasMultipleFiles = nbFiles > 1;
 
     return (
-      <StyledModal {...props} width="100%" maxWidth={450}>
+      <StyledModal {...props} width="100%" maxWidth={450} trapFocus={false}>
         <ModalHeader mb={3}>
           <FormattedMessage id="FilesPreviewModal.AttachmentPreview" defaultMessage="Attachment preview" />
         </ModalHeader>

--- a/components/StyledModal.js
+++ b/components/StyledModal.js
@@ -175,7 +175,9 @@ ModalFooter.defaultProps = {
  * Modal component. Will pass down additional props to `ModalWrapper`, which is
  * a styled `Container`.
  */
-const StyledModal = ({ children, show, onClose, usePortal, ...props }) => {
+const StyledModal = ({ children, show, onClose, usePortal, trapFocus, ...props }) => {
+  const TrapContainer = trapFocus ? FocusTrap : React.Fragment;
+
   // Closes the modal upon the `ESC` key press.
   useKeyBoardShortcut({ callback: () => onClose(), keyMatch: ESCAPE_KEY });
 
@@ -184,7 +186,7 @@ const StyledModal = ({ children, show, onClose, usePortal, ...props }) => {
       <React.Fragment>
         <GlobalModalStyle />
         <Wrapper>
-          <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }}>
+          <TrapContainer focusTrapOptions={{ clickOutsideDeactivates: true }}>
             <Modal {...props}>
               {React.Children.map(children, child => {
                 if (child.type.displayName === 'Header') {
@@ -193,7 +195,7 @@ const StyledModal = ({ children, show, onClose, usePortal, ...props }) => {
                 return child;
               })}
             </Modal>
-          </FocusTrap>
+          </TrapContainer>
         </Wrapper>
       </React.Fragment>
     );
@@ -203,7 +205,7 @@ const StyledModal = ({ children, show, onClose, usePortal, ...props }) => {
       <React.Fragment>
         <GlobalModalStyle />
         <Wrapper>
-          <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }}>
+          <TrapContainer focusTrapOptions={{ clickOutsideDeactivates: true }}>
             <Modal {...props}>
               {React.Children.map(children, child => {
                 if (child.type?.displayName === 'Header') {
@@ -212,7 +214,7 @@ const StyledModal = ({ children, show, onClose, usePortal, ...props }) => {
                 return child;
               })}
             </Modal>
-          </FocusTrap>
+          </TrapContainer>
           <ModalOverlay onClick={onClose} />
         </Wrapper>
       </React.Fragment>,
@@ -242,6 +244,8 @@ StyledModal.propTypes = {
   onClose: PropTypes.func.isRequired,
   /** wether to render the modal at the root with a potal */
   usePortal: PropTypes.bool,
+  /** set this to true if the modal contains a form or buttons */
+  trapFocus: PropTypes.bool,
   /** children */
   children: PropTypes.node,
 };

--- a/components/expenses/ExpenseModal.js
+++ b/components/expenses/ExpenseModal.js
@@ -43,6 +43,7 @@ const ExpenseModal = ({ expense, onDelete, onProcess, onClose, show }) => {
       position="relative"
       padding={0}
       overflowY="hidden"
+      trapFocus={!loading}
     >
       <ModalBody maxHeight="calc(80vh - 80px)" overflowY="auto" mb={80} p={20}>
         <ExpenseSummary

--- a/components/expenses/PayExpenseModal.js
+++ b/components/expenses/PayExpenseModal.js
@@ -119,7 +119,15 @@ const PayExpenseModal = ({ onClose, onSubmit, expense, collective, host, LoggedI
   const payoutMethodLabel = getPayoutLabel(intl, payoutMethodType);
 
   return (
-    <StyledModal show onClose={onClose} width="100%" minWidth={280} maxWidth={334} data-cy="pay-expense-modal">
+    <StyledModal
+      show
+      onClose={onClose}
+      width="100%"
+      minWidth={280}
+      maxWidth={334}
+      data-cy="pay-expense-modal"
+      trapFocus
+    >
       <ModalHeader>
         <H4 fontSize="20px" fontWeight="700">
           <FormattedMessage id="PayExpenseTitle" defaultMessage="Pay expense" />

--- a/components/host-dashboard/AddFundsModal.js
+++ b/components/host-dashboard/AddFundsModal.js
@@ -113,7 +113,7 @@ const AddFundsModal = ({ host, collective, ...props }) => {
   }
 
   return (
-    <StyledModal width="100%" maxWidth={435} {...props}>
+    <StyledModal width="100%" maxWidth={435} {...props} trapFocus>
       <CollectiveModalHeader collective={collective} />
       <Formik
         initialValues={getInitialValues({ hostFeePercent: defaultHostFeePercent, account: collective })}

--- a/components/host-dashboard/CollectiveFeesStructureModal.js
+++ b/components/host-dashboard/CollectiveFeesStructureModal.js
@@ -60,7 +60,7 @@ const CollectiveFeesStructureModal = ({ host, collective, ...props }) => {
   });
 
   return (
-    <StyledModal show maxWidth={432} {...props}>
+    <StyledModal show maxWidth={432} trapFocus {...props}>
       <CollectiveModalHeader collective={collective} mb={3} />
       <ModalBody>
         <P fontSize="16px" lineHeight="24px" fontWeight="500" mb={2}>


### PR DESCRIPTION
`react-trap-focus` crashes if nothing inside of it is focusable, which is unfortunately the case of the expense modal when it's loading (we only show the buttons and links once the expense has been loaded). This PR fixes that by adding a `focusTrap` prop on `StyledModal` to selectively activate the trap. I've also reviewed the other modals to make sure all of theme are covered.