### PR TITLE
Trying to fix the flakiness of rich text editor related testing

### DIFF
--- a/test/cypress/integration/17-conversations.test.js
+++ b/test/cypress/integration/17-conversations.test.js
@@ -37,8 +37,12 @@ describe('Conversations', () => {
       // Conversation page
       cy.contains('Hello World 👋');
       cy.getByDataCy('comment-body').should(
-        'have.html',
-        '<div>Hello from <a href="https://opencollective.com/opencollective">https://opencollective.com/opencollective</a> 👋👋👋<br>Lorem ipsum dolor sit amet, consectetur adipiscing elit. De hominibus dici non necesse est. Immo alio genere; Si longus, levis; Quicquid enim a sapientia proficiscitur, id continuo debet expletum esse omnibus suis partibus.</div>',
+        'contain.html',
+        '<div>Hello from <a href="https://opencollective.com/opencollective">https://opencollective.com/opencollective</a> 👋👋👋',
+      );
+      cy.getByDataCy('comment-body').should(
+        'contain.text',
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. De hominibus dici non necesse est. Immo alio genere; Si longus, levis; Quicquid enim a sapientia proficiscitur, id continuo debet expletum esse omnibus suis partibus.',
       );
 
       // Edit tags


### PR DESCRIPTION
Related to the discussion at https://opencollective.slack.com/archives/C0RMV6F8C/p1629806469130300

Now in this one, I am doing the html validation in two parts for the rich text editor, one to see if the url is parsed properly and then the content is correctly embedded in the generated html. I think for some reason when the Trix editor is interacting with Cypress it seems to add some additional elements. Rather than trying to do an exact html validation I think validating that the url is correctly passed and the content is correctly added is sufficient in my opinion. Because the point of the test is `Creates the conversation then redirects to the conversation page`. Let me know if you think otherwise. 😄 