### PR TITLE
Disable Paypal in Connected Accounts Section if `disablePaypalPayouts` is set

### DIFF
--- a/components/edit-collective/EditConnectedAccount.js
+++ b/components/edit-collective/EditConnectedAccount.js
@@ -151,7 +151,7 @@ class EditConnectedAccount extends React.Component {
       return (
         <EditTransferWiseAccount collective={collective} connectedAccount={this.props.connectedAccount} intl={intl} />
       );
-    } else if (service === 'paypal') {
+    } else if (service === 'paypal' && !collective.settings?.disablePaypalPayouts) {
       return (
         <EditPayPalAccount
           collective={collective}


### PR DESCRIPTION
This is with regard to the discussion on Slack; https://opencollective.slack.com/archives/C0RMV6F8C/p1620845995284200?thread_ts=1620830290.282400&cid=C0RMV6F8C

Related to https://github.com/opencollective/opencollective/issues/3676