### PR TITLE
Navbar: Hide settings on settings

### DIFF
--- a/components/edit-collective/index.js
+++ b/components/edit-collective/index.js
@@ -145,7 +145,11 @@ class EditCollective extends React.Component {
               description={notification.description}
             />
           )}
-          <CollectiveNavbar collective={collective} isAdmin={canEditCollective} />
+          <CollectiveNavbar
+            collective={collective}
+            isAdmin={canEditCollective}
+            callsToAction={{ hasSettings: false }} // We're already in the settings
+          />
           <div className="content">
             {!canEditCollective && (
               <div className="login">


### PR DESCRIPTION
No need to show the settings button when we're already in the settings