### PR TITLE
fix: <a> tag in pricing.fiscalHost.featured (de.json)

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -1474,7 +1474,7 @@
   "pricing.applyFiscalHost": "Apply to a fiscal host",
   "pricing.fiscalHost.applyOpenSource": "If you are an open source project, you can apply to join  the Open Source Collective.",
   "pricing.fiscalHost.description": "A Fiscal Host is an <strong>organization who offers fund-holding as a service</strong>. They keep your money in their bank account and  <strong>handle things like accounting, taxes, admin, payments, and liability</strong>-so you don’t have to!",
-  "pricing.fiscalHost.featured": "Below are some of our most popular hosts or <a href='/hosts'>browse all of them</a>.",
+  "pricing.fiscalHost.featured": "Below are some of our most popular hosts or <hosts-link>browse all of them</hosts-link>.",
   "pricing.fiscalHost.learnMore": "Learn more about becoming a Fiscal Host.",
   "pricing.fiscalHost.more": "See more fiscal hosts",
   "pricing.fiscalHost.reasonToJoin": "If you join a Fiscal Host, <strong>you don’t need to go on an Open Collective paid plan</strong>, as your Collective is already included. Each Fiscal Host sets their own fees and acceptance criteria for Collectives. Open Collective keeps a 5% of the donations your raise via credit card payments (Stripe). All other payment methods such as PayPal and Bank transfers are included in your Host's plan.",


### PR DESCRIPTION
See en.json for example:  https://github.com/opencollective/opencollective-frontend/blob/f12ab8987e634c7e5c0fb1616adf828d637d3c9b/lang/en.json#L1477

<!-- If there's an issue associated with this pull request, add it here -->


# Description

I fixed the `<a>` tag in de.json, so it will be the same like in other languages.




<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots

Hope this will fix following rendering error:

<img width="800" alt="Bildschirmfoto 2021-02-06 um 02 29 07" src="https://user-images.githubusercontent.com/26602940/107104725-26db9180-6823-11eb-9fcd-2383968cd210.png">

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
