### PR TITLE
Use `refetchQueries` to Sync the Updates Section on New Updates

### DIFF
--- a/components/UpdatesWithData.js
+++ b/components/UpdatesWithData.js
@@ -145,6 +145,7 @@ const UPDATES_PER_PAGE = 10;
 export const addUpdatesData = graphql(updatesQuery, {
   options: props => ({
     context: API_V2_CONTEXT,
+    fetchPolicy: 'cache-and-network',
     variables: getUpdatesVariables(props),
   }),
   props: ({ data }) => ({

--- a/components/UpdatesWithData.js
+++ b/components/UpdatesWithData.js
@@ -128,14 +128,14 @@ export const updatesQuery = gqlV2/* GraphQL */ `
   }
 `;
 
-const getUpdatesVariables = props => {
+export const getUpdatesVariables = (slug, limit, includeHostedCollectives, orderBy, searchTerm) => {
   return {
-    collectiveSlug: props.collective.slug,
+    collectiveSlug: slug,
     offset: 0,
-    limit: props.limit || UPDATES_PER_PAGE * 2,
-    includeHostedCollectives: props.includeHostedCollectives || false,
-    orderBy: { field: 'CREATED_AT', direction: props.query?.orderBy === 'oldest' ? 'ASC' : 'DESC' },
-    searchTerm: props.query?.searchTerm,
+    limit: limit || UPDATES_PER_PAGE * 2,
+    includeHostedCollectives: includeHostedCollectives || false,
+    orderBy: { field: 'CREATED_AT', direction: orderBy === 'oldest' ? 'ASC' : 'DESC' },
+    searchTerm: searchTerm,
   };
 };
 
@@ -144,7 +144,13 @@ export const UPDATES_PER_PAGE = 10;
 export const addUpdatesData = graphql(updatesQuery, {
   options: props => ({
     context: API_V2_CONTEXT,
-    variables: getUpdatesVariables(props),
+    variables: getUpdatesVariables(
+      props.collective.slug,
+      props.limit,
+      props.includeHostedCollectives,
+      props.query?.orderBy,
+      props.query?.searchTerm,
+    ),
   }),
   props: ({ data }) => ({
     data,

--- a/components/UpdatesWithData.js
+++ b/components/UpdatesWithData.js
@@ -36,8 +36,7 @@ class UpdatesWithData extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { data, collective } = this.props;
-    const { LoggedInUser } = this.props;
+    const { data, collective, LoggedInUser } = this.props;
     if (!prevProps.LoggedInUser && LoggedInUser && LoggedInUser.canEditCollective(collective)) {
       // We refetch the data to get the updates that are not published yet
       data.refetch({ options: { fetchPolicy: 'network-only' } });
@@ -145,7 +144,7 @@ const UPDATES_PER_PAGE = 10;
 export const addUpdatesData = graphql(updatesQuery, {
   options: props => ({
     context: API_V2_CONTEXT,
-    fetchPolicy: 'cache-and-network',
+    fetchPolicy: props.LoggedInUser?.canEditCollective(props.collective) ? 'cache-and-network' : 'cache-only',
     variables: getUpdatesVariables(props),
   }),
   props: ({ data }) => ({

--- a/components/UpdatesWithData.js
+++ b/components/UpdatesWithData.js
@@ -90,7 +90,7 @@ class UpdatesWithData extends React.Component {
   }
 }
 
-const updatesQuery = gqlV2/* GraphQL */ `
+export const updatesQuery = gqlV2/* GraphQL */ `
   query Updates(
     $collectiveSlug: String!
     $limit: Int
@@ -139,12 +139,11 @@ const getUpdatesVariables = props => {
   };
 };
 
-const UPDATES_PER_PAGE = 10;
+export const UPDATES_PER_PAGE = 10;
 
 export const addUpdatesData = graphql(updatesQuery, {
   options: props => ({
     context: API_V2_CONTEXT,
-    fetchPolicy: props.LoggedInUser?.canEditCollective(props.collective) ? 'cache-and-network' : 'cache-only',
     variables: getUpdatesVariables(props),
   }),
   props: ({ data }) => ({

--- a/components/collective-page/sections/Updates.js
+++ b/components/collective-page/sections/Updates.js
@@ -253,6 +253,7 @@ class SectionUpdates extends React.PureComponent {
 const addUpdatesSectionData = graphql(updatesSectionQuery, {
   options: props => ({
     variables: getUpdatesSectionQueryVariables(props.collective.slug, props.isAdmin),
+    fetchPolicy: 'cache-and-network',
   }),
 });
 

--- a/components/collective-page/sections/Updates.js
+++ b/components/collective-page/sections/Updates.js
@@ -253,7 +253,7 @@ class SectionUpdates extends React.PureComponent {
 const addUpdatesSectionData = graphql(updatesSectionQuery, {
   options: props => ({
     variables: getUpdatesSectionQueryVariables(props.collective.slug, props.isAdmin),
-    fetchPolicy: 'cache-and-network',
+    fetchPolicy: props.isAdmin ? 'cache-and-network' : 'cache-only',
   }),
 });
 

--- a/components/collective-page/sections/Updates.js
+++ b/components/collective-page/sections/Updates.js
@@ -253,7 +253,6 @@ class SectionUpdates extends React.PureComponent {
 const addUpdatesSectionData = graphql(updatesSectionQuery, {
   options: props => ({
     variables: getUpdatesSectionQueryVariables(props.collective.slug, props.isAdmin),
-    fetchPolicy: props.isAdmin ? 'cache-and-network' : 'cache-only',
   }),
 });
 

--- a/pages/createUpdate.js
+++ b/pages/createUpdate.js
@@ -24,7 +24,7 @@ import MessageBox from '../components/MessageBox';
 import StyledButton from '../components/StyledButton';
 import StyledButtonSet from '../components/StyledButtonSet';
 import { H1 } from '../components/Text';
-import { UPDATES_PER_PAGE, updatesQuery } from '../components/UpdatesWithData';
+import { getUpdatesVariables, UPDATES_PER_PAGE, updatesQuery } from '../components/UpdatesWithData';
 import { withUser } from '../components/UserProvider';
 
 const BackButtonWrapper = styled(Container)`
@@ -97,13 +97,7 @@ class CreateUpdatePage extends React.Component {
           {
             query: updatesQuery,
             context: API_V2_CONTEXT,
-            variables: {
-              collectiveSlug: this.props.slug,
-              offset: 0,
-              limit: UPDATES_PER_PAGE,
-              includeHostedCollectives: true,
-              orderBy: { field: 'CREATED_AT', direction: 'DESC' },
-            },
+            variables: getUpdatesVariables(this.props.slug, UPDATES_PER_PAGE, true),
           },
           { query: updatesSectionQuery, variables: getUpdatesSectionQueryVariables(this.props.slug, true) },
         ],

--- a/pages/createUpdate.js
+++ b/pages/createUpdate.js
@@ -12,6 +12,7 @@ import { compose } from '../lib/utils';
 
 import Body from '../components/Body';
 import CollectiveNavbar from '../components/collective-navbar';
+import { getUpdatesSectionQueryVariables, updatesSectionQuery } from '../components/collective-page/sections/Updates';
 import Container from '../components/Container';
 import EditUpdateForm from '../components/EditUpdateForm';
 import ErrorPage from '../components/ErrorPage';
@@ -23,6 +24,7 @@ import MessageBox from '../components/MessageBox';
 import StyledButton from '../components/StyledButton';
 import StyledButtonSet from '../components/StyledButtonSet';
 import { H1 } from '../components/Text';
+import { UPDATES_PER_PAGE, updatesQuery } from '../components/UpdatesWithData';
 import { withUser } from '../components/UserProvider';
 
 const BackButtonWrapper = styled(Container)`
@@ -89,7 +91,23 @@ class CreateUpdatePage extends React.Component {
       if (update.isChangelog) {
         update.isPrivate = false;
       }
-      const res = await this.props.createUpdate({ variables: { update } });
+      const res = await this.props.createUpdate({
+        variables: { update },
+        refetchQueries: [
+          {
+            query: updatesQuery,
+            context: API_V2_CONTEXT,
+            variables: {
+              collectiveSlug: this.props.slug,
+              offset: 0,
+              limit: UPDATES_PER_PAGE,
+              includeHostedCollectives: true,
+              orderBy: { field: 'CREATED_AT', direction: 'DESC' },
+            },
+          },
+          { query: updatesSectionQuery, variables: getUpdatesSectionQueryVariables(this.props.slug, true) },
+        ],
+      });
       this.setState({ isModified: false });
       return this.props.router.push(`/${account.slug}/updates/${res.data.createUpdate.slug}`);
     } catch (e) {


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4482

![updates-cache](https://user-images.githubusercontent.com/12435965/126689785-0d759b49-2eea-4362-b3e3-bfee4ff390c4.gif)
