### PR TITLE
StyledInputTags: Fix state update

### DIFF
--- a/components/StyledInputTags.js
+++ b/components/StyledInputTags.js
@@ -141,7 +141,6 @@ const StyledInputTags = ({ suggestedTags, value, onChange, renderUpdatedTags, de
 
   const handleClose = React.useCallback(() => {
     if (isOpen) {
-      onChange(tags);
       setOpen(false);
     }
   }, [isOpen]);

--- a/test/cypress/integration/17-conversations.test.js
+++ b/test/cypress/integration/17-conversations.test.js
@@ -44,8 +44,7 @@ describe('Conversations', () => {
       const sampleTag = 'alot more amazing stuff';
       cy.getByDataCy('InlineEditField-Trigger-tags').click();
       cy.getByDataCy('styled-input-tags-open').click();
-      cy.getByDataCy('styled-input-tags-input').type(`${sampleTag}{enter}{enter}`);
-      cy.getByDataCy('InlineEditField-Btn-Save').click();
+      cy.getByDataCy('styled-input-tags-input').type(`${sampleTag}{enter}`).blur();
       cy.contains(`${sampleTag}`.toLowerCase());
 
       // Add comment


### PR DESCRIPTION
`handleClose` was not memoized on the right attribute. Anyway, it wasn't needed as callback is already triggered on add/remove.