### PR TITLE
Footer: Fix invalid prop warning on image

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -261,7 +261,6 @@ const Footer = () => {
                 alt="Open Collective logo"
                 height={28}
                 width={167}
-                style={{ maxWidth: '100%' }}
               />
             </Flex>
             <P


### PR DESCRIPTION
Warning was probably introduced in the latest NextJS update