### PR TITLE
LoggedInUser: Remove expense related methods

### DIFF
--- a/lib/LoggedInUser.js
+++ b/lib/LoggedInUser.js
@@ -1,7 +1,6 @@
 import { get, uniqBy } from 'lodash';
 
 import { CollectiveType } from './constants/collectives';
-import EXPENSE_STATUS from './constants/expense-status';
 import ROLES from './constants/roles';
 
 /**
@@ -119,46 +118,6 @@ LoggedInUser.prototype.canEditProject = function (project) {
 };
 
 /**
- * CanApproveExpense if LoggedInUser is:
- * - admin or host of expense.collective
- * - admin or host of expense.collective.host
- */
-LoggedInUser.prototype.canApproveExpense = function (expense) {
-  if (!expense) {
-    return false;
-  } else {
-    return this.hasRole([ROLES.HOST, ROLES.ADMIN], expense.collective) || this.isHostAdmin(expense.collective);
-  }
-};
-
-/**
- * CanEditExpense if not paid yet and LoggedInUser is:
- * - author of the expense and expense.status === 'PENDING' or 'APPROVED'
- * - can approve expense (admin or host of expense.collective or expense.collective.host)
- */
-LoggedInUser.prototype.canEditExpense = function (expense) {
-  // Can't edit paid expenses
-  if (
-    !expense ||
-    expense.status === EXPENSE_STATUS.PAID ||
-    expense.status === EXPENSE_STATUS.PROCESSING ||
-    expense.status === EXPENSE_STATUS.ERROR
-  ) {
-    return false;
-  }
-
-  // Users can only edit their expenses if approved or pending
-  if (expense.fromCollective) {
-    const statusesUserCanEdit = [EXPENSE_STATUS.APPROVED, EXPENSE_STATUS.PENDING];
-    if (expense.fromCollective.id === this.collective.id && statusesUserCanEdit.includes(expense.status)) {
-      return true;
-    }
-  }
-
-  return this.canApproveExpense(expense);
-};
-
-/**
  * Returns true if user can edit this update
  */
 LoggedInUser.prototype.canEditUpdate = function (update) {
@@ -169,13 +128,6 @@ LoggedInUser.prototype.canEditUpdate = function (update) {
   } else if (this.canEditCollective(update.account)) {
     return true;
   }
-};
-
-/**
- * CanPayExpense if LoggedInUser is HOST or ADMIN of the HOST of the collective
- */
-LoggedInUser.prototype.canPayExpense = function (expense) {
-  return this.isHostAdmin(expense.collective);
 };
 
 /**

--- a/lib/__tests__/LoggedInUser.test.js
+++ b/lib/__tests__/LoggedInUser.test.js
@@ -50,13 +50,6 @@ const testUser = new LoggedInUser({
   },
 });
 
-const randomUser = new LoggedInUser({
-  id: 3,
-  memberOf: [],
-  CollectiveId: 2000,
-  collective: { id: 2000, slug: 'random-user-collective' },
-});
-
 hostedCollective.host = testUser;
 
 describe('General permissions', () => {
@@ -121,73 +114,6 @@ describe('Events', () => {
       expect(testUser.canEditEvent(randomEventCollective)).toBe(false);
       expect(testUser.canEditEvent(adminEventCollective)).toBe(true);
       expect(testUser.canEditEvent(adminEventCollectiveParent)).toBe(true);
-    });
-  });
-});
-
-describe('Expenses', () => {
-  describe('canApproveExpense', () => {
-    it('returns true if user can approve/reject expense', () => {
-      expect(testUser.canApproveExpense({ collective: null })).toBe(false);
-      expect(testUser.canApproveExpense({ collective: randomCollective })).toBe(false);
-      expect(testUser.canApproveExpense({ collective: backedCollective })).toBe(false);
-      expect(testUser.canApproveExpense({ collective: memberCollective })).toBe(false);
-      expect(testUser.canApproveExpense({ collective: randomEventCollective })).toBe(false);
-
-      expect(testUser.canApproveExpense({ collective: adminCollective })).toBe(true);
-      expect(testUser.canApproveExpense({ collective: adminEventCollective })).toBe(true);
-      expect(testUser.canApproveExpense({ collective: hostAdminCollective })).toBe(true);
-    });
-  });
-
-  describe('canPayExpense', () => {
-    it('returns true if user can approve/reject expense', () => {
-      expect(testUser.canPayExpense({ collective: null })).toBe(false);
-      expect(testUser.canPayExpense({ collective: randomCollective })).toBe(false);
-      expect(testUser.canPayExpense({ collective: backedCollective })).toBe(false);
-      expect(testUser.canPayExpense({ collective: memberCollective })).toBe(false);
-      expect(testUser.canPayExpense({ collective: randomEventCollective })).toBe(false);
-      expect(testUser.canPayExpense({ collective: adminCollective })).toBe(false);
-      expect(testUser.canPayExpense({ collective: adminEventCollective })).toBe(false);
-
-      // Only host admins can pay expenses
-      expect(testUser.canPayExpense({ collective: hostAdminCollective })).toBe(true);
-    });
-  });
-
-  describe('canEditExpense', () => {
-    it('nobody can edit paid expenses', () => {
-      const paidExpense = { collective: adminCollective, fromCollective: testUser.collective, status: 'PAID' };
-      expect(rootUser.canEditExpense(paidExpense)).toBe(false);
-      expect(testUser.canEditExpense(paidExpense)).toBe(false);
-    });
-
-    it('users can edit their own expenses only if approved or pending', () => {
-      const userExpense = { collective: randomCollective, fromCollective: testUser.collective };
-
-      // Own expense, pending or approved => OK
-      expect(testUser.canEditExpense({ ...userExpense, status: 'PENDING' })).toBe(true);
-      expect(testUser.canEditExpense({ ...userExpense, status: 'APPROVED' })).toBe(true);
-
-      // Own expense, paid or rejected => Not ok
-      expect(testUser.canEditExpense({ ...userExpense, status: 'REJECTED' })).toBe(false);
-      expect(testUser.canEditExpense({ ...userExpense, status: 'PAID' })).toBe(false);
-
-      // Someone else's expense => Not ok
-      expect(randomUser.canEditExpense({ ...userExpense, status: 'APPROVED' })).toBe(false);
-      expect(randomUser.canEditExpense({ ...userExpense, status: 'PENDING' })).toBe(false);
-      expect(randomUser.canEditExpense({ ...userExpense, status: 'REJECTED' })).toBe(false);
-      expect(randomUser.canEditExpense({ ...userExpense, status: 'PAID' })).toBe(false);
-    });
-
-    it('host admins can edit expenses not payed yet', () => {
-      const expense = { collective: hostedCollective, fromCollective: randomUser.collective };
-
-      // Pending
-      expect(testUser.canEditExpense({ ...expense, status: 'APPROVED' })).toBe(true);
-      expect(testUser.canEditExpense({ ...expense, status: 'PENDING' })).toBe(true);
-      expect(testUser.canEditExpense({ ...expense, status: 'REJECTED' })).toBe(true);
-      expect(testUser.canEditExpense({ ...expense, status: 'PAID' })).toBe(false);
     });
   });
 });


### PR DESCRIPTION
These were not used anymore since the expense flow revamps moved these checks to the API.