### PR TITLE
Expense attachments enhancements

### DIFF
--- a/components/StyledLinkButton.js
+++ b/components/StyledLinkButton.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { color, typography, variant } from 'styled-system';
 
 /**
  * A button element but with the styles of a anchor element (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a).
@@ -8,12 +9,26 @@ const StyledLinkButton = styled.button`
   background: none;
   border: none;
   padding: 0;
-  color: ${props => props.color};
   cursor: pointer;
+
+  ${color}
+  ${typography}
 
   :hover {
     color: ${props => props.hoverColor};
   }
+
+  ${variant({
+    prop: 'variant',
+    variants: {
+      danger: {
+        color: 'red.500',
+        '&:hover': {
+          color: 'red.400',
+        },
+      },
+    },
+  })}
 `;
 
 StyledLinkButton.defaultProps = {
@@ -25,6 +40,7 @@ StyledLinkButton.propTypes = {
   onClick: PropTypes.func.isRequired,
   color: PropTypes.string,
   hoverColor: PropTypes.string,
+  variant: PropTypes.oneOf(['danger']),
 };
 
 export default StyledLinkButton;

--- a/components/UploadedFilePreview.js
+++ b/components/UploadedFilePreview.js
@@ -10,10 +10,12 @@ import { imagePreview } from '../lib/image-utils';
 
 import PrivateInfoIcon from './icons/PrivateInfoIcon';
 import Container from './Container';
+import { Box } from './Grid';
 import LoadingPlaceholder from './LoadingPlaceholder';
 import { fadeInDown } from './StyledKeyframes';
 import StyledLink from './StyledLink';
 import StyledSpinner from './StyledSpinner';
+import { P } from './Text';
 
 const ImageLink = styled(StyledLink)`
   cursor: pointer;
@@ -37,7 +39,7 @@ const DownloadIcon = styled(Download)`
   opacity: 0;
 `;
 
-const MainContainer = styled(Container)`
+const CardContainer = styled(Container)`
   position: relative;
   border-radius: 8px;
   padding: 4px;
@@ -53,7 +55,7 @@ const MainContainer = styled(Container)`
   }
 
   ${props =>
-    props.onClick &&
+    props.hasOnClick &&
     css`
       cursor: pointer;
       &:hover {
@@ -89,7 +91,19 @@ const PrivateIconContainer = styled.div`
  * To display the preview of a file uploaded on Open Collective.
  * Supports images and PDFs.
  */
-const UploadedFilePreview = ({ isPrivate, isLoading, isDownloading, url, size, alt, hasLink, ...props }) => {
+const UploadedFilePreview = ({
+  isPrivate,
+  isLoading,
+  isDownloading,
+  url,
+  size,
+  alt,
+  hasLink,
+  fileName,
+  showFileName,
+  border,
+  ...props
+}) => {
   let content = null;
   const isText = endsWith(url, 'csv') || endsWith(url, 'txt') || endsWith(url, 'pdf');
 
@@ -123,7 +137,7 @@ const UploadedFilePreview = ({ isPrivate, isLoading, isDownloading, url, size, a
     );
   } else {
     const resizeWidth = Array.isArray(size) ? max(size) : size;
-    const img = <img src={imagePreview(url, null, { width: resizeWidth })} alt={alt} />;
+    const img = <img src={imagePreview(url, null, { width: resizeWidth })} alt={alt || fileName} />;
     content = !hasLink ? (
       img
     ) : (
@@ -134,9 +148,26 @@ const UploadedFilePreview = ({ isPrivate, isLoading, isDownloading, url, size, a
   }
 
   return (
-    <MainContainer size={size} {...props}>
-      {content}
-    </MainContainer>
+    <Container {...props}>
+      <CardContainer size={size} title={fileName} border={border} hasOnClick={Boolean(props.onClick)}>
+        {content}
+      </CardContainer>
+      {showFileName && (
+        <Box mt="6px" maxWidth={100}>
+          {isLoading ? (
+            <LoadingPlaceholder height={12} />
+          ) : fileName ? (
+            <P fontSize="12px" color="black.600" fontWeight="500">
+              {fileName}
+            </P>
+          ) : (
+            <P fontStyle="italic" fontSize="12px" color="black.600">
+              <FormattedMessage id="File.NoFilename" defaultMessage="No filename" />
+            </P>
+          )}
+        </Box>
+      )}
+    </Container>
   );
 };
 
@@ -145,8 +176,11 @@ UploadedFilePreview.propTypes = {
   isPrivate: PropTypes.bool,
   isLoading: PropTypes.bool,
   isDownloading: PropTypes.bool,
+  showFileName: PropTypes.bool,
   alt: PropTypes.string,
+  fileName: PropTypes.string,
   onClick: PropTypes.func,
+  border: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array]),
   maxHeihgt: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array]),
   /** If true, a link to the original file will be added if possible */

--- a/components/expenses/ExpenseAttachedFiles.js
+++ b/components/expenses/ExpenseAttachedFiles.js
@@ -5,7 +5,7 @@ import { FormattedMessage } from 'react-intl';
 import expenseTypes from '../../lib/constants/expenseTypes';
 
 import { Box, Flex } from '../Grid';
-import StyledButton from '../StyledButton';
+import StyledLinkButton from '../StyledLinkButton';
 import UploadedFilePreview from '../UploadedFilePreview';
 
 import ExpenseInvoiceDownloadHelper, { getExpenseInvoiceFilename } from './ExpenseInvoiceDownloadHelper';
@@ -14,32 +14,27 @@ const ExpenseAttachedFiles = ({ files, onRemove, showInvoice, collective, expens
   return (
     <Flex flexWrap="wrap">
       {showInvoice && expense.type === expenseTypes.INVOICE && (
-        <Box mr={3}>
+        <Box mr={3} mb={3}>
           <ExpenseInvoiceDownloadHelper expense={expense} collective={collective}>
             {({ isLoading, downloadInvoice }) => (
               <UploadedFilePreview
                 onClick={downloadInvoice}
                 isDownloading={isLoading}
-                title={getExpenseInvoiceFilename(collective, expense)}
+                fileName={getExpenseInvoiceFilename(collective, expense)}
                 size={88}
+                showFileName
               />
             )}
           </ExpenseInvoiceDownloadHelper>
         </Box>
       )}
       {files.map((file, idx) => (
-        <Box key={file.id || file.url} mr={3}>
-          <UploadedFilePreview size={88} url={file.url} />
+        <Box key={file.id || file.url} mr={3} mb={3}>
+          <UploadedFilePreview size={88} url={file.url} fileName={file.name} showFileName />
           {onRemove && (
-            <StyledButton
-              isBorderless
-              buttonStyle="dangerSecondary"
-              buttonSize="tiny"
-              mt={1}
-              onClick={() => onRemove(idx)}
-            >
+            <StyledLinkButton variant="danger" fontSize="12px" mt={1} onClick={() => onRemove(idx)}>
               <FormattedMessage id="Remove" defaultMessage="Remove" />
-            </StyledButton>
+            </StyledLinkButton>
           )}
         </Box>
       ))}

--- a/components/expenses/ExpenseAttachedFilesForm.js
+++ b/components/expenses/ExpenseAttachedFilesForm.js
@@ -39,8 +39,8 @@ const ExpenseAttachedFilesForm = ({ onChange, disabled, defaultValue, title, des
         {files?.length > 0 && (
           <AddNewAttachedFilesButton
             disabled={disabled}
-            onSuccess={urls => {
-              const uploadedFiles = [...files, ...urls.map(url => ({ url }))];
+            onSuccess={newFiles => {
+              const uploadedFiles = [...files, ...newFiles];
               setFiles(uploadedFiles);
               onChange(uploadedFiles);
             }}
@@ -66,8 +66,7 @@ const ExpenseAttachedFilesForm = ({ onChange, disabled, defaultValue, title, des
           name="attachedFiles"
           disabled={disabled}
           minHeight={72}
-          onSuccess={urls => {
-            const uploadedFiles = urls.map(url => ({ url }));
+          onSuccess={uploadedFiles => {
             setFiles(uploadedFiles);
             onChange(uploadedFiles);
           }}

--- a/components/expenses/ExpenseFormItems.js
+++ b/components/expenses/ExpenseFormItems.js
@@ -31,7 +31,7 @@ const newExpenseItem = attrs => ({
 });
 
 /** Converts a list of filenames to expense item objects */
-const filesListToItems = files => files.map(url => newExpenseItem({ url }));
+const filesListToItems = files => files.map(({ url }) => newExpenseItem({ url }));
 
 /** Helper to add a new item to the form */
 export const addNewExpenseItem = (formik, defaultValues) => {
@@ -107,7 +107,7 @@ class ExpenseFormItems extends React.PureComponent {
             />
           </strong>
           <P mt={1} pl={22}>
-            {formatErrorMessage(this.props.intl, uploadErrors[0])}
+            {formatErrorMessage(this.props.intl, uploadErrors[0]?.message)}
           </P>
         </MessageBox>
       );

--- a/components/expenses/ExpenseInvoiceDownloadHelper.js
+++ b/components/expenses/ExpenseInvoiceDownloadHelper.js
@@ -7,6 +7,8 @@ import expenseTypes from '../../lib/constants/expenseTypes';
 import { getErrorFromPdfService } from '../../lib/errors';
 import { expenseInvoiceUrl } from '../../lib/url_helpers';
 
+import { TOAST_TYPE, useToasts } from '../ToastProvider';
+
 const getPrettyDate = expense => {
   if (!expense?.createdAt) {
     return '';
@@ -47,6 +49,7 @@ export const downloadExpenseInvoice = async (collective, expense, { setLoading, 
 export const useExpenseInvoiceDownloadHelper = ({ expense, collective, onError, disablePreview }) => {
   const [isLoading, setLoading] = React.useState(false);
   const [error, setError] = React.useState(null);
+  const { addToast } = useToasts();
 
   if (expense.type !== expenseTypes.INVOICE) {
     return { error: null, isLoading: false, filename: '', downloadInvoice: null };
@@ -62,8 +65,12 @@ export const useExpenseInvoiceDownloadHelper = ({ expense, collective, onError, 
         isLoading,
         disablePreview,
         onError: error => {
-          onError(error);
           setError(error);
+          if (onError) {
+            onError(error);
+          } else {
+            addToast({ type: TOAST_TYPE.ERROR, variant: 'light', message: 'Request failed, please try again later' });
+          }
         },
       });
     },

--- a/components/expenses/ExpenseItemForm.js
+++ b/components/expenses/ExpenseItemForm.js
@@ -137,7 +137,7 @@ const ExpenseItemForm = ({
                     name={field.name}
                     isMulti={false}
                     error={meta.error}
-                    onSuccess={url => form.setFieldValue(field.name, url)}
+                    onSuccess={({ url }) => form.setFieldValue(field.name, url)}
                     mockImageGenerator={() => `https://loremflickr.com/120/120/invoice?lock=${attachmentKey}`}
                     fontSize="13px"
                     size={[84, 112]}

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -951,6 +951,7 @@
   "Fields.description": "Description",
   "Fields.name": "Name",
   "Fields.website": "Website",
+  "File.NoFilename": "No filename",
   "FilesPreviewModal.AttachmentPreview": "Attachment preview",
   "FilesUploadFailed": "{count, plural, one {The file} other {# files}} failed to upload",
   "Filter.ByName": "Filter by name",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -951,6 +951,7 @@
   "Fields.description": "Popis",
   "Fields.name": "Název",
   "Fields.website": "Webová stránka",
+  "File.NoFilename": "No filename",
   "FilesPreviewModal.AttachmentPreview": "Attachment preview",
   "FilesUploadFailed": "{count, plural, one {The file} other {# files}} failed to upload",
   "Filter.ByName": "Filtrovat podle jména",

--- a/lang/de.json
+++ b/lang/de.json
@@ -951,6 +951,7 @@
   "Fields.description": "Beschreibung",
   "Fields.name": "Name",
   "Fields.website": "Webseite",
+  "File.NoFilename": "No filename",
   "FilesPreviewModal.AttachmentPreview": "Attachment preview",
   "FilesUploadFailed": "{count, plural, one {The file} other {# files}} failed to upload",
   "Filter.ByName": "Nach Namen filtern",

--- a/lang/en.json
+++ b/lang/en.json
@@ -951,6 +951,7 @@
   "Fields.description": "Description",
   "Fields.name": "Name",
   "Fields.website": "Website",
+  "File.NoFilename": "No filename",
   "FilesPreviewModal.AttachmentPreview": "Attachment preview",
   "FilesUploadFailed": "{count, plural, one {The file} other {# files}} failed to upload",
   "Filter.ByName": "Filter by name",

--- a/lang/es.json
+++ b/lang/es.json
@@ -951,6 +951,7 @@
   "Fields.description": "Descripción",
   "Fields.name": "Nombre",
   "Fields.website": "Sitio Web",
+  "File.NoFilename": "No filename",
   "FilesPreviewModal.AttachmentPreview": "Previsualización del archivo adjunto",
   "FilesUploadFailed": "{count, plural, one {The file} other {# files}} failed to upload",
   "Filter.ByName": "Filtrar por nombre",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -951,6 +951,7 @@
   "Fields.description": "Description",
   "Fields.name": "Nom",
   "Fields.website": "Site Web",
+  "File.NoFilename": "No filename",
   "FilesPreviewModal.AttachmentPreview": "Aperçu des pièces jointes",
   "FilesUploadFailed": "{count, plural, one {Le fichier} other {# fichiers}} n'ont pas put être mis en ligne",
   "Filter.ByName": "Filtrer par nom",

--- a/lang/it.json
+++ b/lang/it.json
@@ -951,6 +951,7 @@
   "Fields.description": "Description",
   "Fields.name": "Nome",
   "Fields.website": "Sito web",
+  "File.NoFilename": "No filename",
   "FilesPreviewModal.AttachmentPreview": "Anteprima allegato",
   "FilesUploadFailed": "{count, plural, one {The file} other {# files}} failed to upload",
   "Filter.ByName": "Filtra per nome",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -951,6 +951,7 @@
   "Fields.description": "説明",
   "Fields.name": "名前",
   "Fields.website": "ウェブサイト",
+  "File.NoFilename": "No filename",
   "FilesPreviewModal.AttachmentPreview": "Attachment preview",
   "FilesUploadFailed": "{count, plural, one {The file} other {# files}} failed to upload",
   "Filter.ByName": "名前によるフィルター",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -951,6 +951,7 @@
   "Fields.description": "설명",
   "Fields.name": "이름",
   "Fields.website": "웹사이트",
+  "File.NoFilename": "No filename",
   "FilesPreviewModal.AttachmentPreview": "Attachment preview",
   "FilesUploadFailed": "{count, plural, one {The file} other {# files}} failed to upload",
   "Filter.ByName": "이름으로 필터링",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -951,6 +951,7 @@
   "Fields.description": "Description",
   "Fields.name": "Name",
   "Fields.website": "Website",
+  "File.NoFilename": "No filename",
   "FilesPreviewModal.AttachmentPreview": "Attachment preview",
   "FilesUploadFailed": "{count, plural, one {The file} other {# files}} failed to upload",
   "Filter.ByName": "Filter by name",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -951,6 +951,7 @@
   "Fields.description": "Descrição",
   "Fields.name": "Nome",
   "Fields.website": "Site",
+  "File.NoFilename": "No filename",
   "FilesPreviewModal.AttachmentPreview": "Visualização do anexo",
   "FilesUploadFailed": "{count, plural, one {O arquivo} other {# arquivos}} falhou ao carregar",
   "Filter.ByName": "Filtrar por nome",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -951,6 +951,7 @@
   "Fields.description": "Descrição",
   "Fields.name": "Nome",
   "Fields.website": "Site",
+  "File.NoFilename": "No filename",
   "FilesPreviewModal.AttachmentPreview": "Attachment preview",
   "FilesUploadFailed": "{count, plural, one {The file} other {# files}} failed to upload",
   "Filter.ByName": "Filtrar por nome",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -951,6 +951,7 @@
   "Fields.description": "Описание",
   "Fields.name": "Название",
   "Fields.website": "Сайт",
+  "File.NoFilename": "No filename",
   "FilesPreviewModal.AttachmentPreview": "Предпросмотр вложений",
   "FilesUploadFailed": "{count, plural, one {The file} other {# files}} failed to upload",
   "Filter.ByName": "Фильтр по названию",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -951,6 +951,7 @@
   "Fields.description": "Опис",
   "Fields.name": "Ім’я",
   "Fields.website": "Вебсайт",
+  "File.NoFilename": "No filename",
   "FilesPreviewModal.AttachmentPreview": "Попередній перегляд вкладення",
   "FilesUploadFailed": "Не вдалося завантажити {count, plural, one {файл} other {# файлів}}",
   "Filter.ByName": "Фільтр за назвою",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -951,6 +951,7 @@
   "Fields.description": "描述",
   "Fields.name": "名称",
   "Fields.website": "网站",
+  "File.NoFilename": "No filename",
   "FilesPreviewModal.AttachmentPreview": "附件预览",
   "FilesUploadFailed": "{count, plural, one {The file} other {# files}} failed to upload",
   "Filter.ByName": "通过名称过滤",

--- a/lib/hooks/useImageUploader.js
+++ b/lib/hooks/useImageUploader.js
@@ -1,12 +1,11 @@
 import React from 'react';
-import { get, partition } from 'lodash';
+import { get, pick } from 'lodash';
 import { defineMessages, useIntl } from 'react-intl';
 
 import I18nFormatters from '../../components/I18nFormatters';
 import { TOAST_TYPE, useToasts } from '../../components/ToastProvider';
 
 import { uploadImageWithXHR } from '../api';
-import { getErrorFromXhrUpload } from '../errors';
 import { allSettled } from '../utils';
 
 const msg = defineMessages({
@@ -53,16 +52,23 @@ export const useImageUploader = ({ isMulti, mockImageGenerator, onSuccess, onRej
 
         setUploading(false);
 
-        const [successes, failures] = partition(results, r => r.status === 'fulfilled');
-        const getResultValue = r => r.value;
-        const getRejectReason = r => getErrorFromXhrUpload(r.reason);
+        const successes = [];
+        const failures = [];
+        results.forEach((result, index) => {
+          const fileInfo = pick(filesToUpload[index], ['name', 'size', 'type']);
+          if (result.status === 'fulfilled') {
+            successes.push({ url: result.value, ...fileInfo });
+          } else {
+            failures.push({ message: result.reason, ...fileInfo });
+          }
+        });
 
         if (onSuccess && successes.length > 0) {
-          await onSuccess(isMulti ? successes.map(getResultValue) : getResultValue(successes[0]));
+          await onSuccess(isMulti ? successes : successes[0]);
         }
 
         if (onReject && failures.length > 0) {
-          onReject(isMulti ? failures.map(getRejectReason) : getRejectReason(failures[0]));
+          onReject(isMulti ? failures : failures[0]);
         }
 
         if (rejectedFiles?.length) {


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/3752#issuecomment-753811484

- Add a default error message in expense attachments preview modals when loading fails
- Add error message whenever downloading an expense attachment from PDF service fails
- Show attachments filenames

![Peek 2021-05-12 13-12](https://user-images.githubusercontent.com/1556356/117966074-cbd6a080-b323-11eb-97ef-f61c8ce4a72a.gif)


![image](https://user-images.githubusercontent.com/1556356/117963300-7a78e200-b320-11eb-9952-a8f0eae7fac6.png)
