### PR TITLE
Modify e2e workflow to run dependabot related workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,10 @@ on:
       - 'i18n/crowdin'
       - 'dependabot/**'
   pull_request_target:
-
+    types:
+      - opened
+      - synchronize
+      - reopened
 env:
   CI: true
   TZ: UTC


### PR DESCRIPTION
This is already tired out on, #6224, #6225 and #6226. This PR adds a slight cleanup to the process so that we only run the workflow on PR synchronizing; not on all PR events. 😄 

Related to, https://github.com/opencollective/opencollective/issues/4207