### PR TITLE
Some Corrections to Proptypes to Avoid Warnings

### DIFF
--- a/components/Avatar.js
+++ b/components/Avatar.js
@@ -73,7 +73,7 @@ Avatar.propTypes = {
   /** Collective image url */
   src: PropTypes.string,
   /** Collective type */
-  type: PropTypes.oneOf(['USER', 'COLLECTIVE', 'FUND', 'ORGANIZATION', 'CHAPTER', 'ANONYMOUS', 'VENDOR']),
+  type: PropTypes.oneOf(Object.keys(CollectiveType)),
   /** Avatar size */
   radius: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array]),
   /** Duration to transition size. Disabled if 0, null or undefined */
@@ -112,7 +112,7 @@ ContributorAvatar.propTypes = {
     collectiveSlug: PropTypes.string,
     isIncognito: PropTypes.bool,
     isGuest: PropTypes.bool,
-    type: PropTypes.oneOf(['USER', 'COLLECTIVE', 'EVENT', 'FUND', 'ORGANIZATION', 'CHAPTER', 'ANONYMOUS']),
+    type: PropTypes.oneOf(Object.keys(CollectiveType)),
   }).isRequired,
   radius: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array]),
 };

--- a/components/Avatar.js
+++ b/components/Avatar.js
@@ -112,7 +112,7 @@ ContributorAvatar.propTypes = {
     collectiveSlug: PropTypes.string,
     isIncognito: PropTypes.bool,
     isGuest: PropTypes.bool,
-    type: PropTypes.oneOf(['USER', 'COLLECTIVE', 'FUND', 'ORGANIZATION', 'CHAPTER', 'ANONYMOUS']),
+    type: PropTypes.oneOf(['USER', 'COLLECTIVE', 'EVENT', 'FUND', 'ORGANIZATION', 'CHAPTER', 'ANONYMOUS']),
   }).isRequired,
   radius: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array]),
 };

--- a/components/ContributorCard.js
+++ b/components/ContributorCard.js
@@ -4,6 +4,7 @@ import { truncate } from 'lodash';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import styled, { css } from 'styled-components';
 
+import { CollectiveType } from '../lib/constants/collectives';
 import roles from '../lib/constants/roles';
 import formatMemberRole from '../lib/i18n/member-role';
 
@@ -188,7 +189,7 @@ ContributorCard.propTypes = {
     description: PropTypes.string,
     collectiveSlug: PropTypes.string,
     isIncognito: PropTypes.bool,
-    type: PropTypes.oneOf(['USER', 'COLLECTIVE', 'ORGANIZATION', 'EVENT', 'FUND', 'CHAPTER', 'ANONYMOUS']),
+    type: PropTypes.oneOf(Object.keys(CollectiveType)),
     totalAmountDonated: PropTypes.number,
     image: PropTypes.string,
     publicMessage: PropTypes.string,

--- a/components/ContributorCard.js
+++ b/components/ContributorCard.js
@@ -188,7 +188,7 @@ ContributorCard.propTypes = {
     description: PropTypes.string,
     collectiveSlug: PropTypes.string,
     isIncognito: PropTypes.bool,
-    type: PropTypes.oneOf(['USER', 'COLLECTIVE', 'ORGANIZATION', 'FUND', 'CHAPTER', 'ANONYMOUS']),
+    type: PropTypes.oneOf(['USER', 'COLLECTIVE', 'ORGANIZATION', 'EVENT', 'FUND', 'CHAPTER', 'ANONYMOUS']),
     totalAmountDonated: PropTypes.number,
     image: PropTypes.string,
     publicMessage: PropTypes.string,


### PR DESCRIPTION
I observed the following two warnings when going in to a collective page; 

```
Warning: Failed prop type: Invalid prop `contributor.type` of value `EVENT` supplied to `ContributorAvatar`, expected one of ["USER","COLLECTIVE","FUND","ORGANIZATION","CHAPTER","ANONYMOUS"].

```
```
Warning: Failed prop type: Invalid prop `contributor.type` of value `EVENT` supplied to `ContributorCard`, expected one of ["USER","COLLECTIVE","FUND","ORGANIZATION","CHAPTER","ANONYMOUS"].
```

This PR fixes them. 😄 