### PR TITLE
Prevent expense form from rerendering with each click due to StyledInputTags

### DIFF
--- a/components/InputField.js
+++ b/components/InputField.js
@@ -255,11 +255,7 @@ class InputField extends React.Component {
                   <label>{capitalize(field.label)}</label>
                 </Box>
                 <Box width={[1, 2 / 12]}>
-                  <StyledInputTags
-                    {...field}
-                    renderUpdatedTags
-                    onChange={entries => field.onChange(entries.map(e => e.value))}
-                  />
+                  <StyledInputTags {...field} onChange={entries => field.onChange(entries.map(e => e.value))} />
                 </Box>
               </Flex>
             )}
@@ -272,11 +268,7 @@ class InputField extends React.Component {
                 )}
                 {field.description && <HelpBlock p={1}>{field.description}</HelpBlock>}
                 <Box width={1}>
-                  <StyledInputTags
-                    {...field}
-                    renderUpdatedTags
-                    onChange={entries => field.onChange(entries.map(e => e.value))}
-                  />
+                  <StyledInputTags {...field} onChange={entries => field.onChange(entries.map(e => e.value))} />
                 </Box>
               </Flex>
             )}

--- a/components/MenuPopover.js
+++ b/components/MenuPopover.js
@@ -173,7 +173,9 @@ class MenuPopover extends React.Component {
   }
 
   hideMenu = () => {
-    this.setState({ showMenu: false });
+    if (this.state.showMenu) {
+      this.setState({ showMenu: false });
+    }
   };
 
   toggleMenu = () => {

--- a/components/StyledDropdown.js
+++ b/components/StyledDropdown.js
@@ -55,6 +55,11 @@ export const DropdownArrow = styled('div')`
 export const Dropdown = styled(({ children, trigger, ...props }) => {
   const dropdownRef = useRef();
   const [isDisplayed, setDisplayed] = React.useState(false);
+  const closeDropdown = React.useCallback(() => {
+    if (isDisplayed) {
+      setDisplayed(false);
+    }
+  }, [isDisplayed]);
 
   useGlobalBlur(dropdownRef, outside => {
     if (outside && isDisplayed) {
@@ -65,7 +70,7 @@ export const Dropdown = styled(({ children, trigger, ...props }) => {
   });
 
   // Closes the modal upon the `ESC` key press.
-  useKeyBoardShortcut({ callback: () => setDisplayed(false), keyMatch: ESCAPE_KEY });
+  useKeyBoardShortcut({ callback: closeDropdown, keyMatch: ESCAPE_KEY });
 
   if (typeof children === 'function' && trigger === 'click') {
     return (
@@ -78,7 +83,7 @@ export const Dropdown = styled(({ children, trigger, ...props }) => {
             },
           },
           dropdownProps: {
-            onClick: () => setTimeout(() => setDisplayed(false), 50),
+            onClick: () => setTimeout(closeDropdown, 50),
           },
         })}
       </div>
@@ -91,7 +96,7 @@ export const Dropdown = styled(({ children, trigger, ...props }) => {
       trigger={trigger}
       {...props}
       onFocus={() => setTimeout(() => setDisplayed(true), 50)}
-      onBlur={() => setTimeout(() => setDisplayed(false), 50)}
+      onBlur={() => setTimeout(closeDropdown, 50)}
       onClick={e => {
         if (isDisplayed) {
           if (document.activeElement?.contains(e.target)) {

--- a/components/StyledModal.js
+++ b/components/StyledModal.js
@@ -177,9 +177,14 @@ ModalFooter.defaultProps = {
  */
 const StyledModal = ({ children, show, onClose, usePortal, trapFocus, ...props }) => {
   const TrapContainer = trapFocus ? FocusTrap : React.Fragment;
+  const onEscape = React.useCallback(() => {
+    if (show) {
+      onClose();
+    }
+  }, [show]);
 
   // Closes the modal upon the `ESC` key press.
-  useKeyBoardShortcut({ callback: () => onClose(), keyMatch: ESCAPE_KEY });
+  useKeyBoardShortcut({ callback: onEscape, keyMatch: ESCAPE_KEY });
 
   if (show && usePortal === false) {
     return (

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -392,15 +392,12 @@ const ExpenseFormBody = ({
               <Flex alignItems="flex-start" mt={3}>
                 <ExpenseTypeTag type={values.type} mr="4px" />
                 <StyledInputTags
-                  renderUpdatedTags
                   suggestedTags={expensesTags}
                   onChange={tags => {
-                    if (step == STEPS.EXPENSE && hasBaseFormFieldsCompleted) {
-                      formik.setFieldValue(
-                        'tags',
-                        tags.map(t => t.value.toLowerCase()),
-                      );
-                    }
+                    formik.setFieldValue(
+                      'tags',
+                      tags.map(t => t.value.toLowerCase()),
+                    );
                   }}
                   value={values.tags}
                 />

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -394,12 +394,14 @@ const ExpenseFormBody = ({
                 <StyledInputTags
                   renderUpdatedTags
                   suggestedTags={expensesTags}
-                  onChange={tags =>
-                    formik.setFieldValue(
-                      'tags',
-                      tags.map(t => t.value.toLowerCase()),
-                    )
-                  }
+                  onChange={tags => {
+                    if (step == STEPS.EXPENSE && hasBaseFormFieldsCompleted) {
+                      formik.setFieldValue(
+                        'tags',
+                        tags.map(t => t.value.toLowerCase()),
+                      );
+                    }
+                  }}
                   value={values.tags}
                 />
               </Flex>

--- a/lib/hooks/useKeyboardKey.js
+++ b/lib/hooks/useKeyboardKey.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 const useKeyboardKey = ({ callback, keyMatch }) => {
   React.useEffect(() => {
-    const eventListener = event => {
+    const onKeyDown = event => {
       let isRecognizedKey = false;
       if ('key' in event) {
         isRecognizedKey = event.key === keyMatch.key || event.key === keyMatch.keyName;
@@ -15,11 +15,11 @@ const useKeyboardKey = ({ callback, keyMatch }) => {
       }
     };
 
-    document.addEventListener('keydown', eventListener);
+    document.addEventListener('keydown', onKeyDown);
     return () => {
-      document.removeEventListener('keydown', eventListener);
+      document.removeEventListener('keydown', onKeyDown);
     };
-  }, []);
+  }, [callback, keyMatch]);
 };
 
 export default useKeyboardKey;

--- a/pages/conversation.js
+++ b/pages/conversation.js
@@ -412,7 +412,6 @@ class ConversationPage extends React.Component {
                                   ) : (
                                     <Box mx={2}>
                                       <StyledInputTags
-                                        renderUpdatedTags
                                         suggestedTags={this.getSuggestedTags(collective)}
                                         defaultValue={conversation.tags}
                                         onChange={options => this.handleTagsChange(options, setValue)}


### PR DESCRIPTION
Hopefully a performance enhancement and also means validation won't be triggered and clear error fields each time (as explained in [Slack](https://opencollective.slack.com/archives/CNA7RE3SN/p1613132448005000))