### PR TITLE
i18n: Remove empty message

### DIFF
--- a/components/edit-collective/sections/Host.js
+++ b/components/edit-collective/sections/Host.js
@@ -293,11 +293,8 @@ class Host extends React.Component {
                   <FormattedMessage id="actions.cancel" defaultMessage={'Cancel'} />
                 </StyledButton>
                 <StyledButton buttonStyle="primary" onClick={() => this.changeHost()} data-cy="continue">
-                  <FormattedMessage
-                    id="collective.editHost.continue.btn"
-                    values={{ action }}
-                    defaultMessage={'{action}'}
-                  />
+                  {/** TODO(i18n): This should be internationalized */}
+                  {action}
                 </StyledButton>
               </Container>
             </ModalFooter>

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -288,7 +288,6 @@
   "collective.edit.host.suggestedHosts.title": "Suggested Hosts",
   "collective.edit.host.useOwn.description": "Create or select a Fiscal Host that you manage, to hold funds for multiple Collectives. The organization will be responsible for accounting, taxes, payments, and liability.",
   "collective.edit.host.viewAllHosts": "View all Fiscal Hosts",
-  "collective.editHost.continue.btn": "{action}",
   "collective.editHost.header": "Withdraw application to {name}",
   "collective.editHost.remove": "Suprimeix {name}",
   "collective.editHost.removeHost": "Are you sure you want to remove {name}?",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -288,7 +288,6 @@
   "collective.edit.host.suggestedHosts.title": "Suggested Hosts",
   "collective.edit.host.useOwn.description": "Create or select a Fiscal Host that you manage, to hold funds for multiple Collectives. The organization will be responsible for accounting, taxes, payments, and liability.",
   "collective.edit.host.viewAllHosts": "View all Fiscal Hosts",
-  "collective.editHost.continue.btn": "{action}",
   "collective.editHost.header": "Withdraw application to {name}",
   "collective.editHost.remove": "Odstranit {name}",
   "collective.editHost.removeHost": "Opravdu chcete odstranit {name}?",

--- a/lang/de.json
+++ b/lang/de.json
@@ -288,7 +288,6 @@
   "collective.edit.host.suggestedHosts.title": "Suggested Hosts",
   "collective.edit.host.useOwn.description": "Create or select a Fiscal Host that you manage, to hold funds for multiple Collectives. The organization will be responsible for accounting, taxes, payments, and liability.",
   "collective.edit.host.viewAllHosts": "Alle Träger anzeigen",
-  "collective.editHost.continue.btn": "{action}",
   "collective.editHost.header": "Withdraw application to {name}",
   "collective.editHost.remove": "{name} entfernen",
   "collective.editHost.removeHost": "Bist du sicher, dass du {name} entfernen möchtest?",

--- a/lang/en.json
+++ b/lang/en.json
@@ -288,7 +288,6 @@
   "collective.edit.host.suggestedHosts.title": "Suggested Hosts",
   "collective.edit.host.useOwn.description": "Create or select a Fiscal Host that you manage, to hold funds for multiple Collectives. The organization will be responsible for accounting, taxes, payments, and liability.",
   "collective.edit.host.viewAllHosts": "View all Fiscal Hosts",
-  "collective.editHost.continue.btn": "{action}",
   "collective.editHost.header": "Withdraw application to {name}",
   "collective.editHost.remove": "Remove {name}",
   "collective.editHost.removeHost": "Are you sure you want to remove {name}?",

--- a/lang/es.json
+++ b/lang/es.json
@@ -288,7 +288,6 @@
   "collective.edit.host.suggestedHosts.title": "Anfitriones sugeridos",
   "collective.edit.host.useOwn.description": "Create or select a Fiscal Host that you manage, to hold funds for multiple Collectives. The organization will be responsible for accounting, taxes, payments, and liability.",
   "collective.edit.host.viewAllHosts": "Ver todos los Anfitriones Fiscales",
-  "collective.editHost.continue.btn": "{action}",
   "collective.editHost.header": "Retirar la solicitud a {name}",
   "collective.editHost.remove": "Eliminar {name}",
   "collective.editHost.removeHost": "¿Está seguro de que desea eliminar {name}?",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -288,7 +288,6 @@
   "collective.edit.host.suggestedHosts.title": "Hôtes suggérés",
   "collective.edit.host.useOwn.description": "Create or select a Fiscal Host that you manage, to hold funds for multiple Collectives. The organization will be responsible for accounting, taxes, payments, and liability.",
   "collective.edit.host.viewAllHosts": "Voir tous les hôtes fiscaux",
-  "collective.editHost.continue.btn": "{action}",
   "collective.editHost.header": "Withdraw application to {name}",
   "collective.editHost.remove": "Supprimer {name}",
   "collective.editHost.removeHost": "Êtes-vous sûr de vouloir supprimer {name} ?",

--- a/lang/it.json
+++ b/lang/it.json
@@ -288,7 +288,6 @@
   "collective.edit.host.suggestedHosts.title": "Suggested Hosts",
   "collective.edit.host.useOwn.description": "Create or select a Fiscal Host that you manage, to hold funds for multiple Collectives. The organization will be responsible for accounting, taxes, payments, and liability.",
   "collective.edit.host.viewAllHosts": "View all Fiscal Hosts",
-  "collective.editHost.continue.btn": "{action}",
   "collective.editHost.header": "Withdraw application to {name}",
   "collective.editHost.remove": "Rimuovi {name}",
   "collective.editHost.removeHost": "Sei sicuro di voler eliminare {name}?",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -288,7 +288,6 @@
   "collective.edit.host.suggestedHosts.title": "Suggested Hosts",
   "collective.edit.host.useOwn.description": "Create or select a Fiscal Host that you manage, to hold funds for multiple Collectives. The organization will be responsible for accounting, taxes, payments, and liability.",
   "collective.edit.host.viewAllHosts": "すべての会計ホストを表示",
-  "collective.editHost.continue.btn": "{action}",
   "collective.editHost.header": "Withdraw application to {name}",
   "collective.editHost.remove": "{name} を削除",
   "collective.editHost.removeHost": "本当に {name} を削除しますか？",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -288,7 +288,6 @@
   "collective.edit.host.suggestedHosts.title": "Suggested Hosts",
   "collective.edit.host.useOwn.description": "Create or select a Fiscal Host that you manage, to hold funds for multiple Collectives. The organization will be responsible for accounting, taxes, payments, and liability.",
   "collective.edit.host.viewAllHosts": "View all Fiscal Hosts",
-  "collective.editHost.continue.btn": "{action}",
   "collective.editHost.header": "Withdraw application to {name}",
   "collective.editHost.remove": "{name} 삭제",
   "collective.editHost.removeHost": "정말 {name}을 삭제하시겠습니까?",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -288,7 +288,6 @@
   "collective.edit.host.suggestedHosts.title": "Suggested Hosts",
   "collective.edit.host.useOwn.description": "Create or select a Fiscal Host that you manage, to hold funds for multiple Collectives. The organization will be responsible for accounting, taxes, payments, and liability.",
   "collective.edit.host.viewAllHosts": "View all Fiscal Hosts",
-  "collective.editHost.continue.btn": "{action}",
   "collective.editHost.header": "Withdraw application to {name}",
   "collective.editHost.remove": "Verwijder {name}",
   "collective.editHost.removeHost": "Ben je zeker dat je {name} wilt verwijderen?",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -288,7 +288,6 @@
   "collective.edit.host.suggestedHosts.title": "Administradores sugeridos",
   "collective.edit.host.useOwn.description": "Crie ou selecione um administrador fiscal que você gerencia para deter fundos para vários Coletivos. A organização será responsável pela contabilidade, impostos, pagamentos e responsabilidade.",
   "collective.edit.host.viewAllHosts": "Ver todos os Administradores Fiscais",
-  "collective.editHost.continue.btn": "{action}",
   "collective.editHost.header": "Retirar a solicitação para {name}",
   "collective.editHost.remove": "Remover {name}",
   "collective.editHost.removeHost": "Tem certeza de que deseja remover {name}?",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -288,7 +288,6 @@
   "collective.edit.host.suggestedHosts.title": "Suggested Hosts",
   "collective.edit.host.useOwn.description": "Create or select a Fiscal Host that you manage, to hold funds for multiple Collectives. The organization will be responsible for accounting, taxes, payments, and liability.",
   "collective.edit.host.viewAllHosts": "View all Fiscal Hosts",
-  "collective.editHost.continue.btn": "{action}",
   "collective.editHost.header": "Withdraw application to {name}",
   "collective.editHost.remove": "Remover {name}",
   "collective.editHost.removeHost": "Você tem certeza de que deseja remover {name}?",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -288,7 +288,6 @@
   "collective.edit.host.suggestedHosts.title": "Suggested Hosts",
   "collective.edit.host.useOwn.description": "Create or select a Fiscal Host that you manage, to hold funds for multiple Collectives. The organization will be responsible for accounting, taxes, payments, and liability.",
   "collective.edit.host.viewAllHosts": "Просмотр всех Фискальных Представителей",
-  "collective.editHost.continue.btn": "{action}",
   "collective.editHost.header": "Withdraw application to {name}",
   "collective.editHost.remove": "Убрать {name}",
   "collective.editHost.removeHost": "Вы уверены что хотите удалить {name}?",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -288,7 +288,6 @@
   "collective.edit.host.suggestedHosts.title": "Пропоновані скарбники",
   "collective.edit.host.useOwn.description": "Create or select a Fiscal Host that you manage, to hold funds for multiple Collectives. The organization will be responsible for accounting, taxes, payments, and liability.",
   "collective.edit.host.viewAllHosts": "Переглянути всіх скарбників",
-  "collective.editHost.continue.btn": "{action}",
   "collective.editHost.header": "Withdraw application to {name}",
   "collective.editHost.remove": "Вилучити {name}",
   "collective.editHost.removeHost": "Ви дійсно бажаєте вилучити {name}?",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -288,7 +288,6 @@
   "collective.edit.host.suggestedHosts.title": "Suggested Hosts",
   "collective.edit.host.useOwn.description": "Create or select a Fiscal Host that you manage, to hold funds for multiple Collectives. The organization will be responsible for accounting, taxes, payments, and liability.",
   "collective.edit.host.viewAllHosts": "查看所有财务托管人",
-  "collective.editHost.continue.btn": "{action}",
   "collective.editHost.header": "Withdraw application to {name}",
   "collective.editHost.remove": "移除 {name}",
   "collective.editHost.removeHost": "你确定要删除 {name} 群组吗？",


### PR DESCRIPTION
See https://docs.opencollective.com/help/contributing/development/translations

This string has no effect since translators have no idea about what kind of values `action` can hold. In such cases, we should either use a `{select, ...}` or a `defineMessages`. Removing the string to not confuse contributors.

![image](https://user-images.githubusercontent.com/1556356/119623670-b4f67a80-be08-11eb-8f28-e2bfafcc0a42.png)
