### PR TITLE
Hide download receipt button for internal transfers

### DIFF
--- a/components/transactions/TransactionDetails.js
+++ b/components/transactions/TransactionDetails.js
@@ -46,6 +46,10 @@ const rejectAndRefundTooltipContent = (showRefundHelp, showRejectHelp) => (
   </Box>
 );
 
+const isInternalTransfer = (fromAccount, toAccount) => {
+  return fromAccount.parentCollective?.id === toAccount.id || fromAccount.parent?.id === toAccount.id;
+};
+
 const DetailTitle = styled.p`
   margin: 8px 8px 4px 8px;
   color: #76777a;
@@ -110,7 +114,7 @@ const TransactionDetails = ({ displayActions, transaction, onMutationSuccess }) 
     parseToBoolean(getEnvVar('REJECT_CONTRIBUTION')) || collectiveHasRejectContributionFeature;
   const showRefundButton = permissions?.canRefund && !isRefunded;
   const showRejectButton = permissions?.canReject && !isOrderRejected && showRejectContribution;
-  const showDownloadInvoiceButton = permissions?.canDownloadInvoice;
+  const showDownloadInvoiceButton = permissions?.canDownloadInvoice && !isInternalTransfer(fromAccount, toAccount);
 
   return (
     <DetailsContainer flexWrap="wrap" alignItems="flex-start">

--- a/components/transactions/TransactionDetails.js
+++ b/components/transactions/TransactionDetails.js
@@ -47,7 +47,7 @@ const rejectAndRefundTooltipContent = (showRefundHelp, showRejectHelp) => (
 );
 
 const isInternalTransfer = (fromAccount, toAccount) => {
-  return fromAccount.parentCollective?.id === toAccount.id || fromAccount.parent?.id === toAccount.id;
+  return fromAccount.parent?.id === toAccount.id;
 };
 
 const DetailTitle = styled.p`

--- a/components/transactions/graphql/fragments.js
+++ b/components/transactions/graphql/fragments.js
@@ -73,7 +73,7 @@ export const transactionsQueryCollectionFragment = gqlV2/* GraphQL */ `
         imageUrl
         isIncognito
         ... on Event {
-          parentCollective {
+          parent {
             id
           }
         }

--- a/components/transactions/graphql/fragments.js
+++ b/components/transactions/graphql/fragments.js
@@ -72,6 +72,16 @@ export const transactionsQueryCollectionFragment = gqlV2/* GraphQL */ `
         type
         imageUrl
         isIncognito
+        ... on Event {
+          parentCollective {
+            id
+          }
+        }
+        ... on Project {
+          parent {
+            id
+          }
+        }
         ... on Individual {
           isGuest
         }


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/4382

![hide-download-reciept-for-internal](https://user-images.githubusercontent.com/12435965/126221437-0638a631-5c0f-4b88-b2ce-446f254b7421.gif)
