### PR TITLE
Recurring-contributions: fetch paymentMethods with a network-only policy

### DIFF
--- a/components/recurring-contributions/UpdatePaymentMethodPopUp.js
+++ b/components/recurring-contributions/UpdatePaymentMethodPopUp.js
@@ -131,6 +131,7 @@ const UpdatePaymentMethodPopUp = ({ setMenuState, contribution, setShowPopup, ro
       slug: router.query.slug,
     },
     context: API_V2_CONTEXT,
+    fetchPolicy: 'network-only',
   });
   const [submitUpdatePaymentMethod, { loading: loadingUpdatePaymentMethod }] = useMutation(
     updatePaymentMethodMutation,


### PR DESCRIPTION
Make sure to not display deleted cards.