### PR TITLE
Enable next cache on Heroku to make the build faster

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "type": "git",
     "url": "https://github.com/opencollective/opencollective-frontend.git"
   },
+  "cacheDirectories": [
+    ".next/cache"
+  ],
   "private": true,
   "engines": {
     "node": "14.x",


### PR DESCRIPTION
As per my comment, https://github.com/opencollective/opencollective/issues/4186#issuecomment-819573893 we can try this one to see if it helps to make the build faster if there's no objection. 😄 

Related to https://github.com/opencollective/opencollective/issues/4186