### PR TITLE
fix(HeroBackground): make image unselectable

### DIFF
--- a/components/collective-page/hero/HeroBackground.js
+++ b/components/collective-page/hero/HeroBackground.js
@@ -28,6 +28,7 @@ export const StyledHeroBackground = styled.div`
 
   img {
     margin: 0;
+    user-select: none;
   }
 
   .reactEasyCrop_Image,


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/4181

# Description

make hero background image unselectable.
<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
