### PR TITLE
Fix Platform Tip Quantity Calculation

### DIFF
--- a/components/contribution-flow/FeesOnTopInput.js
+++ b/components/contribution-flow/FeesOnTopInput.js
@@ -60,9 +60,10 @@ const getOptions = (amount, currency, intl) => {
   ];
 };
 
-const FeesOnTopInput = ({ currency, amount, fees, onChange }) => {
+const FeesOnTopInput = ({ currency, amount, quantity, fees, onChange }) => {
   const intl = useIntl();
-  const options = React.useMemo(() => getOptions(amount, currency, intl), [amount, currency]);
+  const orderAmount = amount * quantity;
+  const options = React.useMemo(() => getOptions(orderAmount, currency, intl), [orderAmount, currency]);
   const formatOptionLabel = option => {
     if (option.currency) {
       return (
@@ -94,13 +95,13 @@ const FeesOnTopInput = ({ currency, amount, fees, onChange }) => {
     } else if (selectedOption.value === 0 && fees) {
       onChange(0);
     } else if (selectedOption.percentage) {
-      const newOption = getOptionFromPercentage(amount, currency, selectedOption.percentage);
+      const newOption = getOptionFromPercentage(orderAmount, currency, selectedOption.percentage);
       if (newOption.value !== fees) {
         onChange(newOption.value);
         setSelectedOption(newOption);
       }
     }
-  }, [selectedOption, amount, isReady]);
+  }, [selectedOption, orderAmount, isReady]);
 
   return (
     <div>
@@ -143,6 +144,7 @@ FeesOnTopInput.propTypes = {
   currency: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   amount: PropTypes.number,
+  quantity: PropTypes.number,
   fees: PropTypes.number,
   interval: PropTypes.oneOf(Object.values(INTERVALS)),
 };

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -199,6 +199,7 @@ const StepDetails = ({ onChange, data, collective, tier, showFeesOnTop }) => {
             amount={data?.amount}
             fees={data?.platformContribution}
             interval={data?.interval}
+            quantity={data?.quantity}
             onChange={value => dispatchChange('platformContribution', value)}
           />
         </Box>

--- a/components/contribution-flow/utils.js
+++ b/components/contribution-flow/utils.js
@@ -123,7 +123,7 @@ export const getTotalAmount = (stepDetails, stepSummary = null) => {
   const amount = get(stepDetails, 'amount') || 0;
   const taxAmount = get(stepSummary, 'amount') || 0;
   const platformFeeAmount = get(stepDetails, 'platformContribution') || 0;
-  return quantity * (amount + platformFeeAmount) + taxAmount;
+  return quantity * amount + platformFeeAmount + taxAmount;
 };
 
 export const getGQLV2AmountInput = (valueInCents, defaultValue) => {


### PR DESCRIPTION
I'm refactoring this to set platform tip per order and not per item, I think it is clearer and match the expected UX.