### PR TITLE
Expense attachments icons are not respecting their container size

### DIFF
--- a/components/UploadedFilePreview.js
+++ b/components/UploadedFilePreview.js
@@ -137,7 +137,7 @@ const UploadedFilePreview = ({
     );
   } else {
     const resizeWidth = Array.isArray(size) ? max(size) : size;
-    const img = <img src={imagePreview(url, null, { width: resizeWidth })} alt={alt || fileName} />;
+    const img = <img src={imagePreview(url, null, { width: ['100%', resizeWidth] })} alt={alt || fileName} />;
     content = !hasLink ? (
       img
     ) : (

--- a/components/UploadedFilePreview.js
+++ b/components/UploadedFilePreview.js
@@ -195,6 +195,7 @@ UploadedFilePreview.propTypes = {
 };
 
 UploadedFilePreview.defaultProps = {
+  size: 88,
   border: '1px solid #dcdee0',
   hasLink: true,
   alt: 'Uploaded file preview',

--- a/components/UploadedFilePreview.js
+++ b/components/UploadedFilePreview.js
@@ -149,7 +149,7 @@ const UploadedFilePreview = ({
 
   return (
     <Container {...props}>
-      <CardContainer size={['100%', ...size]} title={fileName} border={border} hasOnClick={Boolean(props.onClick)}>
+      <CardContainer size={size} title={fileName} border={border} hasOnClick={Boolean(props.onClick)}>
         {content}
       </CardContainer>
       {showFileName && (

--- a/components/UploadedFilePreview.js
+++ b/components/UploadedFilePreview.js
@@ -137,7 +137,7 @@ const UploadedFilePreview = ({
     );
   } else {
     const resizeWidth = Array.isArray(size) ? max(size) : size;
-    const img = <img src={imagePreview(url, null, { width: ['100%', resizeWidth] })} alt={alt || fileName} />;
+    const img = <img src={imagePreview(url, null, { width: resizeWidth })} alt={alt || fileName} />;
     content = !hasLink ? (
       img
     ) : (
@@ -149,7 +149,7 @@ const UploadedFilePreview = ({
 
   return (
     <Container {...props}>
-      <CardContainer size={size} title={fileName} border={border} hasOnClick={Boolean(props.onClick)}>
+      <CardContainer size={['100%', ...size]} title={fileName} border={border} hasOnClick={Boolean(props.onClick)}>
         {content}
       </CardContainer>
       {showFileName && (

--- a/components/UploadedFilePreview.js
+++ b/components/UploadedFilePreview.js
@@ -97,6 +97,7 @@ const UploadedFilePreview = ({
   isDownloading,
   url,
   size,
+  maxHeight,
   alt,
   hasLink,
   fileName,
@@ -149,7 +150,13 @@ const UploadedFilePreview = ({
 
   return (
     <Container {...props}>
-      <CardContainer size={size} title={fileName} border={border} hasOnClick={Boolean(props.onClick)}>
+      <CardContainer
+        size={size}
+        maxHeight={maxHeight}
+        title={fileName}
+        border={border}
+        hasOnClick={Boolean(props.onClick)}
+      >
         {content}
       </CardContainer>
       {showFileName && (
@@ -182,13 +189,12 @@ UploadedFilePreview.propTypes = {
   onClick: PropTypes.func,
   border: PropTypes.string,
   size: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array]),
-  maxHeihgt: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array]),
+  maxHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array]),
   /** If true, a link to the original file will be added if possible */
   hasLink: PropTypes.bool,
 };
 
 UploadedFilePreview.defaultProps = {
-  size: 88,
   border: '1px solid #dcdee0',
   hasLink: true,
   alt: 'Uploaded file preview',

--- a/components/expenses/ExpenseSummary.js
+++ b/components/expenses/ExpenseSummary.js
@@ -192,6 +192,7 @@ const ExpenseSummary = ({
                       isLoading={isLoading || isLoadingLoggedInUser}
                       isPrivate={!attachment.url && !isLoading}
                       size={[640, 48]}
+                      maxHeight={48}
                     />
                   </Box>
                 )}

--- a/components/expenses/ExpenseSummary.js
+++ b/components/expenses/ExpenseSummary.js
@@ -191,7 +191,8 @@ const ExpenseSummary = ({
                       url={attachment.url}
                       isLoading={isLoading || isLoadingLoggedInUser}
                       isPrivate={!attachment.url && !isLoading}
-                      size={48}
+                      size={['100%', 48]}
+                      maxHeight={48}
                     />
                   </Box>
                 )}

--- a/components/expenses/ExpenseSummary.js
+++ b/components/expenses/ExpenseSummary.js
@@ -191,8 +191,7 @@ const ExpenseSummary = ({
                       url={attachment.url}
                       isLoading={isLoading || isLoadingLoggedInUser}
                       isPrivate={!attachment.url && !isLoading}
-                      size={['100%', 48]}
-                      maxHeight={48}
+                      size={[640, 48]}
                     />
                   </Box>
                 )}

--- a/components/expenses/ExpenseSummary.js
+++ b/components/expenses/ExpenseSummary.js
@@ -191,8 +191,7 @@ const ExpenseSummary = ({
                       url={attachment.url}
                       isLoading={isLoading || isLoadingLoggedInUser}
                       isPrivate={!attachment.url && !isLoading}
-                      size={[640, 48]}
-                      maxHeight={48}
+                      size={48}
                     />
                   </Box>
                 )}


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4099

**Screen-cast**

![image-and-pdf-preview](https://user-images.githubusercontent.com/12435965/120520093-42e1e080-c388-11eb-8e78-90920389bb88.gif)

