### PR TITLE
Fix handling of tier currency in the contribution flow

### DIFF
--- a/components/contribution-flow/ContributionSummary.js
+++ b/components/contribution-flow/ContributionSummary.js
@@ -47,10 +47,10 @@ const Amount = styled(Span)`
   text-align: right;
 `;
 
-const ContributionSummary = ({ collective, stepDetails, stepSummary, stepPayment }) => {
+const ContributionSummary = ({ collective, stepDetails, stepSummary, stepPayment, currency }) => {
   const intl = useIntl();
   const totalAmount = getTotalAmount(stepDetails, stepSummary);
-  const pmFeeInfo = getPaymentMethodFees(stepPayment?.paymentMethod, totalAmount, collective.currency);
+  const pmFeeInfo = getPaymentMethodFees(stepPayment?.paymentMethod, totalAmount, currency);
   const platformContribution = stepDetails.platformContribution || 0;
 
   return (
@@ -79,7 +79,7 @@ const ContributionSummary = ({ collective, stepDetails, stepSummary, stepPayment
             <Amount>
               <FormattedMoneyAmount
                 amount={stepDetails.amount}
-                currency={collective.currency}
+                currency={currency}
                 amountStyles={{ color: 'black.700', fontWeight: 400 }}
               />
             </Amount>
@@ -90,7 +90,7 @@ const ContributionSummary = ({ collective, stepDetails, stepSummary, stepPayment
               <Amount>
                 <FormattedMoneyAmount
                   amount={stepSummary.amount}
-                  currency={collective.currency}
+                  currency={currency}
                   amountStyles={{ color: 'black.700', fontWeight: 400 }}
                 />
               </Amount>
@@ -108,7 +108,7 @@ const ContributionSummary = ({ collective, stepDetails, stepSummary, stepPayment
               <Amount>
                 <FormattedMoneyAmount
                   amount={platformContribution}
-                  currency={collective.currency}
+                  currency={currency}
                   amountStyles={{ color: 'black.700', fontWeight: 400 }}
                 />
               </Amount>
@@ -156,7 +156,7 @@ const ContributionSummary = ({ collective, stepDetails, stepSummary, stepPayment
                 )}
                 <FormattedMoneyAmount
                   amount={pmFeeInfo.fee}
-                  currency={collective.currency}
+                  currency={currency}
                   amountStyles={{ color: 'black.700', fontWeight: 400 }}
                 />
               </Amount>
@@ -171,7 +171,7 @@ const ContributionSummary = ({ collective, stepDetails, stepSummary, stepPayment
           <FormattedMessage id="TodaysCharge" defaultMessage="Today's charge" />
         </Label>
         <Amount fontWeight="700">
-          <FormattedMoneyAmount amount={totalAmount} currency={collective.currency} amountStyles={null} />
+          <FormattedMoneyAmount amount={totalAmount} currency={currency} amountStyles={null} />
         </Amount>
       </AmountLine>
       {Boolean(pmFeeInfo.fee) && (
@@ -186,7 +186,7 @@ const ContributionSummary = ({ collective, stepDetails, stepSummary, stepPayment
           <Amount>
             <FormattedMoneyAmount
               amount={totalAmount - pmFeeInfo.fee - platformContribution}
-              currency={collective.currency}
+              currency={currency}
               amountStyles={null}
             />
           </Amount>
@@ -221,6 +221,7 @@ ContributionSummary.propTypes = {
   stepDetails: PropTypes.object,
   stepSummary: PropTypes.object,
   stepPayment: PropTypes.object,
+  currency: PropTypes.string,
 };
 
 export default ContributionSummary;

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -41,6 +41,8 @@ const StepDetails = ({ onChange, data, collective, tier, showFeesOnTop }) => {
     onChange({ stepDetails: { ...data, [field]: value }, stepSummary: null });
   };
 
+  const currency = tier?.amount.currency || collective.currency;
+
   return (
     <Box width={1}>
       {(!tier || tier.amountType === AmountTypes.FLEXIBLE) && (
@@ -73,7 +75,7 @@ const StepDetails = ({ onChange, data, collective, tier, showFeesOnTop }) => {
       {!isFixedContribution ? (
         <Box mb="30px">
           <StyledAmountPicker
-            currency={collective.currency}
+            currency={currency}
             presets={presets}
             otherAmountDisplay="button"
             value={isOtherAmountSelected ? OTHER_AMOUNT_KEY : data?.amount}
@@ -91,7 +93,7 @@ const StepDetails = ({ onChange, data, collective, tier, showFeesOnTop }) => {
               <StyledInputAmount
                 name="custom-amount"
                 type="number"
-                currency={collective.currency}
+                currency={currency}
                 value={data?.amount || null}
                 width={1}
                 min={minAmount}
@@ -108,8 +110,8 @@ const StepDetails = ({ onChange, data, collective, tier, showFeesOnTop }) => {
                     id="contribution.minimumAmount"
                     defaultMessage="The minimum amount is: {minAmount} {currency}"
                     values={{
-                      minAmount: formatCurrency(minAmount, collective.currency),
-                      currency: collective.currency,
+                      minAmount: formatCurrency(minAmount, currency),
+                      currency,
                     }}
                   />
                 </Flex>
@@ -124,7 +126,7 @@ const StepDetails = ({ onChange, data, collective, tier, showFeesOnTop }) => {
             defaultMessage="You’ll contribute with the amount of {amount}{interval, select, month { monthly} year { yearly} other {}}."
             values={{
               interval: tier.interval,
-              amount: <FormattedMoneyAmount amount={getTotalAmount(data)} currency={collective.currency} />,
+              amount: <FormattedMoneyAmount amount={getTotalAmount(data)} currency={currency} />,
             }}
           />
         </Box>
@@ -196,7 +198,7 @@ const StepDetails = ({ onChange, data, collective, tier, showFeesOnTop }) => {
       {showFeesOnTop && (
         <Box mt={28}>
           <FeesOnTopInput
-            currency={collective.currency}
+            currency={currency}
             amount={data?.amount}
             fees={data?.platformContribution}
             interval={data?.interval}

--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -511,13 +511,13 @@ class ContributionFlow extends React.Component {
     return steps;
   }
 
-  getPaypalButtonProps() {
+  getPaypalButtonProps({ currency }) {
     const { stepPayment, stepDetails, stepSummary } = this.state;
     if (stepPayment?.paymentMethod?.type === GQLV2_PAYMENT_METHOD_TYPES.PAYPAL) {
-      const { collective, host } = this.props;
+      const { host } = this.props;
       return {
         host: host,
-        currency: collective.currency,
+        currency: currency,
         style: { size: 'responsive', height: 47 },
         totalAmount: getTotalAmount(stepDetails, stepSummary),
         onClick: () => this.setState({ isSubmitting: true }),
@@ -568,6 +568,8 @@ class ContributionFlow extends React.Component {
     const { collective, host, tier, LoggedInUser, loadingLoggedInUser, skipStepDetails } = this.props;
     const { error, isSubmitted, isSubmitting, stepDetails, stepSummary, stepProfile, stepPayment } = this.state;
 
+    const currency = tier?.amount.currency || collective.currency;
+
     return (
       <Steps
         steps={this.getSteps()}
@@ -613,7 +615,7 @@ class ContributionFlow extends React.Component {
                 stepSummary={stepSummary}
                 isSubmitted={this.state.isSubmitted}
                 loading={isValidating || isSubmitted || isSubmitting}
-                currency={collective.currency}
+                currency={currency}
                 isFreeTier={this.getTierMinAmount(tier) === 0}
               />
             </StepsProgressBox>
@@ -679,9 +681,9 @@ class ContributionFlow extends React.Component {
                       nextStep={nextStep}
                       isRecurringContributionLoggedOut={Boolean(!LoggedInUser && stepDetails?.interval)}
                       isValidating={isValidating || isSubmitted || isSubmitting}
-                      paypalButtonProps={this.getPaypalButtonProps()}
+                      paypalButtonProps={this.getPaypalButtonProps({ currency })}
                       totalAmount={getTotalAmount(stepDetails, stepSummary)}
-                      currency={collective.currency}
+                      currency={currency}
                     />
                   </Box>
                 </Box>
@@ -694,6 +696,7 @@ class ContributionFlow extends React.Component {
                         stepDetails={stepDetails}
                         stepSummary={stepSummary}
                         stepPayment={stepPayment}
+                        currency={currency}
                       />
                     </Box>
                     <ContributeFAQ collective={collective} mt={4} titleProps={{ mb: 2 }} />


### PR DESCRIPTION
Looking at the case where tier.currency != collective.currency.

It's currently properly managed:
- in the Tier card
- in the Success page
- in the API

But wrongly displayed in the contribution flow, this is fixing this part.