### PR TITLE
Make Dependency Version Fixed in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@styled-icons/ionicons-solid": "10.28.0",
     "@styled-icons/material": "10.28.0",
     "@styled-icons/octicons": "10.28.0",
-    "@styled-icons/remix-line": "^10.18.0",
+    "@styled-icons/remix-line": "10.18.0",
     "@styled-system/css": "5.1.5",
     "@styled-system/prop-types": "5.1.5",
     "@styled-system/theme-get": "5.1.2",


### PR DESCRIPTION
As stated in https://docs.opencollective.com/help/contributing/development/best-practice-guidelines#general-rules the dependency versions should be fixed. However working on something else, I just noticed there was a dependency that wasn't fixed in `package.json`. This PR corrects it. 