### PR TITLE
fix (footer): don't show login and signup links for a logged in user

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -11,6 +11,8 @@ import styled from 'styled-components';
 
 import languages from '../lib/constants/locales';
 
+import { useUser } from '../components/UserProvider';
+
 import TranslateIcon from './icons/TranslateIcon';
 import Container from './Container';
 import { Box, Flex } from './Grid';
@@ -226,7 +228,7 @@ const Footer = () => {
   const intl = useIntl();
   const languageOptions = React.useMemo(generateLanguageOptions);
   const defaultLanguage = languageOptions.find(language => language.value === intl.locale);
-
+  const { LoggedInUser } = useUser();
   return (
     <FooterContainer>
       <Container
@@ -375,21 +377,23 @@ const Footer = () => {
                 {intl.formatMessage(messages[key])}
               </P>
               <FlexList justifyContent="center" flexDirection="column" pl={0} pr={2}>
-                {Object.keys(navigation[key]).map(item => (
-                  <ListItem key={item} textAlign={['center', 'left']} mb={3}>
-                    {navigation[key][item][0] === '/' ? (
-                      <Link href={navigation[key][item]}>
-                        <MenuLink as={Container}>
+                {Object.keys(navigation[key]).map(item =>
+                  !LoggedInUser || (LoggedInUser && !(item === 'signup' || item === 'login')) ? (
+                    <ListItem key={item} textAlign={['center', 'left']} mb={2}>
+                      {navigation[key][item][0] === '/' ? (
+                        <Link href={navigation[key][item]}>
+                          <MenuLink as={Container}>
+                            {messages[`${key}.${item}`] ? intl.formatMessage(messages[`${key}.${item}`]) : item}
+                          </MenuLink>
+                        </Link>
+                      ) : (
+                        <MenuLink href={navigation[key][item]}>
                           {messages[`${key}.${item}`] ? intl.formatMessage(messages[`${key}.${item}`]) : item}
                         </MenuLink>
-                      </Link>
-                    ) : (
-                      <MenuLink href={navigation[key][item]}>
-                        {messages[`${key}.${item}`] ? intl.formatMessage(messages[`${key}.${item}`]) : item}
-                      </MenuLink>
-                    )}
-                  </ListItem>
-                ))}
+                      )}
+                    </ListItem>
+                  ) : null,
+                )}
               </FlexList>
             </Box>
           ))}


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve [#4235](https://github.com/opencollective/opencollective/issues/4235)

# Description

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->
Used the **LoggedInUser** object to check if a user is logged in or not and accordingly display the signup and login links in the footer

# Screenshots

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
![Screenshot from 2021-05-17 15-02-36](https://user-images.githubusercontent.com/55311336/118467182-37a07b00-b721-11eb-8ed9-435015f5bf34.png)

