### PR TITLE
enhancement: improve apply to host flow

### DIFF
--- a/components/ApplyToHostBtn.js
+++ b/components/ApplyToHostBtn.js
@@ -15,6 +15,7 @@ class ApplyToHostBtn extends React.Component {
     buttonProps: PropTypes.object,
     buttonRenderer: PropTypes.func,
     router: PropTypes.object,
+    isHidden: PropTypes.bool,
   };
 
   constructor(props) {
@@ -47,7 +48,7 @@ class ApplyToHostBtn extends React.Component {
 
     if (buttonRenderer) {
       return buttonRenderer({
-        onClick: () => this.showApplyToHostModal(router, hostSlug),
+        onClick: () => router.push(`${hostSlug}/apply`),
         'data-cy': 'host-apply-btn',
         ...buttonProps,
         children: (
@@ -78,13 +79,15 @@ class ApplyToHostBtn extends React.Component {
   }
 
   render() {
-    const { hostSlug, router } = this.props;
+    const { hostSlug, router, isHidden } = this.props;
 
     return (
       <Fragment>
         {this.renderButton()}
 
-        {this.state.showModal && <ApplyToHostModal hostSlug={hostSlug} onClose={() => router.push(hostSlug)} />}
+        {this.state.showModal && !isHidden && (
+          <ApplyToHostModal hostSlug={hostSlug} onClose={() => router.push(hostSlug)} />
+        )}
       </Fragment>
     );
   }

--- a/components/ApplyToHostBtn.js
+++ b/components/ApplyToHostBtn.js
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { CheckCircle } from '@styled-icons/boxicons-regular/CheckCircle';
+import { withRouter } from 'next/router';
 import { FormattedMessage } from 'react-intl';
 
 import ApplyToHostModal from './ApplyToHostModal';
@@ -13,6 +14,7 @@ class ApplyToHostBtn extends React.Component {
     withoutIcon: PropTypes.bool,
     buttonProps: PropTypes.object,
     buttonRenderer: PropTypes.func,
+    router: PropTypes.object,
   };
 
   constructor(props) {
@@ -20,12 +22,25 @@ class ApplyToHostBtn extends React.Component {
     this.state = { showModal: false };
   }
 
+  componentDidMount() {
+    const { router } = this.props;
+
+    if (router.query.action === 'apply') {
+      this.setState({ showModal: true });
+    }
+  }
+
+  showApplyToHostModal(router, slug) {
+    router.push(`${slug}/apply`);
+    return this.setState({ showModal: true });
+  }
+
   renderButton() {
-    const { buttonRenderer, withoutIcon, buttonProps, minWidth } = this.props;
+    const { buttonRenderer, withoutIcon, buttonProps, minWidth, hostSlug, router } = this.props;
 
     if (buttonRenderer) {
       return buttonRenderer({
-        onClick: () => this.setState({ showModal: true }),
+        onClick: () => this.showApplyToHostModal(router, hostSlug),
         'data-cy': 'host-apply-btn',
         ...buttonProps,
         children: (
@@ -44,7 +59,7 @@ class ApplyToHostBtn extends React.Component {
       <StyledButton
         buttonStyle="secondary"
         buttonSize="small"
-        onClick={() => this.setState({ showModal: true })}
+        onClick={() => this.showApplyToHostModal(router, hostSlug)}
         minWidth={minWidth}
         data-cy="host-apply-btn"
         {...buttonProps}
@@ -70,4 +85,4 @@ class ApplyToHostBtn extends React.Component {
   }
 }
 
-export default ApplyToHostBtn;
+export default withRouter(ApplyToHostBtn);

--- a/components/ApplyToHostBtn.js
+++ b/components/ApplyToHostBtn.js
@@ -36,11 +36,10 @@ class ApplyToHostBtn extends React.Component {
     if (router.query.action !== 'apply' && prevProps.router.query.action === 'apply') {
       this.setState({ showModal: false });
     }
-  }
 
-  async showApplyToHostModal(router, slug) {
-    await router.push(`${slug}/apply`);
-    return this.setState({ showModal: true });
+    if (router.query.action === 'apply' && prevProps.router.query.action !== 'apply') {
+      this.setState({ showModal: true });
+    }
   }
 
   renderButton() {
@@ -67,7 +66,7 @@ class ApplyToHostBtn extends React.Component {
       <StyledButton
         buttonStyle="secondary"
         buttonSize="small"
-        onClick={() => this.showApplyToHostModal(router, hostSlug)}
+        onClick={() => router.push(`${hostSlug}/apply`)}
         minWidth={minWidth}
         data-cy="host-apply-btn"
         {...buttonProps}
@@ -85,15 +84,7 @@ class ApplyToHostBtn extends React.Component {
       <Fragment>
         {this.renderButton()}
 
-        {this.state.showModal && (
-          <ApplyToHostModal
-            hostSlug={hostSlug}
-            onClose={() => {
-              router.push(hostSlug);
-              this.setState({ showModal: false });
-            }}
-          />
-        )}
+        {this.state.showModal && <ApplyToHostModal hostSlug={hostSlug} onClose={() => router.push(hostSlug)} />}
       </Fragment>
     );
   }

--- a/components/ApplyToHostBtn.js
+++ b/components/ApplyToHostBtn.js
@@ -30,8 +30,16 @@ class ApplyToHostBtn extends React.Component {
     }
   }
 
-  showApplyToHostModal(router, slug) {
-    router.push(`${slug}/apply`);
+  componentDidUpdate(prevProps) {
+    const { router } = this.props;
+
+    if (router.query.action !== 'apply' && prevProps.router.query.action === 'apply') {
+      this.setState({ showModal: false });
+    }
+  }
+
+  async showApplyToHostModal(router, slug) {
+    await router.push(`${slug}/apply`);
     return this.setState({ showModal: true });
   }
 

--- a/components/ApplyToHostBtn.js
+++ b/components/ApplyToHostBtn.js
@@ -71,14 +71,20 @@ class ApplyToHostBtn extends React.Component {
   }
 
   render() {
-    const { hostSlug } = this.props;
+    const { hostSlug, router } = this.props;
 
     return (
       <Fragment>
         {this.renderButton()}
 
         {this.state.showModal && (
-          <ApplyToHostModal hostSlug={hostSlug} onClose={() => this.setState({ showModal: false })} />
+          <ApplyToHostModal
+            hostSlug={hostSlug}
+            onClose={() => {
+              router.push(hostSlug);
+              this.setState({ showModal: false });
+            }}
+          />
         )}
       </Fragment>
     );

--- a/components/ApplyToHostModal.js
+++ b/components/ApplyToHostModal.js
@@ -341,7 +341,7 @@ const ApplyToHostModal = ({ hostSlug, collective, onClose, onSuccess, router, ..
                               creatable
                               renderNewCollectiveOption={() => (
                                 <Link
-                                  href={isOCFHost ? `/foundation/apply/intro` : `/${host.slug}/apply`}
+                                  href={isOCFHost ? `/foundation/apply/intro` : `/${host.slug}/apply-new`}
                                   data-cy="host-apply-new-collective-link"
                                 >
                                   <StyledButton borderRadius="14px" width="100%">

--- a/components/ApplyToHostModal.js
+++ b/components/ApplyToHostModal.js
@@ -341,7 +341,7 @@ const ApplyToHostModal = ({ hostSlug, collective, onClose, onSuccess, router, ..
                               creatable
                               renderNewCollectiveOption={() => (
                                 <Link
-                                  href={isOCFHost ? `/foundation/apply/intro` : `/${host.slug}/apply-new`}
+                                  href={isOCFHost ? `/foundation/apply/intro` : `/${host.slug}/create`}
                                   data-cy="host-apply-new-collective-link"
                                 >
                                   <StyledButton borderRadius="14px" width="100%">

--- a/components/collective-navbar/ActionsMenu.js
+++ b/components/collective-navbar/ActionsMenu.js
@@ -303,6 +303,7 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction, hiddenActionFo
                       <MenuItem py={1} isHiddenOnMobile={hiddenActionForNonMobile === NAVBAR_ACTION_TYPE.APPLY}>
                         <ApplyToHostBtn
                           hostSlug={collective.slug}
+                          isHidden={hiddenActionForNonMobile === NAVBAR_ACTION_TYPE.APPLY}
                           buttonProps={{ isBorderless: true, p: ITEM_PADDING }}
                         />
                       </MenuItem>

--- a/components/create-collective/ConnectGithub.js
+++ b/components/create-collective/ConnectGithub.js
@@ -112,7 +112,7 @@ class ConnectGithub extends React.Component {
                 defaultMessage="Want to apply using {altverification}? {applylink}."
                 values={{
                   applylink: (
-                    <Link href={{ pathname: `/opensource/apply-new/form`, query: { hostTos: true } }}>
+                    <Link href={{ pathname: `/opensource/create/form`, query: { hostTos: true } }}>
                       <FormattedMessage id="clickHere" defaultMessage="Click here" />
                     </Link>
                   ),

--- a/components/create-collective/ConnectGithub.js
+++ b/components/create-collective/ConnectGithub.js
@@ -112,7 +112,7 @@ class ConnectGithub extends React.Component {
                 defaultMessage="Want to apply using {altverification}? {applylink}."
                 values={{
                   applylink: (
-                    <Link href={{ pathname: `/opensource/apply/form`, query: { hostTos: true } }}>
+                    <Link href={{ pathname: `/opensource/apply-new/form`, query: { hostTos: true } }}>
                       <FormattedMessage id="clickHere" defaultMessage="Click here" />
                     </Link>
                   ),

--- a/components/create-collective/CreateOpenSourceCollective.js
+++ b/components/create-collective/CreateOpenSourceCollective.js
@@ -162,7 +162,7 @@ const CreateOpenSourceCollective = () => {
               />
             </StyledButton>
             <Link
-              href={{ pathname: `/opensource/apply/form`, query: { hostTos: true } }}
+              href={{ pathname: `/opensource/apply-new/form`, query: { hostTos: true } }}
               onClick={e => {
                 if (!checked) {
                   e.preventDefault();

--- a/components/create-collective/CreateOpenSourceCollective.js
+++ b/components/create-collective/CreateOpenSourceCollective.js
@@ -162,7 +162,7 @@ const CreateOpenSourceCollective = () => {
               />
             </StyledButton>
             <Link
-              href={{ pathname: `/opensource/apply-new/form`, query: { hostTos: true } }}
+              href={{ pathname: `/opensource/create/form`, query: { hostTos: true } }}
               onClick={e => {
                 if (!checked) {
                   e.preventDefault();

--- a/pages/collective-page.js
+++ b/pages/collective-page.js
@@ -19,6 +19,8 @@ import OnboardingModal from '../components/onboarding-modal/OnboardingModal';
 import Page from '../components/Page';
 import { withUser } from '../components/UserProvider';
 
+import Custom404 from './404';
+
 /** A page rendered when collective is pledged and not active yet */
 const PledgedCollectivePage = dynamic(
   () => import(/* webpackChunkName: 'PledgedCollectivePage' */ '../components/PledgedCollectivePage'),
@@ -52,7 +54,7 @@ const GlobalStyles = createGlobalStyle`
  * to render `components/collective-page` with everything needed.
  */
 class CollectivePage extends React.Component {
-  static async getInitialProps({ client, req, res, query: { slug, status, step, mode } }) {
+  static async getInitialProps({ client, req, res, query: { slug, status, step, mode, action } }) {
     if (res && req && (req.language || req.locale === 'en')) {
       res.set('Cache-Control', 'public, s-maxage=300');
     }
@@ -65,7 +67,7 @@ class CollectivePage extends React.Component {
       skipDataFromTree = true;
     }
 
-    return { slug, status, step, mode, skipDataFromTree };
+    return { slug, status, step, mode, skipDataFromTree, action };
   }
 
   static propTypes = {
@@ -80,6 +82,7 @@ class CollectivePage extends React.Component {
     ]),
     step: PropTypes.string,
     mode: PropTypes.string,
+    action: PropTypes.string,
     LoggedInUser: PropTypes.object, // from withUser
     data: PropTypes.shape({
       loading: PropTypes.bool,
@@ -157,7 +160,7 @@ class CollectivePage extends React.Component {
   }
 
   render() {
-    const { slug, data, LoggedInUser, status, step, mode } = this.props;
+    const { slug, data, LoggedInUser, status, step, mode, action } = this.props;
     const { showOnboardingModal } = this.state;
 
     const loading = data.loading && !data.Collective;
@@ -177,6 +180,11 @@ class CollectivePage extends React.Component {
     }
 
     const collective = data && data.Collective;
+
+    // Don't allow /collective/apply
+    if (action === 'apply' && !collective.isHost) {
+      return <Custom404 />;
+    }
 
     return (
       <Page canonicalURL={this.getCanonicalURL(slug)} {...this.getPageMetaData(collective)}>

--- a/pages/collective-page.js
+++ b/pages/collective-page.js
@@ -182,7 +182,7 @@ class CollectivePage extends React.Component {
     const collective = data && data.Collective;
 
     // Don't allow /collective/apply
-    if (action === 'apply' && !collective.isHost) {
+    if (action === 'apply' && !collective?.isHost) {
       return <Custom404 />;
     }
 

--- a/rewrites.js
+++ b/rewrites.js
@@ -15,7 +15,7 @@ exports.REWRITES = [
     destination: '/staticPage',
   },
   {
-    source: '/foundation/apply/:step(intro|fees|form|success)?',
+    source: '/foundation/apply/:step(intro|fees|form|success)',
     destination: '/ocf-host-application',
   },
   {
@@ -167,7 +167,7 @@ exports.REWRITES = [
   // New Create Collective Flow
   {
     source:
-      '/:hostCollectiveSlug?/:verb(apply|create)/:version(v2)?/:category(opensource|community|climate|covid-19)?/:step(form)?',
+      '/:hostCollectiveSlug?/:verb(apply-new|create)/:version(v2)?/:category(opensource|community|climate|covid-19)?/:step(form)?',
     destination: '/create-collective',
   },
   // Events and Projects using collective page
@@ -318,7 +318,7 @@ exports.REWRITES = [
     destination: '/collective-page',
   },
   {
-    source: '/:slug/:mode(onboarding)?/:step(administrators|contact-info|success)?',
+    source: '/:slug/:action(apply)?/:mode(onboarding)?/:step(administrators|contact-info|success)?',
     destination: '/collective-page',
   },
 ];

--- a/rewrites.js
+++ b/rewrites.js
@@ -167,7 +167,7 @@ exports.REWRITES = [
   // New Create Collective Flow
   {
     source:
-      '/:hostCollectiveSlug?/:verb(apply-new|create)/:version(v2)?/:category(opensource|community|climate|covid-19)?/:step(form)?',
+      '/:hostCollectiveSlug?/:verb(create)/:version(v2)?/:category(opensource|community|climate|covid-19)?/:step(form)?',
     destination: '/create-collective',
   },
   // Events and Projects using collective page


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/4278

# Description

- Change the URL of the "Apply with a new Collective" flow and move it from https://opencollective.com/opensource/apply to https://opencollective.com/opensource/apply/new 

- Now that https://opencollective.com/opensource/apply is free, change its behavior and simply display the Collective Page with the "Apply" modal opened.
<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Demo

https://user-images.githubusercontent.com/46647141/128299404-cd099bba-a6fa-476a-b296-31e5799b23bd.mp4







<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
