### PR TITLE
Sections/About: Fix margins to match new navbar

### DIFF
--- a/components/collective-page/sections/About.js
+++ b/components/collective-page/sections/About.js
@@ -62,7 +62,7 @@ const SectionAbout = ({ collective, canEdit, intl }) => {
                   defaultValue={collective.longDescription}
                   onChange={e => setValue(e.target.value)}
                   placeholder={intl.formatMessage(messages.placeholder)}
-                  toolbarTop={[60, null, 119]}
+                  toolbarTop={[56, 64]}
                   toolbarBackgroundColor="#F7F8FA"
                   withStickyToolbar
                   autoFocus


### PR DESCRIPTION
The new navbar height was not accounted properly in the about section, resulting in a blank space between it and the rich text editor when fixed:

![image](https://user-images.githubusercontent.com/1556356/110777412-60a81980-8261-11eb-8aee-b4eb5cc2f985.png)
