### PR TITLE
Reference Transferwise Environment Variable directly without Destructuring

### DIFF
--- a/components/accept-financial-contributions/AcceptContributionsOurselvesOrOrg.js
+++ b/components/accept-financial-contributions/AcceptContributionsOurselvesOrOrg.js
@@ -31,7 +31,7 @@ import StripeOrBankAccountPicker from './StripeOrBankAccountPicker';
 
 import acceptOrganizationIllustration from '../../public/static/images/create-collective/acceptContributionsOrganizationHoverIllustration.png';
 
-const { TW_API_COLLECTIVE_SLUG } = process.env;
+const TW_API_COLLECTIVE_SLUG = process.env.TW_API_COLLECTIVE_SLUG;
 
 const { ORGANIZATION } = CollectiveType;
 

--- a/components/edit-collective/sections/BankTransfer.js
+++ b/components/edit-collective/sections/BankTransfer.js
@@ -20,7 +20,7 @@ import UpdateBankDetailsForm from '../UpdateBankDetailsForm';
 
 import SettingsSectionTitle from './SettingsSectionTitle';
 
-const { TW_API_COLLECTIVE_SLUG } = process.env;
+const TW_API_COLLECTIVE_SLUG = process.env.TW_API_COLLECTIVE_SLUG;
 
 const hostQuery = gqlV2/* GraphQL */ `
   query EditCollectiveBankTransferHost($slug: String) {

--- a/components/expenses/PayoutBankInformationForm.js
+++ b/components/expenses/PayoutBankInformationForm.js
@@ -21,7 +21,7 @@ import { P } from '../Text';
 const formatStringOptions = strings => strings.map(s => ({ label: s, value: s }));
 const formatTransferWiseSelectOptions = values => values.map(({ key, name }) => ({ label: name, value: key }));
 
-const { TW_API_COLLECTIVE_SLUG } = process.env;
+const TW_API_COLLECTIVE_SLUG = process.env.TW_API_COLLECTIVE_SLUG;
 
 export const msg = defineMessages({
   currency: {


### PR DESCRIPTION
As pointed out by the discussion here, https://github.com/opencollective/opencollective-frontend/pull/6418#discussion_r642676053 there seems to be some problems with Webpacks environment variable de-structuring; https://github.com/webpack/webpack/issues/5392. 

This PR corrects that. I did some search on a cleaner approach and although the official documentation doesn't seem to mention that there's an idea on this post; https://prateeksurana.me/blog/using-environment-variables-with-webpack/#accessing-environment-variables-via-webpack which is to use a separate file for the environment variables, and refer them from that file. We can employ this approach if there's no objection. 🤔 

@znarf @Betree 