### PR TITLE
enhancement(StepDetails): improve tip presets for free tiers

### DIFF
--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -199,7 +199,7 @@ const StepDetails = ({ onChange, data, collective, tier, showFeesOnTop, router }
           <StyledHr borderColor="black.300" mt={16} mb={32} />
         </React.Fragment>
       )}
-      {showFeesOnTop && (
+      {showFeesOnTop && data?.amount > 0 && (
         <Box mt={28}>
           <FeesOnTopInput
             currency={currency}


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/4508

# Description

- [X] If `tier.amount` is 0 and the amount is fixed, do not offer to add a tip.
- [X] If it's a free tier but with a flexible amount (ie. you can freely donate to the collective), we should hide the tip whenever you select 0 and show it you select a positive amount

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots

<img width="688" alt="Screenshot 2021-08-03 at 3 38 04 PM" src="https://user-images.githubusercontent.com/46647141/127999572-3a61bb1f-07bd-4ee4-85b2-80f1c4fc13c2.png">

# 

![free-tip](https://user-images.githubusercontent.com/46647141/127999633-d2d888a9-0216-4f45-951f-2e9d0c24d2d4.gif)

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
