### PR TITLE
Add Correct Condition for Showing the Interval Picker

### DIFF
--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -50,7 +50,7 @@ const StepDetails = ({ onChange, data, collective, tier, showFeesOnTop, router }
 
   return (
     <Box width={1}>
-      {(!tier || tier.amountType === AmountTypes.FLEXIBLE) && (
+      {(!tier || tier.interval === 'flexible') && (
         <StyledButtonSet
           id="interval"
           justifyContent="center"

--- a/test/cypress/integration/22-collective.edit.test.js
+++ b/test/cypress/integration/22-collective.edit.test.js
@@ -131,7 +131,6 @@ describe('edit collective', () => {
     cy.get(tierCardSelector).first().find('[data-cy="contribute-btn"]').click();
 
     // Ensure the new tiers are properly displayed on order form
-    cy.get('#interval').contains('Monthly');
     cy.get('#amount > button').should('have.length', 4); // 3 presets + "Other"
 
     cy.visit(`/${collectiveSlug}/edit/tiers`);


### PR DESCRIPTION
We seem to have the wrong condition to show the interval picker on `tier.AmountType` instead of `tier.interval`. This PR corrects that. This was pointed out by @Betree at https://github.com/opencollective/opencollective-frontend/pull/6396#discussion_r641331470.

Related to https://github.com/opencollective/opencollective/issues/4072

**Screen-cast**

![Peek 2021-05-28 11-08](https://user-images.githubusercontent.com/12435965/120025134-18b5aa80-bfa5-11eb-8dc3-5cc4d18a269b.gif)


