### PR TITLE
Continue migration of payment method types Step 2

### DIFF
--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -299,15 +299,15 @@ class ContributionFlow extends React.Component {
       // TODO: cleanup after this version is deployed in production
 
       // Migration Step 1
-      type: stepPayment.paymentMethod.providerType,
+      // type: stepPayment.paymentMethod.providerType,
+      // legacyType: stepPayment.paymentMethod.providerType,
+      // service: stepPayment.paymentMethod.service,
+      // newType: stepPayment.paymentMethod.type,
+
+      // Migration Step 2
       legacyType: stepPayment.paymentMethod.providerType,
       service: stepPayment.paymentMethod.service,
       newType: stepPayment.paymentMethod.type,
-
-      // Migration Step 2
-      // legacyType: stepPayment.paymentMethod.providerType,
-      // service: stepPayment.paymentMethod.service,
-      // type: stepPayment.paymentMethod.type,
 
       // Migration Step 3
       // service: stepPayment.paymentMethod.service,


### PR DESCRIPTION
Simply stop sending `type`, this is necessary so we can change its type on the API.