### PR TITLE
Correct the Intermittent Failure on the Conversations related E2E Test

### DIFF
--- a/test/cypress/integration/17-conversations.test.js
+++ b/test/cypress/integration/17-conversations.test.js
@@ -70,7 +70,12 @@ describe('Conversations', () => {
       );
       cy.getByDataCy('conversation-preview').should(
         'contain.text',
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. De hominibus dici non necesse est. Immo alio genere; Si longus, lev...',
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. De hominibus dici non necesse est. Immo alio genere; Si longus, lev',
+      );
+      cy.getByDataCy('conversation-preview').should('contain.text', '...');
+      cy.getByDataCy('conversation-preview').should(
+        'not.contain.text',
+        'Quicquid enim a sapientia proficiscitur, id continuo debet expletum esse omnibus suis partibus.',
       );
     });
   });


### PR DESCRIPTION
This was reported at https://github.com/opencollective/opencollective-frontend/pull/6805#issuecomment-911654758

Something we've overlooked here is that due to the [spacing problem](https://github.com/opencollective/opencollective-frontend/pull/6780#issuecomment-908276047) the text can contain `lev...` or `levi...`. In this PR I've tried to tackle this by checking for parts of the string separately. 