### PR TITLE
Mark scroll handlers as passive

### DIFF
--- a/components/HorizontalScroller.js
+++ b/components/HorizontalScroller.js
@@ -65,7 +65,7 @@ class HorizontalScroller extends React.PureComponent {
 
   componentDidMount() {
     if (this.ref.current) {
-      this.ref.current.addEventListener('scroll', this.updateScrollInfo);
+      this.ref.current.addEventListener('scroll', this.updateScrollInfo, { passive: true });
       this.updateScrollInfo();
     }
   }

--- a/components/collective-page/index.js
+++ b/components/collective-page/index.js
@@ -78,7 +78,7 @@ class CollectivePage extends Component {
   }
 
   componentDidMount() {
-    window.addEventListener('scroll', this.onScroll);
+    window.addEventListener('scroll', this.onScroll, { passive: true });
     this.onScroll(); // First tick in case scroll is restored when page loads
   }
 

--- a/components/pricing/index.js
+++ b/components/pricing/index.js
@@ -129,7 +129,7 @@ const Pricing = () => {
   }, 100);
 
   React.useEffect(() => {
-    window.addEventListener('scroll', handleOnScroll);
+    window.addEventListener('scroll', handleOnScroll, { passive: true });
     return () => window.removeEventListener('scroll', handleOnScroll);
   });
 


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#improving_scrolling_performance_with_passive_listeners

This can provide significant performance enhancement by allowing browsers to make scrolling asynchronous.