### PR TITLE
refact(ExpenseFormPayeeSignUpStep): add async slug validation

### DIFF
--- a/components/expenses/ExpenseFormPayeeSignUpStep.js
+++ b/components/expenses/ExpenseFormPayeeSignUpStep.js
@@ -135,7 +135,7 @@ const throttledSearch = debounce((searchFunc, variables) => {
 const ExpenseFormPayeeSignUpStep = ({ formik, collective, onCancel, onNext }) => {
   const intl = useIntl();
   const { formatMessage } = intl;
-  const { values, errors } = formik;
+  const { values, touched, errors } = formik;
   const stepOneCompleted =
     isEmpty(flattenObjectDeep(validatePayoutMethod(values.payoutMethod))) &&
     (values.type === expenseTypes.RECEIPT ||
@@ -153,7 +153,7 @@ const ExpenseFormPayeeSignUpStep = ({ formik, collective, onCancel, onNext }) =>
   };
 
   React.useEffect(() => {
-    if (values.payee?.organization?.name) {
+    if (values.payee?.organization?.name && !touched.payee?.organization?.slug) {
       const slug = suggestSlug(values.payee.organization.name);
       if (values.payee.organization.slug !== slug) {
         formik.setFieldValue('payee.organization.slug', suggestSlug(values.payee.organization.name));

--- a/components/expenses/ExpenseFormPayeeSignUpStep.js
+++ b/components/expenses/ExpenseFormPayeeSignUpStep.js
@@ -1,8 +1,9 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
+import { useLazyQuery } from '@apollo/client';
 import themeGet from '@styled-system/theme-get';
 import { FastField, Field } from 'formik';
-import { isEmpty, omit, pick } from 'lodash';
+import { debounce, isEmpty, omit, pick } from 'lodash';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import styled from 'styled-components';
 
@@ -10,6 +11,7 @@ import { suggestSlug } from '../../lib/collective.lib';
 import expenseTypes from '../../lib/constants/expenseTypes';
 import { ERROR, isErrorType } from '../../lib/errors';
 import { formatFormErrorMessage } from '../../lib/form-utils';
+import { API_V2_CONTEXT, gqlV2 } from '../../lib/graphql/helpers';
 import { flattenObjectDeep } from '../../lib/utils';
 
 import { Box, Flex, Grid } from '../Grid';
@@ -29,6 +31,15 @@ import PayoutMethodForm, { validatePayoutMethod } from './PayoutMethodForm';
 import PayoutMethodSelect from './PayoutMethodSelect';
 
 const EMPTY_ARRAY = [];
+
+const validateSlugQuery = gqlV2/* GraphQL */ `
+  query ValidateSlugQuery($slug: String) {
+    account(slug: $slug, throwIfMissing: false) {
+      id
+      slug
+    }
+  }
+`;
 
 const msg = defineMessages({
   nameLabel: {
@@ -50,6 +61,10 @@ const msg = defineMessages({
   orgSlugLabel: {
     id: 'createCollective.form.slugLabel',
     defaultMessage: 'Set your URL',
+  },
+  orgSlugErrorTaken: {
+    id: 'createCollective.form.error.slug.taken',
+    defaultMessage: 'URL already taken',
   },
   orgWebsiteLabel: {
     id: 'createOrg.form.websiteLabel',
@@ -113,6 +128,10 @@ const RadioOptionContainer = styled.label`
   }
 `;
 
+const throttledSearch = debounce((searchFunc, variables) => {
+  return searchFunc({ variables });
+}, 750);
+
 const ExpenseFormPayeeSignUpStep = ({ formik, collective, onCancel, onNext }) => {
   const intl = useIntl();
   const { formatMessage } = intl;
@@ -124,6 +143,10 @@ const ExpenseFormPayeeSignUpStep = ({ formik, collective, onCancel, onNext }) =>
 
   const setPayoutMethod = React.useCallback(({ value }) => formik.setFieldValue('payoutMethod', value), []);
   const [payeeType, setPayeeType] = React.useState(PAYEE_TYPE.USER);
+  const [validateSlug, { data: existingSlugAccount }] = useLazyQuery(validateSlugQuery, {
+    context: API_V2_CONTEXT,
+  });
+
   const changePayeeType = e => {
     e.stopPropagation();
     setPayeeType(e.target.value);
@@ -131,7 +154,10 @@ const ExpenseFormPayeeSignUpStep = ({ formik, collective, onCancel, onNext }) =>
 
   React.useEffect(() => {
     if (values.payee?.organization?.name) {
-      formik.setFieldValue('payee.organization.slug', suggestSlug(values.payee.organization.name));
+      const slug = suggestSlug(values.payee.organization.name);
+      if (values.payee.organization.slug !== slug) {
+        formik.setFieldValue('payee.organization.slug', suggestSlug(values.payee.organization.name));
+      }
     }
   }, [values.payee?.organization?.name]);
   React.useEffect(() => {
@@ -139,6 +165,18 @@ const ExpenseFormPayeeSignUpStep = ({ formik, collective, onCancel, onNext }) =>
       formik.setFieldValue('payee', omit(values.payee, ['organization']));
     }
   }, [payeeType]);
+  // Slug Validation
+  React.useEffect(() => {
+    if (values.payee?.organization?.slug) {
+      throttledSearch(validateSlug, { slug: values.payee.organization.slug });
+    }
+  }, [values.payee?.organization?.slug]);
+
+  const handleSlugValidation = async value => {
+    if (value === existingSlugAccount?.account?.slug) {
+      return formatMessage(msg.orgSlugErrorTaken);
+    }
+  };
 
   return (
     <Fragment>
@@ -185,9 +223,15 @@ const ExpenseFormPayeeSignUpStep = ({ formik, collective, onCancel, onNext }) =>
                 </StyledInputField>
               )}
             </Field>
-            <Field name="payee.organization.slug">
+            <Field name="payee.organization.slug" validate={handleSlugValidation}>
               {({ field }) => (
-                <StyledInputField name={field.name} label={formatMessage(msg.orgSlugLabel)} labelFontSize="13px" mt={3}>
+                <StyledInputField
+                  mt={3}
+                  labelFontSize="13px"
+                  error={errors.payee?.organization?.slug}
+                  name={field.name}
+                  label={formatMessage(msg.orgSlugLabel)}
+                >
                   {inputProps => <StyledInputGroup {...inputProps} {...field} prepend="opencollective.com/" />}
                 </StyledInputField>
               )}

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -584,6 +584,7 @@
   "createCollective.form.error.name": "Please use fewer than 50 characters",
   "createCollective.form.error.slug": "Please use fewer than 30 characters",
   "createCollective.form.error.slug.hyphen": "Collective slug URL cannot start or end with a hyphen",
+  "createCollective.form.error.slug.taken": "URL already taken",
   "createCollective.form.nameLabel": "Collective name",
   "createCollective.form.slugLabel": "Set your URL",
   "createCollective.form.suggestedLabel": "Suggested",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -584,6 +584,7 @@
   "createCollective.form.error.name": "Please use fewer than 50 characters",
   "createCollective.form.error.slug": "Please use fewer than 30 characters",
   "createCollective.form.error.slug.hyphen": "Collective slug URL cannot start or end with a hyphen",
+  "createCollective.form.error.slug.taken": "URL already taken",
   "createCollective.form.nameLabel": "Collective name",
   "createCollective.form.slugLabel": "Set your URL",
   "createCollective.form.suggestedLabel": "Navrhované",

--- a/lang/de.json
+++ b/lang/de.json
@@ -584,6 +584,7 @@
   "createCollective.form.error.name": "Bitte verwende weniger als 50 Zeichen",
   "createCollective.form.error.slug": "Bitte verwende weniger als 30 Zeichen",
   "createCollective.form.error.slug.hyphen": "Collective slug URL cannot start or end with a hyphen",
+  "createCollective.form.error.slug.taken": "URL already taken",
   "createCollective.form.nameLabel": "Collective name",
   "createCollective.form.slugLabel": "Set your URL",
   "createCollective.form.suggestedLabel": "Empfohlen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -584,6 +584,7 @@
   "createCollective.form.error.name": "Please use fewer than 50 characters",
   "createCollective.form.error.slug": "Please use fewer than 30 characters",
   "createCollective.form.error.slug.hyphen": "Collective slug URL cannot start or end with a hyphen",
+  "createCollective.form.error.slug.taken": "URL already taken",
   "createCollective.form.nameLabel": "Collective name",
   "createCollective.form.slugLabel": "Set your URL",
   "createCollective.form.suggestedLabel": "Suggested",

--- a/lang/es.json
+++ b/lang/es.json
@@ -584,6 +584,7 @@
   "createCollective.form.error.name": "Por favor, usa menos de 50 caracteres",
   "createCollective.form.error.slug": "Por favor, utiliza menos de 30 caracteres",
   "createCollective.form.error.slug.hyphen": "Collective slug URL cannot start or end with a hyphen",
+  "createCollective.form.error.slug.taken": "URL already taken",
   "createCollective.form.nameLabel": "Nombre del Colectivo",
   "createCollective.form.slugLabel": "Establece tu URL",
   "createCollective.form.suggestedLabel": "Sugerido",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -584,6 +584,7 @@
   "createCollective.form.error.name": "Veuillez utiliser moins de 50 caractères",
   "createCollective.form.error.slug": "Veuillez utiliser moins de 30 caractères",
   "createCollective.form.error.slug.hyphen": "Collective slug URL cannot start or end with a hyphen",
+  "createCollective.form.error.slug.taken": "URL already taken",
   "createCollective.form.nameLabel": "Collective name",
   "createCollective.form.slugLabel": "Set your URL",
   "createCollective.form.suggestedLabel": "Suggéré",

--- a/lang/it.json
+++ b/lang/it.json
@@ -584,6 +584,7 @@
   "createCollective.form.error.name": "Utilizza meno di 50 caratteri",
   "createCollective.form.error.slug": "Si prega di utilizzare meno di 30 caratteri",
   "createCollective.form.error.slug.hyphen": "Collective slug URL cannot start or end with a hyphen",
+  "createCollective.form.error.slug.taken": "URL already taken",
   "createCollective.form.nameLabel": "Collective name",
   "createCollective.form.slugLabel": "Set your URL",
   "createCollective.form.suggestedLabel": "Suggested",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -584,6 +584,7 @@
   "createCollective.form.error.name": "Please use fewer than 50 characters",
   "createCollective.form.error.slug": "Please use fewer than 30 characters",
   "createCollective.form.error.slug.hyphen": "Collective slug URL cannot start or end with a hyphen",
+  "createCollective.form.error.slug.taken": "URL already taken",
   "createCollective.form.nameLabel": "Collective name",
   "createCollective.form.slugLabel": "Set your URL",
   "createCollective.form.suggestedLabel": "提案",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -584,6 +584,7 @@
   "createCollective.form.error.name": "50자보다 적게 사용해주세요",
   "createCollective.form.error.slug": "30자보다 적게 사용해주세요",
   "createCollective.form.error.slug.hyphen": "Collective slug URL cannot start or end with a hyphen",
+  "createCollective.form.error.slug.taken": "URL already taken",
   "createCollective.form.nameLabel": "Collective name",
   "createCollective.form.slugLabel": "Set your URL",
   "createCollective.form.suggestedLabel": "제안됨",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -584,6 +584,7 @@
   "createCollective.form.error.name": "Please use fewer than 50 characters",
   "createCollective.form.error.slug": "Please use fewer than 30 characters",
   "createCollective.form.error.slug.hyphen": "Collective slug URL cannot start or end with a hyphen",
+  "createCollective.form.error.slug.taken": "URL already taken",
   "createCollective.form.nameLabel": "Collective name",
   "createCollective.form.slugLabel": "Set your URL",
   "createCollective.form.suggestedLabel": "Suggested",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -584,6 +584,7 @@
   "createCollective.form.error.name": "Por favor, use menos de 50 caracteres",
   "createCollective.form.error.slug": "Por favor, use menos de 30 caracteres",
   "createCollective.form.error.slug.hyphen": "A Slug URL do Coletivo não pode começar ou terminar com um hífen",
+  "createCollective.form.error.slug.taken": "URL already taken",
   "createCollective.form.nameLabel": "Nome do Coletivo",
   "createCollective.form.slugLabel": "Defina sua URL",
   "createCollective.form.suggestedLabel": "Sugerido",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -584,6 +584,7 @@
   "createCollective.form.error.name": "Por favor, não use mais do que 50 caracteres",
   "createCollective.form.error.slug": "Por favor, não use mais do que 30 caracteres",
   "createCollective.form.error.slug.hyphen": "Collective slug URL cannot start or end with a hyphen",
+  "createCollective.form.error.slug.taken": "URL already taken",
   "createCollective.form.nameLabel": "Collective name",
   "createCollective.form.slugLabel": "Set your URL",
   "createCollective.form.suggestedLabel": "Sugerido",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -584,6 +584,7 @@
   "createCollective.form.error.name": "Пожалуйста, используйте менее 50 символов",
   "createCollective.form.error.slug": "Пожалуйста, используйте менее 30 символов",
   "createCollective.form.error.slug.hyphen": "Collective slug URL cannot start or end with a hyphen",
+  "createCollective.form.error.slug.taken": "URL already taken",
   "createCollective.form.nameLabel": "Название коллектива",
   "createCollective.form.slugLabel": "Set your URL",
   "createCollective.form.suggestedLabel": "Рекомендуется",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -584,6 +584,7 @@
   "createCollective.form.error.name": "Введіть до 50 символів",
   "createCollective.form.error.slug": "Введіть до 30 символів",
   "createCollective.form.error.slug.hyphen": "Collective slug URL cannot start or end with a hyphen",
+  "createCollective.form.error.slug.taken": "URL already taken",
   "createCollective.form.nameLabel": "Назва Колективу",
   "createCollective.form.slugLabel": "Вкажіть вашу URL-адресу",
   "createCollective.form.suggestedLabel": "Пропоноване",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -584,6 +584,7 @@
   "createCollective.form.error.name": "请使用小于 50 个字符。",
   "createCollective.form.error.slug": "请使用小于 30 个字符。",
   "createCollective.form.error.slug.hyphen": "Collective slug URL cannot start or end with a hyphen",
+  "createCollective.form.error.slug.taken": "URL already taken",
   "createCollective.form.nameLabel": "Collective 名称",
   "createCollective.form.slugLabel": "设置您的 URL",
   "createCollective.form.suggestedLabel": "已建议",


### PR DESCRIPTION
Solves the issue of figuring out the organization name is already taken only when finishing submitting the expense as a guest.

Related to https://opencollective.freshdesk.com/a/tickets/34574

![deepin-screen-recorder_Select area_20210909144244](https://user-images.githubusercontent.com/2119706/132736127-0f34fda6-a3b2-44ea-8537-7d857f1e7f96.gif)
