### PR TITLE
StyledInput: No min-height for checkboxes

### DIFF
--- a/components/StyledInput.js
+++ b/components/StyledInput.js
@@ -25,7 +25,9 @@ const getBorderColor = ({ error, success }) => {
  * @see See [styled-system docs](https://github.com/jxnblk/styled-system/blob/master/docs/api.md) for usage of those props
  */
 const StyledInput = styled.input`
-  min-height: 36px;
+  &:not([type='checkbox']):not([type='radio']) {
+    min-height: 36px;
+  }
 
   ${background}
   ${border}


### PR DESCRIPTION
Fix a regression on checkboxes.

## Before
![image](https://user-images.githubusercontent.com/1556356/107972574-56716300-6fb4-11eb-9a23-898d0348c3eb.png)

## After
![image](https://user-images.githubusercontent.com/1556356/107972599-5ffacb00-6fb4-11eb-8dea-f8a8f9d7ae15.png)
