### PR TITLE
OCFApplicationForm: Format amounts to string

### DIFF
--- a/components/host-dashboard/PendingApplication.js
+++ b/components/host-dashboard/PendingApplication.js
@@ -21,6 +21,7 @@ import I18nCollectiveTags from '../I18nCollectiveTags';
 import CommentIcon from '../icons/CommentIcon';
 import Link from '../Link';
 import LinkCollective from '../LinkCollective';
+import { APPLICATION_DATA_AMOUNT_FIELDS } from '../ocf-host-application/ApplicationForm';
 import StyledCollectiveCard from '../StyledCollectiveCard';
 import StyledHr from '../StyledHr';
 import StyledLink from '../StyledLink';
@@ -214,8 +215,6 @@ const UserInputContainer = styled(P).attrs({
   fontWeight: '400',
 })``;
 
-const AMOUNT_FIELDS = ['totalAmountRaised', 'totalAmountToBeRaised'];
-
 const PendingApplication = ({ host, application, ...props }) => {
   const intl = useIntl();
   const [isDone, setIsDone] = React.useState(false);
@@ -359,8 +358,10 @@ const PendingApplication = ({ host, application, ...props }) => {
                 <Container mb={3} key={key}>
                   <InfoSectionHeader>{i18nOCFApplicationFormLabel(intl, key)}</InfoSectionHeader>
                   <UserInputContainer>
-                    {AMOUNT_FIELDS.includes(key) && '$'}
-                    {application.customData[key]}
+                    {/** Amount was previously stored as a number in cents */}
+                    {APPLICATION_DATA_AMOUNT_FIELDS.includes(key) && typeof application.customData[key] === 'number'
+                      ? `${application.customData[key] / 100}$`
+                      : application.customData[key]}
                   </UserInputContainer>
                 </Container>
               ))}


### PR DESCRIPTION
Goes with https://github.com/opencollective/opencollective-api/pull/5421

Since the amounts in `applicationData` have no other purpose than being displayed in the interface and in the emails, it's simpler to format them to a string that includes the currency.

This also resolves a small issue: we were previously displaying the amounts in cents in the host dashboard (so an application with $10 would end up with $1000 in the interface).

Before:

```diff
{
    location: 'FR',
    initiativeDuration: '2 years',
-   totalAmountRaised: 4200,
+   totalAmountRaised: '$42',
-   totalAmountToBeRaised: 10000,
+   totalAmountToBeRaised: '$100',
    expectedFundingPartner: 'Lorem ipsum',
    missionImpactExplanation: 'Lorem ipsum',
    websiteAndSocialLinks: 'Lorem ipsum',
}
```