### PR TITLE
Remove Duplicate Function in Contribute.js class

### DIFF
--- a/components/collective-page/sections/Contribute.js
+++ b/components/collective-page/sections/Contribute.js
@@ -202,10 +202,6 @@ class SectionContribute extends React.PureComponent {
     return waysToContribute;
   });
 
-  hasContributors = memoizeOne(contributors => {
-    return contributors.find(c => c.isBacker);
-  });
-
   sortTicketTiers = memoizeOne(tiers => {
     return orderBy([...tiers], ['endsAt'], ['desc']);
   });


### PR DESCRIPTION
This removes the duplicate function `hasContributors` in the `Contribute.js` class. 