### PR TITLE
enh(Events): don't show 'view all events' if all are already visible

### DIFF
--- a/components/collective-page/sections/Events.js
+++ b/components/collective-page/sections/Events.js
@@ -98,7 +98,7 @@ class SectionEvents extends React.PureComponent {
             </Box>
           )}
         </HorizontalScroller>
-        {Boolean(events?.length) && (
+        {Boolean(events?.length > 6) && (
           <ContainerSectionContent>
             <Link href={`/${collective.slug}/events`}>
               <StyledButton mt={4} width={1} buttonSize="small" fontSize="14px">


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/4289

# Description

Show the `View all events` button only if there are more than 6 events.
<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots
<img width="1440" alt="Screenshot 2021-05-25 at 5 57 37 PM" src="https://user-images.githubusercontent.com/46647141/119497915-b5e4c900-bd82-11eb-9153-47a5f4e0adb5.png">

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
