### PR TITLE
Process expense buttons: fix update latency

### DIFF
--- a/components/expenses/ExpenseModal.js
+++ b/components/expenses/ExpenseModal.js
@@ -28,7 +28,6 @@ const ExpenseModal = ({ expense, onDelete, onProcess, onClose, show }) => {
   const { data, loading } = useQuery(expenseModalQuery, {
     variables: { legacyExpenseId: expense.legacyId },
     context: API_V2_CONTEXT,
-    fetchPolicy: 'network-only',
   });
 
   return (

--- a/pages/expenses.js
+++ b/pages/expenses.js
@@ -415,7 +415,6 @@ const addExpensesPageData = graphql(expensesPageQuery, {
     const [dateFrom] = getDateRangeFromPeriod(props.query.period);
     return {
       context: API_V2_CONTEXT,
-      fetchPolicy: 'cache-and-network',
       variables: {
         collectiveSlug: props.collectiveSlug,
         offset: props.query.offset || 0,


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/4132

Forcing the refetch after the expense was processed in the modal and the collective expenses list (not host dashboard) caused an additional delay before updating the component (documented in https://github.com/opencollective/opencollective/issues/4132). Using these fetch policies should not be necessary as we normally update all the necessary fields in the `processExpense` mutation.