### PR TITLE
feat(PublishUpdateBtnWithData): confirm before publishing an update

### DIFF
--- a/components/PublishUpdateBtnWithData.js
+++ b/components/PublishUpdateBtnWithData.js
@@ -8,6 +8,7 @@ import styled from 'styled-components';
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
 import { compose } from '../lib/utils';
 
+import ConfirmationModal from './ConfirmationModal';
 import Container from './Container';
 import StyledButton from './StyledButton';
 import StyledSelect from './StyledSelect';
@@ -38,6 +39,7 @@ class PublishUpdateBtn extends React.Component {
     this.onClick = this.onClick.bind(this);
     this.state = {
       notificationAudience: 'FINANCIAL_CONTRIBUTORS',
+      showModal: false,
     };
   }
 
@@ -45,6 +47,10 @@ class PublishUpdateBtn extends React.Component {
     const { id } = this.props;
     const { notificationAudience } = this.state;
     await this.props.publishUpdate({ variables: { id, notificationAudience } });
+  }
+
+  handleShowModalChange(value) {
+    this.setState({ showModal: value });
   }
 
   handleNotificationChange(selected) {
@@ -127,17 +133,35 @@ class PublishUpdateBtn extends React.Component {
             </Span>
           )}
           {!isLoading && <Notice>{notice}</Notice>}
-          <Container mt="3" display="flex" alignItems="center">
-            <StyledButton
-              buttonStyle="primary"
-              onClick={this.onClick}
-              loading={isLoading}
-              minWidth={100}
-              data-cy="btn-publish"
-            >
-              <FormattedMessage id="update.publish.btn" defaultMessage="Publish" />
-            </StyledButton>
-          </Container>
+          {this.state.showModal ? (
+            <ConfirmationModal
+              show
+              header={<FormattedMessage id="update.publish.modal.header" defaultMessage="Publish update" />}
+              body={
+                <FormattedMessage
+                  id="update.publish.modal.body"
+                  defaultMessage="Are you sure you want to publish this update?"
+                />
+              }
+              onClose={() => this.handleShowModalChange(false)}
+              cancelLabel={<FormattedMessage id="no" defaultMessage="No" />}
+              cancelHandler={() => this.handleShowModalChange(false)}
+              continueLabel={<FormattedMessage id="yes" defaultMessage="Yes" />}
+              continueHandler={this.onClick}
+            />
+          ) : (
+            <Container mt="3" display="flex" alignItems="center">
+              <StyledButton
+                buttonStyle="primary"
+                onClick={() => this.handleShowModalChange(true)}
+                loading={isLoading}
+                minWidth={100}
+                data-cy="btn-publish"
+              >
+                <FormattedMessage id="update.publish.btn" defaultMessage="Publish" />
+              </StyledButton>
+            </Container>
+          )}
         </Container>
       </StyledPublishUpdateBtn>
     );

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1839,6 +1839,8 @@
   "update.private.description": "Only contributors will be able to see the content of this update",
   "update.private.lock_text": "This update is for contributors only",
   "update.publish.btn": "Publish",
+  "update.publish.modal.body": "Are you sure you want to publish this update?",
+  "update.publish.modal.header": "Publish update",
   "update.publish.notify.Everyone": "Your Update will be sent to the admins of {m} hosted Collectives and {n} financial contributors",
   "update.publish.notify.financialContributors": "Your Update will be sent to {n} financial contributors",
   "update.publish.notify.hostedCollectiveAdmins": "Your Update will be sent to the admins of {m} hosted Collectives",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1839,6 +1839,8 @@
   "update.private.description": "Only contributors will be able to see the content of this update",
   "update.private.lock_text": "This update is for contributors only",
   "update.publish.btn": "Publish",
+  "update.publish.modal.body": "Are you sure you want to publish this update?",
+  "update.publish.modal.header": "Publish update",
   "update.publish.notify.Everyone": "Your Update will be sent to the admins of {m} hosted Collectives and {n} financial contributors",
   "update.publish.notify.financialContributors": "Your Update will be sent to {n} financial contributors",
   "update.publish.notify.hostedCollectiveAdmins": "Your Update will be sent to the admins of {m} hosted Collectives",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1839,6 +1839,8 @@
   "update.private.description": "Only contributors will be able to see the content of this update",
   "update.private.lock_text": "This update is for contributors only",
   "update.publish.btn": "Publish",
+  "update.publish.modal.body": "Are you sure you want to publish this update?",
+  "update.publish.modal.header": "Publish update",
   "update.publish.notify.Everyone": "Your Update will be sent to the admins of {m} hosted Collectives and {n} financial contributors",
   "update.publish.notify.financialContributors": "Your Update will be sent to {n} financial contributors",
   "update.publish.notify.hostedCollectiveAdmins": "Your Update will be sent to the admins of {m} hosted Collectives",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1839,6 +1839,8 @@
   "update.private.description": "Only contributors will be able to see the content of this update",
   "update.private.lock_text": "This update is for contributors only",
   "update.publish.btn": "Publish",
+  "update.publish.modal.body": "Are you sure you want to publish this update?",
+  "update.publish.modal.header": "Publish update",
   "update.publish.notify.Everyone": "Your Update will be sent to the admins of {m} hosted Collectives and {n} financial contributors",
   "update.publish.notify.financialContributors": "Your Update will be sent to {n} financial contributors",
   "update.publish.notify.hostedCollectiveAdmins": "Your Update will be sent to the admins of {m} hosted Collectives",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1839,6 +1839,8 @@
   "update.private.description": "Only contributors will be able to see the content of this update",
   "update.private.lock_text": "This update is for contributors only",
   "update.publish.btn": "Publish",
+  "update.publish.modal.body": "Are you sure you want to publish this update?",
+  "update.publish.modal.header": "Publish update",
   "update.publish.notify.Everyone": "Your Update will be sent to the admins of {m} hosted Collectives and {n} financial contributors",
   "update.publish.notify.financialContributors": "Your Update will be sent to {n} financial contributors",
   "update.publish.notify.hostedCollectiveAdmins": "Your Update will be sent to the admins of {m} hosted Collectives",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1839,6 +1839,8 @@
   "update.private.description": "Seuls les contributeurs pourront voir le contenu de cette actualité",
   "update.private.lock_text": "This update is for contributors only",
   "update.publish.btn": "Publier",
+  "update.publish.modal.body": "Are you sure you want to publish this update?",
+  "update.publish.modal.header": "Publish update",
   "update.publish.notify.Everyone": "Your Update will be sent to the admins of {m} hosted Collectives and {n} financial contributors",
   "update.publish.notify.financialContributors": "Your Update will be sent to {n} financial contributors",
   "update.publish.notify.hostedCollectiveAdmins": "Your Update will be sent to the admins of {m} hosted Collectives",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1839,6 +1839,8 @@
   "update.private.description": "Only contributors will be able to see the content of this update",
   "update.private.lock_text": "This update is for contributors only",
   "update.publish.btn": "Publish",
+  "update.publish.modal.body": "Are you sure you want to publish this update?",
+  "update.publish.modal.header": "Publish update",
   "update.publish.notify.Everyone": "Your Update will be sent to the admins of {m} hosted Collectives and {n} financial contributors",
   "update.publish.notify.financialContributors": "Your Update will be sent to {n} financial contributors",
   "update.publish.notify.hostedCollectiveAdmins": "Your Update will be sent to the admins of {m} hosted Collectives",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1839,6 +1839,8 @@
   "update.private.description": "Only contributors will be able to see the content of this update",
   "update.private.lock_text": "This update is for contributors only",
   "update.publish.btn": "Publish",
+  "update.publish.modal.body": "Are you sure you want to publish this update?",
+  "update.publish.modal.header": "Publish update",
   "update.publish.notify.Everyone": "Your Update will be sent to the admins of {m} hosted Collectives and {n} financial contributors",
   "update.publish.notify.financialContributors": "Your Update will be sent to {n} financial contributors",
   "update.publish.notify.hostedCollectiveAdmins": "Your Update will be sent to the admins of {m} hosted Collectives",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1839,6 +1839,8 @@
   "update.private.description": "Only contributors will be able to see the content of this update",
   "update.private.lock_text": "This update is for contributors only",
   "update.publish.btn": "게시",
+  "update.publish.modal.body": "Are you sure you want to publish this update?",
+  "update.publish.modal.header": "Publish update",
   "update.publish.notify.Everyone": "Your Update will be sent to the admins of {m} hosted Collectives and {n} financial contributors",
   "update.publish.notify.financialContributors": "Your Update will be sent to {n} financial contributors",
   "update.publish.notify.hostedCollectiveAdmins": "Your Update will be sent to the admins of {m} hosted Collectives",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1839,6 +1839,8 @@
   "update.private.description": "Only contributors will be able to see the content of this update",
   "update.private.lock_text": "This update is for contributors only",
   "update.publish.btn": "Publish",
+  "update.publish.modal.body": "Are you sure you want to publish this update?",
+  "update.publish.modal.header": "Publish update",
   "update.publish.notify.Everyone": "Your Update will be sent to the admins of {m} hosted Collectives and {n} financial contributors",
   "update.publish.notify.financialContributors": "Your Update will be sent to {n} financial contributors",
   "update.publish.notify.hostedCollectiveAdmins": "Your Update will be sent to the admins of {m} hosted Collectives",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1839,6 +1839,8 @@
   "update.private.description": "Apenas colaboradores poderão ver o conteúdo desta atualização",
   "update.private.lock_text": "This update is for contributors only",
   "update.publish.btn": "Publish",
+  "update.publish.modal.body": "Are you sure you want to publish this update?",
+  "update.publish.modal.header": "Publish update",
   "update.publish.notify.Everyone": "Your Update will be sent to the admins of {m} hosted Collectives and {n} financial contributors",
   "update.publish.notify.financialContributors": "Your Update will be sent to {n} financial contributors",
   "update.publish.notify.hostedCollectiveAdmins": "Your Update will be sent to the admins of {m} hosted Collectives",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1839,6 +1839,8 @@
   "update.private.description": "Only contributors will be able to see the content of this update",
   "update.private.lock_text": "This update is for contributors only",
   "update.publish.btn": "Опубликовать",
+  "update.publish.modal.body": "Are you sure you want to publish this update?",
+  "update.publish.modal.header": "Publish update",
   "update.publish.notify.Everyone": "Your Update will be sent to the admins of {m} hosted Collectives and {n} financial contributors",
   "update.publish.notify.financialContributors": "Your Update will be sent to {n} financial contributors",
   "update.publish.notify.hostedCollectiveAdmins": "Your Update will be sent to the admins of {m} hosted Collectives",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -1839,6 +1839,8 @@
   "update.private.description": "Лише помічники зможуть бачити вміст цього оновлення",
   "update.private.lock_text": "Оновлення лише для помічників",
   "update.publish.btn": "Опублікувати",
+  "update.publish.modal.body": "Are you sure you want to publish this update?",
+  "update.publish.modal.header": "Publish update",
   "update.publish.notify.Everyone": "Ваше оновлення буде надіслано адміністраторам {m} обслуговуваних Колективів та {n} фінансовим помічникам",
   "update.publish.notify.financialContributors": "Ваше оновлення буде надіслано {n} фінансовим помічникам",
   "update.publish.notify.hostedCollectiveAdmins": "Ваше оновлення буде надіслано адміністраторам {m} обслуговуваних Колективів",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1839,6 +1839,8 @@
   "update.private.description": "Only contributors will be able to see the content of this update",
   "update.private.lock_text": "This update is for contributors only",
   "update.publish.btn": "发布",
+  "update.publish.modal.body": "Are you sure you want to publish this update?",
+  "update.publish.modal.header": "Publish update",
   "update.publish.notify.Everyone": "Your Update will be sent to the admins of {m} hosted Collectives and {n} financial contributors",
   "update.publish.notify.financialContributors": "Your Update will be sent to {n} financial contributors",
   "update.publish.notify.hostedCollectiveAdmins": "Your Update will be sent to the admins of {m} hosted Collectives",

--- a/test/cypress/integration/28-update.create.test.js
+++ b/test/cypress/integration/28-update.create.test.js
@@ -16,6 +16,7 @@ describe('create an update', () => {
     cy.get('[data-cy="privateIcon"]').should('not.exist');
     cy.get('[data-cy=PublishUpdateBtn]').contains('Your Update will be sent to');
     cy.getByDataCy('btn-publish').click();
+    cy.getByDataCy('confirmation-modal-continue').click();
     cy.get('[data-cy=meta]').contains('draft').should('not.exist');
 
     cy.get('[data-cy=toggleEditUpdate').click();


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/4016

# Description

show a confirmation modal before publishing an update.
<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots


https://user-images.githubusercontent.com/46647141/108996643-a4791b80-76c4-11eb-9515-d4691368d671.mp4


<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
