### PR TITLE
TopBarMobileMenu: apply new design for changelog icon on small screen

### DIFF
--- a/components/TopBar.js
+++ b/components/TopBar.js
@@ -179,7 +179,9 @@ class TopBar extends React.Component {
           </Hide>
         </Flex>
         <Container mr={3}>
-          <ChangelogTrigger />
+          <Hide xs>
+            <ChangelogTrigger />
+          </Hide>
         </Container>
         <TopBarProfileMenu />
         <Hide sm md lg>

--- a/components/TopBarProfileMenu.js
+++ b/components/TopBarProfileMenu.js
@@ -197,7 +197,7 @@ class TopBarProfileMenu extends React.Component {
           <Avatar collective={get(LoggedInUser, 'collective')} radius="40px" mr={2} />
           <Hide sm md lg>
             <Container mx={-20} my={-1}>
-              <ChangelogTrigger height="24px" width="24px" />
+              <ChangelogTrigger height="24px" width="24px" backgroundSize="9.49px 13.5px" />
             </Container>
           </Hide>
         </Flex>

--- a/components/TopBarProfileMenu.js
+++ b/components/TopBarProfileMenu.js
@@ -5,7 +5,7 @@ import { Query } from '@apollo/client/react/components';
 import { ChevronDown } from '@styled-icons/boxicons-regular/ChevronDown';
 import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
-import { createGlobalStyle } from 'styled-components';
+import styled, { createGlobalStyle } from 'styled-components';
 
 import { getFromLocalStorage, LOCAL_STORAGE_KEYS } from '../lib/local-storage';
 import { parseToBoolean } from '../lib/utils';
@@ -196,8 +196,8 @@ class TopBarProfileMenu extends React.Component {
         <Flex>
           <Avatar collective={get(LoggedInUser, 'collective')} radius="40px" mr={2} />
           <Hide sm md lg>
-            <Container mx={-25} my={-10}>
-              <ChangelogTrigger />
+            <Container mx={-20} my={-1}>
+              <ChangelogTrigger height="24px" width="24px" />
             </Container>
           </Hide>
         </Flex>

--- a/components/TopBarProfileMenu.js
+++ b/components/TopBarProfileMenu.js
@@ -11,6 +11,7 @@ import { getFromLocalStorage, LOCAL_STORAGE_KEYS } from '../lib/local-storage';
 import { parseToBoolean } from '../lib/utils';
 
 import Avatar from './Avatar';
+import ChangelogTrigger from './changelog/ChangelogTrigger';
 import Container from './Container';
 import { Box, Flex } from './Grid';
 import Hide from './Hide';
@@ -192,7 +193,14 @@ class TopBarProfileMenu extends React.Component {
 
     return (
       <Flex alignItems="center" onClick={this.toggleProfileMenu} data-cy="user-menu-trigger">
-        <Avatar collective={get(LoggedInUser, 'collective')} radius="40px" mr={2} />
+        <Flex>
+          <Avatar collective={get(LoggedInUser, 'collective')} radius="40px" mr={2} />
+          <Hide sm md lg>
+            <Container mx={-25} my={-10}>
+              <ChangelogTrigger />
+            </Container>
+          </Hide>
+        </Flex>
         <Hide xs>
           <ChevronDown color="#4E5052" size="1.5em" cursor="pointer" />
         </Hide>

--- a/components/TopBarProfileMenu.js
+++ b/components/TopBarProfileMenu.js
@@ -5,13 +5,13 @@ import { Query } from '@apollo/client/react/components';
 import { ChevronDown } from '@styled-icons/boxicons-regular/ChevronDown';
 import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
-import styled, { createGlobalStyle } from 'styled-components';
+import { createGlobalStyle } from 'styled-components';
 
 import { getFromLocalStorage, LOCAL_STORAGE_KEYS } from '../lib/local-storage';
 import { parseToBoolean } from '../lib/utils';
 
-import Avatar from './Avatar';
 import ChangelogTrigger from './changelog/ChangelogTrigger';
+import Avatar from './Avatar';
 import Container from './Container';
 import { Box, Flex } from './Grid';
 import Hide from './Hide';

--- a/components/changelog/ChangelogNotificationDropdown.js
+++ b/components/changelog/ChangelogNotificationDropdown.js
@@ -15,13 +15,21 @@ const ChangeLogNotificationDropdownArrow = styled(DropdownArrow)`
   &::before {
     border-color: transparent transparent #ffffc2 transparent;
   }
+  @media screen and (max-width: 40em) {
+    right: 90px;
+    top: 55px;
+  }
 `;
 
 const ChangeLogNotificationDropdownContent = styled(DropdownContent)`
   display: block;
-  right: 105px;
+  right: 100px;
   margin-top: 10px;
   background: #ffffc2;
+  @media screen and (max-width: 40em) {
+    right: 75px;
+    top: 55px;
+  }
 `;
 
 const CloseIcon = styled(Times)`

--- a/components/changelog/ChangelogTrigger.js
+++ b/components/changelog/ChangelogTrigger.js
@@ -40,7 +40,7 @@ const FlameIcon = styled(StyledRoundButton)`
 `;
 
 const ChangelogTrigger = props => {
-  const { height, width, setShowNewsAndUpdates, setChangelogViewDate } = props;
+  const { height, width, backgroundSize, setShowNewsAndUpdates, setChangelogViewDate } = props;
   const { data } = useQuery(loggedInUserQuery, { fetchPolicy: 'cache-only' });
   const LoggedInUser = data?.LoggedInUser;
   const hasSeenNewUpdates = LoggedInUser?.hasSeenLatestChangelogEntry;
@@ -74,6 +74,7 @@ const ChangelogTrigger = props => {
             width={width}
             onClick={handleShowNewUpdates}
             backgroundColor="black.100"
+            backgroundSize={backgroundSize}
             url="/static/images/flame-default.svg"
           />
         </StyledTooltip>
@@ -84,6 +85,7 @@ const ChangelogTrigger = props => {
             width={width}
             onClick={handleShowNewUpdates}
             backgroundColor="yellow.100"
+            backgroundSize={backgroundSize}
             url="/static/images/flame-red.svg"
           />
           <ChangelogNotificationDropdown />
@@ -96,6 +98,7 @@ const ChangelogTrigger = props => {
 ChangelogTrigger.propTypes = {
   height: PropTypes.string,
   width: PropTypes.string,
+  backgroundSize: PropTypes.string,
   setShowNewsAndUpdates: PropTypes.func,
   setChangelogViewDate: PropTypes.func,
   client: PropTypes.object.isRequired,

--- a/components/changelog/ChangelogTrigger.js
+++ b/components/changelog/ChangelogTrigger.js
@@ -22,8 +22,8 @@ const CHANGE_LOG_UPDATES_ENABLED = parseToBoolean(process.env.CHANGE_LOG_UPDATES
 
 const FlameIcon = styled(StyledRoundButton)`
   border-radius: 50%;
-  height: 30px;
-  width: 30px;
+  height: ${props => props.height || '30px'};
+  width: ${props => props.width || '30px'};
   margin-left: 2px;
 
   &,
@@ -40,7 +40,7 @@ const FlameIcon = styled(StyledRoundButton)`
 `;
 
 const ChangelogTrigger = props => {
-  const { setShowNewsAndUpdates, setChangelogViewDate } = props;
+  const { height, width, setShowNewsAndUpdates, setChangelogViewDate } = props;
   const { data } = useQuery(loggedInUserQuery, { fetchPolicy: 'cache-only' });
   const LoggedInUser = data?.LoggedInUser;
   const hasSeenNewUpdates = LoggedInUser?.hasSeenLatestChangelogEntry;
@@ -70,6 +70,8 @@ const ChangelogTrigger = props => {
       {hasSeenNewUpdates ? (
         <StyledTooltip content={TooltipContent}>
           <FlameIcon
+            height={height}
+            width={width}
             onClick={handleShowNewUpdates}
             backgroundColor="black.100"
             url="/static/images/flame-default.svg"
@@ -77,7 +79,13 @@ const ChangelogTrigger = props => {
         </StyledTooltip>
       ) : (
         <Dropdown>
-          <FlameIcon onClick={handleShowNewUpdates} backgroundColor="yellow.100" url="/static/images/flame-red.svg" />
+          <FlameIcon
+            height={height}
+            width={width}
+            onClick={handleShowNewUpdates}
+            backgroundColor="yellow.100"
+            url="/static/images/flame-red.svg"
+          />
           <ChangelogNotificationDropdown />
         </Dropdown>
       )}
@@ -86,6 +94,8 @@ const ChangelogTrigger = props => {
 };
 
 ChangelogTrigger.propTypes = {
+  height: PropTypes.string,
+  width: PropTypes.string,
   setShowNewsAndUpdates: PropTypes.func,
   setChangelogViewDate: PropTypes.func,
   client: PropTypes.object.isRequired,


### PR DESCRIPTION


<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/4408

# Description

apply new design for changelog icon on small screen
<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots

<img width="259" alt="Screenshot 2021-07-03 at 5 26 07 PM" src="https://user-images.githubusercontent.com/80162912/124353401-f3f7c700-dc23-11eb-9e08-34045bc5e74f.png">

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
