### PR TITLE
Fix Overlapping UI when Adding Video to Standalone Tier

### DIFF
--- a/components/tier-page/TierVideo.js
+++ b/components/tier-page/TierVideo.js
@@ -20,6 +20,7 @@ const TierVideo = ({ tier, editMutation, canEdit }) => {
       mutation={editMutation}
       canEdit={canEdit}
       showEditIcon={Boolean(tier.videoUrl)}
+      buttonsMinWidth={170}
     >
       {({ isEditing, value, setValue, enableEditor, disableEditor }) => {
         if (isEditing || (!value && canEdit)) {

--- a/components/tier-page/index.js
+++ b/components/tier-page/index.js
@@ -244,13 +244,7 @@ class TierPage extends Component {
                   <div>
                     <TierLongDescription tier={tier} editMutation={editTierMutation} canEdit={canEdit} />
                   </div>
-                  <Container
-                    position={['relative', null, null, 'absolute']}
-                    right={[null, null, null, -390, -490]}
-                    width={['100%', null, null, 380, 472]}
-                    mb={[4, 5]}
-                    top={[0, null, null, -50]}
-                  >
+                  <Container position="relative" width="100%" mb={5} mt={4}>
                     <TierVideo tier={tier} editMutation={editTierMutation} canEdit={canEdit} />
                   </Container>
                 </Container>

--- a/components/tier-page/index.js
+++ b/components/tier-page/index.js
@@ -245,12 +245,12 @@ class TierPage extends Component {
                   <div>
                     <TierLongDescription tier={tier} editMutation={editTierMutation} canEdit={canEdit} />
                   </div>
-                  <Hide lg md>
-                    <Container position="relative" width="100%" mb={5} mt={4}>
-                      <TierVideo tier={tier} editMutation={editTierMutation} canEdit={canEdit} />
-                    </Container>
-                  </Hide>
                 </Container>
+                <Hide lg md>
+                  <Container position="relative" width="100%" mb={5} mt={5}>
+                    <TierVideo tier={tier} editMutation={editTierMutation} canEdit={canEdit} />
+                  </Container>
+                </Hide>
                 <Container display={['block', null, null, 'none']} mt={2} maxWidth={275}>
                   {shareBlock}
                 </Container>

--- a/components/tier-page/index.js
+++ b/components/tier-page/index.js
@@ -17,6 +17,7 @@ import { Sections } from '../collective-page/_constants';
 import Container from '../Container';
 import FormattedMoneyAmount from '../FormattedMoneyAmount';
 import { Box, Flex } from '../Grid';
+import Hide from '../Hide';
 import InlineEditField from '../InlineEditField';
 import Link from '../Link';
 import StyledButton from '../StyledButton';
@@ -244,9 +245,11 @@ class TierPage extends Component {
                   <div>
                     <TierLongDescription tier={tier} editMutation={editTierMutation} canEdit={canEdit} />
                   </div>
-                  <Container position="relative" width="100%" mb={5} mt={4}>
-                    <TierVideo tier={tier} editMutation={editTierMutation} canEdit={canEdit} />
-                  </Container>
+                  <Hide lg md>
+                    <Container position="relative" width="100%" mb={5} mt={4}>
+                      <TierVideo tier={tier} editMutation={editTierMutation} canEdit={canEdit} />
+                    </Container>
+                  </Hide>
                 </Container>
                 <Container display={['block', null, null, 'none']} mt={2} maxWidth={275}>
                   {shareBlock}
@@ -363,6 +366,9 @@ class TierPage extends Component {
               </Flex>
               {/** Share buttons (desktop only) */}
               <Container display={['none', null, null, 'block']}>{shareBlock}</Container>
+              <Container position="relative" mt="170px" ml={-30} mr={-30}>
+                <TierVideo tier={tier} editMutation={editTierMutation} canEdit={canEdit} />
+              </Container>
             </Container>
           </Flex>
         </Flex>


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/3897

I've made the experience for mobile and desktop consistent on this one; it seemed to me that we were trying to have the video in a different location for larger screens; but I don't quite understand the intention behind that. Hopefully this is better in terms of UI experience. Let me know. 😄 

**Screen Cast**

![Peek 2021-05-31 09-13](https://user-images.githubusercontent.com/12435965/120219746-8e618680-c1f0-11eb-8178-4d63c3cfd922.gif)


