### PR TITLE
ProcessExpensesButtons: Use toast to display errors

### DIFF
--- a/components/edit-collective/sections/UserTwoFactorAuth.js
+++ b/components/edit-collective/sections/UserTwoFactorAuth.js
@@ -507,6 +507,8 @@ class UserTwoFactorAuth extends React.Component {
                                       pattern="[0-9]{6}"
                                       inputMode="numeric"
                                       autoFocus
+                                      minLength={6}
+                                      maxLength={6}
                                       data-cy="add-two-factor-auth-totp-code-field"
                                     />
                                   )}

--- a/components/expenses/ExpenseModal.js
+++ b/components/expenses/ExpenseModal.js
@@ -2,9 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/client';
 import { pick } from 'lodash';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
-import { formatErrorMessage } from '../../lib/errors';
 import { API_V2_CONTEXT, gqlV2 } from '../../lib/graphql/helpers';
 
 import { Box, Flex } from '../Grid';
@@ -26,8 +25,6 @@ const expenseModalQuery = gqlV2/* GraphQL */ `
 `;
 
 const ExpenseModal = ({ expense, onDelete, onProcess, onClose, show }) => {
-  const intl = useIntl();
-  const [error, setError] = React.useState(null);
   const { data, loading } = useQuery(expenseModalQuery, {
     variables: { legacyExpenseId: expense.legacyId },
     context: API_V2_CONTEXT,
@@ -71,13 +68,6 @@ const ExpenseModal = ({ expense, onDelete, onProcess, onClose, show }) => {
         dividerMargin="0"
         minHeight={80}
       >
-        {error && (
-          <Box p={2}>
-            <MessageBox flex="1 0 100%" type="error" withIcon>
-              {formatErrorMessage(intl, error)}
-            </MessageBox>
-          </Box>
-        )}
         {data?.expense && (
           <Flex p={3} justifyContent="space-between" alignItems="flex-end">
             <Box display={['none', 'flex']}>
@@ -102,8 +92,6 @@ const ExpenseModal = ({ expense, onDelete, onProcess, onClose, show }) => {
                 host={data.expense.account.host}
                 permissions={data.expense.permissions}
                 buttonProps={{ buttonSize: 'small', minWidth: 130, m: 1, py: 11 }}
-                showError={false}
-                onError={setError}
                 onSuccess={onProcess}
               />
             </Flex>

--- a/components/expenses/PayExpenseButton.js
+++ b/components/expenses/PayExpenseButton.js
@@ -74,7 +74,7 @@ PayoutMethodTypeIcon.propTypes = {
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
-const PayExpenseButton = ({ expense, collective, host, disabled, onSubmit, error, resetError, ...props }) => {
+const PayExpenseButton = ({ expense, collective, host, disabled, onSubmit, error, ...props }) => {
   const [hasModal, showModal] = React.useState(false);
   const disabledMessage = getDisabledMessage(expense, collective, host, expense.payoutMethod);
   const isDisabled = Boolean(disabled || disabledMessage);
@@ -106,7 +106,6 @@ const PayExpenseButton = ({ expense, collective, host, disabled, onSubmit, error
           host={host}
           onClose={() => showModal(false)}
           error={error}
-          resetError={resetError}
           onSubmit={async values => {
             const { action, ...data } = values;
             await onSubmit(action, data);
@@ -158,7 +157,6 @@ PayExpenseButton.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   /** If set, will be displayed in the pay modal */
   error: PropTypes.string,
-  resetError: PropTypes.func,
 };
 
 export default PayExpenseButton;

--- a/components/expenses/PayExpenseModal.js
+++ b/components/expenses/PayExpenseModal.js
@@ -11,18 +11,14 @@ import { PayoutMethodType } from '../../lib/constants/payout-method';
 import { createError, ERROR } from '../../lib/errors';
 import i18nPayoutMethodType from '../../lib/i18n/payout-method-type';
 
-import { EDIT_COLLECTIVE_SECTIONS } from '../edit-collective/Menu';
 import FormattedMoneyAmount from '../FormattedMoneyAmount';
 import { Box, Flex } from '../Grid';
-import { getI18nLink } from '../I18nFormatters';
-import Link from '../Link';
 import MessageBox from '../MessageBox';
 import StyledButton from '../StyledButton';
 import StyledButtonSet from '../StyledButtonSet';
 import StyledInput from '../StyledInput';
 import StyledInputAmount from '../StyledInputAmount';
 import StyledInputField from '../StyledInputField';
-import StyledLink from '../StyledLink';
 import StyledModal, { ModalBody, ModalHeader } from '../StyledModal';
 import { H4, P, Span } from '../Text';
 import { withUser } from '../UserProvider';
@@ -110,7 +106,7 @@ const SectionLabel = styled.p`
 /**
  * Modal displayed by `PayExpenseButton` to trigger the actual payment of an expense
  */
-const PayExpenseModal = ({ onClose, onSubmit, expense, collective, host, LoggedInUser, error, resetError }) => {
+const PayExpenseModal = ({ onClose, onSubmit, expense, collective, host, error }) => {
   const intl = useIntl();
   const payoutMethodType = expense.payoutMethod?.type || PayoutMethodType.OTHER;
   const initialValues = { ...DEFAULT_VALUES, ...getPayoutOptionValue(payoutMethodType, true, host) };
@@ -154,9 +150,6 @@ const PayExpenseModal = ({ onClose, onSubmit, expense, collective, host, LoggedI
                 ...getPayoutOptionValue(payoutMethodType, item === 'AUTO', host),
                 paymentProcessorFee: null,
               });
-              if (resetError) {
-                resetError();
-              }
             }}
           >
             {({ item }) =>
@@ -244,35 +237,7 @@ const PayExpenseModal = ({ onClose, onSubmit, expense, collective, host, LoggedI
             </Amount>
           </AmountLine>
         </Box>
-        {error && (
-          <MessageBox type="error" withIcon my={3}>
-            {error}
-            <br />
-            {/** TODO: Add a proper ID/Type to detect this error */}
-            {error.startsWith('Insufficient Paypal balance') && (
-              <StyledLink as={Link} href={`/${host.slug}/dashboard`}>
-                <FormattedMessage
-                  id="PayExpenseModal.RefillBalanceError"
-                  defaultMessage="Refill your balance from the Host dashboard"
-                />
-              </StyledLink>
-            )}
-            {error.startsWith('Host has two-factor authentication enabled for large payouts.') && (
-              <FormattedMessage
-                id="PayExpenseModal.HostTwoFactorAuthEnabled"
-                defaultMessage="Please go to your <SettingsLink>settings</SettingsLink> to enable two-factor authentication for your account."
-                values={{
-                  SettingsLink: getI18nLink({
-                    as: Link,
-                    href: `${LoggedInUser.collective.slug}/edit/${EDIT_COLLECTIVE_SECTIONS.TWO_FACTOR_AUTH}`,
-                    openInNewTab: true,
-                  }),
-                }}
-              />
-            )}
-          </MessageBox>
-        )}
-        {error && error.startsWith('Two-factor authentication') && (
+        {Boolean(error?.message?.startsWith('Two-factor authentication')) && (
           <StyledInputField
             name="twoFactorAuthenticatorCode"
             htmlFor="twoFactorAuthenticatorCode"
@@ -369,8 +334,7 @@ PayExpenseModal.propTypes = {
   /** Function called when users click on one of the "Pay" buttons */
   onSubmit: PropTypes.func.isRequired,
   /** If set, will be displayed in the pay modal */
-  error: PropTypes.string,
-  resetError: PropTypes.func,
+  error: PropTypes.object,
   /** From withUser */
   LoggedInUser: PropTypes.object,
 };

--- a/components/expenses/ProcessExpenseButtons.js
+++ b/components/expenses/ProcessExpenseButtons.js
@@ -4,14 +4,18 @@ import { useMutation } from '@apollo/client';
 import { Ban as UnapproveIcon } from '@styled-icons/fa-solid/Ban';
 import { Check as ApproveIcon } from '@styled-icons/fa-solid/Check';
 import { Times as RejectIcon } from '@styled-icons/fa-solid/Times';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import styled from 'styled-components';
 
-import { getErrorFromGraphqlException } from '../../lib/errors';
+import { i18nGraphqlException } from '../../lib/errors';
 import { API_V2_CONTEXT, gqlV2 } from '../../lib/graphql/helpers';
 
-import MessageBoxGraphqlError from '../MessageBoxGraphqlError';
+import { EDIT_COLLECTIVE_SECTIONS } from '../edit-collective/Menu';
+import { getI18nLink } from '../I18nFormatters';
+import Link from '../Link';
 import StyledButton from '../StyledButton';
+import { TOAST_TYPE, useToasts } from '../ToastProvider';
+import { useUser } from '../UserProvider';
 
 import { expensePageExpenseFieldsFragment } from './graphql/fragments';
 import MarkExpenseAsUnpaidButton from './MarkExpenseAsUnpaidButton';
@@ -51,25 +55,69 @@ export const hasProcessButtons = permissions => {
   );
 };
 
+const getErrorContent = (intl, error, host, LoggedInUser) => {
+  // TODO: The proper way to check for error types is with error.type, not the message
+  const message = error?.message;
+  if (message) {
+    if (message.startsWith('Insufficient Paypal balance')) {
+      return {
+        title: 'Insufficient Paypal balance',
+        message: (
+          <React.Fragment>
+            <Link href={`/${host.slug}/dashboard`}>
+              <FormattedMessage
+                id="PayExpenseModal.RefillBalanceError"
+                defaultMessage="Refill your balance from the Host dashboard"
+              />
+            </Link>
+          </React.Fragment>
+        ),
+      };
+    } else if (message.startsWith('Host has two-factor authentication enabled for large payouts')) {
+      return {
+        title: 'Host has two-factor authentication enabled for large payouts',
+        message: (
+          <FormattedMessage
+            id="PayExpenseModal.HostTwoFactorAuthEnabled"
+            defaultMessage="Please go to your <SettingsLink>settings</SettingsLink> to enable two-factor authentication for your account."
+            values={{
+              SettingsLink: getI18nLink({
+                as: Link,
+                href: `${LoggedInUser.collective.slug}/edit/${EDIT_COLLECTIVE_SECTIONS.TWO_FACTOR_AUTH}`,
+                openInNewTab: true,
+              }),
+            }}
+          />
+        ),
+      };
+    } else if (message.startsWith('Two-factor authentication')) {
+      return {
+        type: TOAST_TYPE.INFO,
+        message: (
+          <FormattedMessage
+            id="2FA.PleaseEnterCode"
+            defaultMessage="Two-factor authentication enabled: please enter your code."
+          />
+        ),
+      };
+    }
+  }
+
+  return { message: i18nGraphqlException(intl, error) };
+};
+
 /**
  * All the buttons to process an expense, displayed in a React.Fragment to let the parent
  * in charge of the layout.
  */
-const ProcessExpenseButtons = ({
-  expense,
-  collective,
-  host,
-  permissions,
-  buttonProps,
-  showError,
-  onError,
-  onSuccess,
-}) => {
+const ProcessExpenseButtons = ({ expense, collective, host, permissions, buttonProps, onSuccess }) => {
   const [selectedAction, setSelectedAction] = React.useState(null);
   const onUpdate = (cache, response) => onSuccess?.(response.data.processExpense, cache);
   const mutationOptions = { context: API_V2_CONTEXT, update: onUpdate };
-  const [processExpense, { loading }] = useMutation(processExpenseMutation, mutationOptions);
-  const [error, setError] = React.useState(null);
+  const [processExpense, { loading, error }] = useMutation(processExpenseMutation, mutationOptions);
+  const intl = useIntl();
+  const { addToast } = useToasts();
+  const { LoggedInUser } = useUser();
 
   const triggerAction = async (action, paymentParams) => {
     // Prevent submitting the action if another one is being submitted at the same time
@@ -81,12 +129,10 @@ const ProcessExpenseButtons = ({
 
     try {
       const variables = { id: expense.id, legacyId: expense.legacyId, action, paymentParams };
-      return processExpense({ variables });
+      await processExpense({ variables });
     } catch (e) {
-      setError(e);
-      if (onError && selectedAction !== 'PAY') {
-        onError(getErrorFromGraphqlException(e));
-      }
+      // Display a toast with light variant since we're in a modal
+      addToast({ type: TOAST_TYPE.ERROR, variant: 'light', ...getErrorContent(intl, e, host, LoggedInUser) });
     }
   };
 
@@ -102,9 +148,6 @@ const ProcessExpenseButtons = ({
 
   return (
     <React.Fragment>
-      {!loading && showError && error && selectedAction !== 'PAY' && (
-        <MessageBoxGraphqlError flex="1 0 100%" error={error} />
-      )}
       {permissions.canApprove && (
         <StyledButton {...getButtonProps('APPROVE')} buttonStyle="secondary" data-cy="approve-button">
           <ApproveIcon size={12} />
@@ -136,8 +179,7 @@ const ProcessExpenseButtons = ({
           expense={expense}
           collective={collective}
           host={host}
-          error={error && getErrorFromGraphqlException(error).message}
-          resetError={() => setError(null)}
+          error={error}
         />
       )}
       {permissions.canUnapprove && (
@@ -182,7 +224,6 @@ ProcessExpenseButtons.propTypes = {
   /** Props passed to all buttons. Useful to customize sizes, spaces, etc. */
   buttonProps: PropTypes.object,
   showError: PropTypes.bool,
-  onError: PropTypes.func,
   onSuccess: PropTypes.func,
 };
 
@@ -195,7 +236,6 @@ export const DEFAULT_PROCESS_EXPENSE_BTN_PROPS = {
 
 ProcessExpenseButtons.defaultProps = {
   buttonProps: DEFAULT_PROCESS_EXPENSE_BTN_PROPS,
-  showError: true,
 };
 
 export default ProcessExpenseButtons;

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1,4 +1,5 @@
 {
+  "2FA.PleaseEnterCode": "Two-factor authentication enabled: please enter your code.",
   "Accept": "Accepta",
   "acceptContributions.addBankAccount": "Afegir el compte bancari",
   "acceptContributions.bankAccount.info": "Accept contributions via bank transfer. The budget will update when you confirm receipt of funds.",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1,4 +1,5 @@
 {
+  "2FA.PleaseEnterCode": "Two-factor authentication enabled: please enter your code.",
   "Accept": "Přijato",
   "acceptContributions.addBankAccount": "Přidat bankovní účet",
   "acceptContributions.bankAccount.info": "Accept contributions via bank transfer. The budget will update when you confirm receipt of funds.",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1,4 +1,5 @@
 {
+  "2FA.PleaseEnterCode": "Two-factor authentication enabled: please enter your code.",
   "Accept": "Akzeptieren",
   "acceptContributions.addBankAccount": "Bankkonto hinzufügen",
   "acceptContributions.bankAccount.info": "Nehmen Sie Beiträge via Banküberweisung entgegen. Das Budget wird aktualisiert, sobald Sie den Erhalt des Guthabens bestätigt haben.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,4 +1,5 @@
 {
+  "2FA.PleaseEnterCode": "Two-factor authentication enabled: please enter your code.",
   "Accept": "Accept",
   "acceptContributions.addBankAccount": "Add bank account",
   "acceptContributions.bankAccount.info": "Accept contributions via bank transfer. The budget will update when you confirm receipt of funds.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1,4 +1,5 @@
 {
+  "2FA.PleaseEnterCode": "Two-factor authentication enabled: please enter your code.",
   "Accept": "Aceptar",
   "acceptContributions.addBankAccount": "Añadir una cuenta bancaria",
   "acceptContributions.bankAccount.info": "Aceptar contribuciones vía transferencia bancaria. El presupuesto se actualizará cuando confirme la recepción de los fondos.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1,4 +1,5 @@
 {
+  "2FA.PleaseEnterCode": "Two-factor authentication enabled: please enter your code.",
   "Accept": "Accepter",
   "acceptContributions.addBankAccount": "Ajouter un compte bancaire",
   "acceptContributions.bankAccount.info": "Accepter les contributions par virement bancaire. Le budget sera mis à jour lorsque vous confirmerez la réception des fonds.",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1,4 +1,5 @@
 {
+  "2FA.PleaseEnterCode": "Two-factor authentication enabled: please enter your code.",
   "Accept": "Accetta",
   "acceptContributions.addBankAccount": "Aggiungi conto bancario",
   "acceptContributions.bankAccount.info": "Accetta i contributi tramite bonifico bancario. Il budget verrà aggiornato quando avrai confermato la ricezione dell'importo.",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1,4 +1,5 @@
 {
+  "2FA.PleaseEnterCode": "Two-factor authentication enabled: please enter your code.",
   "Accept": "許可",
   "acceptContributions.addBankAccount": "銀行口座を追加",
   "acceptContributions.bankAccount.info": "銀行振込による貢献を受け入れます。予算は、資金の受領を確認すると更新されます。",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1,4 +1,5 @@
 {
+  "2FA.PleaseEnterCode": "Two-factor authentication enabled: please enter your code.",
   "Accept": "동의",
   "acceptContributions.addBankAccount": "은행 계좌 추가",
   "acceptContributions.bankAccount.info": "은행 송금을 통해 기부를 수락합니다. 자금 수령을 확인하면 예산이 업데이트됩니다.",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1,4 +1,5 @@
 {
+  "2FA.PleaseEnterCode": "Two-factor authentication enabled: please enter your code.",
   "Accept": "Accepteren",
   "acceptContributions.addBankAccount": "Bankrekening toevoegen",
   "acceptContributions.bankAccount.info": "Accept contributions via bank transfer. The budget will update when you confirm receipt of funds.",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1,4 +1,5 @@
 {
+  "2FA.PleaseEnterCode": "Two-factor authentication enabled: please enter your code.",
   "Accept": "Aceitar",
   "acceptContributions.addBankAccount": "Adicionar conta bancária",
   "acceptContributions.bankAccount.info": "Aceite contribuições por transferência bancária. O orçamento será atualizado quando você confirmar o recebimento dos fundos.",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1,4 +1,5 @@
 {
+  "2FA.PleaseEnterCode": "Two-factor authentication enabled: please enter your code.",
   "Accept": "Aceitar",
   "acceptContributions.addBankAccount": "Nova conta bancária",
   "acceptContributions.bankAccount.info": "Aceite contribuições por transferência bancária. O orçamento será atualizado quando confirmar a receção dos fundos.",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1,4 +1,5 @@
 {
+  "2FA.PleaseEnterCode": "Two-factor authentication enabled: please enter your code.",
   "Accept": "Принять",
   "acceptContributions.addBankAccount": "Добавить банковский счет",
   "acceptContributions.bankAccount.info": "Accept contributions via bank transfer. The budget will update when you confirm receipt of funds.",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -1,4 +1,5 @@
 {
+  "2FA.PleaseEnterCode": "Two-factor authentication enabled: please enter your code.",
   "Accept": "Прийняти",
   "acceptContributions.addBankAccount": "Додати банківський рахунок",
   "acceptContributions.bankAccount.info": "Accept contributions via bank transfer. The budget will update when you confirm receipt of funds.",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1,4 +1,5 @@
 {
+  "2FA.PleaseEnterCode": "Two-factor authentication enabled: please enter your code.",
   "Accept": "接受",
   "acceptContributions.addBankAccount": "添加银行账户",
   "acceptContributions.bankAccount.info": "接受通过银行转账的捐款。当您确认收到资金时，预算将更新。",

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -265,11 +265,8 @@ export const formatErrorMessage = (intl, error, fallback = ERROR.UNKNOWN) => {
   if (error.type !== ERROR.UNKNOWN) {
     if (error.hasI18nMessage && error.message) {
       return error.message;
-    } else {
-      const i18nMsg = msg[error.type];
-      if (i18nMsg) {
-        return intl.formatMessage(i18nMsg, { ...I18nFormatters, ...error.payload, ...error });
-      }
+    } else if (msg[error.type]) {
+      return intl.formatMessage(msg[error.type], { ...I18nFormatters, ...error.payload, ...error });
     }
   }
 


### PR DESCRIPTION
Fix issue reported in https://opencollective.slack.com/archives/GSNDVCC4F/p1620082887002000?thread_ts=1620027148.001400&cid=GSNDVCC4F (see [dedicated screencast](https://www.loom.com/share/1d76774fd19e40a897cf189abcb9500f)) that caused errors not to be displayed. This issue was introduced in https://github.com/opencollective/opencollective-frontend/pull/5421.

This PR fixes the issue by displaying the error in a toast message. This also has the benefit of simplification and consistency in the way we display the message.