### PR TITLE
Add support for dependabot to correctly execute e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches-ignore:
       - 'i18n/crowdin'
+      - 'dependabot/**'
+  pull_request_target:
+    branches:
+      - 'dependabot/**'
 
 env:
   CI: true
@@ -31,6 +35,8 @@ env:
 
 jobs:
   e2e:
+    if: >-
+      github.event_name == 'push' || github.actor == 'dependabot'
     runs-on: ubuntu-latest
 
     timeout-minutes: 30


### PR DESCRIPTION
Here I am trying to make sure dependabot correctly executes the e2e tests on PR creation since the native dependabot doesn't have access to github secrets anymore. 

Related article: https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/ 

Reference discussion: https://opencollective.slack.com/archives/C0RMV6F8C/p1618823725118900 and https://opencollective.slack.com/archives/C0RMV6F8C/p1618914608130500
