### PR TITLE
Cross-compatibility for virtual cards renaming

### DIFF
--- a/lib/apollo-client.js
+++ b/lib/apollo-client.js
@@ -169,6 +169,34 @@ function createInMemoryCache() {
           },
         },
       },
+      PaymentMethod: {
+        fields: {
+          type: {
+            read(type) {
+              // @deprecated 2021-02-08: virtualcard renamed to giftcard
+              if (type === 'giftcard') {
+                return 'virtualcard';
+              } else {
+                return type;
+              }
+            },
+          },
+        },
+      },
+      PaymentMethodType: {
+        fields: {
+          type: {
+            read(type) {
+              // @deprecated 2021-02-08: virtualcard renamed to giftcard
+              if (type === 'giftcard') {
+                return 'virtualcard';
+              } else {
+                return type;
+              }
+            },
+          },
+        },
+      },
     },
   });
 


### PR DESCRIPTION
A PR that makes frontend compatible with both API versions, before & after https://github.com/opencollective/opencollective-api/pull/5252.

Whenever API returns `giftcard` for a payment method type, Apollo will convert it to the legacy `virtualcard` - making sure legacy frontend works with it.