### PR TITLE
Fix expense summary CSS bugs

### DIFF
--- a/components/expenses/ExpenseSummary.js
+++ b/components/expenses/ExpenseSummary.js
@@ -81,7 +81,7 @@ const ExpenseSummary = ({
         <H4 mb={2} mr={2} fontWeight="500" data-cy="expense-description">
           {isLoading ? <LoadingPlaceholder height={32} minWidth={250} /> : expense.description}
         </H4>
-        <Box display="flex" mb={3} width={1} justifyContent={['space-between', 'end']} alignItems="center">
+        <Box display="flex" mb={3} width={1} justifyContent={['space-between', 'flex-end']} alignItems="center">
           {expense?.status && (
             <Box>
               <ExpenseStatusTag

--- a/components/expenses/ExpenseSummary.js
+++ b/components/expenses/ExpenseSummary.js
@@ -74,14 +74,17 @@ const ExpenseSummary = ({
     >
       <Flex
         flexDirection={['column-reverse', 'row']}
-        alignItems={['flex-start', 'center']}
+        alignItems={['stretch', 'center']}
         justifyContent="space-between"
         data-cy="expense-title"
+        mb={3}
       >
-        <H4 mb={2} mr={2} fontWeight="500" data-cy="expense-description">
-          {isLoading ? <LoadingPlaceholder height={32} minWidth={250} /> : expense.description}
-        </H4>
-        <Box display="flex" mb={3} width={1} justifyContent={['space-between', 'flex-end']} alignItems="center">
+        <Flex mr={[0, 2]}>
+          <H4 fontWeight="500" data-cy="expense-description">
+            {isLoading ? <LoadingPlaceholder height={32} minWidth={250} /> : expense.description}
+          </H4>
+        </Flex>
+        <Flex mb={[3, 0]} justifyContent={['space-between', 'flex-end']} alignItems="center">
           {expense?.status && (
             <Box>
               <ExpenseStatusTag
@@ -110,7 +113,7 @@ const ExpenseSummary = ({
               />
             </Box>
           )}
-        </Box>
+        </Flex>
       </Flex>
       <ExpenseTags expense={expense} isLoading={isLoading} />
       <Flex alignItems="center" mt={3}>


### PR DESCRIPTION
### [Expense status tag bug](https://opencollective.slack.com/archives/CNA7RE3SN/p1612348857001100)

I thought I'd fixed it. Turns out `justify-content: end` only worked on Firefox. Now it's `justify-content: flex-end`, works on Firefox/Chrome/Safari/Edge, and I've learned not only the difference but also the important of cross-browser testing.

![](https://media.giphy.com/media/83QtfwKWdmSEo/giphy.gif)

### Expense summary title bug

Fixes https://github.com/opencollective/opencollective/issues/3928

Last week's PR introduced a bug where the container was not taking the full width and in so causing weird line breaks. Now fixed & tested on Chrome/Firefox/Safari/Edge.