### PR TITLE
Switch to next integrated source-maps

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,11 +1,11 @@
 require('./env');
 
-const withSourceMaps = require('@zeit/next-source-maps')();
 const { REWRITES } = require('./rewrites');
 
 const nextConfig = {
   webpack5: true,
   useFileSystemPublicRoutes: process.env.IS_VERCEL === 'true',
+  productionBrowserSourceMaps: true,
   webpack: (config, { webpack, isServer, buildId }) => {
     config.plugins.push(
       // Ignore __tests__
@@ -151,4 +151,4 @@ const nextConfig = {
   },
 };
 
-module.exports = withSourceMaps(nextConfig);
+module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -22326,11 +22326,6 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
-    "@zeit/next-source-maps": {
-      "version": "0.0.4-canary.1",
-      "resolved": "https://registry.npmjs.org/@zeit/next-source-maps/-/next-source-maps-0.0.4-canary.1.tgz",
-      "integrity": "sha512-SPQCLs7ToaqzQnqXqGSCoL7KTlnOAao+1F5hy7Hkuq85TjHsUC3eeLsmVrBIraIhXG/ARHmZ0JHOesPDtBfpzw=="
-    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@styled-system/prop-types": "5.1.5",
     "@styled-system/theme-get": "5.1.2",
     "@transferwise/approve-api-action-helpers": "^0.9.0",
-    "@zeit/next-source-maps": "0.0.4-canary.1",
     "accepts": "1.3.7",
     "bluebird": "3.7.2",
     "canvas-confetti": "1.4.0",


### PR DESCRIPTION
`@zeit/next-source-maps` is discontinued and this is now the recommended configuration. 