### PR TITLE
Correct the close icon positioning in the onboarding modal

### DIFF
--- a/components/onboarding-modal/OnboardingModal.js
+++ b/components/onboarding-modal/OnboardingModal.js
@@ -15,7 +15,7 @@ import { compose } from '../../lib/utils';
 import Container from '../../components/Container';
 import MessageBox from '../../components/MessageBox';
 import StyledButton from '../../components/StyledButton';
-import Modal, { ModalBody, ModalFooter, ModalHeader, ModalOverlay } from '../../components/StyledModal';
+import Modal, { CloseIcon, ModalBody, ModalFooter, ModalHeader, ModalOverlay } from '../../components/StyledModal';
 import { H1, P } from '../../components/Text';
 
 import { Box, Flex } from '../Grid';
@@ -59,6 +59,9 @@ const ResponsiveModalHeader = styled(ModalHeader)`
     svg {
       display: none;
     }
+  }
+  ${CloseIcon} {
+    margin-top: -100px;
   }
 `;
 


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4614

![close-icon-alignment](https://user-images.githubusercontent.com/12435965/131735712-661c6f1e-fec5-4a74-a21c-b26b8f8779d0.gif)
