### PR TITLE
CSV: Add support for HOST_FEE as separate transactions

### DIFF
--- a/components/transactions/TransactionsDownloadCSV.js
+++ b/components/transactions/TransactionsDownloadCSV.js
@@ -3,8 +3,10 @@ import PropTypes from 'prop-types';
 import { withApollo } from '@apollo/client/react/hoc';
 import { Download as IconDownload } from '@styled-icons/feather/Download';
 import dayjs from 'dayjs';
+import { omit } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 
+import { TransactionKind } from '../../lib/constants/transactions';
 import { exportFile } from '../../lib/export_file';
 import { transactionsQuery } from '../../lib/graphql/queries';
 
@@ -89,6 +91,15 @@ const TransactionsDownloadCSV = ({ collective, client }) => {
       variables: {
         ...dateInterval,
         CollectiveId: collective.id,
+        kinds: Object.values(
+          omit(TransactionKind, [
+            'PLATFORM_FEE',
+            'PREPAID_PAYMENT_METHOD',
+            'PAYMENT_PROCESSOR_FEE',
+            'HOST_FEE',
+            'HOST_FEE_SHARE',
+          ]),
+        ),
       },
     });
     const csv = transformResultInCSV(result.data.allTransactions);

--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -79,6 +79,7 @@ export const transactionsQuery = gql`
     $offset: Int
     $dateFrom: String
     $dateTo: String
+    $kinds: [String]
   ) {
     allTransactions(
       CollectiveId: $CollectiveId
@@ -87,6 +88,7 @@ export const transactionsQuery = gql`
       offset: $offset
       dateFrom: $dateFrom
       dateTo: $dateTo
+      kinds: $kinds
     ) {
       ...TransactionFields
       refundTransaction {

--- a/lib/graphql/schema.graphql
+++ b/lib/graphql/schema.graphql
@@ -3121,6 +3121,7 @@ type Query {
     offset: Int
     dateFrom: String
     dateTo: String
+    kinds: [String]
 
     """
     If false, only the transactions not linked to an expense (orders/refunds) will be returned


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-api/pull/6152

Some updates to the CSV export:
- Hides the Host Fee transactions
- Thanks to https://github.com/opencollective/opencollective-api/pull/6152, display the amount as a column, just as before

Example with a public Webpack transactions export: [webpack-from-2021-05-01-to-2021-06-14 (4).csv](https://github.com/opencollective/opencollective-frontend/files/6650135/webpack-from-2021-05-01-to-2021-06-14.4.csv)
