### PR TITLE
Wise: Use required fields API v1.1

### DIFF
--- a/components/expenses/PayoutBankInformationForm.js
+++ b/components/expenses/PayoutBankInformationForm.js
@@ -120,6 +120,33 @@ const Input = props => {
         </Field>
       </Box>
     );
+  } else if (input.type === 'date') {
+    return (
+      <Box key={input.key} mt={2} flex="1">
+        <Field name={fieldName} validate={validate}>
+          {({ field, meta }) => (
+            <StyledInputField
+              label={input.name}
+              labelFontSize="13px"
+              required={input.required}
+              error={(meta.touched || disabled) && meta.error}
+              hint={input.hint}
+            >
+              {() => (
+                <StyledInput
+                  {...field}
+                  type="date"
+                  error={(meta.touched || disabled) && meta.error}
+                  disabled={disabled}
+                  width="100%"
+                  value={get(formik.values, field.name) || ''}
+                />
+              )}
+            </StyledInputField>
+          )}
+        </Field>
+      </Box>
+    );
   } else if (input.type === 'radio' || input.type === 'select') {
     const options = formatTransferWiseSelectOptions(input.valuesAllowed || []);
     return (

--- a/components/expenses/PayoutBankInformationForm.js
+++ b/components/expenses/PayoutBankInformationForm.js
@@ -30,22 +30,6 @@ export const msg = defineMessages({
   },
 });
 
-const accountHolderFieldOptions = {
-  name: 'Account Holder Name',
-  group: [
-    {
-      required: true,
-      key: 'accountHolderName',
-      name: 'Account Holder Name',
-      type: 'text',
-      example: 'Jane Doe',
-      hint: 'Full name, no abbreviations and without titles.',
-      validationRegexp: '^[^!@#$%&*+]+$',
-      validationError: 'Special characters are not allowed. (!@#$%&*+)',
-    },
-  ],
-};
-
 const requiredFieldsQuery = gqlV2/* GraphQL */ `
   query PayoutBankInformationRequiredFields($slug: String, $currency: String!, $accountDetails: JSON) {
     host(slug: $slug) {
@@ -292,21 +276,6 @@ const DetailsForm = ({ disabled, getFieldName, formik, host, currency }) => {
           <FormattedMessage id="PayoutBankInformationForm.AccountInfo" defaultMessage="Account Information" />
         </P>
       </Box>
-      {
-        // Displays the account holder field only if the other fields are also loaded
-        Boolean(availableMethods?.fields.length) && (
-          <FieldGroup
-            currency={currency}
-            disabled={disabled}
-            field={accountHolderFieldOptions}
-            formik={formik}
-            getFieldName={getFieldName}
-            host={host}
-            key={kebabCase(accountHolderFieldOptions.name)}
-            refetch={refetch}
-          />
-        )
-      }
       {otherFields.map(field => (
         <FieldGroup
           currency={currency}


### PR DESCRIPTION
Requires https://github.com/opencollective/opencollective-api/pull/6395

Refact PayoutBankInformationForm to support "date" fields and removes the local account holder name info in favor of the one returned by the required fields v1.1 endpoint.