### PR TITLE
Update `eslint-plugin-formatjs` to Latest

### DIFF
--- a/components/edit-collective/sections/Host.js
+++ b/components/edit-collective/sections/Host.js
@@ -240,7 +240,7 @@ class Host extends React.Component {
                       <Fineprint>
                         <FormattedMessage
                           id="editCollective.host.change.removeFirst"
-                          defaultMessage="Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host."
+                          defaultMessage="Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host."
                           values={{ type: collective.type }}
                         />
                       </Fineprint>

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -709,7 +709,7 @@
   "editCollective.host.balance": "It currently holds {balance} on behalf of {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {your Account}}.",
   "editCollective.host.cancelApplicationBtn": "Withdraw application",
   "editCollective.host.change.balanceNotEmpty": "To change your Fiscal Host, you first need to empty {type, select, COLLECTIVE {your Collective's balance} FUND {your Fund's balance} other {your balance}}. You can do this by submitting expenses, making financial contributions, or sending the balance to your Fiscal Host using the {emptyBalanceLink} feature.",
-  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
+  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
   "editCollective.host.label": "Your Fiscal Host is {host}.",
   "editCollective.host.pending": "You applied to be hosted by {host} on {date}. Your application is being reviewed.",
   "editCollective.host.removeBtn": "Suprimeix l'amfitrió",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -709,7 +709,7 @@
   "editCollective.host.balance": "It currently holds {balance} on behalf of {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {your Account}}.",
   "editCollective.host.cancelApplicationBtn": "Withdraw application",
   "editCollective.host.change.balanceNotEmpty": "To change your Fiscal Host, you first need to empty {type, select, COLLECTIVE {your Collective's balance} FUND {your Fund's balance} other {your balance}}. You can do this by submitting expenses, making financial contributions, or sending the balance to your Fiscal Host using the {emptyBalanceLink} feature.",
-  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
+  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
   "editCollective.host.label": "Your Fiscal Host is {host}.",
   "editCollective.host.pending": "You applied to be hosted by {host} on {date}. Your application is being reviewed.",
   "editCollective.host.removeBtn": "Remove Host",

--- a/lang/de.json
+++ b/lang/de.json
@@ -709,7 +709,7 @@
   "editCollective.host.balance": "It currently holds {balance} on behalf of {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {your Account}}.",
   "editCollective.host.cancelApplicationBtn": "Bewerbung zurückziehen",
   "editCollective.host.change.balanceNotEmpty": "To change your Fiscal Host, you first need to empty {type, select, COLLECTIVE {your Collective's balance} FUND {your Fund's balance} other {your balance}}. You can do this by submitting expenses, making financial contributions, or sending the balance to your Fiscal Host using the {emptyBalanceLink} feature.",
-  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
+  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
   "editCollective.host.label": "Dein Finanzträger ist {host}.",
   "editCollective.host.pending": "You applied to be hosted by {host} on {date}. Your application is being reviewed.",
   "editCollective.host.removeBtn": "Träger entfernen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -709,7 +709,7 @@
   "editCollective.host.balance": "It currently holds {balance} on behalf of {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {your Account}}.",
   "editCollective.host.cancelApplicationBtn": "Withdraw application",
   "editCollective.host.change.balanceNotEmpty": "To change your Fiscal Host, you first need to empty {type, select, COLLECTIVE {your Collective's balance} FUND {your Fund's balance} other {your balance}}. You can do this by submitting expenses, making financial contributions, or sending the balance to your Fiscal Host using the {emptyBalanceLink} feature.",
-  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
+  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
   "editCollective.host.label": "Your Fiscal Host is {host}.",
   "editCollective.host.pending": "You applied to be hosted by {host} on {date}. Your application is being reviewed.",
   "editCollective.host.removeBtn": "Remove Host",

--- a/lang/es.json
+++ b/lang/es.json
@@ -709,7 +709,7 @@
   "editCollective.host.balance": "It currently holds {balance} on behalf of {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {your Account}}.",
   "editCollective.host.cancelApplicationBtn": "Retirar aplicación",
   "editCollective.host.change.balanceNotEmpty": "To change your Fiscal Host, you first need to empty {type, select, COLLECTIVE {your Collective's balance} FUND {your Fund's balance} other {your balance}}. You can do this by submitting expenses, making financial contributions, or sending the balance to your Fiscal Host using the {emptyBalanceLink} feature.",
-  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
+  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
   "editCollective.host.label": "Tu Responsable Fiscal es {host}.",
   "editCollective.host.pending": "You applied to be hosted by {host} on {date}. Your application is being reviewed.",
   "editCollective.host.removeBtn": "Eliminar host",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -709,7 +709,7 @@
   "editCollective.host.balance": "It currently holds {balance} on behalf of {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {your Account}}.",
   "editCollective.host.cancelApplicationBtn": "Annuler la demande",
   "editCollective.host.change.balanceNotEmpty": "To change your Fiscal Host, you first need to empty {type, select, COLLECTIVE {your Collective's balance} FUND {your Fund's balance} other {your balance}}. You can do this by submitting expenses, making financial contributions, or sending the balance to your Fiscal Host using the {emptyBalanceLink} feature.",
-  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
+  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
   "editCollective.host.label": "Votre hôte fiscal est {host}.",
   "editCollective.host.pending": "You applied to be hosted by {host} on {date}. Your application is being reviewed.",
   "editCollective.host.removeBtn": "Supprimer l'hôte",

--- a/lang/it.json
+++ b/lang/it.json
@@ -709,7 +709,7 @@
   "editCollective.host.balance": "It currently holds {balance} on behalf of {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {your Account}}.",
   "editCollective.host.cancelApplicationBtn": "Ritira l'applicazione",
   "editCollective.host.change.balanceNotEmpty": "To change your Fiscal Host, you first need to empty {type, select, COLLECTIVE {your Collective's balance} FUND {your Fund's balance} other {your balance}}. You can do this by submitting expenses, making financial contributions, or sending the balance to your Fiscal Host using the {emptyBalanceLink} feature.",
-  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
+  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
   "editCollective.host.label": "Your Fiscal Host is {host}.",
   "editCollective.host.pending": "You applied to be hosted by {host} on {date}. Your application is being reviewed.",
   "editCollective.host.removeBtn": "Rimuovi host",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -709,7 +709,7 @@
   "editCollective.host.balance": "It currently holds {balance} on behalf of {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {your Account}}.",
   "editCollective.host.cancelApplicationBtn": "申請を取り下げる",
   "editCollective.host.change.balanceNotEmpty": "To change your Fiscal Host, you first need to empty {type, select, COLLECTIVE {your Collective's balance} FUND {your Fund's balance} other {your balance}}. You can do this by submitting expenses, making financial contributions, or sending the balance to your Fiscal Host using the {emptyBalanceLink} feature.",
-  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
+  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
   "editCollective.host.label": "Your Fiscal Host is {host}.",
   "editCollective.host.pending": "You applied to be hosted by {host} on {date}. Your application is being reviewed.",
   "editCollective.host.removeBtn": "ホストを削除",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -709,7 +709,7 @@
   "editCollective.host.balance": "It currently holds {balance} on behalf of {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {your Account}}.",
   "editCollective.host.cancelApplicationBtn": "Withdraw application",
   "editCollective.host.change.balanceNotEmpty": "To change your Fiscal Host, you first need to empty {type, select, COLLECTIVE {your Collective's balance} FUND {your Fund's balance} other {your balance}}. You can do this by submitting expenses, making financial contributions, or sending the balance to your Fiscal Host using the {emptyBalanceLink} feature.",
-  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
+  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
   "editCollective.host.label": "Your Fiscal Host is {host}.",
   "editCollective.host.pending": "You applied to be hosted by {host} on {date}. Your application is being reviewed.",
   "editCollective.host.removeBtn": "호스트 제거",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -709,7 +709,7 @@
   "editCollective.host.balance": "It currently holds {balance} on behalf of {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {your Account}}.",
   "editCollective.host.cancelApplicationBtn": "Withdraw application",
   "editCollective.host.change.balanceNotEmpty": "To change your Fiscal Host, you first need to empty {type, select, COLLECTIVE {your Collective's balance} FUND {your Fund's balance} other {your balance}}. You can do this by submitting expenses, making financial contributions, or sending the balance to your Fiscal Host using the {emptyBalanceLink} feature.",
-  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
+  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
   "editCollective.host.label": "Your Fiscal Host is {host}.",
   "editCollective.host.pending": "You applied to be hosted by {host} on {date}. Your application is being reviewed.",
   "editCollective.host.removeBtn": "Remove Host",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -709,7 +709,7 @@
   "editCollective.host.balance": "It currently holds {balance} on behalf of {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {your Account}}.",
   "editCollective.host.cancelApplicationBtn": "Retirar aplicação",
   "editCollective.host.change.balanceNotEmpty": "To change your Fiscal Host, you first need to empty {type, select, COLLECTIVE {your Collective's balance} FUND {your Fund's balance} other {your balance}}. You can do this by submitting expenses, making financial contributions, or sending the balance to your Fiscal Host using the {emptyBalanceLink} feature.",
-  "editCollective.host.change.removeFirst": "Sem um gestor de administração fiscal, {type, select, COLLECTIVE {your Collective} FUND {your Fund}} não poderá mais aceitar contribuições financeiras. Você poderá inscrever outro gestor de administração fiscal.",
+  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
   "editCollective.host.label": "Seu Fiscal Host é {host}.",
   "editCollective.host.pending": "Você se inscreveu para ser administrado por {host} em {date}. Sua inscrição está sendo revisada.",
   "editCollective.host.removeBtn": "Remover Host",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -709,7 +709,7 @@
   "editCollective.host.balance": "It currently holds {balance} on behalf of {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {your Account}}.",
   "editCollective.host.cancelApplicationBtn": "Cancelar inscrição",
   "editCollective.host.change.balanceNotEmpty": "To change your Fiscal Host, you first need to empty {type, select, COLLECTIVE {your Collective's balance} FUND {your Fund's balance} other {your balance}}. You can do this by submitting expenses, making financial contributions, or sending the balance to your Fiscal Host using the {emptyBalanceLink} feature.",
-  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
+  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
   "editCollective.host.label": "Your Fiscal Host is {host}.",
   "editCollective.host.pending": "You applied to be hosted by {host} on {date}. Your application is being reviewed.",
   "editCollective.host.removeBtn": "Remover Administrador",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -709,7 +709,7 @@
   "editCollective.host.balance": "It currently holds {balance} on behalf of {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {your Account}}.",
   "editCollective.host.cancelApplicationBtn": "Отменить заявку",
   "editCollective.host.change.balanceNotEmpty": "To change your Fiscal Host, you first need to empty {type, select, COLLECTIVE {your Collective's balance} FUND {your Fund's balance} other {your balance}}. You can do this by submitting expenses, making financial contributions, or sending the balance to your Fiscal Host using the {emptyBalanceLink} feature.",
-  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
+  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
   "editCollective.host.label": "Ваш Фискальный Представитель - {host}.",
   "editCollective.host.pending": "You applied to be hosted by {host} on {date}. Your application is being reviewed.",
   "editCollective.host.removeBtn": "Удалить представителя",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -709,7 +709,7 @@
   "editCollective.host.balance": "It currently holds {balance} on behalf of {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {your Account}}.",
   "editCollective.host.cancelApplicationBtn": "Скасувати заявку",
   "editCollective.host.change.balanceNotEmpty": "To change your Fiscal Host, you first need to empty {type, select, COLLECTIVE {your Collective's balance} FUND {your Fund's balance} other {your balance}}. You can do this by submitting expenses, making financial contributions, or sending the balance to your Fiscal Host using the {emptyBalanceLink} feature.",
-  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
+  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
   "editCollective.host.label": "Ваш скарбник {host}.",
   "editCollective.host.pending": "You applied to be hosted by {host} on {date}. Your application is being reviewed.",
   "editCollective.host.removeBtn": "Вилучити скарбника",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -709,7 +709,7 @@
   "editCollective.host.balance": "It currently holds {balance} on behalf of {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {your Account}}.",
   "editCollective.host.cancelApplicationBtn": "Withdraw application",
   "editCollective.host.change.balanceNotEmpty": "To change your Fiscal Host, you first need to empty {type, select, COLLECTIVE {your Collective's balance} FUND {your Fund's balance} other {your balance}}. You can do this by submitting expenses, making financial contributions, or sending the balance to your Fiscal Host using the {emptyBalanceLink} feature.",
-  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
+  "editCollective.host.change.removeFirst": "Without a Fiscal Host, {type, select, COLLECTIVE {your Collective} FUND {your Fund} other {}} won't be able to accept financial contributions. You will be able to apply to another Fiscal Host.",
   "editCollective.host.label": "您的财务托管人是 {host}。",
   "editCollective.host.pending": "You applied to be hosted by {host} on {date}. Your application is being reviewed.",
   "editCollective.host.removeBtn": "移除主体",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4522,23 +4522,6 @@
         }
       }
     },
-    "@formatjs/ecma402-abstract": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.7.0.tgz",
-      "integrity": "sha512-0IQF4oDZdO8ruyrNJZuRle3F/YiGgRwTNrZyMI1N1X8GERZusOrXU9Stw+j/lyyfDWaJK44b+Qnri/qfLPCtGQ==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
-          "dev": true
-        }
-      }
-    },
     "@formatjs/fast-memoize": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.1.1.tgz",
@@ -18958,9 +18941,9 @@
       "dev": true
     },
     "@types/eslint": {
-      "version": "7.2.10",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.10.tgz",
-      "integrity": "sha512-kUEPnMKrqbtpCq/KTaGFFKAcz6Ethm2EjCoKIDaCmfRBWLbFuTcOJfTlorwbnboXBzahqWLgUp1BQeKHiJzPUQ==",
+      "version": "7.2.13",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.13.tgz",
+      "integrity": "sha512-LKmQCWAlnVHvvXq4oasNUMTJJb2GwSyTY8+1C7OH5ILR8mPLaljv1jxL1bXW3xB3jFbQxTKxJAvI8PyjB09aBg==",
       "dev": true,
       "requires": {
         "@types/estree": "*",
@@ -18968,9 +18951,9 @@
       }
     },
     "@types/estree": {
-      "version": "0.0.47",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.47.tgz",
-      "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.48.tgz",
+      "integrity": "sha512-LfZwXoGUDo0C3me81HXgkBg5CTQYb6xzEl+fNmbO4JdRiSKQ8A0GD1OBBvKAIsbCUgoyAty7m99GqqMQe784ew==",
       "dev": true
     },
     "@types/fs-extra": {
@@ -19355,25 +19338,24 @@
       "integrity": "sha512-HrCIVMLjE1MOozVoD86622S7aunluLb2PJdPfb3nYiEtohm8mIB/vyv0Fd37AdeMFrTUQXEunw78YloMA3Qilg=="
     },
     "@typescript-eslint/types": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.10.1.tgz",
-      "integrity": "sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.1.tgz",
+      "integrity": "sha512-4z+knEihcyX7blAGi7O3Fm3O6YRCP+r56NJFMNGsmtdw+NCdpG5SgNz427LS9nQkRVTswZLhz484hakQwB8RRg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.1.tgz",
-      "integrity": "sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.1.tgz",
+      "integrity": "sha512-GhKxmC4sHXxHGJv8e8egAZeTZ6HI4mLU6S7FUzvFOtsk7ZIDN1ksA9r9DyOgNqowA9yAtZXV0Uiap61bIO81FQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "3.10.1",
-        "@typescript-eslint/visitor-keys": "3.10.1",
-        "debug": "^4.1.1",
-        "glob": "^7.1.6",
+        "@typescript-eslint/types": "4.28.1",
+        "@typescript-eslint/visitor-keys": "4.28.1",
+        "debug": "^4.3.1",
+        "globby": "^11.0.3",
         "is-glob": "^4.0.1",
-        "lodash": "^4.17.15",
-        "semver": "^7.3.2",
-        "tsutils": "^3.17.1"
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
       },
       "dependencies": {
         "semver": {
@@ -19388,12 +19370,21 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1.tgz",
-      "integrity": "sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.1.tgz",
+      "integrity": "sha512-K4HMrdFqr9PFquPu178SaSb92CaWe2yErXyPumc8cYWxFmhgJsNY9eSePmO05j0JhBvf2Cdhptd6E6Yv9HVHcg==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^1.1.0"
+        "@typescript-eslint/types": "4.28.1",
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        }
       }
     },
     "@webassemblyjs/ast": {
@@ -25289,50 +25280,28 @@
       }
     },
     "eslint-plugin-formatjs": {
-      "version": "2.14.9",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-formatjs/-/eslint-plugin-formatjs-2.14.9.tgz",
-      "integrity": "sha512-oJq9DrL0T0Y3+AHBv1IRa59wwrJx4iQynVdoXXT6TFXxhp9HQbMGvfuCcsXmHArkKaz2Vb8PmRKm/xufC2EnXg==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-formatjs/-/eslint-plugin-formatjs-2.17.0.tgz",
+      "integrity": "sha512-Raq2up309KHEUzbSccxZCeZpcrQ6i2t3R/lwNoFWi/JSAYz20yBtfvCEaku/LmYjFf8hf10ONbJgHhhVLyEKJQ==",
       "dev": true,
       "requires": {
-        "@formatjs/icu-messageformat-parser": "1.2.1",
-        "@formatjs/ts-transformer": "3.3.10",
+        "@formatjs/icu-messageformat-parser": "2.0.7",
+        "@formatjs/ts-transformer": "3.4.4",
         "@types/emoji-regex": "^8.0.0",
         "@types/eslint": "^7.2.0",
-        "@typescript-eslint/typescript-estree": "^3.6.0",
+        "@typescript-eslint/typescript-estree": "^4.11.0",
         "emoji-regex": "^9.0.0",
         "tslib": "^2.1.0"
       },
       "dependencies": {
-        "@formatjs/icu-messageformat-parser": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-1.2.1.tgz",
-          "integrity": "sha512-gGG2AGCmdNGSJJFDrblNvz1j0yOw9tIhUy0t9vRFlMQOlAIknaLYxNjl3S6ztLg47QAZC7BT8uFnIGZ2/nhxAA==",
-          "dev": true,
-          "requires": {
-            "@formatjs/ecma402-abstract": "1.7.0",
-            "@formatjs/icu-skeleton-parser": "1.2.1",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@formatjs/icu-skeleton-parser": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.2.1.tgz",
-          "integrity": "sha512-mTpmCozmksatv3gQ+6/9dwwtoR+r+DFms22X6D6GLS4TaeaFKIPmC3k/DlsMGZIr3Q+dT+is5IcexChrPBGmCg==",
-          "dev": true,
-          "requires": {
-            "@formatjs/ecma402-abstract": "1.7.0",
-            "tslib": "^2.1.0"
-          }
-        },
         "@formatjs/ts-transformer": {
-          "version": "3.3.10",
-          "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.3.10.tgz",
-          "integrity": "sha512-HBj5BObky4D/haB9pSPLLcFVSWcUO0JByw+vaV91JML8alPJMHRD133x4h05KbVlmTY9NufeKhvXc3xc1zmiFA==",
+          "version": "3.4.4",
+          "resolved": "https://registry.npmjs.org/@formatjs/ts-transformer/-/ts-transformer-3.4.4.tgz",
+          "integrity": "sha512-23QAwecL1emi0RWuV1w+FhsF7Xp6eJTSkXgWHSV94Ff0hfwfjLZMNNSiYQBT1CEHKzerRvuGi4rrbj4Zc46/pg==",
           "dev": true,
           "requires": {
-            "@formatjs/icu-messageformat-parser": "1.2.1",
-            "tslib": "^2.1.0",
-            "typescript": "^4.0"
+            "@formatjs/icu-messageformat-parser": "2.0.7",
+            "tslib": "^2.1.0"
           }
         },
         "emoji-regex": {
@@ -25342,9 +25311,9 @@
           "dev": true
         },
         "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
           "dev": true
         }
       }
@@ -41354,9 +41323,9 @@
       }
     },
     "typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+      "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "eslint-config-opencollective": "^3.0.0",
     "eslint-plugin-babel": "^5.3.1",
     "eslint-plugin-cypress": "^2.11.3",
-    "eslint-plugin-formatjs": "^2.14.9",
+    "eslint-plugin-formatjs": "^2.17.0",
     "eslint-plugin-graphql": "^4.0.0",
     "eslint-plugin-import": "^2.23.2",
     "eslint-plugin-node": "^11.1.0",
@@ -207,6 +207,7 @@
     "raw-loader": "^4.0.2",
     "react-test-renderer": "^17.0.2",
     "shx": "^0.3.3",
+    "typescript": "^4.3.4",
     "url-loader": "^4.1.1",
     "webpack-bundle-analyzer": "^4.4.2"
   },


### PR DESCRIPTION
This updates the `eslint-plugin-formatjs` plugin to latest. It seems that dependabot wasn't automatically able to get this correctly as with the new updates to `eslint-plugin-formatjs` we need to also include `typescript` as a dev dependency. I am unable to find a specific place in the documentation of `formatjs` which says this; but it seems that this was introduced probably at [v2.15.0](https://github.com/formatjs/formatjs/blob/main/packages/eslint-plugin-formatjs/CHANGELOG.md#2150-2021-05-10).

Related to https://github.com/opencollective/opencollective-frontend/pull/6550