### PR TITLE
Fix generated meta properties

### DIFF
--- a/test/cypress/integration/02-collective.transactions.test.js
+++ b/test/cypress/integration/02-collective.transactions.test.js
@@ -2,13 +2,13 @@ describe('collective.transactions', () => {
   it('Should have no-index meta for user profiles', () => {
     cy.visit('/xdamman/transactions');
     cy.getByDataCy('transactions-page-content'); // Wait for page to be loaded
-    cy.get('meta[property="robots"]').should('have.attr', 'content', 'none');
+    cy.get('meta[name="robots"]').should('have.attr', 'content', 'none');
   });
 
   it('Should NOT have no-index meta for collectives', () => {
     cy.visit('/apex/transactions');
     cy.getByDataCy('transactions-page-content'); // Wait for page to be loaded
-    cy.get('meta[property="robots"]').should('not.exist');
+    cy.get('meta[name="robots"]').should('not.exist');
   });
 
   it("shows the 'Download CSV' button", () => {

--- a/test/cypress/integration/04-collective.test.js
+++ b/test/cypress/integration/04-collective.test.js
@@ -38,7 +38,7 @@ describe('Collective page', () => {
   it('Should not have no-index meta', () => {
     // Wait for page to be loaded
     cy.getByDataCy('collective-title');
-    cy.get('meta[property="robots"]').should('not.exist');
+    cy.get('meta[name="robots"]').should('not.exist');
   });
 
   describe('Hero', () => {

--- a/test/cypress/integration/04-organization.test.js
+++ b/test/cypress/integration/04-organization.test.js
@@ -13,7 +13,7 @@ describe('New organization profile', () => {
   it('Should not have no-index meta', () => {
     // Wait for page to be loaded
     cy.getByDataCy('collective-title');
-    cy.get('meta[property="robots"]').should('not.exist');
+    cy.get('meta[name="robots"]').should('not.exist');
   });
 
   it('Has a team section', () => {

--- a/test/cypress/integration/05-user.test.js
+++ b/test/cypress/integration/05-user.test.js
@@ -13,7 +13,7 @@ describe('New users profiles', () => {
   });
 
   it('Should have no-index meta', () => {
-    cy.get('meta[property="robots"]').should('have.attr', 'content', 'none');
+    cy.get('meta[name="robots"]').should('have.attr', 'content', 'none');
   });
 
   describe('Contributions section', () => {

--- a/test/cypress/integration/06-host.test.js
+++ b/test/cypress/integration/06-host.test.js
@@ -9,7 +9,7 @@ describe('New host page', () => {
   it('Should not have no-index meta', () => {
     // Wait for page to be loaded
     cy.getByDataCy('collective-title');
-    cy.get('meta[property="robots"]').should('not.exist');
+    cy.get('meta[name="robots"]').should('not.exist');
   });
 
   describe('Contributions section', () => {


### PR DESCRIPTION
There was an issue in the way we generated the `robots` meta: we were using `property` instead of `name`. This PR fixes that and changes the structure of the code to better accommodate these cases.

It also removes the ability to pass `metas` to `Header` since this was not used anywhere in the code.