### PR TITLE
CollectiveFeatures: Add id on the object

### DIFF
--- a/components/collective-page/graphql/fragments.js
+++ b/components/collective-page/graphql/fragments.js
@@ -53,6 +53,7 @@ export const contributorsFieldsFragment = gql`
  */
 export const collectiveNavbarFieldsFragment = gql`
   fragment NavbarFields on CollectiveFeatures {
+    id
     ABOUT
     CONNECTED_ACCOUNTS
     RECEIVE_FINANCIAL_CONTRIBUTIONS

--- a/components/collective-page/graphql/queries.js
+++ b/components/collective-page/graphql/queries.js
@@ -102,6 +102,7 @@ export const collectivePageQuery = gql`
           hostFeeSharePercent
         }
         features {
+          id
           VIRTUAL_CARDS
         }
       }

--- a/lib/graphql/schema.graphql
+++ b/lib/graphql/schema.graphql
@@ -337,9 +337,13 @@ input CollectiveAttributesInputType {
 }
 
 """
-Describes the features enabled and available for this collective
+Describes the features enabled and available for this account
 """
 type CollectiveFeatures {
+  """
+  The id of the account
+  """
+  id: String!
   RECEIVE_FINANCIAL_CONTRIBUTIONS: CollectiveFeatureStatus
   RECURRING_CONTRIBUTIONS: CollectiveFeatureStatus
   TRANSACTIONS: CollectiveFeatureStatus

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -231,7 +231,7 @@ interface Account {
   ): UpdateCollection!
 
   """
-  Describes the features enabled and available for this collective
+  Describes the features enabled and available for this account
   """
   features: CollectiveFeatures!
   virtualCards(
@@ -779,7 +779,7 @@ type Bot implements Account {
   ): UpdateCollection!
 
   """
-  Describes the features enabled and available for this collective
+  Describes the features enabled and available for this account
   """
   features: CollectiveFeatures!
   virtualCards(
@@ -1039,7 +1039,7 @@ type Collective implements Account & AccountWithHost & AccountWithContributions 
   ): UpdateCollection!
 
   """
-  Describes the features enabled and available for this collective
+  Describes the features enabled and available for this account
   """
   features: CollectiveFeatures!
   virtualCards(
@@ -1139,9 +1139,13 @@ input CollectiveCreateInput {
 }
 
 """
-Describes the features enabled and available for this collective
+Describes the features enabled and available for this account
 """
 type CollectiveFeatures {
+  """
+  The id of the account
+  """
+  id: String!
   RECEIVE_FINANCIAL_CONTRIBUTIONS: CollectiveFeatureStatus
   RECURRING_CONTRIBUTIONS: CollectiveFeatureStatus
   TRANSACTIONS: CollectiveFeatureStatus
@@ -3281,7 +3285,7 @@ type Event implements Account & AccountWithHost & AccountWithContributions {
   ): UpdateCollection!
 
   """
-  Describes the features enabled and available for this collective
+  Describes the features enabled and available for this account
   """
   features: CollectiveFeatures!
   virtualCards(
@@ -4232,7 +4236,7 @@ type Fund implements Account & AccountWithHost & AccountWithContributions {
   ): UpdateCollection!
 
   """
-  Describes the features enabled and available for this collective
+  Describes the features enabled and available for this account
   """
   features: CollectiveFeatures!
   virtualCards(
@@ -4569,7 +4573,7 @@ type Host implements Account & AccountWithContributions {
   ): UpdateCollection!
 
   """
-  Describes the features enabled and available for this collective
+  Describes the features enabled and available for this account
   """
   features: CollectiveFeatures!
   virtualCards(
@@ -5133,7 +5137,7 @@ type Individual implements Account {
   ): UpdateCollection!
 
   """
-  Describes the features enabled and available for this collective
+  Describes the features enabled and available for this account
   """
   features: CollectiveFeatures!
   virtualCards(
@@ -6551,7 +6555,7 @@ type Organization implements Account & AccountWithContributions {
   ): UpdateCollection!
 
   """
-  Describes the features enabled and available for this collective
+  Describes the features enabled and available for this account
   """
   features: CollectiveFeatures!
   virtualCards(
@@ -7088,7 +7092,7 @@ type Project implements Account & AccountWithHost & AccountWithContributions {
   ): UpdateCollection!
 
   """
-  Describes the features enabled and available for this collective
+  Describes the features enabled and available for this account
   """
   features: CollectiveFeatures!
   virtualCards(
@@ -8254,7 +8258,7 @@ type Vendor implements Account & AccountWithHost & AccountWithContributions {
   ): UpdateCollection!
 
   """
-  Describes the features enabled and available for this collective
+  Describes the features enabled and available for this account
   """
   features: CollectiveFeatures!
   virtualCards(


### PR DESCRIPTION
Fixes an issue introduced with https://github.com/opencollective/opencollective-frontend/pull/6682
Require https://github.com/opencollective/opencollective-api/pull/6368

```
Warning: fragment with name NavbarFields already exists.
graphql-tag enforces all fragment names across your application to be unique; read more about
this in the docs: http://dev.apollodata.com/core/fragments.html#unique-names
Cache data may be lost when replacing the features field of a Organization object.

To address this problem (which is not a bug in Apollo Client), either ensure all objects of type CollectiveFeatures have an ID or a custom merge function, or define a custom merge function for the Organization.features field, so InMemoryCache can safely merge these objects:

  existing: {"__typename":"CollectiveFeatures","VIRTUAL_CARDS":"DISABLED"}
  incoming: {"__typename":"CollectiveFeatures","ABOUT":"ACTIVE","CONNECTED_ACCOUNTS":"AVAILABLE","RECEIVE_FINANCIAL_CONTRIBUTIONS":"ACTIVE","RECURRING_CONTRIBUTIONS":"AVAILABLE","EVENTS":"AVAILABLE","PROJECTS":"UNSUPPORTED","USE_EXPENSES":"ACTIVE","RECEIVE_EXPENSES":"AVAILABLE","COLLECTIVE_GOALS":"DISABLED","TOP_FINANCIAL_CONTRIBUTORS":"ACTIVE","CONVERSATIONS":"AVAILABLE","UPDATES":"ACTIVE","TEAM":"ACTIVE","CONTACT_FORM":"ACTIVE","RECEIVE_HOST_APPLICATIONS":"ACTIVE","HOST_DASHBOARD":"ACTIVE","TRANSACTIONS":"ACTIVE","REQUEST_VIRTUAL_CARDS":"DISABLED"}

For more information about these options, please refer to the documentation:

  * Ensuring entity objects have IDs: https://go.apollo.dev/c/generating-unique-identifiers
  * Defining custom merge functions: https://go.apollo.dev/c/merging-non-normalized-objects
```