### PR TITLE
Make sure GitHub is spelled correctly in Hero.js

### DIFF
--- a/components/collective-page/hero/Hero.js
+++ b/components/collective-page/hero/Hero.js
@@ -198,7 +198,7 @@ const Hero = ({ collective, host, isAdmin, onPrimaryColorChange }) => {
                 )}
                 {collective.githubHandle && (
                   <StyledLink data-cy="githubProfileUrl" href={githubProfileUrl(collective.githubHandle)} openInNewTab>
-                    <StyledRoundButton size={32} mr={3} title="Github" aria-label="Github link">
+                    <StyledRoundButton size={32} mr={3} title="GitHub" aria-label="GitHub link">
                       <Github size={12} />
                     </StyledRoundButton>
                   </StyledLink>


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/pull/4539. 

This was mentioned in the above PR, so I thought we need to fix this before it's completely forgotten. 😉 