### PR TITLE
Rewrites: Fix typo in event expense page URL

### DIFF
--- a/rewrites.js
+++ b/rewrites.js
@@ -140,7 +140,7 @@ exports.REWRITES = [
   },
   {
     source:
-      '/:parentCollectiveSlug?/:collectiveType(evenExpenseAdminActionsts|projects)?/:collectiveSlug/expenses/:ExpenseId([0-9]+)/:version(v2)?',
+      '/:parentCollectiveSlug?/:collectiveType(events|projects)?/:collectiveSlug/expenses/:ExpenseId([0-9]+)/:version(v2)?',
     destination: '/expense',
   },
   {


### PR DESCRIPTION
Introduced in https://github.com/opencollective/opencollective-frontend/pull/5855

Not a big deal since we don't really link there at this time (see https://github.com/opencollective/opencollective/issues/4587), but it's still nice to keep supporting it. 