### PR TITLE
fix: remove contibution section sub-heading

### DIFF
--- a/components/collective-page/CategoryHeader.js
+++ b/components/collective-page/CategoryHeader.js
@@ -120,12 +120,6 @@ const getCategoryData = (intl, collective, category) => {
       return {
         img: contributeSectionHeaderIcon,
         title: i18nNavbarCategory(intl, category),
-        subtitle: (
-          <FormattedMessage
-            id="CollectivePage.SectionContributions.Subtitle"
-            defaultMessage="How we are supporting other Collectives."
-          />
-        ),
       };
     default:
       return null;

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -332,7 +332,6 @@
   "CollectivePage.SectionConnect.Title": "Connect",
   "CollectivePage.SectionContribute.info": "Support {collectiveName} by contributing to them once, monthly, or yearly.",
   "CollectivePage.SectionContribute.Subtitle": "Become a financial contributor.",
-  "CollectivePage.SectionContributions.Subtitle": "How we are supporting other Collectives.",
   "CollectivePage.SectionEvents.ViewAll": "View all events",
   "CollectivePage.SectionProjects.Title": "Projects",
   "CollectivePage.SectionRecurringContributions.Title": "Recurring Contributions",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -332,7 +332,6 @@
   "CollectivePage.SectionConnect.Title": "Connect",
   "CollectivePage.SectionContribute.info": "Support {collectiveName} by contributing to them once, monthly, or yearly.",
   "CollectivePage.SectionContribute.Subtitle": "Become a financial contributor.",
-  "CollectivePage.SectionContributions.Subtitle": "How we are supporting other Collectives.",
   "CollectivePage.SectionEvents.ViewAll": "View all events",
   "CollectivePage.SectionProjects.Title": "Projects",
   "CollectivePage.SectionRecurringContributions.Title": "Recurring Contributions",

--- a/lang/de.json
+++ b/lang/de.json
@@ -332,7 +332,6 @@
   "CollectivePage.SectionConnect.Title": "Verbinden",
   "CollectivePage.SectionContribute.info": "Deutsch.",
   "CollectivePage.SectionContribute.Subtitle": "Werde eine finanzielle Unterstützung.",
-  "CollectivePage.SectionContributions.Subtitle": "Wie wir andere Kollektive unterstützen.",
   "CollectivePage.SectionEvents.ViewAll": "Alle Veranstaltungen anzeigen",
   "CollectivePage.SectionProjects.Title": "Projekte",
   "CollectivePage.SectionRecurringContributions.Title": "Regelmäßige Beiträge",

--- a/lang/en.json
+++ b/lang/en.json
@@ -332,7 +332,6 @@
   "CollectivePage.SectionConnect.Title": "Connect",
   "CollectivePage.SectionContribute.info": "Support {collectiveName} by contributing to them once, monthly, or yearly.",
   "CollectivePage.SectionContribute.Subtitle": "Become a financial contributor.",
-  "CollectivePage.SectionContributions.Subtitle": "How we are supporting other Collectives.",
   "CollectivePage.SectionEvents.ViewAll": "View all events",
   "CollectivePage.SectionProjects.Title": "Projects",
   "CollectivePage.SectionRecurringContributions.Title": "Recurring Contributions",

--- a/lang/es.json
+++ b/lang/es.json
@@ -332,7 +332,6 @@
   "CollectivePage.SectionConnect.Title": "Conectar",
   "CollectivePage.SectionContribute.info": "Apoya a {collectiveName} contribuyendo con ellos una vez, mensual o anualmente.",
   "CollectivePage.SectionContribute.Subtitle": "Conviértete en un contribuyente financiero.",
-  "CollectivePage.SectionContributions.Subtitle": "Cómo estamos apoyando a otros Colectivos.",
   "CollectivePage.SectionEvents.ViewAll": "Ver todos los eventos",
   "CollectivePage.SectionProjects.Title": "Proyectos",
   "CollectivePage.SectionRecurringContributions.Title": "Contribuciones Recurrentes",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -332,7 +332,6 @@
   "CollectivePage.SectionConnect.Title": "Se connecter",
   "CollectivePage.SectionContribute.info": "Soutenez {collectiveName} en contribuant une fois, mensuellement ou annuellement.",
   "CollectivePage.SectionContribute.Subtitle": "Devenez un contributeur financier.",
-  "CollectivePage.SectionContributions.Subtitle": "Comment nous soutenons les autres collectifs.",
   "CollectivePage.SectionEvents.ViewAll": "Voir tous les événements",
   "CollectivePage.SectionProjects.Title": "Projets",
   "CollectivePage.SectionRecurringContributions.Title": "Contributions Récurrentes",

--- a/lang/it.json
+++ b/lang/it.json
@@ -332,7 +332,6 @@
   "CollectivePage.SectionConnect.Title": "Connetti",
   "CollectivePage.SectionContribute.info": "Support {collectiveName} by contributing to them once, monthly, or yearly.",
   "CollectivePage.SectionContribute.Subtitle": "Become a financial contributor.",
-  "CollectivePage.SectionContributions.Subtitle": "How we are supporting other Collectives.",
   "CollectivePage.SectionEvents.ViewAll": "View all events",
   "CollectivePage.SectionProjects.Title": "Projects",
   "CollectivePage.SectionRecurringContributions.Title": "Recurring Contributions",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -332,7 +332,6 @@
   "CollectivePage.SectionConnect.Title": "Connect",
   "CollectivePage.SectionContribute.info": "Support {collectiveName} by contributing to them once, monthly, or yearly.",
   "CollectivePage.SectionContribute.Subtitle": "Become a financial contributor.",
-  "CollectivePage.SectionContributions.Subtitle": "How we are supporting other Collectives.",
   "CollectivePage.SectionEvents.ViewAll": "View all events",
   "CollectivePage.SectionProjects.Title": "プロジェクト",
   "CollectivePage.SectionRecurringContributions.Title": "定期的な寄付",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -332,7 +332,6 @@
   "CollectivePage.SectionConnect.Title": "Connect",
   "CollectivePage.SectionContribute.info": "Support {collectiveName} by contributing to them once, monthly, or yearly.",
   "CollectivePage.SectionContribute.Subtitle": "Become a financial contributor.",
-  "CollectivePage.SectionContributions.Subtitle": "How we are supporting other Collectives.",
   "CollectivePage.SectionEvents.ViewAll": "View all events",
   "CollectivePage.SectionProjects.Title": "Projects",
   "CollectivePage.SectionRecurringContributions.Title": "Recurring Contributions",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -332,7 +332,6 @@
   "CollectivePage.SectionConnect.Title": "Connect",
   "CollectivePage.SectionContribute.info": "Support {collectiveName} by contributing to them once, monthly, or yearly.",
   "CollectivePage.SectionContribute.Subtitle": "Become a financial contributor.",
-  "CollectivePage.SectionContributions.Subtitle": "How we are supporting other Collectives.",
   "CollectivePage.SectionEvents.ViewAll": "View all events",
   "CollectivePage.SectionProjects.Title": "Projects",
   "CollectivePage.SectionRecurringContributions.Title": "Recurring Contributions",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -332,7 +332,6 @@
   "CollectivePage.SectionConnect.Title": "Connect",
   "CollectivePage.SectionContribute.info": "Support {collectiveName} by contributing to them once, monthly, or yearly.",
   "CollectivePage.SectionContribute.Subtitle": "Become a financial contributor.",
-  "CollectivePage.SectionContributions.Subtitle": "How we are supporting other Collectives.",
   "CollectivePage.SectionEvents.ViewAll": "View all events",
   "CollectivePage.SectionProjects.Title": "Projects",
   "CollectivePage.SectionRecurringContributions.Title": "Recurring Contributions",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -332,7 +332,6 @@
   "CollectivePage.SectionConnect.Title": "Connect",
   "CollectivePage.SectionContribute.info": "Support {collectiveName} by contributing to them once, monthly, or yearly.",
   "CollectivePage.SectionContribute.Subtitle": "Become a financial contributor.",
-  "CollectivePage.SectionContributions.Subtitle": "How we are supporting other Collectives.",
   "CollectivePage.SectionEvents.ViewAll": "View all events",
   "CollectivePage.SectionProjects.Title": "Проекты",
   "CollectivePage.SectionRecurringContributions.Title": "Периодические Вклады",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -332,7 +332,6 @@
   "CollectivePage.SectionConnect.Title": "Під'єднати",
   "CollectivePage.SectionContribute.info": "Підтримайте {collectiveName} своїм щомісячним або щорічним внеском.",
   "CollectivePage.SectionContribute.Subtitle": "Стати фінансовим помічником.",
-  "CollectivePage.SectionContributions.Subtitle": "How we are supporting other Collectives.",
   "CollectivePage.SectionEvents.ViewAll": "Переглянути всі події",
   "CollectivePage.SectionProjects.Title": "Проєкти",
   "CollectivePage.SectionRecurringContributions.Title": "Повторювані внески",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -332,7 +332,6 @@
   "CollectivePage.SectionConnect.Title": "连接",
   "CollectivePage.SectionContribute.info": "Support {collectiveName} by contributing to them once, monthly, or yearly.",
   "CollectivePage.SectionContribute.Subtitle": "成为财政捐助者。",
-  "CollectivePage.SectionContributions.Subtitle": "我们如何支持其他 Collective。",
   "CollectivePage.SectionEvents.ViewAll": "查看所有活动",
   "CollectivePage.SectionProjects.Title": "项目",
   "CollectivePage.SectionRecurringContributions.Title": "定期捐款",


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve [opencollective/opencollective/issues/3902](https://github.com/opencollective/opencollective/issues/3902)

# Description
"How we are supporting other collectives" Sub-Heading under Contributions Section was removed

# Screenshots
![Screenshot (15)](https://user-images.githubusercontent.com/43727167/107125612-0bc75b00-68d1-11eb-951a-f68f258148ba.png)

