### PR TITLE
Hide About section for host admins if empty

### DIFF
--- a/lib/collective-sections.js
+++ b/lib/collective-sections.js
@@ -115,7 +115,7 @@ const getDefaultSectionsForCollectiveType = (type, isHost, isActive) => {
 };
 
 const filterSectionsByData = (sections, collective, isAdmin, isHostAdmin) => {
-  const toRemove = getSectionsToRemoveForUser(collective, isAdmin, isHostAdmin);
+  const toRemove = getSectionsToRemoveForUser(collective, isAdmin);
   const checkSectionActive = section => {
     if (toRemove.has(section.name) || !section.isEnabled) {
       return false;
@@ -150,7 +150,7 @@ const showContributeSection = (collective, isAdmin) => {
   }
 };
 
-const getSectionsToRemoveForUser = (collective, isAdmin, isHostAdmin) => {
+const getSectionsToRemoveForUser = (collective, isAdmin) => {
   const toRemove = new Set();
   collective = collective || {};
   const features = collective.features || {};
@@ -193,7 +193,7 @@ const getSectionsToRemoveForUser = (collective, isAdmin, isHostAdmin) => {
     // If there's no connected accounts, there's no benefit in enabling the section as it will return null anyway
     toRemove.add(Sections.CONNECTED_COLLECTIVES);
   }
-  if (!collective.hasLongDescription && !collective.longDescription && !isAdmin && !isHostAdmin) {
+  if (!collective.hasLongDescription && !collective.longDescription && !isAdmin) {
     toRemove.add(Sections.ABOUT);
   }
   if (!collective.memberOf?.length) {


### PR DESCRIPTION
Host admins can't edit collective's About section, so there's no reason to have this condition