### PR TITLE
fix: keep github FAQ at the top

### DIFF
--- a/components/create-collective/ConnectGithub.js
+++ b/components/create-collective/ConnectGithub.js
@@ -176,7 +176,10 @@ class ConnectGithub extends React.Component {
               display={['block', null, 'block']}
               width={[1, 1 / 5]}
               maxWidth={[250, null, 335]}
-              alignSelf={['center', 'none']}
+              alignSelf={['center', 'flex-start']}
+              position="sticky"
+              top={0}
+              pt={[0, 3]}
             />
           </Flex>
         )}


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve opencollective/opencollective#3994

# Description

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

This PR resolves the positioning issue with the GitHub FAQ by keeping it fixed to the top even when scrolling

# Screenshots

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->

* Mobile
![final_603294b138c96000706fd994_604167](https://user-images.githubusercontent.com/24629960/108642777-283cc900-7475-11eb-96f9-24dbf8f50b57.gif)

* Desktop
![final_60329398148e4d003dd0a8ec_47536](https://user-images.githubusercontent.com/24629960/108642787-3be82f80-7475-11eb-9d41-72ebe5b24766.gif)
