### PR TITLE
NavBar: use relative position on Safari

### DIFF
--- a/components/collective-navbar/index.js
+++ b/components/collective-navbar/index.js
@@ -56,6 +56,15 @@ const NavBarContainer = styled.div`
   z-index: 999;
   background: white;
   box-shadow: 0px 6px 10px -5px rgba(214, 214, 214, 0.5);
+
+  /*
+  ** CSS hack to target only Safari, hotfix for https://github.com/opencollective/opencollective/issues/4403
+  */
+  @media not all and (min-resolution: 0.001dpcm) {
+    @supports (-webkit-appearance: none) {
+      position: relative;
+    }
+  }
 `;
 
 const NavbarContentContainer = styled(Container)`


### PR DESCRIPTION
Hotfix for https://github.com/opencollective/opencollective/issues/4403

Despite the HTML specs specifying it, Safari does not seems to treat `position: sticky` as `position: relative` when elements are resting, which leads to the dropdown not being able to overflow its parent.

This **temporary** fix uses a `position: relative` on Safari, which disables the attachment at the top but ensures that users are able to see the dropdown. We should iterate on this, another proposal will be made in a new issue.

![image](https://user-images.githubusercontent.com/1556356/123944901-e4ffe300-d99d-11eb-95c8-ebaef04f927c.png)
