### PR TITLE
Add full name account holder validation

### DIFF
--- a/components/expenses/PayoutBankInformationForm.js
+++ b/components/expenses/PayoutBankInformationForm.js
@@ -76,8 +76,8 @@ const requiredFieldsQuery = gqlV2/* GraphQL */ `
 
 const Input = props => {
   const { input, getFieldName, disabled, currency, loading, refetch, formik, host } = props;
-  const fieldName =
-    input.key === 'accountHolderName' ? getFieldName(`data.${input.key}`) : getFieldName(`data.details.${input.key}`);
+  const isAccountHolderName = input.key === 'accountHolderName';
+  const fieldName = isAccountHolderName ? getFieldName(`data.${input.key}`) : getFieldName(`data.details.${input.key}`);
   let validate = input.required ? value => (value ? undefined : `${input.name} is required`) : undefined;
   if (input.type === 'text') {
     if (input.validationRegexp) {
@@ -87,6 +87,8 @@ const Input = props => {
           return `${input.name} is required`;
         } else if (!matches && value) {
           return input.validationError || `Invalid ${input.name}`;
+        } else if (isAccountHolderName && value.match(/^[^\s]{1}\b/)) {
+          return 'Your full name is required';
         }
       };
     }


### PR DESCRIPTION
This is a fix on our side to compensate for a validation that happens in Wise's backend at the time of transfer.
The behavior is simple, we should enforce full account holder name and block users from submitting contracted names like "A Fisher".