### PR TITLE
CollectivePage: Don't crash with minor GraphQL errors

### DIFF
--- a/components/ToastProvider.js
+++ b/components/ToastProvider.js
@@ -36,6 +36,7 @@ const ToastProvider = ({ children }) => {
   const context = {
     toasts,
     addToast: useCallback(params => setToasts([...toasts, createToast(params)]), [toasts]),
+    addToasts: useCallback(toastsParams => setToasts([...toasts, ...toastsParams.map(createToast)]), [toasts]),
     removeToasts: useCallback(
       filterFunc => {
         const newToasts = toasts.filter(toast => !filterFunc(toast));

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -122,6 +122,19 @@ export const generateNotFoundError = searchTerm => {
   return createError(ERROR.NOT_FOUND, { payload: { searchTerm } });
 };
 
+export const getErrorFromGraphQLError = error => {
+  let message = get(error, 'message');
+  const sequelizeErrorMessage = get(error, 'extensions.exception.errors[0].message');
+  if (sequelizeErrorMessage) {
+    message = `${message}: ${sequelizeErrorMessage}`;
+  }
+
+  return createError(get(error, 'extensions.code'), {
+    message,
+    payload: error?.extensions,
+  });
+};
+
 /**
  * From a GraphQL error exception, returns an object like:
  *
@@ -139,16 +152,7 @@ export const getErrorFromGraphqlException = exception => {
       return createError();
     }
   } else {
-    let message = get(firstError, 'message');
-    const sequelizeErrorMessage = get(firstError, 'extensions.exception.errors[0].message');
-    if (sequelizeErrorMessage) {
-      message = `${message}: ${sequelizeErrorMessage}`;
-    }
-
-    return createError(get(firstError, 'extensions.code'), {
-      message,
-      payload: firstError?.extensions,
-    });
+    return getErrorFromGraphQLError(firstError);
   }
 };
 


### PR DESCRIPTION
Improves the situation for Fixer outage by "hiding" the amounts that we're not able to display and showing an error toast rather than crashing the entire page:

TODO:
- [ ] I'm fighting with https://github.com/apollographql/react-apollo/issues/2253 for client-side browsing

![image](https://user-images.githubusercontent.com/1556356/112621746-663d5c00-8e2a-11eb-8777-238e75853313.png)
