### PR TITLE
Navbar: De-duplicate "request grant" action in ActionsMenu

### DIFF
--- a/components/collective-navbar/ActionsMenu.js
+++ b/components/collective-navbar/ActionsMenu.js
@@ -102,7 +102,7 @@ const ActionsDropdown = styled(Dropdown)`
   }
 
   ${props =>
-    props.isHiddenOnNonMobile &&
+    props.$isHiddenOnNonMobile &&
     css`
       @media screen and (min-width: 40em) {
         display: none;
@@ -178,10 +178,9 @@ export const getContributeRoute = collective => {
   return { route, params };
 };
 
-const CollectiveNavbarActionsMenu = ({ collective, callsToAction, hiddenActionForNonMobile, secondAction }) => {
+const CollectiveNavbarActionsMenu = ({ collective, callsToAction, hiddenActionForNonMobile }) => {
   const enabledCTAs = Object.keys(pickBy(callsToAction, Boolean));
   const isEmpty = enabledCTAs.length < 1;
-  const hasOnlyTwoCTAs = enabledCTAs.length === 2;
   const hasOnlyOneHiddenCTA = enabledCTAs.length === 1 && hiddenActionForNonMobile === enabledCTAs[0];
   const hostedCollectivesLimit = get(collective, 'plan.hostedCollectivesLimit');
   const hostWithinLimit = hostedCollectivesLimit
@@ -202,8 +201,7 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction, hiddenActionFo
       borderTop={['1px solid #e1e1e1', 'none']}
     >
       <Box px={1}>
-        {hasOnlyTwoCTAs && <Box display={['none', 'block']}>{secondAction?.component}</Box>}
-        <ActionsDropdown trigger="click" isHiddenOnNonMobile={hasOnlyTwoCTAs}>
+        <ActionsDropdown trigger="click" $isHiddenOnNonMobile={enabledCTAs.length <= 2}>
           {({ triggerProps, dropdownProps }) => (
             <React.Fragment>
               <Flex alignItems="center">
@@ -248,7 +246,7 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction, hiddenActionFo
                       </MenuItem>
                     )}
                     {callsToAction.hasRequestGrant && (
-                      <MenuItem py={1}>
+                      <MenuItem py={1} isHiddenOnMobile={hiddenActionForNonMobile === NAVBAR_ACTION_TYPE.REQUEST_GRANT}>
                         <StyledLink
                           as={Link}
                           route="create-expense"
@@ -379,7 +377,6 @@ CollectiveNavbarActionsMenu.propTypes = {
     addPrepaidBudget: PropTypes.bool,
   }).isRequired,
   hiddenActionForNonMobile: PropTypes.oneOf(Object.values(NAVBAR_ACTION_TYPE)),
-  secondAction: PropTypes.object,
 };
 
 CollectiveNavbarActionsMenu.defaultProps = {

--- a/components/collective-navbar/index.js
+++ b/components/collective-navbar/index.js
@@ -191,7 +191,6 @@ const getDefaultCallsToActions = (collective, isAdmin, isHostAdmin, isRoot) => {
 
 /**
  * Returns the main CTA that should be displayed as a button outside of the action menu in this component.
- * Returns the second CTA that should be displayed as a button in ActionsMenu.js if only 2 CTAs.
  */
 const getMainAction = (collective, callsToAction) => {
   if (!collective || !callsToAction) {
@@ -239,6 +238,20 @@ const getMainAction = (collective, callsToAction) => {
         />
       ),
     };
+  } else if (callsToAction.includes('hasRequestGrant')) {
+    return {
+      type: NAVBAR_ACTION_TYPE.REQUEST_GRANT,
+      component: (
+        <Link route="create-expense" params={{ collectiveSlug: collective.slug }}>
+          <MainActionBtn tabIndex="-1">
+            <MoneyCheckAlt size="1em" />
+            <Span ml={2}>
+              <FormattedMessage id="ExpenseForm.Type.Request" defaultMessage="Request Grant" />
+            </Span>
+          </MainActionBtn>
+        </Link>
+      ),
+    };
   } else if (callsToAction.includes('hasSubmitExpense')) {
     return {
       type: NAVBAR_ACTION_TYPE.SUBMIT_EXPENSE,
@@ -276,20 +289,6 @@ const getMainAction = (collective, callsToAction) => {
             <Envelope size="1em" />
             <Span ml={2}>
               <FormattedMessage id="Contact" defaultMessage="Contact" />
-            </Span>
-          </MainActionBtn>
-        </Link>
-      ),
-    };
-  } else if (callsToAction.includes('hasRequestGrant')) {
-    return {
-      type: NAVBAR_ACTION_TYPE.REQUEST_GRANT,
-      component: (
-        <Link route="create-expense" params={{ collectiveSlug: collective.slug }}>
-          <MainActionBtn tabIndex="-1">
-            <MoneyCheckAlt size="1em" />
-            <Span ml={2}>
-              <FormattedMessage id="ExpenseForm.Type.Request" defaultMessage="Request Grant" />
             </Span>
           </MainActionBtn>
         </Link>
@@ -393,7 +392,7 @@ const CollectiveNavbar = ({
   callsToAction = { ...getDefaultCallsToActions(collective, isAdmin, isHostAdmin, isRoot), ...callsToAction };
   const actionsArray = Object.keys(pickBy(callsToAction, Boolean));
   const mainAction = getMainAction(collective, actionsArray);
-  const secondAction = getMainAction(collective, without(actionsArray, mainAction?.type));
+  const secondAction = actionsArray.length === 2 && getMainAction(collective, without(actionsArray, mainAction?.type));
   const navbarRef = useRef();
 
   useGlobalBlur(navbarRef, outside => {
@@ -508,6 +507,7 @@ const CollectiveNavbar = ({
             {mainAction && (
               <Container display={['none', 'flex']} alignItems="center">
                 {mainAction.component}
+                {secondAction?.component || null}
               </Container>
             )}
             {!isLoading && (
@@ -515,7 +515,6 @@ const CollectiveNavbar = ({
                 collective={collective}
                 callsToAction={callsToAction}
                 hiddenActionForNonMobile={mainAction?.type}
-                secondAction={secondAction}
               />
             )}
             {!onlyInfos && (


### PR DESCRIPTION
Also:
- Moved second action button out of `ActionsMenu` for consistency and to simplify the de-duplication
- Gave priority to `hasRequestGrant` in CTAs order
- Fixed a proptype warning using [transient prop](https://styled-components.com/docs/api#transient-props)