### PR TITLE
TransactionItem: Display net amount for expenses on collective page

### DIFF
--- a/components/transactions/TransactionItem.js
+++ b/components/transactions/TransactionItem.js
@@ -31,6 +31,28 @@ import TransactionDetails from './TransactionDetails';
 /** To separate individual information below description */
 const INFO_SEPARATOR = ' • ';
 
+const getDisplayedAmount = (transaction, collective) => {
+  const isCredit = transaction.type === TransactionTypes.CREDIT;
+  const hasOrder = transaction.order !== null;
+  const isSelf = transaction.fromAccount.slug === collective.slug;
+
+  if (isCredit && hasOrder) {
+    // Credit from donations should display the full amount donated by the user
+    return transaction.amount;
+  } else if (!isCredit && !hasOrder) {
+    // Expense Debits should display the Amount with Payment Method fees only on collective's profile
+    return isSelf ? transaction.netAmount : transaction.amount;
+  } else if (transaction.isRefunded) {
+    if ((isSelf && !transaction.isRefund) || (transaction.isRefund && isCredit)) {
+      return transaction.netAmount;
+    } else {
+      return transaction.amount;
+    }
+  } else {
+    return transaction.netAmount;
+  }
+};
+
 const TransactionItem = ({ displayActions, collective, transaction, onMutationSuccess }) => {
   const {
     toAccount,
@@ -39,8 +61,6 @@ const TransactionItem = ({ displayActions, collective, transaction, onMutationSu
     order,
     expense,
     type,
-    amount,
-    netAmount,
     description,
     createdAt,
     isRefunded,
@@ -62,15 +82,7 @@ const TransactionItem = ({ displayActions, collective, transaction, onMutationSu
   const isFromCollectiveAdmin = LoggedInUser && LoggedInUser.canEditCollective(fromAccount);
   const isToCollectiveAdmin = LoggedInUser && LoggedInUser.canEditCollective(toAccount);
   const canDownloadInvoice = isRoot || isHostAdmin || isFromCollectiveAdmin || isToCollectiveAdmin;
-  let displayedAmount =
-    (isCredit && hasOrder) || // Credit from donations should display the full amount donated by the user
-    (!isCredit && !hasOrder) // Expense Debits should display the Amount without Payment Method fees
-      ? amount
-      : netAmount;
-  // The refunded transaction logic because it's a bit messy, the conditional was conceived by trial
-  if (isRefunded) {
-    displayedAmount = (fromAccount.slug == collective.slug && !isRefund) || (isRefund && isCredit) ? netAmount : amount;
-  }
+  const displayedAmount = getDisplayedAmount(transaction, collective);
 
   return (
     <Item data-cy="transaction-item">


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/4010

Displays full amount (expense.amount + fees) on the collective page but keep displaying the base amount on payee's profile.

Also refactored into a `getDisplayedAmount` because ternaries were growing too much with this new condition.

## Preview

Expense amount: $4200
Payment processor fees: $500

**Webpack /transactions**
![image](https://user-images.githubusercontent.com/1556356/109937193-f296ac00-7cce-11eb-86b6-d5b1bbcf08b1.png)


**User profile**
![image](https://user-images.githubusercontent.com/1556356/109937236-fde9d780-7cce-11eb-9ee6-cb24505f8e34.png)
