### PR TITLE
Homepage: Fix "discover more" and "read our stories" links

### DIFF
--- a/components/home/sections/JoinUs.js
+++ b/components/home/sections/JoinUs.js
@@ -134,7 +134,7 @@ const JoinUs = ({ page }) => (
           </Wrapper>
         </Link>
 
-        <Link href="/hiring">
+        <Link href="https://blog.opencollective.com/tag/case-studies/">
           <Wrapper color="black.900" my={4} width={['288px', '648px', '569px', null, '594px']} className="linkWrapper">
             <Container mb={2} width={['192px', 1]}>
               <H3

--- a/components/home/sections/OCUsers.js
+++ b/components/home/sections/OCUsers.js
@@ -179,7 +179,7 @@ const OCUsers = () => {
         </Container>
       </Flex>
       <Box mt={4}>
-        <StyledLink buttonStyle="standard" buttonSize="medium" href="https://blog.opencollective.com/tag/case-studies/">
+        <StyledLink as={Link} buttonStyle="standard" buttonSize="medium" href="/discover">
           <FormattedMessage id="home.discover" defaultMessage="Discover more" />
         </StyledLink>
       </Box>


### PR DESCRIPTION
Reported in https://opencollective.slack.com/archives/C9767R4V9/p1616534392001400 / https://opencollective.freshdesk.com/a/tickets/14042