### PR TITLE
Events: Remove link to send email

### DIFF
--- a/components/collective-page/sections/SponsorsAndParticipants.js
+++ b/components/collective-page/sections/SponsorsAndParticipants.js
@@ -105,11 +105,6 @@ const Participants = ({ collective: event, LoggedInUser, refetch }) => {
             <StyledAdminActions>
               <ul>
                 <li>
-                  <a href={`mailto:${event.slug}@${event.parentCollective.slug}.opencollective.com`}>
-                    <FormattedMessage id="Event.SendEmail" defaultMessage="Send email" />
-                  </a>
-                </li>
-                <li>
                   <StyledLinkButton onClick={() => exportRSVPs(event)}>
                     <FormattedMessage id="Export.Format" defaultMessage="Export {format}" values={{ format: 'CSV' }} />
                   </StyledLinkButton>

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -762,7 +762,6 @@
   "event.privateInstructions.description": "These instructions will be provided by email to the participants.",
   "event.privateInstructions.label": "Private instructions",
   "event.responses.title.going": "{n} {n, plural, one {person going} other {people going}}",
-  "Event.SendEmail": "Send email",
   "event.sponsors.title": "Patrocinadors",
   "event.type.label": "Tipus",
   "EventCover.LocalTime": "Your Time",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -762,7 +762,6 @@
   "event.privateInstructions.description": "These instructions will be provided by email to the participants.",
   "event.privateInstructions.label": "Private instructions",
   "event.responses.title.going": "{n} {n, plural, one {person going} other {people going}}",
-  "Event.SendEmail": "Poslat e-mail",
   "event.sponsors.title": "Sponzoři",
   "event.type.label": "Typ",
   "EventCover.LocalTime": "Váš čas",

--- a/lang/de.json
+++ b/lang/de.json
@@ -762,7 +762,6 @@
   "event.privateInstructions.description": "These instructions will be provided by email to the participants.",
   "event.privateInstructions.label": "Private instructions",
   "event.responses.title.going": "{n} {n, plural, one {person going} other {people going}}",
-  "Event.SendEmail": "Email senden",
   "event.sponsors.title": "Sponsoren",
   "event.type.label": "Typ",
   "EventCover.LocalTime": "Deine Zeit",

--- a/lang/en.json
+++ b/lang/en.json
@@ -762,7 +762,6 @@
   "event.privateInstructions.description": "These instructions will be provided by email to the participants.",
   "event.privateInstructions.label": "Private instructions",
   "event.responses.title.going": "{n} {n, plural, one {person going} other {people going}}",
-  "Event.SendEmail": "Send email",
   "event.sponsors.title": "Sponsors",
   "event.type.label": "Type",
   "EventCover.LocalTime": "Your Time",

--- a/lang/es.json
+++ b/lang/es.json
@@ -762,7 +762,6 @@
   "event.privateInstructions.description": "Estas instrucciones serás enviadas a los participantes por correo electrónico.",
   "event.privateInstructions.label": "Instrucciones privadas",
   "event.responses.title.going": "{n} {n, plural, one {persona atenderá} other {personas atenderán}}",
-  "Event.SendEmail": "Enviar correo electrónico",
   "event.sponsors.title": "Patrocinadores",
   "event.type.label": "Tipo",
   "EventCover.LocalTime": "Tu Hora",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -762,7 +762,6 @@
   "event.privateInstructions.description": "These instructions will be provided by email to the participants.",
   "event.privateInstructions.label": "Private instructions",
   "event.responses.title.going": "{n} {n, plural, one {personne confirmée} other {personnes ont confirmé}}",
-  "Event.SendEmail": "Envoyer un email",
   "event.sponsors.title": "Sponsors",
   "event.type.label": "Type",
   "EventCover.LocalTime": "Votre Heure",

--- a/lang/it.json
+++ b/lang/it.json
@@ -762,7 +762,6 @@
   "event.privateInstructions.description": "These instructions will be provided by email to the participants.",
   "event.privateInstructions.label": "Private instructions",
   "event.responses.title.going": "{n} {n, plural, one {person going} other {people going}}",
-  "Event.SendEmail": "Invia email",
   "event.sponsors.title": "Sponsors",
   "event.type.label": "Tipo",
   "EventCover.LocalTime": "Il Tuo Tempo",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -762,7 +762,6 @@
   "event.privateInstructions.description": "These instructions will be provided by email to the participants.",
   "event.privateInstructions.label": "Private instructions",
   "event.responses.title.going": "{n} {n, plural, one {人が参加} other {人が参加}}",
-  "Event.SendEmail": "メールを送信",
   "event.sponsors.title": "スポンサー",
   "event.type.label": "タイプ",
   "EventCover.LocalTime": "Your Time",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -762,7 +762,6 @@
   "event.privateInstructions.description": "These instructions will be provided by email to the participants.",
   "event.privateInstructions.label": "Private instructions",
   "event.responses.title.going": "{n} {n, plural, one {person going} other {people going}}",
-  "Event.SendEmail": "이메일 보내기",
   "event.sponsors.title": "스폰서",
   "event.type.label": "유형",
   "EventCover.LocalTime": "내 시간",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -762,7 +762,6 @@
   "event.privateInstructions.description": "These instructions will be provided by email to the participants.",
   "event.privateInstructions.label": "Private instructions",
   "event.responses.title.going": "{n} {n, plural, one {person going} other {people going}}",
-  "Event.SendEmail": "Send email",
   "event.sponsors.title": "Sponsors",
   "event.type.label": "Type",
   "EventCover.LocalTime": "Your Time",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -762,7 +762,6 @@
   "event.privateInstructions.description": "Estas instruções serão fornecidas por e-mail aos participantes.",
   "event.privateInstructions.label": "Instruções privadas",
   "event.responses.title.going": "{n}{n, plural, one {pessoa indo} other {pessoas indo}}",
-  "Event.SendEmail": "Enviar e-mail",
   "event.sponsors.title": "Patrocinadores",
   "event.type.label": "Tipo",
   "EventCover.LocalTime": "Seu Tempo",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -762,7 +762,6 @@
   "event.privateInstructions.description": "These instructions will be provided by email to the participants.",
   "event.privateInstructions.label": "Private instructions",
   "event.responses.title.going": "{n} {n, plural, one {pessoa vai} other {pessoas vão}}",
-  "Event.SendEmail": "Enviar email",
   "event.sponsors.title": "Patrocinadores",
   "event.type.label": "Tipo",
   "EventCover.LocalTime": "Seu horário",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -762,7 +762,6 @@
   "event.privateInstructions.description": "These instructions will be provided by email to the participants.",
   "event.privateInstructions.label": "Private instructions",
   "event.responses.title.going": "{n} {n, plural, one {человек собирается} other {люди собираются}}",
-  "Event.SendEmail": "Отправить email",
   "event.sponsors.title": "Спонсоры",
   "event.type.label": "Тип",
   "EventCover.LocalTime": "Ваше Время",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -762,7 +762,6 @@
   "event.privateInstructions.description": "These instructions will be provided by email to the participants.",
   "event.privateInstructions.label": "Private instructions",
   "event.responses.title.going": "{n} {n, plural, one {person going} other {people going}}",
-  "Event.SendEmail": "Надіслати електронного листа",
   "event.sponsors.title": "Спонсори",
   "event.type.label": "Тип",
   "EventCover.LocalTime": "Ваш час",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -762,7 +762,6 @@
   "event.privateInstructions.description": "These instructions will be provided by email to the participants.",
   "event.privateInstructions.label": "Private instructions",
   "event.responses.title.going": "{n} {n, plural, one {person going} other {people going}}",
-  "Event.SendEmail": "发送邮件",
   "event.sponsors.title": "赞助者",
   "event.type.label": "类型",
   "EventCover.LocalTime": "你的事件",


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-frontend/pull/6175
First step for https://github.com/opencollective/opencollective/issues/4131

This will remove the link to send an email to event participants since there's now an easier way to achieve that through updates. Not removing the feature itself for now in case someone is currently planning on using it.