### PR TITLE
Card state is cleared after closing the assign card modal

### DIFF
--- a/components/edit-collective/AssignVirtualCardModal.js
+++ b/components/edit-collective/AssignVirtualCardModal.js
@@ -149,6 +149,7 @@ const AssignVirtualCardModal = ({ collective, host, virtualCard, onSuccess, onCl
         });
         onSuccess?.();
       }
+      handleClose();
     },
     validate(values) {
       const errors = {};
@@ -194,7 +195,7 @@ const AssignVirtualCardModal = ({ collective, host, virtualCard, onSuccess, onCl
   return (
     <Modal width="382px" onClose={handleClose} trapFocus {...modalProps}>
       <form onSubmit={formik.handleSubmit}>
-        <ModalHeader onClose={onClose}>
+        <ModalHeader onClose={handleClose}>
           {isEditing ? (
             <FormattedMessage id="Host.VirtualCards.CardDetails" defaultMessage="Card Details" />
           ) : (


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4288 

**Screen-cast**

![cleared-state](https://user-images.githubusercontent.com/12435965/118577995-3d598900-b740-11eb-9cc0-1abf870f1d20.gif)

