### PR TITLE
feat(ChangelogTrigger): add ToolTip for notification icon

### DIFF
--- a/components/changelog/ChangelogTrigger.js
+++ b/components/changelog/ChangelogTrigger.js
@@ -4,6 +4,7 @@ import { gql, useQuery } from '@apollo/client';
 import { graphql, withApollo } from '@apollo/client/react/hoc';
 import themeGet from '@styled-system/theme-get';
 import { cloneDeep } from 'lodash';
+import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 
 import { API_V2_CONTEXT, gqlV2 } from '../../lib/graphql/helpers';
@@ -13,6 +14,7 @@ import { Flex } from '../Grid';
 import { withNewsAndUpdates } from '../NewsAndUpdatesProvider';
 import { Dropdown } from '../StyledDropdown';
 import StyledRoundButton from '../StyledRoundButton';
+import StyledTooltip from '../StyledTooltip';
 
 import ChangelogNotificationDropdown from './ChangelogNotificationDropdown';
 
@@ -55,6 +57,10 @@ const ChangelogTrigger = props => {
     });
   };
 
+  const TooltipContent = (
+    <FormattedMessage id="ChangelogTrigger.tooltip.content" defaultMessage="What's new with Open Collective" />
+  );
+
   if (!LoggedInUser || !CHANGE_LOG_UPDATES_ENABLED) {
     return null;
   }
@@ -62,10 +68,18 @@ const ChangelogTrigger = props => {
   return (
     <Flex>
       {hasSeenNewUpdates ? (
-        <FlameIcon onClick={handleShowNewUpdates} backgroundColor="black.100" url="/static/images/flame-default.svg" />
+        <StyledTooltip content={TooltipContent}>
+          <FlameIcon
+            onClick={handleShowNewUpdates}
+            backgroundColor="black.100"
+            url="/static/images/flame-default.svg"
+          />
+        </StyledTooltip>
       ) : (
         <Dropdown>
-          <FlameIcon onClick={handleShowNewUpdates} backgroundColor="yellow.100" url="/static/images/flame-red.svg" />
+          <StyledTooltip content={TooltipContent}>
+            <FlameIcon onClick={handleShowNewUpdates} backgroundColor="yellow.100" url="/static/images/flame-red.svg" />
+          </StyledTooltip>
           <ChangelogNotificationDropdown />
         </Dropdown>
       )}

--- a/components/changelog/ChangelogTrigger.js
+++ b/components/changelog/ChangelogTrigger.js
@@ -77,9 +77,7 @@ const ChangelogTrigger = props => {
         </StyledTooltip>
       ) : (
         <Dropdown>
-          <StyledTooltip content={TooltipContent}>
-            <FlameIcon onClick={handleShowNewUpdates} backgroundColor="yellow.100" url="/static/images/flame-red.svg" />
-          </StyledTooltip>
+          <FlameIcon onClick={handleShowNewUpdates} backgroundColor="yellow.100" url="/static/images/flame-red.svg" />
           <ChangelogNotificationDropdown />
         </Dropdown>
       )}

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -203,6 +203,7 @@
   "CancelEdit": "Cancel·la la modificació",
   "ChangelogNotification.firstLine": "We have new stuff for you!",
   "ChangelogNotification.secondLine": "Click on the {image} to take a look",
+  "ChangelogTrigger.tooltip.content": "What's new with Open Collective",
   "checkingBrowser": "Your browser is being verified. If this message doesn't disappear, try to move your mouse or to touch your screen for mobile.",
   "clickHere": "Clica aquí",
   "Clipboard.Copied": "S'ha copiat!",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -203,6 +203,7 @@
   "CancelEdit": "Zrušit úpravu",
   "ChangelogNotification.firstLine": "We have new stuff for you!",
   "ChangelogNotification.secondLine": "Click on the {image} to take a look",
+  "ChangelogTrigger.tooltip.content": "What's new with Open Collective",
   "checkingBrowser": "Your browser is being verified. If this message doesn't disappear, try to move your mouse or to touch your screen for mobile.",
   "clickHere": "Klikněte zde",
   "Clipboard.Copied": "Zkopírováno!",

--- a/lang/de.json
+++ b/lang/de.json
@@ -203,6 +203,7 @@
   "CancelEdit": "Bearbeitung abbrechen",
   "ChangelogNotification.firstLine": "We have new stuff for you!",
   "ChangelogNotification.secondLine": "Click on the {image} to take a look",
+  "ChangelogTrigger.tooltip.content": "What's new with Open Collective",
   "checkingBrowser": "Ihr Browser wird überprüft. Wenn diese Nachricht nicht verschwindet, versuchen Sie die Maus zu bewegen oder den Bildschirm auf dem Handy zu berühren.",
   "clickHere": "Klick hier",
   "Clipboard.Copied": "Kopiert!",

--- a/lang/en.json
+++ b/lang/en.json
@@ -203,6 +203,7 @@
   "CancelEdit": "Cancel edit",
   "ChangelogNotification.firstLine": "We have new stuff for you!",
   "ChangelogNotification.secondLine": "Click on the {image} to take a look",
+  "ChangelogTrigger.tooltip.content": "What's new with Open Collective",
   "checkingBrowser": "Your browser is being verified. If this message doesn't disappear, try to move your mouse or to touch your screen for mobile.",
   "clickHere": "Click here",
   "Clipboard.Copied": "Copied!",

--- a/lang/es.json
+++ b/lang/es.json
@@ -203,6 +203,7 @@
   "CancelEdit": "Cancelar edición",
   "ChangelogNotification.firstLine": "We have new stuff for you!",
   "ChangelogNotification.secondLine": "Click on the {image} to take a look",
+  "ChangelogTrigger.tooltip.content": "What's new with Open Collective",
   "checkingBrowser": "Tu navegador está siendo verificado. Si este mensaje no desaparece, intenta mover el ratón o tocar la pantalla si estas en un móvil.",
   "clickHere": "Haga clic aquí",
   "Clipboard.Copied": "¡Copiado!",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -203,6 +203,7 @@
   "CancelEdit": "Annuler l'édition",
   "ChangelogNotification.firstLine": "We have new stuff for you!",
   "ChangelogNotification.secondLine": "Click on the {image} to take a look",
+  "ChangelogTrigger.tooltip.content": "What's new with Open Collective",
   "checkingBrowser": "Votre navigateur est en cours de vérification. Si ce message ne disparaît pas, essayez de déplacer votre souris ou de toucher votre écran (pour les mobiles).",
   "clickHere": "Cliquez ici",
   "Clipboard.Copied": "Copié",

--- a/lang/it.json
+++ b/lang/it.json
@@ -203,6 +203,7 @@
   "CancelEdit": "Annulla modifica",
   "ChangelogNotification.firstLine": "We have new stuff for you!",
   "ChangelogNotification.secondLine": "Click on the {image} to take a look",
+  "ChangelogTrigger.tooltip.content": "What's new with Open Collective",
   "checkingBrowser": "Il tuo browser è in fase di verifica. Se questo messaggio non scompare, prova a spostare il mouse o a toccare lo schermo del tuo cellulare.",
   "clickHere": "Clicca qui",
   "Clipboard.Copied": "Copiato!",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -203,6 +203,7 @@
   "CancelEdit": "編集をキャンセル",
   "ChangelogNotification.firstLine": "We have new stuff for you!",
   "ChangelogNotification.secondLine": "Click on the {image} to take a look",
+  "ChangelogTrigger.tooltip.content": "What's new with Open Collective",
   "checkingBrowser": "Your browser is being verified. If this message doesn't disappear, try to move your mouse or to touch your screen for mobile.",
   "clickHere": "こちらからどうぞ",
   "Clipboard.Copied": "コピーしました!",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -203,6 +203,7 @@
   "CancelEdit": "변경 취소",
   "ChangelogNotification.firstLine": "We have new stuff for you!",
   "ChangelogNotification.secondLine": "Click on the {image} to take a look",
+  "ChangelogTrigger.tooltip.content": "What's new with Open Collective",
   "checkingBrowser": "Your browser is being verified. If this message doesn't disappear, try to move your mouse or to touch your screen for mobile.",
   "clickHere": "더 알아보기",
   "Clipboard.Copied": "복사되었습니다!",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -203,6 +203,7 @@
   "CancelEdit": "Bewerking annuleren",
   "ChangelogNotification.firstLine": "We have new stuff for you!",
   "ChangelogNotification.secondLine": "Click on the {image} to take a look",
+  "ChangelogTrigger.tooltip.content": "What's new with Open Collective",
   "checkingBrowser": "Your browser is being verified. If this message doesn't disappear, try to move your mouse or to touch your screen for mobile.",
   "clickHere": "Hier klikken",
   "Clipboard.Copied": "Gekopieerd!",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -203,6 +203,7 @@
   "CancelEdit": "Cancelar edição",
   "ChangelogNotification.firstLine": "We have new stuff for you!",
   "ChangelogNotification.secondLine": "Click on the {image} to take a look",
+  "ChangelogTrigger.tooltip.content": "What's new with Open Collective",
   "checkingBrowser": "Seu navegador está sendo verificado. Se essa mensagem não desaparecer, tente mover seu mouse ou toque na tela de seu smartfone.",
   "clickHere": "Clique aqui",
   "Clipboard.Copied": "Copiado!",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -203,6 +203,7 @@
   "CancelEdit": "Cancelar edição",
   "ChangelogNotification.firstLine": "We have new stuff for you!",
   "ChangelogNotification.secondLine": "Click on the {image} to take a look",
+  "ChangelogTrigger.tooltip.content": "What's new with Open Collective",
   "checkingBrowser": "Your browser is being verified. If this message doesn't disappear, try to move your mouse or to touch your screen for mobile.",
   "clickHere": "Clique aqui",
   "Clipboard.Copied": "Copiado!",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -203,6 +203,7 @@
   "CancelEdit": "Отменить изменения",
   "ChangelogNotification.firstLine": "We have new stuff for you!",
   "ChangelogNotification.secondLine": "Click on the {image} to take a look",
+  "ChangelogTrigger.tooltip.content": "What's new with Open Collective",
   "checkingBrowser": "Ваш браузер проверяется. Если это сообщение не исчезло, попробуйте переместить мышку или прикоснуться к экрану телефона.",
   "clickHere": "Нажмите здесь",
   "Clipboard.Copied": "Скопировано!",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -203,6 +203,7 @@
   "CancelEdit": "Скасувати зміни",
   "ChangelogNotification.firstLine": "We have new stuff for you!",
   "ChangelogNotification.secondLine": "Click on the {image} to take a look",
+  "ChangelogTrigger.tooltip.content": "What's new with Open Collective",
   "checkingBrowser": "Your browser is being verified. If this message doesn't disappear, try to move your mouse or to touch your screen for mobile.",
   "clickHere": "Натисніть тут",
   "Clipboard.Copied": "Скопійовано!",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -203,6 +203,7 @@
   "CancelEdit": "取消编辑",
   "ChangelogNotification.firstLine": "We have new stuff for you!",
   "ChangelogNotification.secondLine": "Click on the {image} to take a look",
+  "ChangelogTrigger.tooltip.content": "What's new with Open Collective",
   "checkingBrowser": "您的浏览器正在验证中。如果此消息没有消失，请尝试移动您的鼠标或触摸您的屏幕以移动设备。",
   "clickHere": "单击此处",
   "Clipboard.Copied": "已复制！",


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/4407

# Description

Add ToolTip for Changelog Notification Icon.

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots

<img width="274" alt="Screenshot 2021-07-03 at 7 17 39 AM" src="https://user-images.githubusercontent.com/46647141/124339972-7e620b80-dbcf-11eb-918d-6bd4d020d067.png">

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
