### PR TITLE
Add Projects Creation Button to Projects Page

### DIFF
--- a/pages/contribute.js
+++ b/pages/contribute.js
@@ -280,6 +280,13 @@ class TiersPage extends React.Component {
                           </StyledButton>
                         </Link>
                       )}
+                      {LoggedInUser?.canEditCollective(collective) && verb === 'projects' && (
+                        <Link href={`/${collective.slug}/projects/new`}>
+                          <StyledButton buttonStyle="primary">
+                            <FormattedMessage id="SectionProjects.CreateProject" defaultMessage="Create Project" />
+                          </StyledButton>
+                        </Link>
+                      )}
                     </Flex>
                     {subtitle && (
                       <P color="black.700" mt={3}>


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4543

![projects-button](https://user-images.githubusercontent.com/12435965/129146616-07449573-3ad2-4342-8c5b-8fd796d8ef96.gif)
