### PR TITLE
Remove `collectiveCoverData` query

### DIFF
--- a/components/transactions/TransactionItem.js
+++ b/components/transactions/TransactionItem.js
@@ -91,7 +91,8 @@ const TransactionItem = ({ displayActions, collective, transaction, onMutationSu
   const hasExpense = expense !== null;
   const isCredit = type === TransactionTypes.CREDIT;
   const Item = isCredit ? CreditItem : DebitItem;
-  const isOwnUserProfile = LoggedInUser && LoggedInUser.CollectiveId === collective.id;
+  const legacyCollectiveId = collective.legacyId || collective.id;
+  const isOwnUserProfile = LoggedInUser && LoggedInUser.CollectiveId === legacyCollectiveId;
   const avatarCollective = hasOrder ? (isCredit ? fromAccount : toAccount) : isCredit ? fromAccount : toAccount;
   const displayedAmount = getDisplayedAmount(transaction, collective);
 
@@ -323,7 +324,8 @@ TransactionItem.propTypes = {
     usingGiftCardFromCollective: PropTypes.object,
   }),
   collective: PropTypes.shape({
-    id: PropTypes.number,
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    legacyId: PropTypes.number,
     slug: PropTypes.string.isRequired,
   }).isRequired,
   onMutationSuccess: PropTypes.func,

--- a/components/transactions/TransactionsDownloadCSV.js
+++ b/components/transactions/TransactionsDownloadCSV.js
@@ -90,7 +90,7 @@ const TransactionsDownloadCSV = ({ collective, client }) => {
       query: transactionsQuery,
       variables: {
         ...dateInterval,
-        CollectiveId: collective.id,
+        CollectiveId: collective.legacyId,
         kinds: Object.values(
           omit(TransactionKind, [
             'PLATFORM_FEE',
@@ -211,7 +211,7 @@ TransactionsDownloadCSV.propTypes = {
   filters: PropTypes.object,
   collective: PropTypes.shape({
     slug: PropTypes.string,
-    id: PropTypes.number.isRequired,
+    legacyId: PropTypes.number.isRequired,
     currency: PropTypes.string.isRequired,
   }).isRequired,
   client: PropTypes.object,

--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -3,6 +3,8 @@ import { graphql } from '@apollo/client/react/hoc';
 
 import { collectiveNavbarFieldsFragment } from '../../components/collective-page/graphql/fragments';
 
+import { API_V2_CONTEXT, gqlV2 } from './helpers';
+
 export const transactionFieldsFragment = gql`
   fragment TransactionFields on Transaction {
     id
@@ -501,124 +503,6 @@ export const legacyCollectiveQuery = gql`
   }
 `;
 
-const collectiveCoverQuery = gql`
-  query CollectiveCover($slug: String, $throwIfMissing: Boolean) {
-    Collective(slug: $slug, throwIfMissing: $throwIfMissing) {
-      id
-      type
-      slug
-      path
-      name
-      currency
-      hostFeePercent
-      settings
-      imageUrl
-      isIncognito
-      backgroundImage
-      isHost
-      isActive
-      isArchived
-      canApply
-      tags
-      canContact
-      features {
-        ...NavbarFields
-      }
-      stats {
-        id
-        balance
-        updates
-        events
-        yearlyBudget
-        totalAmountReceived
-        backers {
-          all
-        }
-      }
-      ... on Collective {
-        host {
-          id
-          slug
-          name
-          imageUrl
-          settings
-          plan {
-            id
-            name
-            hostFees
-            hostFeeSharePercent
-          }
-        }
-      }
-      ... on Fund {
-        host {
-          id
-          slug
-          name
-          imageUrl
-          settings
-          plan {
-            id
-            name
-            hostFees
-            hostFeeSharePercent
-          }
-        }
-      }
-      ... on Event {
-        host {
-          id
-          slug
-          name
-          imageUrl
-          settings
-          plan {
-            id
-            name
-          }
-        }
-      }
-      ... on Project {
-        host {
-          id
-          slug
-          name
-          imageUrl
-          settings
-          plan {
-            id
-            name
-          }
-        }
-      }
-      parentCollective {
-        id
-        slug
-        name
-      }
-      location {
-        name
-      }
-      members {
-        id
-        role
-        createdAt
-        description
-        member {
-          id
-          description
-          name
-          slug
-          type
-          isIncognito
-          imageUrl
-        }
-      }
-    }
-  }
-  ${collectiveNavbarFieldsFragment}
-`;
-
 export const subscriptionsQuery = gql`
   query Subscriptions($slug: String) {
     Collective(slug: $slug) {
@@ -717,6 +601,23 @@ export const subscriptionsQuery = gql`
   }
 `;
 
-export const addCollectiveCoverData = (component, options) => {
-  return graphql(collectiveCoverQuery, options)(component);
+export const collectiveNavbarQuery = gqlV2`
+  query CollectiveNavbar($slug: String!) {
+    account(slug: $slug) {
+      id
+      legacyId
+      type
+      slug
+      name
+      imageUrl(height: 256)
+      features {
+        ...NavbarFields
+      }
+    }
+  }
+  ${collectiveNavbarFieldsFragment}
+`;
+
+export const addCollectiveNavbarData = component => {
+  return graphql(collectiveNavbarQuery, { options: { context: API_V2_CONTEXT } })(component);
 };

--- a/pages/createUpdate.js
+++ b/pages/createUpdate.js
@@ -7,7 +7,7 @@ import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import styled from 'styled-components';
 
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
-import { addCollectiveCoverData } from '../lib/graphql/queries';
+import { addCollectiveNavbarData } from '../lib/graphql/queries';
 import { compose } from '../lib/utils';
 
 import Body from '../components/Body';
@@ -56,10 +56,12 @@ class CreateUpdatePage extends React.Component {
   }
 
   static propTypes = {
-    slug: PropTypes.string, // for addCollectiveCoverData
+    slug: PropTypes.string, // for addCollectiveNavbarData
     action: PropTypes.string, // not used atm, not clear where it's coming from, not in the route
     createUpdate: PropTypes.func, // from addMutation/createUpdateQuery
-    data: PropTypes.object.isRequired, // from withData
+    data: PropTypes.shape({
+      account: PropTypes.object,
+    }).isRequired, // from withData
     LoggedInUser: PropTypes.object,
     router: PropTypes.object,
     intl: PropTypes.object.isRequired,
@@ -71,26 +73,25 @@ class CreateUpdatePage extends React.Component {
       update: {},
       status: '',
       error: '',
-      updateType: props.data?.Collective?.slug === 'opencollective' ? UPDATE_TYPES[1] : UPDATE_TYPES[0],
+      updateType: props.data?.account?.slug === 'opencollective' ? UPDATE_TYPES[1] : UPDATE_TYPES[0],
     };
   }
 
   createUpdate = async update => {
-    const {
-      data: { Collective },
-    } = this.props;
+    const { data } = this.props;
+    const { account } = data;
 
     this.setState({ error: '', status: 'submitting' });
 
     try {
-      update.account = { legacyId: Collective.id };
+      update.account = { id: account.id };
       update.isChangelog = this.isChangelog();
       if (update.isChangelog) {
         update.isPrivate = false;
       }
       const res = await this.props.createUpdate({ variables: { update } });
       this.setState({ isModified: false });
-      return this.props.router.push(`/${Collective.slug}/updates/${res.data.createUpdate.slug}`);
+      return this.props.router.push(`/${account.slug}/updates/${res.data.createUpdate.slug}`);
     } catch (e) {
       this.setState({ status: 'error', error: e.message });
     }
@@ -109,11 +110,11 @@ class CreateUpdatePage extends React.Component {
   render() {
     const { data, LoggedInUser, intl } = this.props;
 
-    if (!data.Collective) {
+    if (!data.account) {
       return <ErrorPage data={data} />;
     }
 
-    const collective = data.Collective;
+    const collective = data.account;
     const isAdmin = LoggedInUser && LoggedInUser.canEditCollective(collective);
 
     return (
@@ -223,6 +224,6 @@ const addCreateUpdateMutation = graphql(createUpdateMutation, {
   },
 });
 
-const addGraphql = compose(addCollectiveCoverData, addCreateUpdateMutation);
+const addGraphql = compose(addCollectiveNavbarData, addCreateUpdateMutation);
 
 export default withUser(addGraphql(withRouter(injectIntl(CreateUpdatePage))));

--- a/pages/orders.js
+++ b/pages/orders.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { addCollectiveCoverData } from '../lib/graphql/queries';
+import { addCollectiveNavbarData } from '../lib/graphql/queries';
 
 import CollectiveNavbar from '../components/collective-navbar';
 import Container from '../components/Container';
@@ -16,23 +16,26 @@ class OrdersPage extends React.Component {
   }
 
   static propTypes = {
-    slug: PropTypes.string, // for addCollectiveCoverData
+    slug: PropTypes.string, // for addCollectiveNavbarData
     filter: PropTypes.string,
     value: PropTypes.string,
-    data: PropTypes.object.isRequired, // from withData
+    data: PropTypes.shape({
+      account: PropTypes.object,
+      loading: PropTypes.bool,
+    }).isRequired, // from withData
     LoggedInUser: PropTypes.object,
   };
 
   render() {
     const { slug, data, LoggedInUser } = this.props;
-    const collective = data?.collective;
+    const collective = data?.account;
     return (
       <Page>
-        {(data?.loading || data?.Collective) && (
+        {(data?.loading || data?.account) && (
           <Container mb={4}>
             <CollectiveNavbar
               isLoading={data.loading}
-              collective={data.Collective}
+              collective={data.account}
               isAdmin={LoggedInUser?.canEditCollective(collective)}
             />
           </Container>
@@ -45,10 +48,4 @@ class OrdersPage extends React.Component {
   }
 }
 
-export default withUser(
-  addCollectiveCoverData(OrdersPage, {
-    options: props => ({
-      variables: { slug: props.slug, throwIfMissing: false },
-    }),
-  }),
-);
+export default withUser(addCollectiveNavbarData(OrdersPage));

--- a/pages/update.js
+++ b/pages/update.js
@@ -28,7 +28,7 @@ class UpdatePage extends React.Component {
   }
 
   static propTypes = {
-    collectiveSlug: PropTypes.string, // for addCollectiveCoverData
+    collectiveSlug: PropTypes.string, // for addCollectiveNavbarData
     updateSlug: PropTypes.string,
     LoggedInUser: PropTypes.object, // from withUser
     client: PropTypes.object, // from withApollo

--- a/pages/updates.js
+++ b/pages/updates.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { NAVBAR_CATEGORIES } from '../lib/collective-sections';
-import { addCollectiveCoverData } from '../lib/graphql/queries';
+import { addCollectiveNavbarData } from '../lib/graphql/queries';
 
 import Body from '../components/Body';
 import CollectiveNavbar from '../components/collective-navbar';
@@ -19,20 +19,20 @@ class UpdatesPage extends React.Component {
   }
 
   static propTypes = {
-    slug: PropTypes.string, // for addCollectiveCoverData
+    slug: PropTypes.string, // for addCollectiveNavbarData
     action: PropTypes.string, // not clear whre it's coming from, not in the route
-    data: PropTypes.object.isRequired, // from withData
+    data: PropTypes.shape({ account: PropTypes.object }).isRequired, // from withData
     LoggedInUser: PropTypes.object, // from withUser
   };
 
   render() {
     const { data, action, LoggedInUser } = this.props;
 
-    if (!data.Collective) {
+    if (!data.account) {
       return <ErrorPage data={data} />;
     }
 
-    const collective = data.Collective;
+    const collective = data.account;
 
     return (
       <div className="UpdatesPage">
@@ -57,4 +57,4 @@ class UpdatesPage extends React.Component {
   }
 }
 
-export default withUser(addCollectiveCoverData(UpdatesPage));
+export default withUser(addCollectiveNavbarData(UpdatesPage));


### PR DESCRIPTION
I was investigating some degraded performance issues on a few pages for `opencollective`, like https://opencollective.com/opencollective/updates/new. It turns out that all the pages I checked were using this legacy `collectiveCoverQuery` that is from the old collective page. This query fetches way more data than what's needed - **including all members (without limit)** :fearful: 

I've created an alternative `collectiveNavbarQuery` plugged on GQLV2 with the same goal (providing the base data for the navbar) but fetches fewer data.