### PR TITLE
Add `ABOUT` Feature to Collective Tests

### DIFF
--- a/lib/__tests__/collective-sections.test.js
+++ b/lib/__tests__/collective-sections.test.js
@@ -140,6 +140,7 @@ describe('Collective sections', () => {
     });
     describe('For collective', () => {
       const features = {
+        ABOUT: 'ACTIVE',
         COLLECTIVE_GOALS: 'DISABLED',
         CONVERSATIONS: 'DISABLED',
         UPDATES: 'AVAILABLE',


### PR DESCRIPTION
This resolves a breaking of the CI with one of our recent commits. 🙂 

Related: https://github.com/opencollective/opencollective-frontend/pull/6685#issuecomment-888409668