### PR TITLE
StyledInput: Fix min-height on Firefox

### DIFF
--- a/components/StyledInput.js
+++ b/components/StyledInput.js
@@ -25,6 +25,8 @@ const getBorderColor = ({ error, success }) => {
  * @see See [styled-system docs](https://github.com/jxnblk/styled-system/blob/master/docs/api.md) for usage of those props
  */
 const StyledInput = styled.input`
+  min-height: 36px;
+
   ${background}
   ${border}
   ${color}


### PR DESCRIPTION
Fix an issue on Firefox where inputs appeared shrink. 