### PR TITLE
Update robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,20 @@
+User-agent: SemrushBot-SA
+Disallow: /
+
+User-agent: SemrushBot-BA
+Disallow: /
+
+User-agent: SemrushBot-SI
+Disallow: /
+
+User-agent: SemrushBot-SWA
+Disallow: /
+
+User-agent: SemrushBot-CT
+Disallow: /
+
+User-agent: SemrushBot-BM
+Disallow: /
+
+User-agent: MJ12bot
+Disallow: /

--- a/server/routes.js
+++ b/server/routes.js
@@ -87,13 +87,14 @@ module.exports = (expressApp, nextApp) => {
    * Prevent indexation from search engines
    * (out of 'production' environment)
    */
-  app.get('/robots.txt', (req, res) => {
+  app.get('/robots.txt', (req, res, next) => {
     const hostname = req.get('original-hostname') || req.hostname;
-    res.setHeader('Content-Type', 'text/plain');
     if (hostname !== 'opencollective.com') {
+      res.setHeader('Content-Type', 'text/plain');
       res.send('User-agent: *\nDisallow: /');
     } else {
-      res.send('User-agent: *\nAllow: /');
+      // Will send public/robots.txt
+      next();
     }
   });
 


### PR DESCRIPTION
We'll start to politely disallow robots:
- linked to SEO dark/grey activity (Semrush, Majestic)

Maybe later:
- with high activity and unknown/limited benefit (Bytespider)
