### PR TITLE
Variant props added to change the theme of Toast

### DIFF
--- a/components/GlobalToasts.js
+++ b/components/GlobalToasts.js
@@ -20,6 +20,7 @@ class GlobalToasts extends PureComponent {
         title: PropTypes.string,
         message: PropTypes.string,
         createdAt: PropTypes.number,
+        variant: PropTypes.string,
       }),
     ),
   };
@@ -115,6 +116,7 @@ class GlobalToasts extends PureComponent {
           {this.props.toasts.map(toast => (
             <Box key={toast.id} mt={24}>
               <Toast
+                variant={toast.variant}
                 toast={toast}
                 timeLeft={this.getTimeLeft(toast)}
                 onClose={() => this.props.removeToasts(t => t.id === toast.id)}

--- a/components/StyledButton.js
+++ b/components/StyledButton.js
@@ -54,7 +54,6 @@ const StyledButtonContent = styled.button`
       const baseActiveStyles = props.theme.buttons[props.buttonStyle]?.['&:active'] || {};
 
       return css`
-        color: #e8e9eb;
         background: transparent;
         background-color: transparent;
         border: 1px solid transparent !important;

--- a/components/StyledButton.js
+++ b/components/StyledButton.js
@@ -54,6 +54,7 @@ const StyledButtonContent = styled.button`
       const baseActiveStyles = props.theme.buttons[props.buttonStyle]?.['&:active'] || {};
 
       return css`
+        color: #e8e9eb;
         background: transparent;
         background-color: transparent;
         border: 1px solid transparent !important;

--- a/components/Toast.js
+++ b/components/Toast.js
@@ -8,20 +8,95 @@ import { defineMessages, useIntl } from 'react-intl';
 import styled, { css } from 'styled-components';
 import { variant } from 'styled-system';
 
-import Container from './Container';
 import { Flex } from './Grid';
 import StyledButton from './StyledButton';
-import { Span } from './Text';
 import { TOAST_TYPE } from './ToastProvider';
+
+const CloseButton = styled(StyledButton).attrs({
+  'data-cy': 'dismiss-toast-btn',
+  buttonSize: 'tiny',
+  isBorderless: true,
+})``;
+
+const ToastTitle = styled.span`
+  font-size: 11px;
+  line-height: 12px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+`;
+
+const ToastMessage = styled.span`
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  margin-top: 8px;
+`;
+
+const IconContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%;
+  min-width: 28px;
+  width: 28px;
+  height: 28px;
+  color: #ffffff;
+`;
+
+const Separator = styled.div`
+  width: 4px;
+  height: 100%;
+  min-height: 40px;
+  margin: 0 12px;
+`;
 
 const variantType = variant({
   variants: {
     light: {
       bg: '#ffffff',
+      borderColor: '#FFFFFF',
+
+      [ToastTitle]: { color: 'black.800' },
+      [ToastMessage]: { color: 'black.600' },
+      [CloseButton]: { color: 'black.500' },
+
+      '&[data-type="INFO"]': {
+        [IconContainer]: { bg: 'blue.500' },
+        [Separator]: { bg: 'blue.500' },
+      },
+      '&[data-type="ERROR"]': {
+        [IconContainer]: { bg: 'red.500' },
+        [Separator]: { bg: 'red.500' },
+      },
+      '&[data-type="SUCCESS"]': {
+        [IconContainer]: { bg: 'green.500' },
+        [Separator]: { bg: 'green.500' },
+      },
     },
 
     dark: {
-      bg: 'rgba(49, 50, 51, 0.8)',
+      bg: '#5a5b5c',
+      borderColor: 'black.700',
+
+      [ToastTitle]: { color: '#FFFFFF' },
+      [ToastMessage]: { color: 'black.300' },
+      [CloseButton]: { color: 'black.200', '&:hover': { color: 'black.800' } },
+      [IconContainer]: { border: '2px solid' },
+
+      '&[data-type="INFO"]': {
+        [IconContainer]: { color: 'blue.200' },
+        [Separator]: { bg: 'blue.200' },
+      },
+      '&[data-type="ERROR"]': {
+        [IconContainer]: { color: 'red.500' },
+        [Separator]: { bg: 'red.500' },
+      },
+      '&[data-type="SUCCESS"]': {
+        [IconContainer]: { color: 'green.500' },
+        [Separator]: { bg: 'green.500' },
+      },
     },
   },
 });
@@ -33,7 +108,6 @@ const StyledToast = styled.div`
   justify-content: space-between;
   align-items: stretch;
   padding: 24px;
-
   border-radius: 8px;
   border: 1px solid #efefef;
   opacity: 1;
@@ -65,6 +139,7 @@ const StyledToast = styled.div`
       }
     }}
   }
+
   ${variantType}
 `;
 
@@ -78,26 +153,6 @@ const DEFAULT_TITLES = defineMessages({
     defaultMessage: 'Error',
   },
 });
-
-const getVariant = variantType => {
-  switch (variantType) {
-    case 'light':
-      return { titleColor: '#313233', messageColor: '#76777A', crossIcon: '#C4C7CC' };
-    default:
-      return { titleColor: '#ffffff', messageColor: '#C4C7CC', crossIcon: '#E8E9EB' };
-  }
-};
-
-const getColor = toast => {
-  switch (toast.type) {
-    case TOAST_TYPE.SUCCESS:
-      return 'green.500';
-    case TOAST_TYPE.ERROR:
-      return 'red.500';
-    default:
-      return 'blue.500';
-  }
-};
 
 const getDefaultTitle = (intl, toastType) => {
   return DEFAULT_TITLES[toastType] ? intl.formatMessage(DEFAULT_TITLES[toastType]) : null;
@@ -121,58 +176,31 @@ const getIcon = toast => {
 const Toast = ({ toast, timeLeft, onClose, variant }) => {
   const intl = useIntl();
   const [isClosing, setClosing] = React.useState(false);
-  const color = getColor(toast);
-  const variantStyle = getVariant(variant);
-  const messageColor = variantStyle.messageColor;
-  const titleColor = variantStyle.titleColor;
-  const crossIcon = variantStyle.crossIcon;
 
   return (
-    <StyledToast timeLeft={timeLeft} isClosing={isClosing} data-cy="toast-notification" variant={variant}>
+    <StyledToast
+      timeLeft={timeLeft}
+      isClosing={isClosing}
+      data-type={toast.type}
+      variant={variant}
+      data-cy="toast-notification"
+    >
       <Flex alignItems="center">
-        <Container
-          bg={color}
-          height={28}
-          width={28}
-          minWidth={28}
-          borderRadius="50%"
-          display="flex"
-          justifyContent="center"
-          alignItems="center"
-          color="#ffffff"
-        >
-          {getIcon(toast)}
-        </Container>
-        <Container width="4px" height="100%" minHeight="40px" mx="12px" bg={color} />
+        <IconContainer>{getIcon(toast)}</IconContainer>
+        <Separator />
         <Flex flexDirection="column" justifyContent="center">
-          <Span
-            fontSize="11px"
-            lineHeight="12px"
-            fontWeight="500"
-            textTransform="uppercase"
-            letterSpacing="0.06em"
-            color={titleColor}
-          >
-            {toast.title || getDefaultTitle(intl, toast.type)}
-          </Span>
-          {toast.message && (
-            <Span fontSize="12px" lineHeight="16px" fontWeight="500" letterSpacing="0.06em" color={messageColor} mt={2}>
-              {toast.message}
-            </Span>
-          )}
+          <ToastTitle>{toast.title || getDefaultTitle(intl, toast.type)}</ToastTitle>
+          {toast.message && <ToastMessage>{toast.message}</ToastMessage>}
         </Flex>
       </Flex>
-      <StyledButton
-        data-cy="dismiss-toast-btn"
-        buttonSize="tiny"
-        isBorderless
+      <CloseButton
         onClick={() => {
           setClosing(true);
           onClose();
         }}
       >
-        <Close size={12} color={crossIcon} />
-      </StyledButton>
+        <Close size={12} />
+      </CloseButton>
     </StyledToast>
   );
 };

--- a/components/Toast.js
+++ b/components/Toast.js
@@ -70,7 +70,7 @@ const getVariant = variantType => {
     case 'dark':
       return { bg: 'rgba(49, 50, 51, 0.8)', titleColor: '#ffffff', messageColor: '#C4C7CC', crossIcon: '#E8E9EB' };
     default:
-      return { bg: '#ffffff', titleColor: '#313233', messageColor: '#76777A', crossIcon: '#E8E9EB' };
+      return { bg: '#ffffff', titleColor: '#313233', messageColor: '#76777A', crossIcon: '#C4C7CC' };
   }
 };
 

--- a/components/Toast.js
+++ b/components/Toast.js
@@ -6,13 +6,13 @@ import { Times } from '@styled-icons/fa-solid/Times';
 import { Close } from '@styled-icons/material/Close';
 import { defineMessages, useIntl } from 'react-intl';
 import styled, { css } from 'styled-components';
+import { variant } from 'styled-system';
 
 import Container from './Container';
 import { Flex } from './Grid';
 import StyledButton from './StyledButton';
 import { Span } from './Text';
 import { TOAST_TYPE } from './ToastProvider';
-import { variant } from 'styled-system';
 
 const variants = {
   light: {

--- a/components/Toast.js
+++ b/components/Toast.js
@@ -14,20 +14,17 @@ import StyledButton from './StyledButton';
 import { Span } from './Text';
 import { TOAST_TYPE } from './ToastProvider';
 
-const variants = {
-  light: {
-    bg: '#ffffff',
-    titleColor: '#313233',
-    messageColor: '#76777A',
-    crossIcon: '#C4C7CC',
+const variantType = variant({
+  variants: {
+    light: {
+      bg: '#ffffff',
+    },
+
+    dark: {
+      bg: 'rgba(49, 50, 51, 0.8)',
+    },
   },
-  dark: {
-    bg: 'rgba(49, 50, 51, 0.8)',
-    titleColor: '#ffffff',
-    messageColor: '#C4C7CC',
-    crossIcon: '#E8E9EB',
-  },
-};
+});
 
 const StyledToast = styled.div`
   position: relative;
@@ -36,7 +33,7 @@ const StyledToast = styled.div`
   justify-content: space-between;
   align-items: stretch;
   padding: 24px;
-  background: ${props => props.variantType.bg};
+
   border-radius: 8px;
   border: 1px solid #efefef;
   opacity: 1;
@@ -68,7 +65,7 @@ const StyledToast = styled.div`
       }
     }}
   }
-  ${variant({ variants })}
+  ${variantType}
 `;
 
 const DEFAULT_TITLES = defineMessages({
@@ -85,9 +82,9 @@ const DEFAULT_TITLES = defineMessages({
 const getVariant = variantType => {
   switch (variantType) {
     case 'light':
-      return { bg: '#ffffff', titleColor: '#313233', messageColor: '#76777A', crossIcon: '#C4C7CC' };
+      return { titleColor: '#313233', messageColor: '#76777A', crossIcon: '#C4C7CC' };
     default:
-      return { bg: 'rgba(49, 50, 51, 0.8)', titleColor: '#ffffff', messageColor: '#C4C7CC', crossIcon: '#E8E9EB' };
+      return { titleColor: '#ffffff', messageColor: '#C4C7CC', crossIcon: '#E8E9EB' };
   }
 };
 
@@ -131,7 +128,7 @@ const Toast = ({ toast, timeLeft, onClose, variant }) => {
   const crossIcon = variantStyle.crossIcon;
 
   return (
-    <StyledToast timeLeft={timeLeft} isClosing={isClosing} data-cy="toast-notification" variantType={variantStyle}>
+    <StyledToast timeLeft={timeLeft} isClosing={isClosing} data-cy="toast-notification" variant={variant}>
       <Flex alignItems="center">
         <Container
           bg={color}

--- a/components/Toast.js
+++ b/components/Toast.js
@@ -68,9 +68,9 @@ const DEFAULT_TITLES = defineMessages({
 const getVariant = variantType => {
   switch (variantType) {
     case 'dark':
-      return { bg: 'rgba(49, 50, 51, 0.8)', titleColor: '#ffffff', messageColor: '#C4C7CC' };
+      return { bg: 'rgba(49, 50, 51, 0.8)', titleColor: '#ffffff', messageColor: '#C4C7CC', crossIcon: '#E8E9EB' };
     default:
-      return { bg: '#ffffff', titleColor: '#313233', messageColor: '#76777A;' };
+      return { bg: '#ffffff', titleColor: '#313233', messageColor: '#76777A', crossIcon: '#E8E9EB' };
   }
 };
 
@@ -111,6 +111,7 @@ const Toast = ({ toast, timeLeft, onClose, variant }) => {
   const variantStyle = getVariant(variant);
   const messageColor = variantStyle.messageColor;
   const titleColor = variantStyle.titleColor;
+  const crossIcon = variantStyle.crossIcon;
   return (
     <StyledToast timeLeft={timeLeft} isClosing={isClosing} data-cy="toast-notification" variantType={variantStyle}>
       <Flex alignItems="center">
@@ -155,7 +156,7 @@ const Toast = ({ toast, timeLeft, onClose, variant }) => {
           onClose();
         }}
       >
-        <Close size={12} color={titleColor} />
+        <Close size={12} color={crossIcon} />
       </StyledButton>
     </StyledToast>
   );

--- a/components/Toast.js
+++ b/components/Toast.js
@@ -68,9 +68,9 @@ const DEFAULT_TITLES = defineMessages({
 const getVariant = variantType => {
   switch (variantType) {
     case 'dark':
-      return { bg: 'rgba(49, 50, 51, 0.8)', color: '#ffffff' };
+      return { bg: 'rgba(49, 50, 51, 0.8)', titleColor: '#ffffff', messageColor: '#C4C7CC' };
     default:
-      return { bg: '#ffffff', color: '#313233' };
+      return { bg: '#ffffff', titleColor: '#313233', messageColor: '#76777A;' };
   }
 };
 
@@ -109,7 +109,8 @@ const Toast = ({ toast, timeLeft, onClose, variant }) => {
   const [isClosing, setClosing] = React.useState(false);
   const color = getColor(toast);
   const variantStyle = getVariant(variant);
-  const messageColor = variantStyle.color;
+  const messageColor = variantStyle.messageColor;
+  const titleColor = variantStyle.titleColor;
   return (
     <StyledToast timeLeft={timeLeft} isClosing={isClosing} data-cy="toast-notification" variantType={variantStyle}>
       <Flex alignItems="center">
@@ -134,7 +135,7 @@ const Toast = ({ toast, timeLeft, onClose, variant }) => {
             fontWeight="500"
             textTransform="uppercase"
             letterSpacing="0.06em"
-            color="black.800"
+            color={titleColor}
           >
             {toast.title || getDefaultTitle(intl, toast.type)}
           </Span>
@@ -154,7 +155,7 @@ const Toast = ({ toast, timeLeft, onClose, variant }) => {
           onClose();
         }}
       >
-        <Close size={12} />
+        <Close size={12} color={titleColor} />
       </StyledButton>
     </StyledToast>
   );

--- a/components/Toast.js
+++ b/components/Toast.js
@@ -20,7 +20,7 @@ const StyledToast = styled.div`
   justify-content: space-between;
   align-items: stretch;
   padding: 24px;
-  background: white;
+  background: ${props => (props.variantType ? props.variantType.bg : 'white')};
   border-radius: 8px;
   border: 1px solid #efefef;
   opacity: 1;
@@ -65,6 +65,15 @@ const DEFAULT_TITLES = defineMessages({
   },
 });
 
+const getVariant = variantType => {
+  switch (variantType) {
+    case 'dark':
+      return { bg: 'rgba(49, 50, 51, 0.8)', color: '#ffffff' };
+    default:
+      return { bg: '#ffffff', color: '#313233' };
+  }
+};
+
 const getColor = toast => {
   switch (toast.type) {
     case TOAST_TYPE.SUCCESS:
@@ -95,12 +104,14 @@ const getIcon = toast => {
   }
 };
 
-const Toast = ({ toast, timeLeft, onClose }) => {
+const Toast = ({ toast, timeLeft, onClose, variant }) => {
   const intl = useIntl();
   const [isClosing, setClosing] = React.useState(false);
   const color = getColor(toast);
+  const variantStyle = getVariant(variant);
+  const messageColor = variantStyle.color;
   return (
-    <StyledToast timeLeft={timeLeft} isClosing={isClosing} data-cy="toast-notification">
+    <StyledToast timeLeft={timeLeft} isClosing={isClosing} data-cy="toast-notification" variantType={variantStyle}>
       <Flex alignItems="center">
         <Container
           bg={color}
@@ -128,7 +139,7 @@ const Toast = ({ toast, timeLeft, onClose }) => {
             {toast.title || getDefaultTitle(intl, toast.type)}
           </Span>
           {toast.message && (
-            <Span fontSize="12px" lineHeight="16px" fontWeight="500" letterSpacing="0.06em" color="black.600" mt={2}>
+            <Span fontSize="12px" lineHeight="16px" fontWeight="500" letterSpacing="0.06em" color={messageColor} mt={2}>
               {toast.message}
             </Span>
           )}
@@ -159,6 +170,7 @@ Toast.propTypes = {
   }).isRequired,
   onClose: PropTypes.func,
   timeLeft: PropTypes.number,
+  variant: PropTypes.string,
 };
 
 Toast.defaultProps = {

--- a/components/Toast.js
+++ b/components/Toast.js
@@ -12,6 +12,22 @@ import { Flex } from './Grid';
 import StyledButton from './StyledButton';
 import { Span } from './Text';
 import { TOAST_TYPE } from './ToastProvider';
+import { variant } from 'styled-system';
+
+const variants = {
+  light: {
+    bg: '#ffffff',
+    titleColor: '#313233',
+    messageColor: '#76777A',
+    crossIcon: '#C4C7CC',
+  },
+  dark: {
+    bg: 'rgba(49, 50, 51, 0.8)',
+    titleColor: '#ffffff',
+    messageColor: '#C4C7CC',
+    crossIcon: '#E8E9EB',
+  },
+};
 
 const StyledToast = styled.div`
   position: relative;
@@ -20,7 +36,7 @@ const StyledToast = styled.div`
   justify-content: space-between;
   align-items: stretch;
   padding: 24px;
-  background: ${props => (props.variantType ? props.variantType.bg : 'white')};
+  background: ${props => props.variantType.bg};
   border-radius: 8px;
   border: 1px solid #efefef;
   opacity: 1;
@@ -52,6 +68,7 @@ const StyledToast = styled.div`
       }
     }}
   }
+  ${variant({ variants })}
 `;
 
 const DEFAULT_TITLES = defineMessages({
@@ -67,10 +84,10 @@ const DEFAULT_TITLES = defineMessages({
 
 const getVariant = variantType => {
   switch (variantType) {
-    case 'dark':
-      return { bg: 'rgba(49, 50, 51, 0.8)', titleColor: '#ffffff', messageColor: '#C4C7CC', crossIcon: '#E8E9EB' };
-    default:
+    case 'light':
       return { bg: '#ffffff', titleColor: '#313233', messageColor: '#76777A', crossIcon: '#C4C7CC' };
+    default:
+      return { bg: 'rgba(49, 50, 51, 0.8)', titleColor: '#ffffff', messageColor: '#C4C7CC', crossIcon: '#E8E9EB' };
   }
 };
 
@@ -112,6 +129,7 @@ const Toast = ({ toast, timeLeft, onClose, variant }) => {
   const messageColor = variantStyle.messageColor;
   const titleColor = variantStyle.titleColor;
   const crossIcon = variantStyle.crossIcon;
+
   return (
     <StyledToast timeLeft={timeLeft} isClosing={isClosing} data-cy="toast-notification" variantType={variantStyle}>
       <Flex alignItems="center">
@@ -172,11 +190,12 @@ Toast.propTypes = {
   }).isRequired,
   onClose: PropTypes.func,
   timeLeft: PropTypes.number,
-  variant: PropTypes.string,
+  variant: PropTypes.oneOf(['light', 'dark']),
 };
 
 Toast.defaultProps = {
   timeLeft: 6000,
+  variant: 'dark',
 };
 
 export default Toast;

--- a/components/ToastProvider.js
+++ b/components/ToastProvider.js
@@ -8,6 +8,8 @@ export const ToastContext = React.createContext({
    * - {TOAST_TYPE} type (default: INFO)
    * - {string} title
    * - {string} message (optional)
+   * - {light|dark} variant (default: dark)
+   * - {number} duration (default: 15000)
    */
   addToast: () => {},
 });
@@ -35,7 +37,11 @@ const ToastProvider = ({ children }) => {
 
   const context = {
     toasts,
+    /** Use this helper to add multiple toasts at once */
+    addToasts: useCallback(toastsParams => setToasts([...toasts, ...toastsParams.map(createToast)]), [toasts]),
+    /** To add a single toast */
     addToast: useCallback(params => setToasts([...toasts, createToast(params)]), [toasts]),
+    /** To remove displayed toasts */
     removeToasts: useCallback(
       filterFunc => {
         const newToasts = toasts.filter(toast => !filterFunc(toast));


### PR DESCRIPTION
Resolve: https://github.com/opencollective/opencollective/issues/4063

# Description

 Now passing a `variant` props like `dark` will provide you a dark theme feel in Toast. Default will be `white`.
Design: [Figma Link](https://www.figma.com/file/N4Xbl652BhzOutXmzhcrLGch/%5BDS%5D-02-Atoms?node-id=3480%3A1027)
# Screenshots

**Light Theme:**
<img width="322" alt="Screenshot 2021-04-05 at 8 55 26 PM" src="https://user-images.githubusercontent.com/10995431/113591343-64a53c80-9651-11eb-9863-01303221a619.png">

[Default] **Dark Theme:**
<img width="316" alt="Screenshot 2021-04-05 at 8 16 51 PM" src="https://user-images.githubusercontent.com/10995431/113587207-1477ab80-964c-11eb-9911-ba5b03a73162.png">


