### PR TITLE
Downgrade to webpack 5 due to `next/images` not loading properly

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,7 @@ const { REWRITES } = require('./rewrites');
 
 const nextConfig = {
   eslint: { ignoreDuringBuilds: true },
-  webpack5: true,
+  webpack5: false,
   useFileSystemPublicRoutes: process.env.IS_VERCEL === 'true',
   productionBrowserSourceMaps: true,
   webpack: (config, { webpack, isServer, buildId }) => {


### PR DESCRIPTION
This was observed after upgrading to web-pack 5. It seems that some `next/image`s are not loading properly. Thus we decided to move back to web-pack 4 for now until this is solved. 🤔 

![image](https://user-images.githubusercontent.com/12435965/128217335-bafae31d-8693-467b-90ac-96429361b818.png)

Relevant Slack Discussion: https://opencollective.slack.com/archives/C0RMV6F8C/p1628019237036000