### PR TITLE
CSP: Implement nonce for script-src

### DIFF
--- a/lib/paypal.js
+++ b/lib/paypal.js
@@ -34,7 +34,7 @@ const getPaypal = async params => {
     url.searchParams.set('intent', params.intent);
     url.searchParams.set('disable-funding', 'credit,card');
     url.searchParams.set('vault', 'true');
-    await loadScriptAsync(url.href);
+    await loadScriptAsync(url.href, { attrs: { 'data-csp-nonce': window.__NEXT_DATA__.cspNonce } });
     latestPayPalParams = params;
   }
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,6 @@
 require('./env');
 
 const withSourceMaps = require('@zeit/next-source-maps')();
-const { getCSPHeaderForNextJS } = require('./server/content-security-policy');
 const { REWRITES } = require('./rewrites');
 
 const nextConfig = {
@@ -116,14 +115,6 @@ const nextConfig = {
     });
 
     return config;
-  },
-  async headers() {
-    const cspHeader = getCSPHeaderForNextJS();
-    if (cspHeader) {
-      return [{ source: '/', headers: [cspHeader] }];
-    } else {
-      return [];
-    }
   },
   async rewrites() {
     return REWRITES;

--- a/server/content-security-policy.js
+++ b/server/content-security-policy.js
@@ -42,6 +42,7 @@ const COMMON_DIRECTIVES = {
   scriptSrc: [
     SELF,
     UNSAFE_INLINE, // Required by current PayPal integration. https://developer.paypal.com/docs/checkout/troubleshoot/support/#browser-features-and-polyfills provides a way to deal with that through nonces.
+    "'nonce-__OC_REQUEST_NONCE__'",
     'maps.googleapis.com',
     'js.stripe.com',
     '*.paypal.com',
@@ -79,7 +80,7 @@ const generateDirectives = customValues => {
 
 /**
  * A adapter inspired by  https://github.com/helmetjs/helmet/blob/master/middlewares/content-security-policy/index.ts
- * to generate the header string. Usefull for plugging to Zeit.
+ * to generate the header string. Useful for plugging to Vercel.
  */
 const getHeaderValueFromDirectives = directives => {
   return Object.entries(directives)
@@ -90,10 +91,7 @@ const getHeaderValueFromDirectives = directives => {
       if (typeof rawDirectiveValue === 'string') {
         directiveValue = ` ${rawDirectiveValue}`;
       } else if (Array.isArray(rawDirectiveValue)) {
-        directiveValue = '';
-        for (const element of rawDirectiveValue) {
-          directiveValue = `${directiveValue} ${element}`;
-        }
+        directiveValue = rawDirectiveValue.join(' ');
       } else if (typeof rawDirectiveValue === 'boolean' && !rawDirectiveValue) {
         return '';
       }
@@ -102,12 +100,15 @@ const getHeaderValueFromDirectives = directives => {
         return directiveName;
       }
 
-      return `${directiveName}${directiveValue}`;
+      return `${directiveName} ${directiveValue}`;
     })
     .filter(Boolean)
-    .join(';');
+    .join('; ');
 };
 
+/**
+ * Get a config compatible with Helmet's format
+ */
 const getContentSecurityPolicyConfig = () => {
   if (env === 'development' || env === 'e2e') {
     return {
@@ -155,7 +156,7 @@ const getContentSecurityPolicyConfig = () => {
 
 module.exports = {
   getContentSecurityPolicyConfig,
-  getCSPHeaderForNextJS: () => {
+  getCSPHeader: () => {
     const config = getContentSecurityPolicyConfig();
     if (config) {
       return {

--- a/server/index.js
+++ b/server/index.js
@@ -17,7 +17,6 @@ const { Sentry } = require('./sentry');
 const hyperwatch = require('./hyperwatch');
 const rateLimiter = require('./rate-limiter');
 const duplicateHandler = require('./duplicate-handler');
-const { getContentSecurityPolicyConfig } = require('./content-security-policy');
 const { serviceLimiterMiddleware, increaseServiceLevel } = require('./service-limiter');
 const { parseToBooleanDefaultFalse } = require('./utils');
 
@@ -48,7 +47,8 @@ const start = id =>
       app.use(serviceLimiterMiddleware);
     }
 
-    app.use(helmet({ contentSecurityPolicy: getContentSecurityPolicyConfig() }));
+    // Content security policy is generated from `_document` for compatibility with Vercel
+    app.use(helmet({ contentSecurityPolicy: false }));
 
     app.use(cookieParser());
 


### PR DESCRIPTION
Moved the CSP generation to `_document` to make this change compatible with Vercel (as NextJs does not support dynamic headers without a custom server at the moment).