### PR TITLE
Make the Close Icon Consistent Across Modals

### DIFF
--- a/components/NewsAndUpdatesModal.js
+++ b/components/NewsAndUpdatesModal.js
@@ -17,17 +17,11 @@ import MessageBox from './MessageBox';
 import StyledButton from './StyledButton';
 import StyledCarousel from './StyledCarousel';
 import StyledLink from './StyledLink';
-import Modal, { CloseIcon, ModalBody, ModalFooter, ModalHeader } from './StyledModal';
+import Modal, { ModalBody, ModalFooter, ModalHeader } from './StyledModal';
 import { P, Span } from './Text';
 
 const ModalHeaderWrapper = styled(ModalHeader)`
   height: 58px;
-  ${CloseIcon} {
-    margin-top: 30px;
-    height: 12px;
-    width: 12px;
-    color: #76777a;
-  }
 `;
 
 const ModalWrapper = styled(Modal)`

--- a/components/StyledModal.js
+++ b/components/StyledModal.js
@@ -13,7 +13,7 @@ import Avatar from './Avatar';
 import Container from './Container';
 import { Flex } from './Grid';
 import { fadeIn } from './StyledKeyframes';
-import { P } from './Text';
+import { P, Span } from './Text';
 
 const Wrapper = styled(Flex)`
   position: fixed;
@@ -108,17 +108,21 @@ const Divider = styled.div`
 `;
 
 export const CloseIcon = styled(Times)`
-  font-size: 12px;
-  width: 15px;
-  height: 15px;
-  color: #dadada;
+  height: 12px;
+  width: 12px;
+  color: #76777a;
+  vertical-align: middle;
   cursor: pointer;
 `;
 
 export const ModalHeader = ({ children, onClose, hideCloseIcon, ...props }) => (
   <Header {...props}>
     {children || <div />}
-    {!hideCloseIcon && <CloseIcon onClick={onClose} />}
+    {!hideCloseIcon && (
+      <Span style={{ alignItems: 'center', display: 'flex' }}>
+        <CloseIcon onClick={onClose} />
+      </Span>
+    )}
   </Header>
 );
 


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4440

![close-icon-consistency](https://user-images.githubusercontent.com/12435965/127704830-157fd46e-e337-4a38-9605-016d1856c147.gif)
