### PR TITLE
react-intl: add default locale

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -122,7 +122,7 @@ class OpenCollectiveFrontendApp extends App {
   render() {
     const { client, Component, pageProps, scripts, locale, messages } = this.props;
 
-    const intl = createIntl({ locale, messages }, cache);
+    const intl = createIntl({ locale: locale || 'en', messages }, cache);
 
     return (
       <Fragment>


### PR DESCRIPTION
This PR is an attempt at solving a warning that often appears in test logs:

```
 Error: [@formatjs/intl Error INVALID_CONFIG] "locale" was not configured, using "en" as fallback. See formatjs.io/docs/react-intl/api#intlshape for more details 

    at new InvalidConfigError (/home/runner/work/opencollective-frontend/opencollective-frontend/node_modules/@formatjs/intl/src/error.js:37:23)
    at Object.createIntl (/home/runner/work/opencollective-frontend/opencollective-frontend/node_modules/@formatjs/intl/src/create-intl.js:35:21)
    at createIntl (/home/runner/work/opencollective-frontend/opencollective-frontend/node_modules/react-intl/src/components/provider.js:63:27)
    at _app_OpenCollectiveFrontendApp.render (/home/runner/work/opencollective-frontend/opencollective-frontend/.next/server/pages/_app.js:4999:86)
    at processChild (/home/runner/work/opencollective-frontend/opencollective-frontend/node_modules/react-dom/cjs/react-dom-server.node.development.js:3450:18)
    at resolve (/home/runner/work/opencollective-frontend/opencollective-frontend/node_modules/react-dom/cjs/react-dom-server.node.development.js:3270:5)
    at ReactDOMServerRenderer.render (/home/runner/work/opencollective-frontend/opencollective-frontend/node_modules/react-dom/cjs/react-dom-server.node.development.js:3753:22)
    at ReactDOMServerRenderer.read (/home/runner/work/opencollective-frontend/opencollective-frontend/node_modules/react-dom/cjs/react-dom-server.node.development.js:3690:29)
    at renderToString (/home/runner/work/opencollective-frontend/opencollective-frontend/node_modules/react-dom/cjs/react-dom-server.node.development.js:4298:27)
    at renderPage (/home/runner/work/opencollective-frontend/opencollective-frontend/node_modules/next/dist/next-server/server/render.js:54:851)
    at Object.ctx.renderPage (/home/runner/work/opencollective-frontend/opencollective-frontend/.next/server/pages/_document.js:1205:16)
    at Function.getInitialProps (/home/runner/work/opencollective-frontend/opencollective-frontend/.next/server/pages/_document.js:5346:19)
    at Function.getInitialProps (/home/runner/work/opencollective-frontend/opencollective-frontend/.next/server/pages/_document.js:1218:114)
    at loadGetInitialProps (/home/runner/work/opencollective-frontend/opencollective-frontend/node_modules/next/dist/next-server/lib/utils.js:5:101)
    at renderToHTML (/home/runner/work/opencollective-frontend/opencollective-frontend/node_modules/next/dist/next-server/server/render.js:54:1142)
    at runMicrotasks (<anonymous>) {
  code: 'INVALID_CONFIG'
}
```