### PR TITLE
Fix transactions kind filter

### DIFF
--- a/components/collective-page/sections/Budget.js
+++ b/components/collective-page/sections/Budget.js
@@ -5,7 +5,6 @@ import { get, orderBy } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import styled, { css } from 'styled-components';
 
-import { TransactionKind } from '../../../lib/constants/transactions';
 import { API_V2_CONTEXT, gqlV2 } from '../../../lib/graphql/helpers';
 
 import { DebitItem } from '../../budget/DebitCreditList';
@@ -19,6 +18,7 @@ import LoadingPlaceholder from '../../LoadingPlaceholder';
 import StyledCard from '../../StyledCard';
 import StyledFilters from '../../StyledFilters';
 import { P } from '../../Text';
+import { getDefaultKinds } from '../../transactions/filters/TransactionsKindFilter';
 import { transactionsQueryCollectionFragment } from '../../transactions/graphql/fragments';
 import TransactionItem from '../../transactions/TransactionItem';
 import { withUser } from '../../UserProvider';
@@ -46,16 +46,9 @@ export const budgetSectionWithHostQuery = gqlV2/* GraphQL */ `
   ${expenseHostFields}
 `;
 
-const DEFAULT_KINDS = [
-  TransactionKind.ADDED_FUNDS,
-  TransactionKind.CONTRIBUTION,
-  TransactionKind.EXPENSE,
-  TransactionKind.PLATFORM_TIP,
-];
-
 // Any change here should be reflected in API's `server/graphql/cache.js`
 export const getBudgetSectionQueryVariables = (collectiveSlug, hostSlug) => {
-  return { slug: collectiveSlug, hostSlug, limit: 3, kind: DEFAULT_KINDS };
+  return { slug: collectiveSlug, hostSlug, limit: 3, kind: getDefaultKinds() };
 };
 
 const BudgetItemContainer = styled.div`

--- a/components/collective-page/sections/Transactions.js
+++ b/components/collective-page/sections/Transactions.js
@@ -12,6 +12,7 @@ import MessageBox from '../../MessageBox';
 import StyledButton from '../../StyledButton';
 import StyledFilters from '../../StyledFilters';
 import StyledLinkButton from '../../StyledLinkButton';
+import { getDefaultKinds } from '../../transactions/filters/TransactionsKindFilter';
 import { transactionsQueryCollectionFragment } from '../../transactions/graphql/fragments';
 import TransactionsList from '../../transactions/TransactionsList';
 import { Dimensions } from '../_constants';
@@ -37,8 +38,14 @@ const I18nFilters = defineMessages({
 });
 
 export const transactionsSectionQuery = gqlV2/* GraphQL */ `
-  query TransactionsSection($slug: String!, $limit: Int!, $hasOrder: Boolean, $hasExpense: Boolean) {
-    transactions(account: { slug: $slug }, limit: $limit, hasOrder: $hasOrder, hasExpense: $hasExpense) {
+  query TransactionsSection(
+    $slug: String!
+    $limit: Int!
+    $hasOrder: Boolean
+    $hasExpense: Boolean
+    $kind: [TransactionKind]
+  ) {
+    transactions(account: { slug: $slug }, limit: $limit, hasOrder: $hasOrder, hasExpense: $hasExpense, kind: $kind) {
       ...TransactionsQueryCollectionFragment
     }
   }
@@ -46,7 +53,7 @@ export const transactionsSectionQuery = gqlV2/* GraphQL */ `
 `;
 
 export const getTransactionsSectionQueryVariables = slug => {
-  return { slug, limit: NB_DISPLAYED };
+  return { slug, limit: NB_DISPLAYED, kind: getDefaultKinds() };
 };
 
 const SectionTransactions = props => {

--- a/components/transactions/filters/TransactionsKindFilter.js
+++ b/components/transactions/filters/TransactionsKindFilter.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { omit, size } from 'lodash';
+import { intersection, omit, size } from 'lodash';
 import { useIntl } from 'react-intl';
 import { components as ReactSelectComponents } from 'react-select';
 import styled from 'styled-components';
@@ -83,7 +83,7 @@ const TransactionsKindFilter = ({ onChange, value, kinds, ...props }) => {
   const displayedKinds = kinds || Object.values(DISPLAYED_TRANSACTION_KINDS);
   const options = displayedKinds.map(getOption);
   const selectedOptions = React.useMemo(
-    () => (!value ? getDefaultKinds() : parseTransactionKinds(value)).map(getOption),
+    () => (!value ? intersection(getDefaultKinds(), displayedKinds) : parseTransactionKinds(value)).map(getOption),
     [value],
   );
   return (


### PR DESCRIPTION
- Use getDefaultKinds where it makes sense
- Display the intersection of existingKinds and getDefaultKinds by default in the filter
