### PR TITLE
OnBoarding: Fix contact step button

### DIFF
--- a/components/onboarding-modal/OnboardingStepsProgress.js
+++ b/components/onboarding-modal/OnboardingStepsProgress.js
@@ -22,15 +22,9 @@ StepLabel.defaultProps = {
 const steps = [{ name: 'Welcome' }, { name: 'Administrators' }, { name: 'Contact' }];
 
 const params = {
-  0: {
-    routerStep: undefined,
-  },
-  1: {
-    routerStep: 'administrators',
-  },
-  2: {
-    routerStep: 'contact',
-  },
+  0: undefined,
+  1: 'administrators',
+  2: 'contact-info',
 };
 
 class OnboardingStepsProgress extends React.Component {
@@ -39,10 +33,6 @@ class OnboardingStepsProgress extends React.Component {
     mode: PropTypes.string,
     slug: PropTypes.string,
     router: PropTypes.object,
-  };
-
-  getStepParams = (step, param) => {
-    return params[step][param];
   };
 
   render() {
@@ -55,7 +45,7 @@ class OnboardingStepsProgress extends React.Component {
           focus={steps[this.props.step]}
           onStepSelect={step => {
             const newStep = steps.findIndex(element => element.name === step.name);
-            this.props.router.push(`/${slug}/${mode}/${this.getStepParams(newStep, 'routerStep')}`);
+            this.props.router.push(`/${slug}/${mode}/${params[newStep] || ''}`);
           }}
         >
           {({ step }) => {


### PR DESCRIPTION
Small follow-up on https://github.com/opencollective/opencollective-frontend/pull/5855. Also simplified the code.

- Contact step button was linking to `onboarding/contact` instead of `onboading/contact-info`
- First step button was linking to `onboarding/undefined`