### PR TITLE
Do Not Generate Reciept for Balances Moving Between Same Host

### DIFF
--- a/components/transactions/TransactionDetails.js
+++ b/components/transactions/TransactionDetails.js
@@ -46,8 +46,9 @@ const rejectAndRefundTooltipContent = (showRefundHelp, showRejectHelp) => (
   </Box>
 );
 
+// Check whether transfer is child collective to parent or if the transfer is from host to one of its collectives
 const isInternalTransfer = (fromAccount, toAccount) => {
-  return fromAccount.parent?.id === toAccount.id;
+  return fromAccount.parent?.id === toAccount.id || fromAccount.id === toAccount.host?.id;
 };
 
 const DetailTitle = styled.p`


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/4382#issuecomment-878711106

This prevents the showing of the download receipt button for balances moving between a host and its own collective as per the above linked comment. 