### PR TITLE
Remove support for unexisting Payout Method Type

### DIFF
--- a/components/expenses/PayoutMethodTypeWithIcon.js
+++ b/components/expenses/PayoutMethodTypeWithIcon.js
@@ -31,15 +31,6 @@ const PayoutMethodTypeWithIcon = ({ isLoading, type, fontSize, fontWeight, color
           </Span>
         </Flex>
       );
-    case PayoutMethodType.CREDIT_CARD:
-      return (
-        <Flex alignItems="center">
-          <CreditCard size={iconSize} color="#9D9FA3" />
-          <Span ml={2} fontWeight={fontWeight} fontSize={fontSize} color={color}>
-            <FormattedMessage id="CreditCard" defaultMessage="Credit Card" />
-          </Span>
-        </Flex>
-      );
     case PayoutMethodType.BANK_ACCOUNT:
       return (
         <Flex alignItems="center">


### PR DESCRIPTION
Expenses without attached Payout Method would appear as "Credit Card".

<img width="848" alt="Screenshot 2021-08-31 at 15 33 30" src="https://user-images.githubusercontent.com/806/131511840-682b9f74-2dc8-498f-b219-2304d4192b98.png">
