### PR TITLE
Ignore @shopify/address in depcheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -266,7 +266,8 @@
       "imagemin",
       "imagemin-optipng",
       "imagemin-pngquant",
-      "@storybook/*"
+      "@storybook/*",
+      "@shopify/address"
     ]
   }
 }


### PR DESCRIPTION
Temporary work around for a regression of unclear origin.

Maybe a new version of babel that is not pinned in depcheck.

<img width="1188" alt="Screenshot 2021-06-23 at 08 44 57" src="https://user-images.githubusercontent.com/806/123049072-6e903d80-d3ff-11eb-957d-82d79951d0bc.png">
