### PR TITLE
HTMLContent: Fix regressions on blockquotes

### DIFF
--- a/components/HTMLContent.js
+++ b/components/HTMLContent.js
@@ -112,6 +112,8 @@ const HTMLContent = styled(({ content, collapsable, sanitize, ...props }) => {
     font-size: 1em;
     border-left: 5px solid #e9e9e9;
     background-color: #f9f9f9;
+    margin: 0;
+    padding: 8px;
   }
 
   pre {


### PR DESCRIPTION
Issue was probably linked to recent bootstrap removal.

## Before
![image](https://user-images.githubusercontent.com/1556356/107340865-8c977a00-6abe-11eb-80a2-bed8ba02dba9.png)

## After
![image](https://user-images.githubusercontent.com/1556356/107340801-74bff600-6abe-11eb-8166-263ec6225caf.png)
