### PR TITLE
Move settings button to NavBar actions

### DIFF
--- a/components/collective-navbar/ActionsMenu.js
+++ b/components/collective-navbar/ActionsMenu.js
@@ -7,6 +7,7 @@ import { MoneyCheckAlt } from '@styled-icons/fa-solid/MoneyCheckAlt';
 import { ChevronDown } from '@styled-icons/feather/ChevronDown/ChevronDown';
 import { AttachMoney } from '@styled-icons/material/AttachMoney';
 import { Dashboard } from '@styled-icons/material/Dashboard';
+import { Settings } from '@styled-icons/material/Settings';
 import { Stack } from '@styled-icons/remix-line/Stack';
 import themeGet from '@styled-system/theme-get';
 import { get, pickBy } from 'lodash';
@@ -313,6 +314,19 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction, hiddenActionFo
                         />
                       </MenuItem>
                     )}
+                    {callsToAction.hasSettings && (
+                      <MenuItem py={1} isHiddenOnMobile={hiddenActionForNonMobile === NAVBAR_ACTION_TYPE.SETTINGS}>
+                        <StyledLink
+                          as={Link}
+                          route="editCollective"
+                          params={{ slug: collective.slug }}
+                          p={ITEM_PADDING}
+                        >
+                          <Settings size={20} />
+                          <FormattedMessage id="Settings" defaultMessage="Settings" />
+                        </StyledLink>
+                      </MenuItem>
+                    )}
                   </Box>
                 </DropdownContent>
               </div>
@@ -356,6 +370,8 @@ CollectiveNavbarActionsMenu.propTypes = {
     addFunds: PropTypes.bool,
     /** Add prepaid budget to an organization */
     addPrepaidBudget: PropTypes.bool,
+    /** Button to Edit the Collective */
+    hasSettings: PropTypes.bool,
   }).isRequired,
   hiddenActionForNonMobile: PropTypes.oneOf(Object.values(NAVBAR_ACTION_TYPE)),
 };

--- a/components/collective-navbar/ActionsMenu.js
+++ b/components/collective-navbar/ActionsMenu.js
@@ -15,6 +15,7 @@ import { FormattedMessage } from 'react-intl';
 import styled, { css } from 'styled-components';
 
 import { getContributeRoute } from '../../lib/collective.lib';
+import { getSettingsRoute } from '../../lib/url_helpers';
 
 import AddFundsBtn from '../AddFundsBtn';
 import AddPrepaidBudgetBtn from '../AddPrepaidBudgetBtn';
@@ -201,6 +202,19 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction, hiddenActionFo
                 <DropdownArrow />
                 <DropdownContent>
                   <Box as="ul" p={0} m={0} minWidth={184}>
+                    {callsToAction.hasSettings && (
+                      <MenuItem py={1} isHiddenOnMobile={hiddenActionForNonMobile === NAVBAR_ACTION_TYPE.SETTINGS}>
+                        <StyledLink
+                          as={Link}
+                          route={getSettingsRoute(collective)}
+                          p={ITEM_PADDING}
+                          data-cy="edit-collective-btn"
+                        >
+                          <Settings size={20} />
+                          <FormattedMessage id="Settings" defaultMessage="Settings" />
+                        </StyledLink>
+                      </MenuItem>
+                    )}
                     {callsToAction.hasDashboard && (
                       <MenuItem isHiddenOnMobile={hiddenActionForNonMobile === NAVBAR_ACTION_TYPE.DASHBOARD}>
                         <StyledLink
@@ -312,19 +326,6 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction, hiddenActionFo
                           hostWithinLimit={hostWithinLimit}
                           buttonProps={{ isBorderless: true, p: ITEM_PADDING }}
                         />
-                      </MenuItem>
-                    )}
-                    {callsToAction.hasSettings && (
-                      <MenuItem py={1} isHiddenOnMobile={hiddenActionForNonMobile === NAVBAR_ACTION_TYPE.SETTINGS}>
-                        <StyledLink
-                          as={Link}
-                          route="editCollective"
-                          params={{ slug: collective.slug }}
-                          p={ITEM_PADDING}
-                        >
-                          <Settings size={20} />
-                          <FormattedMessage id="Settings" defaultMessage="Settings" />
-                        </StyledLink>
                       </MenuItem>
                     )}
                   </Box>

--- a/components/collective-navbar/index.js
+++ b/components/collective-navbar/index.js
@@ -20,6 +20,7 @@ import { getContributeRoute } from '../../lib/collective.lib';
 import { getFilteredSectionsForCollective, isSectionEnabled, NAVBAR_CATEGORIES } from '../../lib/collective-sections';
 import { CollectiveType } from '../../lib/constants/collectives';
 import useGlobalBlur from '../../lib/hooks/useGlobalBlur';
+import { getSettingsRoute } from '../../lib/url_helpers';
 
 import AddFundsBtn from '../AddFundsBtn';
 import AddPrepaidBudgetBtn from '../AddPrepaidBudgetBtn';
@@ -208,7 +209,21 @@ const getMainAction = (collective, callsToAction) => {
   }
 
   // Order of the condition defines main call to action: first match gets displayed
-  if (callsToAction.includes('hasDashboard')) {
+  if (callsToAction.includes(NAVBAR_ACTION_TYPE.SETTINGS)) {
+    return {
+      type: NAVBAR_ACTION_TYPE.SETTINGS,
+      component: (
+        <Link route={getSettingsRoute(collective)} data-cy="edit-collective-btn">
+          <MainActionBtn tabIndex="-1">
+            <Settings size="1em" />
+            <Span ml={2}>
+              <FormattedMessage id="Settings" defaultMessage="Settings" />
+            </Span>
+          </MainActionBtn>
+        </Link>
+      ),
+    };
+  } else if (callsToAction.includes('hasDashboard')) {
     return {
       type: NAVBAR_ACTION_TYPE.DASHBOARD,
       component: (
@@ -334,20 +349,6 @@ const getMainAction = (collective, callsToAction) => {
             </MainActionBtn>
           )}
         </AddPrepaidBudgetBtn>
-      ),
-    };
-  } else if (callsToAction.includes(NAVBAR_ACTION_TYPE.SETTINGS)) {
-    return {
-      type: NAVBAR_ACTION_TYPE.SETTINGS,
-      component: (
-        <Link route="editCollective" params={{ collectiveSlug: collective.slug }}>
-          <MainActionBtn tabIndex="-1">
-            <Settings size="1em" />
-            <Span ml={2}>
-              <FormattedMessage id="Settings" defaultMessage="Settings" />
-            </Span>
-          </MainActionBtn>
-        </Link>
       ),
     };
   } else {

--- a/components/collective-navbar/index.js
+++ b/components/collective-navbar/index.js
@@ -8,6 +8,7 @@ import { MoneyCheckAlt } from '@styled-icons/fa-solid/MoneyCheckAlt';
 import { AttachMoney } from '@styled-icons/material/AttachMoney';
 import { Close } from '@styled-icons/material/Close';
 import { Dashboard } from '@styled-icons/material/Dashboard';
+import { Settings } from '@styled-icons/material/Settings';
 import { Stack } from '@styled-icons/remix-line/Stack';
 import themeGet from '@styled-system/theme-get';
 import { get, pickBy, without } from 'lodash';
@@ -194,6 +195,7 @@ const getDefaultCallsToActions = (collective, sections, isAdmin, isHostAdmin, is
     hasRequestGrant: isFund || get(settings, 'fundingRequest') === true,
     addPrepaidBudget: isRoot && type === CollectiveType.ORGANIZATION,
     addFunds: isHostAdmin,
+    hasSettings: isAdmin,
   };
 };
 
@@ -332,6 +334,20 @@ const getMainAction = (collective, callsToAction) => {
             </MainActionBtn>
           )}
         </AddPrepaidBudgetBtn>
+      ),
+    };
+  } else if (callsToAction.includes(NAVBAR_ACTION_TYPE.SETTINGS)) {
+    return {
+      type: NAVBAR_ACTION_TYPE.SETTINGS,
+      component: (
+        <Link route="editCollective" params={{ collectiveSlug: collective.slug }}>
+          <MainActionBtn tabIndex="-1">
+            <Settings size="1em" />
+            <Span ml={2}>
+              <FormattedMessage id="Settings" defaultMessage="Settings" />
+            </Span>
+          </MainActionBtn>
+        </Link>
       ),
     };
   } else {
@@ -564,6 +580,7 @@ CollectiveNavbar.propTypes = {
     hasApply: PropTypes.bool,
     hasDashboard: PropTypes.bool,
     hasManageSubscriptions: PropTypes.bool,
+    hasSettings: PropTypes.bool,
   }),
   /** Used to check what sections can be used */
   isAdmin: PropTypes.bool,

--- a/components/collective-navbar/menu.js
+++ b/components/collective-navbar/menu.js
@@ -16,6 +16,7 @@ export const NAVBAR_ACTION_TYPE = {
   CONTRIBUTE: 'hasContribute',
   MANAGE_SUBSCRIPTIONS: 'hasManageSubscriptions',
   REQUEST_GRANT: 'hasRequestGrant',
+  SETTINGS: 'hasSettings',
 };
 
 const titles = defineMessages({

--- a/components/collective-page/hero/Hero.js
+++ b/components/collective-page/hero/Hero.js
@@ -4,7 +4,6 @@ import { Palette } from '@styled-icons/boxicons-regular/Palette';
 import { Camera } from '@styled-icons/feather/Camera';
 import { Github } from '@styled-icons/feather/Github';
 import { Globe } from '@styled-icons/feather/Globe';
-import { Settings } from '@styled-icons/feather/Settings';
 import { Twitter } from '@styled-icons/feather/Twitter';
 import { get } from 'lodash';
 import dynamic from 'next/dynamic';
@@ -19,7 +18,6 @@ import Container from '../../Container';
 import DefinedTerm, { Terms } from '../../DefinedTerm';
 import { Box, Flex } from '../../Grid';
 import I18nCollectiveTags from '../../I18nCollectiveTags';
-import Link from '../../Link';
 import LinkCollective from '../../LinkCollective';
 import LoadingPlaceholder from '../../LoadingPlaceholder';
 import MessageBox from '../../MessageBox';
@@ -151,25 +149,6 @@ const Hero = ({ collective, host, isAdmin, onPrimaryColorChange }) => {
           <Container position="relative" mb={2} width={128}>
             <HeroAvatar collective={collective} isAdmin={isAdmin} handleHeroMessage={handleHeroMessage} />
           </Container>
-          {isAdmin && (
-            <Box>
-              <Link
-                route={isEvent ? 'editEvent' : 'editCollective'}
-                params={
-                  isEvent
-                    ? { parentCollectiveSlug: collective.parentCollective?.slug, eventSlug: collective.slug }
-                    : { slug: collective.slug }
-                }
-              >
-                <StyledButton buttonSize="tiny" minWidth={96} my={3} data-cy="edit-collective-btn" tabIndex="-1">
-                  <Settings size={14} />
-                  <Span ml={1} css={{ verticalAlign: 'middle' }}>
-                    <FormattedMessage id="Settings" defaultMessage="Settings" />
-                  </Span>
-                </StyledButton>
-              </Link>
-            </Box>
-          )}
           <Box maxWidth={['70%', '60%', null, '40%', '45%']}>
             <H1
               color="black.800"

--- a/lib/url_helpers.js
+++ b/lib/url_helpers.js
@@ -1,5 +1,7 @@
 import { isEmpty, pickBy } from 'lodash';
 
+import { CollectiveType } from './constants/collectives';
+
 export const invoiceServiceURL = process.env.PDF_SERVICE_URL;
 
 // ---- Utils ----
@@ -108,4 +110,13 @@ export const linkedInShareURL = opts => {
  */
 export const mailToURL = (address = '', opts) => {
   return `mailto://${address}${objectToQueryString(opts)}`;
+};
+
+export const getSettingsRoute = account => {
+  if (account.type === CollectiveType.EVENT) {
+    const parent = account.parentCollective || account.parent;
+    return `/${parent?.slug || 'collective'}/events/${account.slug}/edit`;
+  } else {
+    return `/${account.slug}/edit`;
+  }
 };

--- a/test/cypress/integration/23-event.create.test.js
+++ b/test/cypress/integration/23-event.create.test.js
@@ -37,7 +37,7 @@ describe('event.create.test.js', () => {
     cy.get('[data-cy=Tickets] [data-cy=contribute-card-tier] [data-cy=amount]').contains(15);
     cy.disableSmoothScroll();
     cy.get('#top').scrollIntoView();
-    cy.getByDataCy('edit-collective-btn').click();
+    cy.get('[data-cy="edit-collective-btn"]:visible').click();
     // edit event info
     cy.get('.inputs .inputField.name input').type(`{selectall}${updatedTitle}`);
     cy.get('.actions > [data-cy="collective-save"]').click();
@@ -62,7 +62,7 @@ describe('event.create.test.js', () => {
     cy.get('[data-cy="financial-contributions"] [data-cy=contribute-card-tier]').should('have.length', 1);
     cy.get('h1[data-cy=collective-title]').contains(updatedTitle);
     // delete event tiers
-    cy.getByDataCy('edit-collective-btn').click();
+    cy.get('[data-cy="edit-collective-btn"]:visible').click();
     cy.getByDataCy('menu-item-advanced').click();
     cy.contains('button', 'Delete this Event').click();
     cy.get('[data-cy=delete]').click();


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve [opencollective/issues/3878](https://github.com/opencollective/opencollective/issues/3878)
Resolve https://github.com/opencollective/opencollective/issues/3482

# Description
This PR provides admins to view settings in their "Actions" menu on collective page Navbar

# Screenshots

Mobile View
![Screenshot (19)](https://user-images.githubusercontent.com/43727167/107544503-4fcba000-6bf0-11eb-8d1f-7865f6b96f28.png)

Desktop View
![Screenshot (20)](https://user-images.githubusercontent.com/43727167/107544513-50fccd00-6bf0-11eb-8744-79a142fe2cfa.png)

