### PR TITLE
Fix ScheduledExpenses banner refresh UX

### DIFF
--- a/components/host-dashboard/HostDashboardExpenses.js
+++ b/components/host-dashboard/HostDashboardExpenses.js
@@ -226,6 +226,7 @@ const HostDashboardExpenses = ({ hostSlug }) => {
       {!expenses.loading && data?.host && (
         <ScheduledExpensesBanner
           host={data.host}
+          expenses={paginatedExpenses.nodes}
           onSubmit={() => {
             expenses.refetch();
           }}

--- a/components/host-dashboard/ScheduledExpensesBanner.js
+++ b/components/host-dashboard/ScheduledExpensesBanner.js
@@ -32,11 +32,14 @@ const scheduledExpensesQuery = gqlV2/* GraphQL */ `
   }
 `;
 
-const ScheduledExpensesBanner = ({ host, onSubmit, secondButton }) => {
+const ScheduledExpensesBanner = ({ host, onSubmit, secondButton, expenses }) => {
   const scheduledExpenses = useQuery(scheduledExpensesQuery, {
     variables: { hostId: host.id, limit: 100, status: 'SCHEDULED_FOR_PAYMENT', payoutMethodType: 'BANK_ACCOUNT' },
     context: API_V2_CONTEXT,
   });
+  React.useEffect(() => {
+    scheduledExpenses.refetch();
+  }, [expenses]);
   const { addToast } = useToasts();
   const [showConfirmationModal, setConfirmationModalDisplay] = React.useState(false);
 
@@ -123,6 +126,7 @@ ScheduledExpensesBanner.propTypes = {
   host: PropTypes.shape({
     id: PropTypes.string,
   }).isRequired,
+  expenses: PropTypes.array,
   onSubmit: PropTypes.function,
   secondButton: PropTypes.node,
 };


### PR DESCRIPTION
It was a bit buggy and the banner wouldn't update after expenses were paid or mutated.
Now it works as expected:
![deepin-screen-recorder_Select area_20210701192805](https://user-images.githubusercontent.com/2119706/124196398-b586ce80-daa2-11eb-840b-02e344a6bc0a.gif)
