### PR TITLE
Make the button outlines in the actions menu consistent

### DIFF
--- a/components/collective-navbar/ActionsMenu.js
+++ b/components/collective-navbar/ActionsMenu.js
@@ -279,7 +279,13 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction, hiddenActionFo
                       <AddFundsBtn collective={collective} host={collective.host}>
                         {btnProps => (
                           <MenuItem py={1} isHiddenOnMobile={hiddenActionForNonMobile === NAVBAR_ACTION_TYPE.ADD_FUNDS}>
-                            <StyledButton p={ITEM_PADDING} isBorderless {...btnProps} data-cy="add-funds-btn">
+                            <StyledButton
+                              borderRadius={0}
+                              p={ITEM_PADDING}
+                              isBorderless
+                              {...btnProps}
+                              data-cy="add-funds-btn"
+                            >
                               <AttachMoney size="20px" />
                               <Span>
                                 <FormattedMessage id="menu.addFunds" defaultMessage="Add Funds" />
@@ -315,7 +321,7 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction, hiddenActionFo
                             py={1}
                             isHiddenOnMobile={hiddenActionForNonMobile === NAVBAR_ACTION_TYPE.ASSIGN_CARD}
                           >
-                            <StyledButton p={ITEM_PADDING} isBorderless {...btnProps}>
+                            <StyledButton borderRadius={0} p={ITEM_PADDING} isBorderless {...btnProps}>
                               <CreditCard size="20px" />
                               <Span>
                                 <FormattedMessage id="menu.assignCard" defaultMessage="Assign a Card" />
@@ -332,7 +338,7 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction, hiddenActionFo
                             py={1}
                             isHiddenOnMobile={hiddenActionForNonMobile === NAVBAR_ACTION_TYPE.ASSIGN_CARD}
                           >
-                            <StyledButton p={ITEM_PADDING} isBorderless {...btnProps}>
+                            <StyledButton borderRadius={0} p={ITEM_PADDING} isBorderless {...btnProps}>
                               <CreditCard size="20px" />
                               <Span>
                                 <FormattedMessage


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4553

![button-outline-fix](https://user-images.githubusercontent.com/12435965/129789351-24f41a20-1e41-49ee-bcae-de7ecdb364a4.gif)
