### PR TITLE
fix: stop recurring contribution select menu closing immediately

### DIFF
--- a/components/recurring-contributions/UpdateOrderPopUp.js
+++ b/components/recurring-contributions/UpdateOrderPopUp.js
@@ -222,15 +222,21 @@ const UpdateOrderPopUp = ({ setMenuState, contribution, setShowPopup }) => {
                   </P>
                   {checked && flexible ? (
                     <Fragment>
-                      <StyledSelect
-                        data-cy="tier-amount-select"
-                        onChange={setSelectedAmountOption}
-                        value={selectedAmountOption}
-                        options={amountOptions}
-                        my={2}
-                        minWidth={150}
-                        isSearchable={false}
-                      />
+                      <div
+                        onClick={e => {
+                          e.preventDefault();
+                        }}
+                      >
+                        <StyledSelect
+                          data-cy="tier-amount-select"
+                          onChange={setSelectedAmountOption}
+                          value={selectedAmountOption}
+                          options={amountOptions}
+                          my={2}
+                          minWidth={150}
+                          isSearchable={false}
+                        />
+                      </div>
                       {selectedAmountOption?.label === 'Other' && (
                         <Flex flexDirection="column">
                           <P fontSize="12px" fontWeight="600" my={2}>


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/3853

# Description

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->
This PR introduces a fix for the issue with the select menu closing immediately when trying to edit recurring contributions.

The cause of the error from what I could see was because clicking on the select menu triggered `onClick` for the radio menu. I was able to find an [issue](https://github.com/JedWatson/react-select/issues/532) with a couple of suggestions and found this solution.

# Screenshots

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
https://user-images.githubusercontent.com/24629960/112068696-db661400-8b40-11eb-8060-beb1f4f404e2.mp4

https://user-images.githubusercontent.com/24629960/112068693-da34e700-8b40-11eb-8c3d-8db3c9dd411a.mp4

https://user-images.githubusercontent.com/24629960/112068698-dbfeaa80-8b40-11eb-807b-d0d29a7bcbc1.mp4

