### PR TITLE
RecurringContributionCard: No react component in title

### DIFF
--- a/components/recurring-contributions/RecurringContributionsCard.js
+++ b/components/recurring-contributions/RecurringContributionsCard.js
@@ -100,12 +100,7 @@ const RecurringContributionsCard = ({
                   >
                     {getPaymentMethodName(contribution.paymentMethod)}
                   </P>
-                  <P
-                    fontSize="11px"
-                    color="black.700"
-                    truncateOverflow
-                    title={getPaymentMethodMetadata(contribution.paymentMethod)}
-                  >
+                  <P fontSize="11px" color="black.700" truncateOverflow>
                     {getPaymentMethodMetadata(contribution.paymentMethod)}
                   </P>
                 </Flex>


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/4624
Thanks @SudharakaP for reporting this

`getPaymentMethodMetadata` returns react components, so we can't use this for `title`.