### PR TITLE
Only Show On-Boarding Modal when User is Member of Collective

### DIFF
--- a/components/onboarding-modal/OnboardingContentBox.js
+++ b/components/onboarding-modal/OnboardingContentBox.js
@@ -10,9 +10,9 @@ import Container from '../../components/Container';
 import StyledHr from '../../components/StyledHr';
 import StyledInputField from '../../components/StyledInputField';
 import StyledInputGroup from '../../components/StyledInputGroup';
-import { H1, P } from '../../components/Text';
 
 import { Box, Flex } from '../Grid';
+import { H1, P } from '../Text';
 
 import OnboardingProfileCard from './OnboardingProfileCard';
 import OnboardingSkipButton from './OnboardingSkipButton';

--- a/pages/collective-page.js
+++ b/pages/collective-page.js
@@ -176,8 +176,6 @@ class CollectivePage extends React.Component {
     }
 
     const collective = data && data.Collective;
-    const isMember =
-      LoggedInUser && LoggedInUser.memberOf.filter(member => member.collective.id === collective.id).length > 0;
 
     return (
       <Page canonicalURL={this.getCanonicalURL(slug)} {...this.getPageMetaData(collective)}>
@@ -222,7 +220,7 @@ class CollectivePage extends React.Component {
                 />
               )}
             </CollectiveThemeProvider>
-            {isMember && mode === 'onboarding' && (
+            {mode === 'onboarding' && LoggedInUser?.canEditCollective(collective) && (
               <OnboardingModal
                 showOnboardingModal={showOnboardingModal}
                 setShowOnboardingModal={this.setShowOnboardingModal}

--- a/pages/collective-page.js
+++ b/pages/collective-page.js
@@ -176,6 +176,8 @@ class CollectivePage extends React.Component {
     }
 
     const collective = data && data.Collective;
+    const isMember =
+      LoggedInUser && LoggedInUser.memberOf.filter(member => member.collective.id === collective.id).length > 0;
 
     return (
       <Page canonicalURL={this.getCanonicalURL(slug)} {...this.getPageMetaData(collective)}>
@@ -220,7 +222,7 @@ class CollectivePage extends React.Component {
                 />
               )}
             </CollectiveThemeProvider>
-            {LoggedInUser && mode === 'onboarding' && (
+            {isMember && mode === 'onboarding' && (
               <OnboardingModal
                 showOnboardingModal={showOnboardingModal}
                 setShowOnboardingModal={this.setShowOnboardingModal}


### PR DESCRIPTION
This makes sure the on-boarding modal is only shown when user is a member of the collective.

Resolve https://github.com/opencollective/opencollective/issues/3130

# Screencast

![onboarding-modal-bug-fix](https://user-images.githubusercontent.com/12435965/109270941-a5dd3d80-77c3-11eb-8842-da6841278718.gif)
