### PR TITLE
Vercel: Fix pre-deploys

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,7 +5,7 @@ const { getCSPHeaderForNextJS } = require('./server/content-security-policy');
 const { REWRITES } = require('./rewrites');
 
 const nextConfig = {
-  useFileSystemPublicRoutes: false,
+  useFileSystemPublicRoutes: process.env.IS_VERCEL === 'true',
   webpack: (config, { webpack, isServer, buildId }) => {
     config.plugins.push(
       // Ignore __tests__


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4102

Though it will introduce other issues, it seems that enabling filesystem routing solves the immediate crash with Vercel.