### PR TITLE
Homepage: fix missing image

### DIFF
--- a/components/home/sections/WhatCanYouDo.js
+++ b/components/home/sections/WhatCanYouDo.js
@@ -150,7 +150,6 @@ const WhatCanYouDo = () => {
             height={350}
             src="/static/images/home/managemoney-illustration-lg.png"
             alt="Manage money"
-            display={['block', null, null, 'none']}
           />
         </Box>
         <Box width={[null, '224px', '274px', null, '408px']} textAlign="left" ml={[null, 4, 0, 5]}>


### PR DESCRIPTION
Supposedly broken in https://github.com/opencollective/opencollective-frontend/pull/6181/files#diff-bd58d8564835626dee9c2eb0d0f5a74a053f1e6599b3592de650ed55641881eeR155, but I haven't tried to confirm

![image](https://user-images.githubusercontent.com/1556356/132865090-b970bcad-19e1-4add-a8a9-a0d21edcf0b2.png)
