### PR TITLE
Fix for financial contributors widget cut-off on smaller screens

### DIFF
--- a/components/ExportImages.js
+++ b/components/ExportImages.js
@@ -59,7 +59,7 @@ class ExportImages extends React.Component {
           {
             name: 'Financial contributors widget',
             url: `https://opencollective.com/${collective.slug}/tiers/${tier.slug}.svg?avatarHeight=36`,
-            code: `<object type="image/svg+xml" data="https://opencollective.com/${collective.slug}/tiers/${tier.slug}.svg?avatarHeight=36&width=600" style="max-width: 100%;"></object>`,
+            code: `<object type="image/svg+xml" data="https://opencollective.com/${collective.slug}/tiers/${tier.slug}.svg?avatarHeight=36&width=600"></object>`,
             options: [
               {
                 name: 'width',
@@ -123,7 +123,7 @@ class ExportImages extends React.Component {
               <Container as="li" key={image.name} mb={4}>
                 <Label fontWeight="500">{image.name}</Label>
                 <div
-                  style={{ maxWidth: '100%', overflowY: 'auto' }}
+                  style={{ maxWidth: '100%' }}
                   dangerouslySetInnerHTML={{
                     __html: image.code,
                   }}


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/3694

**Screen-cast**

![Peek 2021-05-11 07-57](https://user-images.githubusercontent.com/12435965/117837741-8edcb200-b22e-11eb-86e4-5b3d59c62978.gif)
