### PR TITLE
Fix ActionsMenu bug

### DIFF
--- a/components/StyledDropdown.js
+++ b/components/StyledDropdown.js
@@ -1,6 +1,9 @@
 import React, { useRef } from 'react';
 import styled, { css } from 'styled-components';
 
+import useGlobalBlur from '../lib/hooks/useGlobalBlur';
+import useKeyBoardShortcut, { ESCAPE_KEY } from '../lib/hooks/useKeyboardKey';
+
 export const DropdownContent = styled.div`
   display: none;
   position: absolute;
@@ -47,31 +50,34 @@ export const DropdownArrow = styled('div')`
  *
  * When using `click` as a `trigger` you must pass a function as `children` and
  * make sure you pass down the `triggerProps` and `dropdownProps`.
+ * The ref must be on the wrapping div in order to work in Firefox (Mac) and Safari.
  */
 export const Dropdown = styled(({ children, trigger, ...props }) => {
   const dropdownRef = useRef();
   const [isDisplayed, setDisplayed] = React.useState(false);
 
+  useGlobalBlur(dropdownRef, outside => {
+    if (outside && isDisplayed) {
+      setTimeout(() => {
+        setDisplayed(false);
+      }, 50);
+    }
+  });
+
+  // Closes the modal upon the `ESC` key press.
+  useKeyBoardShortcut({ callback: () => setDisplayed(false), keyMatch: ESCAPE_KEY });
+
   if (typeof children === 'function' && trigger === 'click') {
     return (
-      <div {...props} data-expanded={isDisplayed}>
+      <div ref={dropdownRef} {...props} data-expanded={isDisplayed}>
         {children({
           isDisplayed,
           triggerProps: {
-            onClick: () => setDisplayed(!isDisplayed),
-            onBlur: () => {
-              if (isDisplayed) {
-                setTimeout(() => {
-                  if (!document.activeElement || !dropdownRef.current?.contains(document.activeElement)) {
-                    setDisplayed(false);
-                  }
-                }, 50);
-              }
+            onClick: () => {
+              setDisplayed(!isDisplayed);
             },
           },
           dropdownProps: {
-            ref: dropdownRef,
-            onBlur: () => setTimeout(() => setDisplayed(false), 50),
             onClick: () => setTimeout(() => setDisplayed(false), 50),
           },
         })}

--- a/components/collective-navbar/index.js
+++ b/components/collective-navbar/index.js
@@ -38,7 +38,6 @@ const MainContainer = styled(Container)`
   background: white;
   display: flex;
   justify-content: flex-start;
-  overflow-y: auto;
 `;
 
 const AvatarBox = styled(Box)`
@@ -376,6 +375,8 @@ const CollectiveNavbar = ({
   const secondAction = getMainAction(collective, isAdmin, without(actionsArray, mainAction?.type));
   const navbarRef = useRef();
 
+  /** This is to close the navbar dropdown menus (desktop)/slide-out menu (tablet)/non-collapsible menu (mobile)
+   * when we click a category header to scroll down to (i.e. Connect) or sub-section page to open (i.e. Updates) */
   useGlobalBlur(navbarRef, outside => {
     if (!outside && isExpanded) {
       setTimeout(() => {


### PR DESCRIPTION
Fixes https://github.com/opencollective/opencollective/issues/3826

Users can now click anywhere outside the actions menu to close it.

* Uses `useGlobalBlur` instead of `onBlur` props to control menu
* Moves the ref up to the containing div
* Removes overflow CSS rule from `MainContainer` as it was causing the actions menu to be hidden behind the collective page content on Safari only
* you can use the ESC key to close the menu

Tested on Safari, Firefox, Chrome, and Edge to make sure no further issues were caused by this fix.