### PR TITLE
Trying to fix flacky e2e test related to the rich text editor

### DIFF
--- a/test/cypress/integration/34-expenses.comment.test.js
+++ b/test/cypress/integration/34-expenses.comment.test.js
@@ -53,9 +53,8 @@ describe('New Expense Flow comments', () => {
     cy.login({ redirect: expenseUrl, email: user.email });
     cy.get('[data-cy="RichTextEditor"] trix-editor').as('editor');
     cy.get('@editor').type('Add emojis here ⬇️⬇️⬇️');
-    cy.wait(500);
+    cy.wait(2000);
     cy.getByDataCy('submit-comment-btn').click();
-    cy.wait(500);
     cy.getByDataCy('comment-reaction-picker-trigger').click();
     cy.contains('[data-cy="comment-reaction-picker-popper"] button', '👍️').click({ force: true });
     cy.getByDataCy('comment-reactions').contains('👍️ 1');


### PR DESCRIPTION
It was observed in several PRs; https://github.com/opencollective/opencollective-frontend/pull/6327 and https://github.com/opencollective/opencollective-frontend/pull/6330 that the rich text editor related e2e test has become a bit flacky; I am trying to fix that in this PR. 😄 

I think this is related to out cypress update where it became flacky; https://github.com/opencollective/opencollective-frontend/pull/6310