### PR TITLE
Settings: Use generic fragment for navbar fields

### DIFF
--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -156,23 +156,6 @@ export const loggedInUserQuery = gql`
   }
 `;
 
-const featuresFieldsFragment = gql`
-  fragment FeatureFields on CollectiveFeatures {
-    RECEIVE_FINANCIAL_CONTRIBUTIONS
-    RECURRING_CONTRIBUTIONS
-    EVENTS
-    PROJECTS
-    USE_EXPENSES
-    RECEIVE_EXPENSES
-    USE_EXPENSES
-    COLLECTIVE_GOALS
-    TOP_FINANCIAL_CONTRIBUTORS
-    CONVERSATIONS
-    UPDATES
-    TEAM
-  }
-`;
-
 export const editCollectivePageFieldsFragment = gql`
   fragment EditCollectivePageFields on CollectiveInterface {
     id
@@ -327,10 +310,10 @@ export const editCollectivePageFieldsFragment = gql`
       slug
     }
     features {
-      ...FeatureFields
+      ...NavbarFields
     }
   }
-  ${featuresFieldsFragment}
+  ${collectiveNavbarFieldsFragment}
 `;
 
 export const editCollectivePageQuery = gql`


### PR DESCRIPTION
For some reason, the query used its own fragment instead of the generic one.

![image](https://user-images.githubusercontent.com/1556356/118932692-97c53600-b948-11eb-8fa8-c06407d92b8c.png)
