### PR TITLE
TopBarProfileMenu: Display profile name rather than slug

### DIFF
--- a/components/TopBarProfileMenu.js
+++ b/components/TopBarProfileMenu.js
@@ -480,11 +480,10 @@ class TopBarProfileMenu extends React.Component {
             fontWeight="500"
             letterSpacing="1px"
             mx={2}
-            className="LoginTopBarProfileButton-name"
             cursor="pointer"
             data-cy="topbar-login-username"
           >
-            {LoggedInUser.username}
+            {LoggedInUser.collective.name || LoggedInUser.username}
           </P>
         </Hide>
         <Avatar collective={get(LoggedInUser, 'collective')} radius="3rem" mr={2} />

--- a/test/cypress/integration/00-ssr-errors.test.js
+++ b/test/cypress/integration/00-ssr-errors.test.js
@@ -40,6 +40,6 @@ describe('the NotFound page when logged in', () => {
   });
 
   it('has the user properly logged in', () => {
-    cy.get('.LoginTopBarProfileButton-name').should('contain', 'testuseradmin');
+    cy.getByDataCy('topbar-login-username').should('contain', 'Test User Admin');
   });
 });

--- a/test/cypress/integration/07-signin.test.js
+++ b/test/cypress/integration/07-signin.test.js
@@ -8,7 +8,7 @@ describe('signin', () => {
     cy.visit('/signin?next=/testuseradmin');
     cy.get('input[name=email]').type('testuser+admin@opencollective.com');
     cy.get('button[type=submit]').click();
-    cy.get('.LoginTopBarProfileButton-name').contains('testuseradmin', { timeout: 15000 });
+    cy.getByDataCy('topbar-login-username').contains('Test User Admin', { timeout: 15000 });
   });
 
   it('can signin with a valid token and is redirected', () => {

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -305,12 +305,9 @@ Cypress.Commands.add('checkStepsProgress', ({ enabled = [], disabled = [] }) => 
 /**
  * Check if user is logged in by searching for its username in navbar
  */
-Cypress.Commands.add('assertLoggedIn', (username, timeout) => {
+Cypress.Commands.add('assertLoggedIn', params => {
   cy.log('Ensure user is logged in');
-  const loginSection = cy.get('.LoginTopBarProfileButton-name', { timeout });
-  if (username) {
-    loginSection.should('contain', username);
-  }
+  cy.getByDataCy('topbar-login-username', params);
 });
 
 /**


### PR DESCRIPTION
Only display slug as a fallback if name is empty