### PR TITLE
Rename Button in Deposit Address Section in Crypto flow to `Finish` Instead of `Contribute`

### DIFF
--- a/components/contribution-flow/ContributionFlowButtons.js
+++ b/components/contribution-flow/ContributionFlowButtons.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
 import Currency from '../Currency';
-import FormattedMoneyAmount from '../FormattedMoneyAmount';
 import { Box, Flex } from '../Grid';
 import PayWithPaypalButton from '../PayWithPaypalButton';
 import StyledButton from '../StyledButton';
@@ -87,21 +86,14 @@ class ContributionFlowButtons extends React.Component {
                   )}{' '}
                   &rarr;
                 </React.Fragment>
+              ) : isCrypto ? (
+                <FormattedMessage id="Finish" defaultMessage="Finish" />
               ) : totalAmount ? (
                 <FormattedMessage
                   id="contribute.amount"
                   defaultMessage="Contribute {amount}"
                   values={{
-                    amount: isCrypto ? (
-                      <FormattedMoneyAmount
-                        amount={totalAmount}
-                        currency={currency}
-                        amountStyles={{ fontWeight: 500 }}
-                        isCrypto={isCrypto}
-                      />
-                    ) : (
-                      <Currency value={totalAmount} currency={currency} precision="auto" />
-                    ),
+                    amount: <Currency value={totalAmount} currency={currency} precision="auto" />,
                   }}
                 />
               ) : (


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4594

![image](https://user-images.githubusercontent.com/12435965/131154306-62da9c23-79dc-483d-99f0-4cef39d66aec.png)
