### PR TITLE
Disable all animations on E2E

### DIFF
--- a/components/GlobalToasts.js
+++ b/components/GlobalToasts.js
@@ -2,6 +2,8 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import FlipMove from 'react-flip-move';
 
+import { DISABLE_ANIMATIONS } from '../lib/animations';
+
 import Container from './Container';
 import { Box } from './Grid';
 import Toast from './Toast';
@@ -112,7 +114,7 @@ class GlobalToasts extends PureComponent {
         onMouseLeave={this.startAfterDelay}
         zIndex={100000}
       >
-        <FlipMove>
+        <FlipMove disableAllAnimations={DISABLE_ANIMATIONS}>
           {this.props.toasts.map(toast => (
             <Box key={toast.id} mt={24}>
               <Toast

--- a/components/expenses/ExpensesList.js
+++ b/components/expenses/ExpensesList.js
@@ -5,6 +5,8 @@ import FlipMove from 'react-flip-move';
 import { FormattedMessage } from 'react-intl';
 import styled, { css } from 'styled-components';
 
+import { DISABLE_ANIMATIONS } from '../../lib/animations';
+
 import ExpenseBudgetItem from '../budget/ExpenseBudgetItem';
 import FormattedMoneyAmount from '../FormattedMoneyAmount';
 import { Box, Flex } from '../Grid';
@@ -57,7 +59,7 @@ const ExpensesList = ({
           </ExpenseContainer>
         ))
       ) : (
-        <FlipMove enterAnimation="fade" leaveAnimation="fade">
+        <FlipMove enterAnimation="fade" leaveAnimation="fade" disableAllAnimations={DISABLE_ANIMATIONS}>
           {expenses.map((expense, idx) => (
             <ExpenseContainer key={expense.id} isFirst={!idx} data-cy={`expense-${expense.status}`}>
               <ExpenseBudgetItem

--- a/lib/animations.js
+++ b/lib/animations.js
@@ -1,0 +1,1 @@
+export const DISABLE_ANIMATIONS = ['e2e', 'ci'].includes(process.env.OC_ENV);


### PR DESCRIPTION
An attempt at solving a very frequent false positive on E2E tests that looks like `03-expenses-page.test.js`:

>   Too many elements found. Found '15', expected '10'.
>       + expected - actual
> 
>       -15
>       +10

My guess with this PR is that the root cause comes from `ReactFlipMove`, because the animation it triggers does not remove the items from the DOM instantly - which can affect the test if it checks too fast.