### PR TITLE
EditPaypalAccount: Set autoComplete=off on credentials

### DIFF
--- a/components/edit-collective/EditPayPalAccount.js
+++ b/components/edit-collective/EditPayPalAccount.js
@@ -111,7 +111,13 @@ const EditPayPalAccount = props => {
           disabled={isCreating}
         >
           {inputProps => (
-            <StyledInput type="text" {...inputProps} onChange={formik.handleChange} value={formik.values.clientId} />
+            <StyledInput
+              type="text"
+              {...inputProps}
+              onChange={formik.handleChange}
+              value={formik.values.clientId}
+              autoComplete="off"
+            />
           )}
         </StyledInputField>
         <StyledInputField
@@ -122,7 +128,13 @@ const EditPayPalAccount = props => {
           disabled={isCreating}
         >
           {inputProps => (
-            <StyledInput type="text" {...inputProps} onChange={formik.handleChange} value={formik.values.token} />
+            <StyledInput
+              type="text"
+              {...inputProps}
+              onChange={formik.handleChange}
+              value={formik.values.token}
+              autoComplete="off"
+            />
           )}
         </StyledInputField>
 


### PR DESCRIPTION
Having the browser remembering these values is a problem