### PR TITLE
Show Correct Icon for Pay Button on Bank Account

### DIFF
--- a/components/expenses/PayExpenseButton.js
+++ b/components/expenses/PayExpenseButton.js
@@ -58,14 +58,13 @@ const getDisabledMessage = (expense, collective, host, payoutMethod) => {
   }
 };
 
-const PayoutMethodTypeIcon = ({ type, ...props }) => {
-  switch (type) {
-    case PayoutMethodType.PAYPAL:
-      return <PaypalIcon {...props} />;
-    case PayoutMethodType.BANK_ACCOUNT:
-      return <TransferwiseIcon {...props} />;
-    default:
-      return <OtherIcon {...props} />;
+const PayoutMethodTypeIcon = ({ type, host, ...props }) => {
+  if (type === PayoutMethodType.PAYPAL) {
+    return <PaypalIcon {...props} />;
+  } else if (type === PayoutMethodType.BANK_ACCOUNT && host?.transferwise) {
+    return <TransferwiseIcon {...props} />;
+  } else {
+    return <OtherIcon {...props} />;
   }
 };
 
@@ -87,7 +86,7 @@ const PayExpenseButton = ({ expense, collective, host, disabled, onSubmit, error
       disabled={isDisabled}
       onClick={() => showModal(true)}
     >
-      <PayoutMethodTypeIcon type={expense.payoutMethod?.type} size={12} />
+      <PayoutMethodTypeIcon type={expense.payoutMethod?.type} host={host} size={12} />
       <Span ml="6px">
         <FormattedMessage id="actions.goToPay" defaultMessage="Go to Pay" />
       </Span>


### PR DESCRIPTION
We were not showing the correct icon for the pay button for bank transfer and instead was showing the transferwise icon. This PR corrects it. 🐨 

Related discussion https://opencollective.slack.com/archives/C020ZQSLM5M/p1622531197000600?thread_ts=1622154064.009900&cid=C020ZQSLM5M

Related to https://github.com/opencollective/opencollective/issues/3893

![image](https://user-images.githubusercontent.com/12435965/120332124-48b1c600-c2a3-11eb-982a-04dac7fa29c9.png)
