### PR TITLE
Responsive address form that changes by country

### DIFF
--- a/components/I18nAddressFields.js
+++ b/components/I18nAddressFields.js
@@ -1,0 +1,259 @@
+/** This component aims to create a responsive address form based on the user's country that they select.
+ * Shopify has a good article about internationalising address forms: https://ux.shopify.com/designing-address-forms-for-everyone-everywhere-f481f6baf513
+ * And they also have an API and npm package to tell you what address fields a country uses, and in what order https://github.com/Shopify/quilt/tree/master/packages/address
+ * Additional material:
+ * Shopify API country codes ("ISO 3166-1 alpha-2 country codes with some differences"): https://shopify.dev/docs/admin-api/graphql/reference/common-objects/countrycode
+ * Shopify locale code uses ISO locale codes: https://shopify.dev/docs/admin-api/graphql/reference/translations/locale
+ * How Etsy Localizes addresses https://codeascraft.com/2018/09/26/how-etsy-localizes-addresses/
+ * Form i18n techniques https://medium.com/flexport-design/form-internationalization-techniques-3e4d394cd7e5 */
+
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import AddressFormatter from '@shopify/address';
+import { get, isEmpty, isUndefined, orderBy, pick, truncate } from 'lodash';
+import { useIntl } from 'react-intl';
+
+import LoadingPlaceholder from './LoadingPlaceholder';
+import StyledInput from './StyledInput';
+import StyledInputField from './StyledInputField';
+import StyledSelect from './StyledSelect';
+import StyledTextarea from './StyledTextarea';
+
+/** Constants */
+
+/** Countries present in InputTypeCountry dropdown but not Shopify's API.
+ * All except Antarctica (AQ) are U.S. territories and use that address format.
+ * The Shopify default address format is also U.S. format therefore for all
+ * of these we use the U.S. default.
+ * All language codes in locales.js are supported by the Shopify API 👍
+ */
+const missingCountries = ['AS', 'AQ', 'GU', 'MH', 'FM', 'MP', 'PW', 'PR', 'VI'];
+const addressFormatter = new AddressFormatter('EN');
+
+const wrangleAddressData = addressInfo => {
+  if (typeof addressInfo !== 'object') {
+    return addressInfo;
+  }
+  const formLayout = addressInfo.formatting.edit;
+  const necessaryFields = ['address1', 'address2', 'city', 'zip', 'province'];
+
+  // Get form fields in correct order for the chosen country
+  const matches = formLayout.match(/([A-Za-z])\w+/g).filter(match => necessaryFields.includes(match));
+
+  // Change field names to match https://github.com/Shopify/quilt/blob/master/packages/address/src/utilities.ts
+  const mappedMatches = matches.map(match => {
+    if (match === 'zip') {
+      return 'postalCode';
+    } else if (match === 'province') {
+      return 'zone';
+    } else {
+      return match;
+    }
+  });
+
+  const addressFormFields = Object.entries(addressInfo.labels)
+    .filter(entry => mappedMatches.includes(entry[0]))
+    .sort((a, b) => {
+      return mappedMatches.indexOf(a[0]) - mappedMatches.indexOf(b[0]);
+    });
+
+  // Check if we need to render drop-down list of "zones" (i.e. provinces, states, etc.)
+  const zones = get(addressInfo, 'zones', []);
+  if (mappedMatches.includes('zone') && !isEmpty(zones)) {
+    const zoneIndex = addressFormFields.find(idx => idx[0] === 'zone');
+    zoneIndex.push(addressInfo.zones);
+  }
+
+  return addressFormFields;
+};
+
+/** Checks if the key from labels is also present in optionalLabels */
+const isFieldOptional = (addressInfo, fieldName) => {
+  return !Object.keys(addressInfo.optionalLabels).includes(fieldName);
+};
+
+/** Generates zone/province/state options for select */
+const getZoneLabel = zone => {
+  return `${truncate(zone.name, { length: 30 })} - ${zone.code}`;
+};
+
+const getZoneSelectOptions = zonesInfo => {
+  if (!zonesInfo) {
+    return null;
+  }
+  const zonesArray = zonesInfo[2];
+  const options = zonesArray.map(zone => ({
+    value: zone.name,
+    label: getZoneLabel(zone),
+  }));
+
+  return orderBy(options, 'label');
+};
+
+/** Upon changing selectedCountry, if previous address fields are no longer needed,
+ * it clears them i.e. changing from Canada to Germany in the Expense form we no
+ * longer need 'zone' in our payeeLocation.address object.
+ */
+const getAddressFieldDifferences = (formAddressValues, addressFields) => {
+  const addressFieldsArray = addressFields.map(field => field[0]);
+  const differenceInAddressFields = !isEmpty(
+    Object.keys(formAddressValues).filter(key => !addressFieldsArray.includes(key)),
+  );
+  if (differenceInAddressFields) {
+    return pick(formAddressValues, addressFieldsArray);
+  } else {
+    return null;
+  }
+};
+
+/** Controlled component to be used in forms that require addresses that need some validation
+ * i.e. Expenses and Contributions. Can be used with or without Formik.
+ * See PropTypes info for differing props based on Formik vs. non-Formik.*/
+const I18nAddressFields = ({ selectedCountry, value, onChange, onCountryChange }) => {
+  const intl = useIntl();
+  const locale = intl.locale;
+
+  /** Pass user's chosen locale to AddressFormatter if present. */
+  React.useEffect(() => {
+    if (intl.locale) {
+      addressFormatter.updateLocale(intl.locale);
+    }
+  }, [locale]);
+
+  /** If country chosen from InputTypeCountry is one of missingCountries, use 'US' instead */
+  const country = missingCountries.includes(selectedCountry) ? 'US' : selectedCountry;
+
+  /** Prepare the address form data */
+  const [data, setData] = React.useState(null);
+  const [fields, setFields] = React.useState(null);
+  const [loading, setLoading] = React.useState(true);
+
+  const zoneOptions = React.useMemo(() => {
+    if (!fields) {
+      return null;
+    }
+    const zoneFields = fields.find(field => field[0] === 'zone');
+    // If there are no zone fields for the country, return
+    if (isUndefined(zoneFields)) {
+      return null;
+    }
+    const zoneSelectOptions = getZoneSelectOptions(zoneFields);
+    const formValueZone = get(value, 'zone', undefined);
+    // If there are previous form values for zone, and they're from a different
+    // country, we need to clear these.
+    if (!isUndefined(formValueZone)) {
+      const isZoneFromDifferentCountry = isUndefined(
+        zoneSelectOptions.find(option => option.value === formValueZone.value),
+      );
+      if (isZoneFromDifferentCountry) {
+        onChange({ name: 'zone', value: null });
+      }
+    }
+    return zoneSelectOptions;
+  }, [fields]);
+
+  React.useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await addressFormatter.getCountry(country);
+        setData(pick(response, ['formatting', 'labels', 'optionalLabels', 'zones']));
+        const countryInfo = pick(response, ['formatting', 'labels', 'optionalLabels', 'zones']);
+        const addressFields = wrangleAddressData(countryInfo);
+        setFields(addressFields);
+        onCountryChange(getAddressFieldDifferences(value, addressFields));
+      } catch (e) {
+        console.warn('Call to Shopify API failed. Falling back to plain address form. Error: ', e.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [selectedCountry]);
+
+  if (loading) {
+    return <LoadingPlaceholder width="100%" height={163} mt={3} />;
+  }
+
+  // If the call to Shopify fails, fallback to the free text address field
+  if (!loading && (!data || !fields)) {
+    return (
+      <StyledInputField name="payeeLocation.address" label="address" labelFontSize="13px" required mt={3}>
+        {inputProps => (
+          <StyledTextarea
+            {...inputProps}
+            data-cy="payee-address"
+            onChange={e => {
+              onChange(e.target);
+            }}
+            value={typeof value === 'object' ? JSON.stringify(value) : value}
+            minHeight={100}
+            placeholder="P. Sherman 42&#10;Wallaby Way&#10;Sydney"
+          />
+        )}
+      </StyledInputField>
+    );
+  }
+
+  return (
+    <Fragment>
+      {fields.map(addressField => (
+        <Fragment key={addressField[0]}>
+          {addressField[0] === 'zone' ? (
+            <StyledInputField
+              name={addressField[0]}
+              label={addressField[1]}
+              labelFontSize="13px"
+              mt={3}
+              required={isFieldOptional(data, addressField[0])}
+            >
+              {({ id, name }) => (
+                <StyledSelect
+                  name={name}
+                  inputId={id}
+                  minWidth={150}
+                  options={zoneOptions}
+                  placeholder={`Please select your ${addressField[1]}`}
+                  onChange={e => {
+                    onChange({ name, value: e });
+                  }}
+                  value={value[addressField[0]]}
+                />
+              )}
+            </StyledInputField>
+          ) : (
+            <StyledInputField
+              name={addressField[0]}
+              label={addressField[1]}
+              labelFontSize="13px"
+              mt={3}
+              required={isFieldOptional(data, addressField[0])}
+            >
+              {inputProps => (
+                <StyledInput
+                  {...inputProps}
+                  data-cy={`payee-address-${addressField[0]}`}
+                  onChange={e => {
+                    onChange(e.target);
+                  }}
+                  value={value[addressField[0]]}
+                />
+              )}
+            </StyledInputField>
+          )}
+        </Fragment>
+      ))}
+    </Fragment>
+  );
+};
+
+I18nAddressFields.propTypes = {
+  /** ISO country code passed down from ExpenseFormPayeeStep. */
+  selectedCountry: PropTypes.string.isRequired,
+  /** String if using old address textarea; object if using new address fields. */
+  value: PropTypes.oneOf([PropTypes.object, PropTypes.string]).isRequired,
+  onChange: PropTypes.func.isRequired,
+  onCountryChange: PropTypes.func.isRequired,
+};
+
+export default I18nAddressFields;

--- a/components/LocationAddress.js
+++ b/components/LocationAddress.js
@@ -5,6 +5,17 @@ import { FormattedMessage } from 'react-intl';
 import LoadingPlaceholder from './LoadingPlaceholder';
 import { Span } from './Text';
 
+/** If using I18nAddressFields component, address will be stringified JSON */
+const isAddressJson = address => {
+  let addressObject;
+  try {
+    addressObject = JSON.parse(address);
+  } catch (e) {
+    return false;
+  }
+  return addressObject;
+};
+
 /**
  * Displays a location object
  */
@@ -25,9 +36,22 @@ const LocationAddress = ({ location, isLoading, showMessageIfEmpty }) => {
     );
   }
 
+  const addressJSON = isAddressJson(location.address);
+
   return (
     <React.Fragment>
-      {location.address}
+      {addressJSON ? (
+        <React.Fragment>
+          {Object.entries(addressJSON).map(([addressLineKey, addressLineValue], idx) => (
+            <React.Fragment key={addressLineKey}>
+              {idx !== 0 && <br />}
+              {addressLineValue}
+            </React.Fragment>
+          ))}
+        </React.Fragment>
+      ) : (
+        <React.Fragment>{location.address}</React.Fragment>
+      )}
       {location.address && location.country && <br />}
       {location.country}
     </React.Fragment>

--- a/components/LocationAddress.js
+++ b/components/LocationAddress.js
@@ -5,17 +5,6 @@ import { FormattedMessage } from 'react-intl';
 import LoadingPlaceholder from './LoadingPlaceholder';
 import { Span } from './Text';
 
-/** If using I18nAddressFields component, address will be stringified JSON */
-const isAddressJson = address => {
-  let addressObject;
-  try {
-    addressObject = JSON.parse(address);
-  } catch (e) {
-    return false;
-  }
-  return addressObject;
-};
-
 /**
  * Displays a location object
  */
@@ -36,23 +25,10 @@ const LocationAddress = ({ location, isLoading, showMessageIfEmpty }) => {
     );
   }
 
-  const addressJSON = isAddressJson(location.address);
-
   return (
     <React.Fragment>
-      {addressJSON ? (
-        <React.Fragment>
-          {Object.entries(addressJSON).map(([addressLineKey, addressLineValue], idx) => (
-            <React.Fragment key={addressLineKey}>
-              {idx !== 0 && <br />}
-              {addressLineValue}
-            </React.Fragment>
-          ))}
-        </React.Fragment>
-      ) : (
-        <React.Fragment>{location.address}</React.Fragment>
-      )}
-      {location.address && location.country && <br />}
+      {location.address}
+      <br />
       {location.country}
     </React.Fragment>
   );

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -106,11 +106,14 @@ export const prepareExpenseForSubmit = expenseData => {
     expenseData.payee?.isNewUser || expenseData.payee?.isInvite
       ? pick(expenseData.payee, ['name', 'email', 'organization', 'newsletterOptIn'])
       : { [payeeIdField]: expenseData.payee.id };
+
+  const payeeLocation = isInvoice ? pick(expenseData.payeeLocation, ['address', 'country', 'structured']) : null;
+
   return {
     ...pick(expenseData, ['id', 'description', 'longDescription', 'type', 'privateMessage', 'invoiceInfo', 'tags']),
     payee,
+    payeeLocation,
     payoutMethod: pick(expenseData.payoutMethod, ['id', 'name', 'data', 'isSaved', 'type']),
-    payeeLocation: isInvoice ? pick(expenseData.payeeLocation, ['address', 'country']) : null,
     attachedFiles: isInvoice ? expenseData.attachedFiles?.map(file => pick(file, ['id', 'url'])) : [],
     // Omit item's ids that were created for keying purposes
     items: expenseData.items.map(item => {
@@ -162,6 +165,7 @@ const validate = expense => {
 const setLocationFromPayee = (formik, payee) => {
   formik.setFieldValue('payeeLocation.country', payee.location.country || null);
   formik.setFieldValue('payeeLocation.address', payee.location.address || '');
+  formik.setFieldValue('payeeLocation.structured', payee.location.structured);
 };
 
 const HiddenFragment = styled.div`
@@ -310,9 +314,6 @@ const ExpenseFormBody = ({
                 loggedInAccount={loggedInAccount}
                 onNext={() => {
                   const validation = validatePayoutMethod(values.payoutMethod);
-                  if (typeof values.payeeLocation.address === 'object') {
-                    values.payeeLocation.address = JSON.stringify(values.payeeLocation.address);
-                  }
                   if (isEmpty(validation)) {
                     setStep(STEPS.EXPENSE);
                   } else {

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -310,6 +310,9 @@ const ExpenseFormBody = ({
                 loggedInAccount={loggedInAccount}
                 onNext={() => {
                   const validation = validatePayoutMethod(values.payoutMethod);
+                  if (typeof values.payeeLocation.address === 'object') {
+                    values.payeeLocation.address = JSON.stringify(values.payeeLocation.address);
+                  }
                   if (isEmpty(validation)) {
                     setStep(STEPS.EXPENSE);
                   } else {

--- a/components/expenses/ExpenseFormPayeeSignUpStep.js
+++ b/components/expenses/ExpenseFormPayeeSignUpStep.js
@@ -15,6 +15,7 @@ import { formatFormErrorMessage } from '../../lib/form-utils';
 import { flattenObjectDeep } from '../../lib/utils';
 
 import { Box, Flex, Grid } from '../Grid';
+import I18nAddressFields, { serializeAddress } from '../I18nAddressFields';
 import InputTypeCountry from '../InputTypeCountry';
 import LoginBtn from '../LoginBtn';
 import StyledButton from '../StyledButton';
@@ -355,28 +356,31 @@ const ExpenseFormPayeeSignUpStep = ({ formik, payoutProfiles, collective, onCanc
             </StyledInputField>
           )}
         </Field>
-        <FastField name="payeeLocation.address">
-          {({ field }) => (
-            <StyledInputField
-              name={field.name}
-              label={formatMessage(msg.address)}
-              labelFontSize="13px"
-              error={formatFormErrorMessage(intl, errors.payeeLocation?.address)}
-              required
-              mt={3}
-            >
-              {inputProps => (
-                <StyledTextarea
-                  {...inputProps}
-                  {...field}
-                  minHeight={100}
-                  data-cy="payee-address"
-                  placeholder="P. Sherman 42&#10;Wallaby Way&#10;Sydney"
-                />
-              )}
-            </StyledInputField>
-          )}
-        </FastField>
+        <Box>
+          <Field name="payeeLocation.structured">
+            {({ field }) => (
+              <I18nAddressFields
+                name={field.name}
+                selectedCountry={values.payeeLocation?.country}
+                value={field.value || {}}
+                onChange={({ name, value }) => {
+                  const address = {
+                    ...(formik.values.payeeLocation?.structured || {}),
+                    [name]: value,
+                  };
+
+                  formik.setFieldValue('payeeLocation.structured', address);
+                  formik.setFieldValue('payeeLocation.address', serializeAddress(address));
+                }}
+                onCountryChange={addressObject => {
+                  if (addressObject) {
+                    formik.setFieldValue('payeeLocation.structured', addressObject);
+                  }
+                }}
+              />
+            )}
+          </Field>
+        </Box>
         <FastField name="invoiceInfo">
           {({ field }) => (
             <StyledInputField

--- a/components/expenses/ExpenseFormPayeeStep.js
+++ b/components/expenses/ExpenseFormPayeeStep.js
@@ -18,6 +18,7 @@ import CollectivePicker, {
 } from '../CollectivePicker';
 import CollectivePickerAsync from '../CollectivePickerAsync';
 import { Box, Flex } from '../Grid';
+import I18nAddressFields from '../I18nAddressFields';
 import InputTypeCountry from '../InputTypeCountry';
 import StyledButton from '../StyledButton';
 import StyledHr from '../StyledHr';
@@ -237,7 +238,9 @@ const ExpenseFormPayeeStep = ({
                       <InputTypeCountry
                         data-cy="payee-country"
                         inputId={id}
-                        onChange={value => formik.setFieldValue(field.name, value)}
+                        onChange={value => {
+                          formik.setFieldValue(field.name, value);
+                        }}
                         value={field.value}
                         error={error}
                       />
@@ -245,28 +248,41 @@ const ExpenseFormPayeeStep = ({
                   </StyledInputField>
                 )}
               </FastField>
-              <FastField name="payeeLocation.address">
+              <Field name="payeeLocation.address">
                 {({ field }) => (
-                  <StyledInputField
-                    name={field.name}
-                    label={formatMessage(msg.address)}
-                    labelFontSize="13px"
-                    error={formatFormErrorMessage(intl, errors.payeeLocation?.address)}
-                    required
-                    mt={3}
-                  >
-                    {inputProps => (
-                      <StyledTextarea
-                        {...inputProps}
-                        {...field}
-                        minHeight={100}
-                        data-cy="payee-address"
-                        placeholder="P. Sherman 42&#10;Wallaby Way&#10;Sydney"
-                      />
-                    )}
-                  </StyledInputField>
+                  <I18nAddressFields
+                    selectedCountry={values.payeeLocation?.country}
+                    value={field.value}
+                    onChange={({ name, value }) => {
+                      // If name === field.name we are using fallback textarea,
+                      // so we set payeeLocation.address directly
+                      if (name === field.name) {
+                        formik.setFieldValue(field.name, value);
+                      }
+                      // Otherwise we are setting multiple address fields.
+                      // However, if payeeLocation.address is a string coming
+                      // from the old single address field, we don't want to
+                      // use the spread iterator.
+                      else {
+                        formik.setFieldValue(
+                          'payeeLocation.address',
+                          typeof formik.values.payeeLocation.address === 'object'
+                            ? {
+                                ...formik.values.payeeLocation.address,
+                                [name]: value,
+                              }
+                            : { [name]: value },
+                        );
+                      }
+                    }}
+                    onCountryChange={addressObject => {
+                      if (addressObject) {
+                        formik.setFieldValue('payeeLocation.address', addressObject);
+                      }
+                    }}
+                  />
                 )}
-              </FastField>
+              </Field>
               <FastField name="invoiceInfo">
                 {({ field }) => (
                   <StyledInputField

--- a/components/expenses/ExpenseFormPayeeStep.js
+++ b/components/expenses/ExpenseFormPayeeStep.js
@@ -18,7 +18,7 @@ import CollectivePicker, {
 } from '../CollectivePicker';
 import CollectivePickerAsync from '../CollectivePickerAsync';
 import { Box, Flex } from '../Grid';
-import I18nAddressFields from '../I18nAddressFields';
+import I18nAddressFields, { serializeAddress } from '../I18nAddressFields';
 import InputTypeCountry from '../InputTypeCountry';
 import StyledButton from '../StyledButton';
 import StyledHr from '../StyledHr';
@@ -60,6 +60,7 @@ const EMPTY_ARRAY = [];
 const setLocationFromPayee = (formik, payee) => {
   formik.setFieldValue('payeeLocation.country', payee?.location?.country || null);
   formik.setFieldValue('payeeLocation.address', payee?.location?.address || '');
+  formik.setFieldValue('payeeLocation.structured', payee?.location?.structured);
 };
 
 const getPayoutMethodsFromPayee = payee => {
@@ -248,41 +249,47 @@ const ExpenseFormPayeeStep = ({
                   </StyledInputField>
                 )}
               </FastField>
-              <Field name="payeeLocation.address">
-                {({ field }) => (
-                  <I18nAddressFields
-                    selectedCountry={values.payeeLocation?.country}
-                    value={field.value}
-                    onChange={({ name, value }) => {
-                      // If name === field.name we are using fallback textarea,
-                      // so we set payeeLocation.address directly
-                      if (name === field.name) {
-                        formik.setFieldValue(field.name, value);
-                      }
-                      // Otherwise we are setting multiple address fields.
-                      // However, if payeeLocation.address is a string coming
-                      // from the old single address field, we don't want to
-                      // use the spread iterator.
-                      else {
-                        formik.setFieldValue(
-                          'payeeLocation.address',
-                          typeof formik.values.payeeLocation.address === 'object'
-                            ? {
-                                ...formik.values.payeeLocation.address,
-                                [name]: value,
-                              }
-                            : { [name]: value },
-                        );
-                      }
-                    }}
-                    onCountryChange={addressObject => {
-                      if (addressObject) {
-                        formik.setFieldValue('payeeLocation.address', addressObject);
-                      }
-                    }}
-                  />
-                )}
-              </Field>
+              {values.payeeLocation.structured || values.payeeLocation.address === '' ? (
+                <Field name="payeeLocation.structured">
+                  {({ field }) => (
+                    <I18nAddressFields
+                      name={field.name}
+                      selectedCountry={values.payeeLocation?.country}
+                      value={field.value || {}}
+                      onChange={({ name, value }) => {
+                        const address = {
+                          ...(formik.values.payeeLocation?.structured || {}),
+                          [name]: value,
+                        };
+
+                        formik.setFieldValue('payeeLocation.structured', address);
+                        formik.setFieldValue('payeeLocation.address', serializeAddress(address));
+                      }}
+                      onCountryChange={addressObject => {
+                        if (addressObject) {
+                          formik.setFieldValue('payeeLocation.structured', addressObject);
+                        }
+                      }}
+                    />
+                  )}
+                </Field>
+              ) : (
+                <FastField name="payeeLocation.address">
+                  {({ field }) => (
+                    <StyledInputField name={field.name} label="Address" labelFontSize="13px" required mt={3}>
+                      {inputProps => (
+                        <StyledTextarea
+                          {...inputProps}
+                          {...field}
+                          data-cy="payee-address"
+                          minHeight={100}
+                          placeholder="P. Sherman 42&#10;Wallaby Way&#10;Sydney"
+                        />
+                      )}
+                    </StyledInputField>
+                  )}
+                </FastField>
+              )}
               <FastField name="invoiceInfo">
                 {({ field }) => (
                   <StyledInputField

--- a/components/expenses/graphql/fragments.js
+++ b/components/expenses/graphql/fragments.js
@@ -12,6 +12,7 @@ export const loggedInAccountExpensePayoutFieldsFragment = gqlV2/* GraphQL */ `
     location {
       address
       country
+      structured
     }
     payoutMethods {
       id
@@ -47,6 +48,7 @@ export const loggedInAccountExpensePayoutFieldsFragment = gqlV2/* GraphQL */ `
           location {
             address
             country
+            structured
           }
           payoutMethods {
             id
@@ -146,6 +148,7 @@ export const expensePageExpenseFieldsFragment = gqlV2/* GraphQL */ `
     payeeLocation {
       address
       country
+      structured
     }
     createdByAccount {
       id

--- a/lib/graphql/schema.graphql
+++ b/lib/graphql/schema.graphql
@@ -251,12 +251,6 @@ type Collective implements CollectiveInterface {
     includeInactive: Boolean = false
   ): [Event]
   projects(limit: Int, offset: Int): [Project]
-
-  """
-  Get all child collectives (with type=COLLECTIVE, doesn't return events)
-  """
-  childCollectives: [Collective]
-    @deprecated(reason: "2020/01/08 - Connected-collectives are now handled through members")
   paymentMethods(
     service: String
     limit: Int
@@ -264,11 +258,6 @@ type Collective implements CollectiveInterface {
     isConfirmed: Boolean = true
     types: [String]
     orderBy: PaymenMethodOrderField = type
-
-    """
-    Defines if the organization "collective" payment method should be returned
-    """
-    includeOrganizationCollectivePaymentMethod: Boolean = false
 
     """
     Defines if the host "collective" payment method should be returned
@@ -284,26 +273,7 @@ type Collective implements CollectiveInterface {
   """
   List all the gift cards batches emitted by this collective. May include `null` for unbatched gift cards.
   """
-  virtualCardsBatches: [PaymentMethodBatchInfo] @deprecated(reason: "2020-02-05: Use giftCardsBatches")
-
-  """
-  List all the gift cards batches emitted by this collective. May include `null` for unbatched gift cards.
-  """
   giftCardsBatches: [PaymentMethodBatchInfo]
-
-  """
-  Get the gift cards created by this collective. RemoteUser must be a collective admin.
-  """
-  createdVirtualCards(
-    limit: Int
-    offset: Int
-    batch: String
-
-    """
-    Wether the gift card has been claimed or not
-    """
-    isConfirmed: Boolean
-  ): PaginatedPaymentMethod @deprecated(reason: "2020-02-05: Use createdGiftCards")
 
   """
   Get the gift cards created by this collective. RemoteUser must be a collective admin.
@@ -606,12 +576,6 @@ interface CollectiveInterface {
     includeInactive: Boolean = false
   ): [Event]
   projects(limit: Int, offset: Int): [Project]
-
-  """
-  Get all child collectives (with type=COLLECTIVE, doesn't return events)
-  """
-  childCollectives: [Collective]
-    @deprecated(reason: "2020/01/08 - Connected-collectives are now handled through members")
   paymentMethods(
     service: String
     limit: Int
@@ -633,11 +597,6 @@ interface CollectiveInterface {
     orderBy: PaymenMethodOrderField
 
     """
-    Defines if the organization "collective" payment method should be returned
-    """
-    includeOrganizationCollectivePaymentMethod: Boolean = false
-
-    """
     Defines if the host "collective" payment method should be returned
     """
     includeHostCollectivePaymentMethod: Boolean = false
@@ -651,22 +610,7 @@ interface CollectiveInterface {
   """
   List all the gift cards batches emitted by this collective. May include `null` as key for unbatched gift cards.
   """
-  virtualCardsBatches: [PaymentMethodBatchInfo] @deprecated(reason: "2021-02-08: Renamed to giftCardBatches")
-
-  """
-  List all the gift cards batches emitted by this collective. May include `null` as key for unbatched gift cards.
-  """
   giftCardsBatches: [PaymentMethodBatchInfo]
-  createdVirtualCards(
-    limit: Int
-    offset: Int
-    batch: String
-
-    """
-    Wether the gift card has been claimed or not
-    """
-    isConfirmed: Boolean
-  ): PaginatedPaymentMethod @deprecated(reason: "2021-02-08: Renamed to giftCardBatches")
   createdGiftCards(
     limit: Int
     offset: Int
@@ -844,7 +788,7 @@ type CollectiveStatsType {
   totalNetAmountReceived: Int
   yearlyBudget: Int
   yearlyBudgetManaged: Int
-  topFundingSources: JSON
+  topFundingSources: JSON @deprecated(reason: "2021-01-29: Not used anymore")
   activeRecurringContributions: JSON
 }
 
@@ -877,16 +821,6 @@ input CommentInputType {
 }
 
 """
-List of comments with pagination info
-"""
-type CommentListType {
-  comments: [CommentType]
-  limit: Int
-  offset: Int
-  total: Int
-}
-
-"""
 This represents a Comment
 """
 type CommentType {
@@ -894,7 +828,6 @@ type CommentType {
   createdAt: DateString
   updatedAt: DateString
   html: String
-  markdown: String @deprecated(reason: "2020-01-25: Use html")
   createdByUser: UserDetails
   fromCollective: CollectiveInterface
   collective: CollectiveInterface
@@ -1283,12 +1216,6 @@ type Event implements CollectiveInterface {
     includeInactive: Boolean = false
   ): [Event]
   projects(limit: Int, offset: Int): [Project]
-
-  """
-  Get all child collectives (with type=COLLECTIVE, doesn't return events)
-  """
-  childCollectives: [Collective]
-    @deprecated(reason: "2020/01/08 - Connected-collectives are now handled through members")
   paymentMethods(
     service: String
     limit: Int
@@ -1296,11 +1223,6 @@ type Event implements CollectiveInterface {
     isConfirmed: Boolean = true
     types: [String]
     orderBy: PaymenMethodOrderField = type
-
-    """
-    Defines if the organization "collective" payment method should be returned
-    """
-    includeOrganizationCollectivePaymentMethod: Boolean = false
 
     """
     Defines if the host "collective" payment method should be returned
@@ -1316,26 +1238,7 @@ type Event implements CollectiveInterface {
   """
   List all the gift cards batches emitted by this collective. May include `null` for unbatched gift cards.
   """
-  virtualCardsBatches: [PaymentMethodBatchInfo] @deprecated(reason: "2020-02-05: Use giftCardsBatches")
-
-  """
-  List all the gift cards batches emitted by this collective. May include `null` for unbatched gift cards.
-  """
   giftCardsBatches: [PaymentMethodBatchInfo]
-
-  """
-  Get the gift cards created by this collective. RemoteUser must be a collective admin.
-  """
-  createdVirtualCards(
-    limit: Int
-    offset: Int
-    batch: String
-
-    """
-    Wether the gift card has been claimed or not
-    """
-    isConfirmed: Boolean
-  ): PaginatedPaymentMethod @deprecated(reason: "2020-02-05: Use createdGiftCards")
 
   """
   Get the gift cards created by this collective. RemoteUser must be a collective admin.
@@ -1409,8 +1312,6 @@ type Expense implements Transaction {
   host: User
   createdByUser: UserDetails
   fromCollective: CollectiveInterface
-  usingVirtualCardFromCollective: CollectiveInterface
-    @deprecated(reason: "2021-02-08: Renamed to usingGiftCardFromCollective")
   usingGiftCardFromCollective: CollectiveInterface
   collective: CollectiveInterface
   createdAt: DateString
@@ -1682,12 +1583,6 @@ type Fund implements CollectiveInterface {
     includeInactive: Boolean = false
   ): [Event]
   projects(limit: Int, offset: Int): [Project]
-
-  """
-  Get all child collectives (with type=COLLECTIVE, doesn't return events)
-  """
-  childCollectives: [Collective]
-    @deprecated(reason: "2020/01/08 - Connected-collectives are now handled through members")
   paymentMethods(
     service: String
     limit: Int
@@ -1695,11 +1590,6 @@ type Fund implements CollectiveInterface {
     isConfirmed: Boolean = true
     types: [String]
     orderBy: PaymenMethodOrderField = type
-
-    """
-    Defines if the organization "collective" payment method should be returned
-    """
-    includeOrganizationCollectivePaymentMethod: Boolean = false
 
     """
     Defines if the host "collective" payment method should be returned
@@ -1715,26 +1605,7 @@ type Fund implements CollectiveInterface {
   """
   List all the gift cards batches emitted by this collective. May include `null` for unbatched gift cards.
   """
-  virtualCardsBatches: [PaymentMethodBatchInfo] @deprecated(reason: "2020-02-05: Use giftCardsBatches")
-
-  """
-  List all the gift cards batches emitted by this collective. May include `null` for unbatched gift cards.
-  """
   giftCardsBatches: [PaymentMethodBatchInfo]
-
-  """
-  Get the gift cards created by this collective. RemoteUser must be a collective admin.
-  """
-  createdVirtualCards(
-    limit: Int
-    offset: Int
-    batch: String
-
-    """
-    Wether the gift card has been claimed or not
-    """
-    isConfirmed: Boolean
-  ): PaginatedPaymentMethod @deprecated(reason: "2020-02-05: Use createdGiftCards")
 
   """
   Get the gift cards created by this collective. RemoteUser must be a collective admin.
@@ -1998,17 +1869,6 @@ type Mutation {
   editCollective(collective: CollectiveInputType!): CollectiveInterface
   deleteCollective(id: Int!): CollectiveInterface
   deleteUserCollective(id: Int!): CollectiveInterface
-
-  """
-  Approve a collective
-  """
-  approveCollective(id: Int!): CollectiveInterface @deprecated(reason: "2020-11-16: Please use API V2")
-
-  """
-  Reject a collective
-  """
-  rejectCollective(id: Int!, rejectionReason: String): CollectiveInterface
-    @deprecated(reason: "2020-11-16: Please use API V2")
   archiveCollective(id: Int!): CollectiveInterface
   unarchiveCollective(id: Int!): CollectiveInterface
   sendMessageToCollective(collectiveId: Int!, message: String!, subject: String): SendMessageToCollectiveResult
@@ -2068,8 +1928,8 @@ type Mutation {
     token: String!
   ): UserDetails
   editConnectedAccount(connectedAccount: ConnectedAccountInputType!): ConnectedAccountType
-  markOrderAsPaid(id: Int!): OrderType
-  markPendingOrderAsExpired(id: Int!): OrderType
+  markOrderAsPaid(id: Int!): OrderType @deprecated(reason: "2021-01-29: Not used anymore")
+  markPendingOrderAsExpired(id: Int!): OrderType @deprecated(reason: "2021-01-29: Not used anymore")
 
   """
   Update a single tier
@@ -2094,15 +1954,16 @@ type Mutation {
   createOrder(order: OrderInputType!): OrderType
     @deprecated(reason: "2020-10-13: This endpoint has been moved to GQLV2")
   confirmOrder(order: ConfirmOrderInputType!): OrderType
-  addFundsToCollective(order: OrderInputType!): OrderType
-  createUpdate(update: UpdateInputType!): UpdateType @deprecated(reason: "This endpoint has been moved to GQLV2")
-  editUpdate(update: UpdateAttributesInputType!): UpdateType
+  createUpdate(update: UpdateInputType!): UpdateType
+    @deprecated(reason: "2021-01-29: This endpoint has been moved to GQLV2")
+  editUpdate(update: UpdateAttributesInputType!): UpdateType @deprecated(reason: "2021-01-29: Not used anymore")
   publishUpdate(id: Int!, notificationAudience: UpdateAudienceTypeEnum!): UpdateType
-  unpublishUpdate(id: Int!): UpdateType
-  deleteUpdate(id: Int!): UpdateType
-  createComment(comment: CommentInputType!): CommentType
-  editComment(comment: CommentAttributesInputType!): CommentType
-  deleteComment(id: Int!): CommentType
+    @deprecated(reason: "2021-01-29: Not used anymore")
+  unpublishUpdate(id: Int!): UpdateType @deprecated(reason: "2021-01-29: Not used anymore")
+  deleteUpdate(id: Int!): UpdateType @deprecated(reason: "2021-01-29: Not used anymore")
+  createComment(comment: CommentInputType!): CommentType @deprecated(reason: "2021-01-29: Not used anymore")
+  editComment(comment: CommentAttributesInputType!): CommentType @deprecated(reason: "2021-01-29: Not used anymore")
+  deleteComment(id: Int!): CommentType @deprecated(reason: "2021-01-29: Not used anymore")
   refundTransaction(id: Int!): Transaction
   addFundsToOrg(totalAmount: Int!, CollectiveId: Int!, HostCollectiveId: Int!, description: String): PaymentMethodType
   createApplication(application: ApplicationInput!): Application
@@ -2122,7 +1983,7 @@ type Mutation {
     token: String!
     data: StripeCreditCardDataInputType!
     monthlyLimitPerMember: Int
-  ): PaymentMethodType
+  ): PaymentMethodType @deprecated(reason: "2021-01-29: Not used anymore")
 
   """
   Replace a payment method
@@ -2134,67 +1995,6 @@ type Mutation {
     token: String!
     data: StripeCreditCardDataInputType!
   ): PaymentMethodType
-  createVirtualCards(
-    CollectiveId: Int!
-    PaymentMethodId: Int
-
-    """
-    A list of emails to generate gift cards for (only if numberOfVirtualCards is not provided)
-    """
-    emails: [String]
-
-    """
-    Number of gift cards to generate (only if emails is not provided)
-    """
-    numberOfVirtualCards: Int
-
-    """
-    An optional currency. If not provided, will use the collective currency.
-    """
-    currency: String
-
-    """
-    The amount as an Integer with cents.
-    """
-    amount: Int
-
-    """
-    Batch name for the created gift cards.
-    """
-    batch: String
-    monthlyLimitPerMember: Int
-
-    """
-    Limit this payment method to make donations to collectives having those tags
-    """
-    limitedToTags: [String]
-
-    """
-    Limit this payment method to make donations to those collectives
-    """
-    limitedToCollectiveIds: [Int]
-
-    """
-    Limit this payment method to make donations to the collectives hosted by those hosts
-    """
-    limitedToHostCollectiveIds: [Int]
-
-    """
-    Set `limitedToHostCollectiveIds` to open-source collectives only
-    """
-    limitedToOpenSourceCollectives: Boolean
-
-    """
-    A custom message attached to the email that will be sent for this gift card
-    """
-    description: String
-
-    """
-    A custom message that will be sent in the invitation email
-    """
-    customMessage: String
-    expiryDate: String
-  ): [PaymentMethodType] @deprecated(reason: "2021-02-08: Renamed to createGiftCards")
   createGiftCards(
     CollectiveId: Int!
     PaymentMethodId: Int
@@ -2448,8 +2248,6 @@ type Order implements Transaction {
   host: User
   createdByUser: UserDetails
   fromCollective: CollectiveInterface
-  usingVirtualCardFromCollective: CollectiveInterface
-    @deprecated(reason: "2021-02-08: Renamed to usingGiftCardFromCollective")
   usingGiftCardFromCollective: CollectiveInterface
   collective: CollectiveInterface
   createdAt: DateString
@@ -2812,12 +2610,6 @@ type Organization implements CollectiveInterface {
     includeInactive: Boolean = false
   ): [Event]
   projects(limit: Int, offset: Int): [Project]
-
-  """
-  Get all child collectives (with type=COLLECTIVE, doesn't return events)
-  """
-  childCollectives: [Collective]
-    @deprecated(reason: "2020/01/08 - Connected-collectives are now handled through members")
   paymentMethods(
     service: String
     limit: Int
@@ -2825,11 +2617,6 @@ type Organization implements CollectiveInterface {
     isConfirmed: Boolean = true
     types: [String]
     orderBy: PaymenMethodOrderField = type
-
-    """
-    Defines if the organization "collective" payment method should be returned
-    """
-    includeOrganizationCollectivePaymentMethod: Boolean = false
 
     """
     Defines if the host "collective" payment method should be returned
@@ -2845,26 +2632,7 @@ type Organization implements CollectiveInterface {
   """
   List all the gift cards batches emitted by this collective. May include `null` for unbatched gift cards.
   """
-  virtualCardsBatches: [PaymentMethodBatchInfo] @deprecated(reason: "2020-02-05: Use giftCardsBatches")
-
-  """
-  List all the gift cards batches emitted by this collective. May include `null` for unbatched gift cards.
-  """
   giftCardsBatches: [PaymentMethodBatchInfo]
-
-  """
-  Get the gift cards created by this collective. RemoteUser must be a collective admin.
-  """
-  createdVirtualCards(
-    limit: Int
-    offset: Int
-    batch: String
-
-    """
-    Wether the gift card has been claimed or not
-    """
-    isConfirmed: Boolean
-  ): PaginatedPaymentMethod @deprecated(reason: "2020-02-05: Use createdGiftCards")
 
   """
   Get the gift cards created by this collective. RemoteUser must be a collective admin.
@@ -2978,7 +2746,6 @@ type PaymentMethodType {
   To group multiple payment methods. Used for Gift Cards
   """
   batch: String
-  SourcePaymentMethodId: Int @deprecated(reason: "2020-09-28: Not used")
   type: String
   data: JSON
   name: String
@@ -3230,12 +2997,6 @@ type Project implements CollectiveInterface {
     includeInactive: Boolean = false
   ): [Event]
   projects(limit: Int, offset: Int): [Project]
-
-  """
-  Get all child collectives (with type=COLLECTIVE, doesn't return events)
-  """
-  childCollectives: [Collective]
-    @deprecated(reason: "2020/01/08 - Connected-collectives are now handled through members")
   paymentMethods(
     service: String
     limit: Int
@@ -3243,11 +3004,6 @@ type Project implements CollectiveInterface {
     isConfirmed: Boolean = true
     types: [String]
     orderBy: PaymenMethodOrderField = type
-
-    """
-    Defines if the organization "collective" payment method should be returned
-    """
-    includeOrganizationCollectivePaymentMethod: Boolean = false
 
     """
     Defines if the host "collective" payment method should be returned
@@ -3263,26 +3019,7 @@ type Project implements CollectiveInterface {
   """
   List all the gift cards batches emitted by this collective. May include `null` for unbatched gift cards.
   """
-  virtualCardsBatches: [PaymentMethodBatchInfo] @deprecated(reason: "2020-02-05: Use giftCardsBatches")
-
-  """
-  List all the gift cards batches emitted by this collective. May include `null` for unbatched gift cards.
-  """
   giftCardsBatches: [PaymentMethodBatchInfo]
-
-  """
-  Get the gift cards created by this collective. RemoteUser must be a collective admin.
-  """
-  createdVirtualCards(
-    limit: Int
-    offset: Int
-    batch: String
-
-    """
-    Wether the gift card has been claimed or not
-    """
-    isConfirmed: Boolean
-  ): PaginatedPaymentMethod @deprecated(reason: "2020-02-05: Use createdGiftCards")
 
   """
   Get the gift cards created by this collective. RemoteUser must be a collective admin.
@@ -3324,14 +3061,8 @@ type Query {
   ): CollectiveInterface
   Tier(id: Int!): Tier
   LoggedInUser: UserDetails
-  AuthenticatedUser: CollectiveInterface
+  AuthenticatedUser: CollectiveInterface @deprecated(reason: "2021-01-29: Not used anymore")
   allInvoices(fromCollectiveSlug: String!): [InvoiceType]
-  Invoice(
-    """
-    Slug of the invoice. Format: :year:2digitMonth.:hostSlug.:fromCollectiveSlug
-    """
-    invoiceSlug: String!
-  ): InvoiceType @deprecated(reason: "2020-03-09: This field was deprecated after introducing InvoiceByDateRange")
   InvoiceByDateRange(
     """
     Like the Slug of the invoice but spilt out into parts and includes dateFrom
@@ -3382,9 +3113,8 @@ type Query {
     type: TransactionType
   ): PaginatedTransactions
   Update(collectiveSlug: String, updateSlug: String, id: Int): UpdateType
+    @deprecated(reason: "2021-01-29: Not used anymore")
   Application(id: Int): Application
-  allComments(ExpenseId: Int, UpdateId: Int, limit: Int, offset: Int): [UpdateType]
-    @deprecated(reason: "2020-11-17: [LegacyExpenseFlow] Please use API V2")
   allUpdates(CollectiveId: Int!, includeHostedCollectives: Boolean, limit: Int, offset: Int): [UpdateType]
   allOrders(
     CollectiveId: Int
@@ -3397,7 +3127,7 @@ type Query {
     status: String
     limit: Int
     offset: Int
-  ): [OrderType]
+  ): [OrderType] @deprecated(reason: "2021-01-29: Not used anymore")
   Transaction(id: Int, uuid: String): Transaction
   allCollectives(
     """
@@ -3481,8 +3211,6 @@ type Query {
     minNbCollectivesHosted: Int! = 0
   ): CollectiveSearchResults
   allCollectiveTags: [String]
-  member(id: Int, CollectiveId: Int, MemberCollectiveId: Int, TierId: Int): Member
-    @deprecated(reason: "2020-09-08: This endpoint does not seems to be used anymore")
   allMembers(
     CollectiveId: Int
     collectiveSlug: String
@@ -3574,8 +3302,8 @@ type Query {
     offset: Int
     dateFrom: String
     dateTo: String
-  ): [Transaction]
-  Order(id: Int!): OrderType
+  ): [Transaction] @deprecated(reason: "2021-01-29: Not used anymore")
+  Order(id: Int!): OrderType @deprecated(reason: "2021-01-29: Not used anymore")
 }
 
 type SendMessageToCollectiveResult {
@@ -3592,12 +3320,6 @@ type StatsMemberType {
   total amount donated directly by this member
   """
   directDonations: Int
-
-  """
-  total amount donated by this member through gift cards
-  """
-  donationsThroughEmittedVirtualCards: Int
-    @deprecated(reason: "2021-02-08: Not used anymore. Virtual cards have been renamed to gift cards")
 
   """
   total amount donated by this member either directly or using a gift card it has emitted
@@ -3835,8 +3557,6 @@ interface Transaction {
   host: CollectiveInterface
   paymentMethod: PaymentMethodType
   fromCollective: CollectiveInterface
-  usingVirtualCardFromCollective: CollectiveInterface
-    @deprecated(reason: "2021-02-08: Renamed to usingGiftCardFromCollective")
   usingGiftCardFromCollective: CollectiveInterface
   collective: CollectiveInterface
   type: String
@@ -3984,14 +3704,11 @@ type UpdateType {
   publishedAt: DateString
   summary: String
   html: String
-  markdown: String @deprecated(reason: "2020-01-25: Use html")
   tags: [String]
   createdByUser: UserDetails
   fromCollective: CollectiveInterface
   collective: CollectiveInterface
   tier: Tier
-  comments(limit: Int, offset: Int): CommentListType
-    @deprecated(reason: "Deprecated since 2020-03-18: This field has never been active and will be removed soon.")
 }
 
 """
@@ -4174,12 +3891,6 @@ type User implements CollectiveInterface {
     includeInactive: Boolean = false
   ): [Event]
   projects(limit: Int, offset: Int): [Project]
-
-  """
-  Get all child collectives (with type=COLLECTIVE, doesn't return events)
-  """
-  childCollectives: [Collective]
-    @deprecated(reason: "2020/01/08 - Connected-collectives are now handled through members")
   paymentMethods(
     service: String
     limit: Int
@@ -4187,11 +3898,6 @@ type User implements CollectiveInterface {
     isConfirmed: Boolean = true
     types: [String]
     orderBy: PaymenMethodOrderField = type
-
-    """
-    Defines if the organization "collective" payment method should be returned
-    """
-    includeOrganizationCollectivePaymentMethod: Boolean = false
 
     """
     Defines if the host "collective" payment method should be returned
@@ -4207,26 +3913,7 @@ type User implements CollectiveInterface {
   """
   List all the gift cards batches emitted by this collective. May include `null` for unbatched gift cards.
   """
-  virtualCardsBatches: [PaymentMethodBatchInfo] @deprecated(reason: "2020-02-05: Use giftCardsBatches")
-
-  """
-  List all the gift cards batches emitted by this collective. May include `null` for unbatched gift cards.
-  """
   giftCardsBatches: [PaymentMethodBatchInfo]
-
-  """
-  Get the gift cards created by this collective. RemoteUser must be a collective admin.
-  """
-  createdVirtualCards(
-    limit: Int
-    offset: Int
-    batch: String
-
-    """
-    Wether the gift card has been claimed or not
-    """
-    isConfirmed: Boolean
-  ): PaginatedPaymentMethod @deprecated(reason: "2020-02-05: Use createdGiftCards")
 
   """
   Get the gift cards created by this collective. RemoteUser must be a collective admin.

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -578,7 +578,17 @@ type Bot implements Account {
   """
   Get all members (admins, members, backers, followers)
   """
-  members(limit: Int = 100, offset: Int = 0, role: [MemberRole], accountType: [AccountType]): MemberCollection
+  members(
+    limit: Int = 100
+    offset: Int = 0
+    role: [MemberRole]
+    accountType: [AccountType]
+
+    """
+    Order of the results
+    """
+    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: ASC }
+  ): MemberCollection
   memberOf(
     limit: Int
     offset: Int
@@ -797,7 +807,17 @@ type Collective implements Account & AccountWithHost & AccountWithContributions 
   """
   Get all members (admins, members, backers, followers)
   """
-  members(limit: Int = 100, offset: Int = 0, role: [MemberRole], accountType: [AccountType]): MemberCollection
+  members(
+    limit: Int = 100
+    offset: Int = 0
+    role: [MemberRole]
+    accountType: [AccountType]
+
+    """
+    Order of the results
+    """
+    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: ASC }
+  ): MemberCollection
   memberOf(
     limit: Int
     offset: Int
@@ -2924,7 +2944,17 @@ type Event implements Account & AccountWithHost & AccountWithContributions {
   """
   Get all members (admins, members, backers, followers)
   """
-  members(limit: Int = 100, offset: Int = 0, role: [MemberRole], accountType: [AccountType]): MemberCollection
+  members(
+    limit: Int = 100
+    offset: Int = 0
+    role: [MemberRole]
+    accountType: [AccountType]
+
+    """
+    Order of the results
+    """
+    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: ASC }
+  ): MemberCollection
   memberOf(
     limit: Int
     offset: Int
@@ -3790,7 +3820,17 @@ type Fund implements Account & AccountWithHost & AccountWithContributions {
   """
   Get all members (admins, members, backers, followers)
   """
-  members(limit: Int = 100, offset: Int = 0, role: [MemberRole], accountType: [AccountType]): MemberCollection
+  members(
+    limit: Int = 100
+    offset: Int = 0
+    role: [MemberRole]
+    accountType: [AccountType]
+
+    """
+    Order of the results
+    """
+    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: ASC }
+  ): MemberCollection
   memberOf(
     limit: Int
     offset: Int
@@ -4086,7 +4126,17 @@ type Host implements Account & AccountWithContributions {
   """
   Get all members (admins, members, backers, followers)
   """
-  members(limit: Int = 100, offset: Int = 0, role: [MemberRole], accountType: [AccountType]): MemberCollection
+  members(
+    limit: Int = 100
+    offset: Int = 0
+    role: [MemberRole]
+    accountType: [AccountType]
+
+    """
+    Order of the results
+    """
+    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: ASC }
+  ): MemberCollection
   memberOf(
     limit: Int
     offset: Int
@@ -4583,7 +4633,17 @@ type Individual implements Account {
   """
   Get all members (admins, members, backers, followers)
   """
-  members(limit: Int = 100, offset: Int = 0, role: [MemberRole], accountType: [AccountType]): MemberCollection
+  members(
+    limit: Int = 100
+    offset: Int = 0
+    role: [MemberRole]
+    accountType: [AccountType]
+
+    """
+    Order of the results
+    """
+    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: ASC }
+  ): MemberCollection
   memberOf(
     limit: Int
     offset: Int
@@ -4793,6 +4853,11 @@ type Location {
   Longitude
   """
   long: Float
+
+  """
+  Structured JSON address
+  """
+  structured: JSON
 }
 
 """
@@ -4823,6 +4888,11 @@ input LocationInput {
   Longitude
   """
   long: Float
+
+  """
+  Structured JSON address
+  """
+  structured: JSON
 }
 
 """
@@ -5450,31 +5520,6 @@ type Mutation {
   ): CreditCardWithStripeError!
 
   """
-  Add a new payment method to be used with an Order
-  """
-  addStripeCreditCard(
-    """
-    The credit card info
-    """
-    creditCardInfo: CreditCardCreateInput!
-
-    """
-    Name associated to this credit card
-    """
-    name: String!
-
-    """
-    Whether this credit card should be saved for future payments
-    """
-    isSavedForLater: Boolean = true
-
-    """
-    Account to add the credit card to
-    """
-    account: AccountReferenceInput!
-  ): CreditCardWithStripeError! @deprecated(reason: "2020-10-23: Use addCreditCard")
-
-  """
   Confirm a credit card is ready for use after strong customer authentication
   """
   confirmCreditCard(paymentMethod: PaymentMethodReferenceInput!): CreditCardWithStripeError!
@@ -5828,7 +5873,17 @@ type Organization implements Account & AccountWithContributions {
   """
   Get all members (admins, members, backers, followers)
   """
-  members(limit: Int = 100, offset: Int = 0, role: [MemberRole], accountType: [AccountType]): MemberCollection
+  members(
+    limit: Int = 100
+    offset: Int = 0
+    role: [MemberRole]
+    accountType: [AccountType]
+
+    """
+    Order of the results
+    """
+    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: ASC }
+  ): MemberCollection
   memberOf(
     limit: Int
     offset: Int
@@ -6287,7 +6342,17 @@ type Project implements Account & AccountWithHost & AccountWithContributions {
   """
   Get all members (admins, members, backers, followers)
   """
-  members(limit: Int = 100, offset: Int = 0, role: [MemberRole], accountType: [AccountType]): MemberCollection
+  members(
+    limit: Int = 100
+    offset: Int = 0
+    role: [MemberRole]
+    accountType: [AccountType]
+
+    """
+    Order of the results
+    """
+    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: ASC }
+  ): MemberCollection
   memberOf(
     limit: Int
     offset: Int

--- a/next.config.js
+++ b/next.config.js
@@ -106,6 +106,13 @@ const nextConfig = {
       config.optimization.minimize = false;
     }
 
+    // mjs
+    config.module.rules.push({
+      test: /\.mjs$/,
+      include: /node_modules/,
+      type: 'javascript/auto',
+    });
+
     return config;
   },
   async headers() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35869,6 +35869,37 @@
         "tslib": "^1.9.3"
       }
     },
+    "@shopify/address": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@shopify/address/-/address-2.10.1.tgz",
+      "integrity": "sha512-uWej0twR/8xNVjdBytFZMRme1fCtudkKXSk7emlw1vOKLJAUGhXlqKSviAdHLP6ruPSe8TF/3aWmbVqgt3Ol5Q==",
+      "requires": {
+        "@shopify/address-consts": "^2.2.0",
+        "tslib": "^1.14.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@shopify/address-consts": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@shopify/address-consts/-/address-consts-2.2.0.tgz",
+      "integrity": "sha512-Ihny6BlhUKvemPoWewncqneu/cUfa4P6rw7AO0x9E9YC0FyW+7JOHjbS9PordOf0pcd1xizVQ0s0lgr9JkUBxA==",
+      "requires": {
+        "tslib": "^1.14.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@popperjs/core": "2.6.0",
     "@sentry/browser": "6.1.0",
     "@sentry/node": "6.1.0",
+    "@shopify/address": "^2.10.1",
     "@styled-icons/boxicons-regular": "10.23.0",
     "@styled-icons/boxicons-solid": "10.23.0",
     "@styled-icons/fa-brands": "10.26.0",

--- a/test/cypress/integration/27-expenses.test.js
+++ b/test/cypress/integration/27-expenses.test.js
@@ -178,12 +178,38 @@ describe('New expense flow', () => {
 
     // This can happen if you start with an invoice then switch to receipts
     it('should prevent submitting receipts if missing items', () => {
+      cy.server();
+      cy.route({
+        method: 'POST',
+        url: 'https://country-service.shopifycloud.com/graphql',
+        response: {
+          country: {
+            name: 'Angola',
+            labels: {
+              address1: 'Address',
+              address2: 'Apartment, suite, etc.',
+              city: 'City',
+              postalCode: 'Postal code',
+              zone: 'Region',
+            },
+            optionalLabels: {
+              address2: 'Apartment, suite, etc. (optional)',
+            },
+            formatting: {
+              edit: '{firstName}{lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
+              show: '{firstName} {lastName}_{company}_{address1}_{address2}_{city}_{country}_{phone}',
+            },
+            zones: [],
+          },
+        },
+      });
       cy.getByDataCy('radio-expense-type-INVOICE').click();
       cy.getByDataCy('payout-method-select').click();
       cy.contains('[data-cy="select-option"]', 'New PayPal account').click();
       cy.getByDataCy('payee-country').click();
       cy.contains('[data-cy="select-option"]', 'Angola - AO').click();
-      cy.get('textarea[data-cy="payee-address"]').type('Street Name, 123');
+      cy.get('input[data-cy="payee-address-address1"]').type('Street Name, 123');
+      cy.get('input[data-cy="payee-address-city"]').type('Citycitycity');
       cy.get('input[name="payoutMethod.data.email"]').type('paypal-test@opencollective.com');
       cy.getByDataCy('expense-next').click();
       // Fill the form with valid data

--- a/test/cypress/integration/27-expenses.test.js
+++ b/test/cypress/integration/27-expenses.test.js
@@ -264,7 +264,8 @@ describe('New expense flow', () => {
 
         cy.getByDataCy('payee-country').click();
         cy.contains('[data-cy="select-option"]', 'Angola - AO').click();
-        cy.get('textarea[data-cy="payee-address"]').type('Street Name, 123');
+        cy.get('[data-cy="payee-address-address1"]').type('Street Name, 123');
+        cy.get('[data-cy="payee-address-city"]').type('City');
 
         cy.getByDataCy('payout-method-select').click();
         cy.contains('[data-cy="select-option"]', 'New custom payout method').click();


### PR DESCRIPTION
Requires https://github.com/opencollective/opencollective-api/pull/5385
Resolves https://github.com/opencollective/opencollective/issues/3630

Uses the [Shopify address package and API](https://github.com/Shopify/quilt/tree/master/packages/address) to render a form that is responsive to the chosen country's postal format, including making fields required vs optional. Can also be localised based on what language the user chooses to browse Open Collective in.

### German address
![Screenshot 2021-01-29 at 17 57 25](https://user-images.githubusercontent.com/37520401/106312208-3a548e80-625e-11eb-8c33-ee7f3ed3465e.png)
![Screenshot 2021-01-29 at 17 56 52](https://user-images.githubusercontent.com/37520401/106312213-3b85bb80-625e-11eb-8ed4-eff7d60d5323.png)

### Japanese address
![Screenshot 2021-01-29 at 18 16 15](https://user-images.githubusercontent.com/37520401/106312218-3d4f7f00-625e-11eb-8717-f71a1c6223c0.png)
![Screenshot 2021-01-29 at 18 16 30](https://user-images.githubusercontent.com/37520401/106312217-3c1e5200-625e-11eb-922d-00dfeac8f12d.png)

Not in scope of this PR: making sure the user address and payout method address match https://opencollective.slack.com/archives/G46PNRCGP/p1612218589031700 (https://github.com/opencollective/opencollective/issues/3340)