### PR TITLE
Improve eslint configuration to remove some eslint exceptions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -80,6 +80,15 @@
 
     // This is deprecated and replaced by jsx-a11y/label-has-associated-control;
     // https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md
-    "jsx-a11y/label-has-for": ["off"]
+    "jsx-a11y/label-has-for": ["off"],
+    // The rational behind this is; https://github.com/brendanmorrell/eslint-plugin-styled-components-a11y/issues/18#issuecomment-837229005
+    "jsx-a11y/label-has-associated-control": [
+      "error",
+      {
+        "required": {
+          "some": ["nesting", "id"]
+        }
+      }
+    ]
   }
 }

--- a/components/CreateGiftCardsForm.js
+++ b/components/CreateGiftCardsForm.js
@@ -353,7 +353,6 @@ class CreateGiftCardsForm extends Component {
     return (
       <Box>
         <Flex flexDirection="column" mb="2em">
-          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
           <label style={{ width: '100%' }} htmlFor="gift-cards-recipients">
             <Flex flexDirection="column">
               <FormattedMessage id="giftCards.create.recipients" defaultMessage="Recipients" />
@@ -407,7 +406,6 @@ class CreateGiftCardsForm extends Component {
     return (
       <Container display="flex" flexDirection="column" width={1} justifyContent="center">
         <Flex justifyContent="center" mt={3} mb={4} alignItems="center">
-          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
           <label htmlFor="giftcard-numberOfGiftCards">
             <FormattedMessage id="giftCards.create.number" defaultMessage="Number of gift cards" />
           </label>

--- a/components/InputField.js
+++ b/components/InputField.js
@@ -18,8 +18,6 @@ import StyledSelect from './StyledSelect';
 import StyledTextarea from './StyledTextarea';
 import TimezonePicker from './TimezonePicker';
 
-/* eslint-disable jsx-a11y/label-has-associated-control */
-
 // Dynamic imports: this components have a huge impact on bundle size and are externalized
 // We use the DYNAMIC_IMPORT env variable to skip dynamic while using Jest
 let DateTime;


### PR DESCRIPTION
This minor enhancement gets rid of our eslint exceptions for the a11y rule; `jsx-a11y/label-has-associated-control`. This is suggested by @42tte at https://github.com/brendanmorrell/eslint-plugin-styled-components-a11y/issues/18#issuecomment-837229005. Thanks a bunch @42tte; greatly appreciate the help. 🎉 

Related to https://github.com/opencollective/opencollective-frontend/pull/5961 (specifically the review; https://github.com/opencollective/opencollective-frontend/pull/5961#discussion_r595201395)

Related to https://github.com/brendanmorrell/eslint-plugin-styled-components-a11y/issues/18