### PR TITLE
Contribute: show `All ways to contribute` button conditionally

### DIFF
--- a/components/collective-page/sections/Contribute.js
+++ b/components/collective-page/sections/Contribute.js
@@ -334,7 +334,7 @@ class SectionContribute extends React.PureComponent {
             )}
 
             {/* "View all ways to contribute" button */}
-            {!isEvent && (
+            {(tiers.length > 6 || hasOtherWaysToContribute) && (
               <ContainerSectionContent pb={4}>
                 <Link href={`/${collective.slug}/contribute`}>
                   <StyledButton mt={3} width={1} buttonSize="small" fontSize="14px">


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/4234

# Description

Display button if there are more than 6 tires or it has other ways to contribute as per-

https://github.com/opencollective/opencollective-frontend/blob/d78d8553f13831d7bb381ba94178167883fe41b2/components/collective-page/sections/Contribute.js#L213-L214

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots

<img width="1440" alt="Screenshot 2021-05-07 at 2 03 16 PM" src="https://user-images.githubusercontent.com/46647141/117422363-23989480-af3d-11eb-8d61-6f15c77ae737.png">

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
