### PR TITLE
Fix null payeeLocation crash

### DIFF
--- a/components/expenses/ExpenseFormPayeeStep.js
+++ b/components/expenses/ExpenseFormPayeeStep.js
@@ -249,7 +249,7 @@ const ExpenseFormPayeeStep = ({
                   </StyledInputField>
                 )}
               </FastField>
-              {values.payeeLocation.structured || values.payeeLocation.address === '' ? (
+              {values.payeeLocation?.structured || !values.payeeLocation?.address ? (
                 <Field name="payeeLocation.structured">
                   {({ field }) => (
                     <I18nAddressFields


### PR DESCRIPTION
Fix https://sentry.io/organizations/open-collective/issues/2231796279

I'm not sure what the conditions are for `payeeLocation` to be null, maybe it's reset when someone selects another payee? Anyway, the other parts of the code were assuming it can be null so I've changed that here too.