### PR TITLE
Remove Invite from PayoutMethodType enum

### DIFF
--- a/components/expenses/ExpensePayeeDetails.js
+++ b/components/expenses/ExpensePayeeDetails.js
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 
 import expenseStatus from '../../lib/constants/expense-status';
 import expenseTypes from '../../lib/constants/expenseTypes';
-import { PayoutMethodType } from '../../lib/constants/payout-method';
+import { INVITE, PayoutMethodType } from '../../lib/constants/payout-method';
 
 import Avatar from '../Avatar';
 import Container from '../Container';
@@ -110,7 +110,7 @@ const ExpensePayeeDetails = ({ expense, host, isLoading, borderless, isLoadingLo
             <PayoutMethodTypeWithIcon
               type={
                 !expense.payoutMethod?.type && (expense.draft || expense.payee.isInvite)
-                  ? PayoutMethodType.INVITE
+                  ? INVITE
                   : expense.payoutMethod?.type
               }
             />

--- a/components/expenses/PayoutMethodTypeWithIcon.js
+++ b/components/expenses/PayoutMethodTypeWithIcon.js
@@ -5,7 +5,7 @@ import { ExchangeAlt as OtherIcon } from '@styled-icons/fa-solid/ExchangeAlt';
 import { University as BankIcon } from '@styled-icons/fa-solid/University';
 import { FormattedMessage } from 'react-intl';
 
-import { PayoutMethodType } from '../../lib/constants/payout-method';
+import { INVITE, PayoutMethodType } from '../../lib/constants/payout-method';
 
 import Avatar from '../Avatar';
 import { Flex } from '../Grid';
@@ -48,7 +48,7 @@ const PayoutMethodTypeWithIcon = ({ isLoading, type, fontSize, fontWeight, color
           </Span>
         </Flex>
       );
-    case PayoutMethodType.INVITE:
+    case INVITE:
       return (
         <Flex alignItems="center">
           <Avatar name="?" size={iconSize} backgroundColor="blue.100" color="blue.400" fontWeight="500" />
@@ -72,7 +72,7 @@ const PayoutMethodTypeWithIcon = ({ isLoading, type, fontSize, fontWeight, color
 
 PayoutMethodTypeWithIcon.propTypes = {
   isLoading: PropTypes.bool,
-  type: PropTypes.oneOf(Object.values(PayoutMethodType)),
+  type: PropTypes.oneOf([...Object.values(PayoutMethodType), INVITE]),
   fontSize: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   fontWeight: PropTypes.string,
   color: PropTypes.string,

--- a/lib/constants/payout-method.js
+++ b/lib/constants/payout-method.js
@@ -3,9 +3,10 @@ export const PayoutMethodType = {
   BANK_ACCOUNT: 'BANK_ACCOUNT',
   PAYPAL: 'PAYPAL',
   OTHER: 'OTHER',
-  /** Virtual property, doesn't exist in our backend */
-  INVITE: 'INVITE',
 };
+
+// Submit on Behalf placeholder. Not an actual Payout Method Type and only exists in the frontend.
+export const INVITE = 'INVITE';
 
 // This is not internationalized on purpose
 export const BANK_TRANSFER_DEFAULT_INSTRUCTIONS = `Thank you for your contributions! Here are the payment instructions. Be sure to include the reference details, so we can validate the transaction. This is a manual process, so it can take a few days.


### PR DESCRIPTION
INVITE was showing up in the Payout Method filter in the Expenses view, since it is only a placeholder, I created its own constant.