### PR TITLE
Make sure dependabot PRs CI runs are not duplicated

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,6 +32,20 @@ env:
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 jobs:
+  check_duplicate_runs:
+    name: Check for duplicate runs
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: always
+          cancel_others: true
+          skip_after_successful_duplicate: true
+          do_not_skip: '["pull_request_target"]'
   e2e:
     if: >-
       github.event_name == 'push' || github.actor == 'dependabot[bot]'


### PR DESCRIPTION
This make sure if dependabot rebases the PR runs are not duplicated. 

Related to https://github.com/opencollective/opencollective/issues/4207