### PR TITLE
LoggedInUser: Remove paymentMethods fields

### DIFF
--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -121,17 +121,6 @@ export const loggedInUserQuery = gql`
         location {
           country
         }
-        paymentMethods(limit: 10, hasBalanceAboveZero: true) {
-          id
-          uuid
-          currency
-          name
-          service
-          type
-          data
-          balance
-          expiryDate
-        }
         payoutMethods {
           id
           type
@@ -162,17 +151,6 @@ export const loggedInUserQuery = gql`
           stats {
             id
             balance
-          }
-          paymentMethods(limit: 10, hasBalanceAboveZero: true) {
-            id
-            uuid
-            currency
-            name
-            service
-            type
-            data
-            balance
-            expiryDate
           }
           settings
         }


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/2126

Removes the two heaviest fields in the `LoggedInUser` query that are fetching all payment methods and their balances. Most of these were used in the previous versions of the contribution flow, but we now fetch them dynamically.