### PR TITLE
Remove Unnecessary `isRequired` prop from `GlobalNewsAndUpdates.js`

### DIFF
--- a/components/GlobalNewsAndUpdates.js
+++ b/components/GlobalNewsAndUpdates.js
@@ -10,7 +10,7 @@ const GlobalNewsAndUpdates = () => {
 };
 
 GlobalNewsAndUpdates.propTypes = {
-  showNewsAndUpdates: PropTypes.bool.isRequired,
+  showNewsAndUpdates: PropTypes.bool,
   setShowNewsAndUpdates: PropTypes.func,
 };
 


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/4326

A small regression from the aforementioned issue where we've added a `isRequired` unnecessarily. 🐨 