### PR TITLE
Prevent access to host metrics pages when not active

### DIFF
--- a/components/edit-collective/sections/HostMetrics.js
+++ b/components/edit-collective/sections/HostMetrics.js
@@ -9,6 +9,8 @@ import { API_V2_CONTEXT, gqlV2 } from '../../../lib/graphql/helpers';
 import Container from '../../Container';
 import { Box } from '../../Grid';
 import Loading from '../../Loading';
+import MessageBox from '../../MessageBox';
+import MessageBoxGraphqlError from '../../MessageBoxGraphqlError';
 import StyledCard from '../../StyledCard';
 import { P, Span } from '../../Text';
 import SettingsTitle from '../SettingsTitle';
@@ -20,6 +22,7 @@ const metricsQuery = gqlV2/* GraphQL */ `
       slug
       hostFeePercent
       platformFeePercent
+      isActive
       plan {
         id
         name
@@ -64,13 +67,21 @@ const metricsQuery = gqlV2/* GraphQL */ `
 `;
 
 const HostMetrics = props => {
-  const { loading, data } = useQuery(metricsQuery, {
+  const { loading, data, error } = useQuery(metricsQuery, {
     context: API_V2_CONTEXT,
     variables: { slug: props.collective.slug },
   });
 
   if (loading) {
     return <Loading />;
+  } else if (error) {
+    return <MessageBoxGraphqlError error={error} maxWidth={500} m="0 auto" />;
+  } else if (data.host && !data.host.isActive) {
+    return (
+      <MessageBox withIcon type="error" maxWidth={400} m="0 auto">
+        <FormattedMessage id="host.onlyActive" defaultMessage="This page is only available for active fiscal hosts" />
+      </MessageBox>
+    );
   }
 
   const displayHostFees = data.host.hostFeePercent || data.host.hostMetrics.hostFees.value ? true : false;

--- a/components/host-dashboard/HostDashboardReports.js
+++ b/components/host-dashboard/HostDashboardReports.js
@@ -9,6 +9,8 @@ import { API_V2_CONTEXT, gqlV2 } from '../../lib/graphql/helpers';
 import Container from '../Container';
 import { Box, Flex } from '../Grid';
 import Loading from '../Loading';
+import MessageBox from '../MessageBox';
+import MessageBoxGraphqlError from '../MessageBoxGraphqlError';
 import StyledCard from '../StyledCard';
 import StyledHr from '../StyledHr';
 import StyledTooltip from '../StyledTooltip';
@@ -26,6 +28,7 @@ const mainReportsQuery = gqlV2/* GraphQL */ `
       name
       currency
       isHost
+      isActive
       type
       hostFeePercent
       hostMetrics {
@@ -84,14 +87,21 @@ SectionTitle.propTypes = {
 };
 
 const HostDashboardReports = ({ hostSlug }) => {
-  // TODO: Use common data from this query with the hook below
-  const { data, loading } = useQuery(mainReportsQuery, { variables: { hostSlug }, context: API_V2_CONTEXT });
+  const { data, loading, error } = useQuery(mainReportsQuery, { variables: { hostSlug }, context: API_V2_CONTEXT });
   if (loading) {
     return <Loading />;
+  } else if (error) {
+    return <MessageBoxGraphqlError error={error} maxWidth={500} m="0 auto" />;
+  } else if (data.host && !data.host.isActive) {
+    return (
+      <MessageBox withIcon type="error" maxWidth={400} m="0 auto">
+        <FormattedMessage id="host.onlyActive" defaultMessage="This page is only available for active fiscal hosts" />
+      </MessageBox>
+    );
   }
+
   const currency = data?.host.currency;
   const hostMetrics = data?.host.hostMetrics;
-
   return (
     <Box maxWidth={800} m="0 auto" px={2}>
       <Flex alignItems="center" mb={24} flexWrap="wrap">

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1287,6 +1287,7 @@
   "Host.Metrics.PlatformTips.description": "Total Platform Tips collected since the first of the month.",
   "Host.Metrics.TotalMoneyManages": "Total Money Managed",
   "Host.Metrics.TotalMoneyManages.description": "Total amount held in your bank account for the Host and its Collectives.",
+  "host.onlyActive": "This page is only available for active fiscal hosts",
   "host.organization.create": "Create an Organization",
   "Host.Plan": "Pla d’amfitrió",
   "Host.Plan.AddedFunds.unlimited": "Unlimited added funds",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1287,6 +1287,7 @@
   "Host.Metrics.PlatformTips.description": "Total Platform Tips collected since the first of the month.",
   "Host.Metrics.TotalMoneyManages": "Total Money Managed",
   "Host.Metrics.TotalMoneyManages.description": "Total amount held in your bank account for the Host and its Collectives.",
+  "host.onlyActive": "This page is only available for active fiscal hosts",
   "host.organization.create": "Create an Organization",
   "Host.Plan": "Host Plan",
   "Host.Plan.AddedFunds.unlimited": "Unlimited added funds",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1287,6 +1287,7 @@
   "Host.Metrics.PlatformTips.description": "Total Platform Tips collected since the first of the month.",
   "Host.Metrics.TotalMoneyManages": "Total Money Managed",
   "Host.Metrics.TotalMoneyManages.description": "Total amount held in your bank account for the Host and its Collectives.",
+  "host.onlyActive": "This page is only available for active fiscal hosts",
   "host.organization.create": "Create an Organization",
   "Host.Plan": "Host Plan",
   "Host.Plan.AddedFunds.unlimited": "Unlimited added funds",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1287,6 +1287,7 @@
   "Host.Metrics.PlatformTips.description": "Total Platform Tips collected since the first of the month.",
   "Host.Metrics.TotalMoneyManages": "Total Money Managed",
   "Host.Metrics.TotalMoneyManages.description": "Total amount held in your bank account for the Host and its Collectives.",
+  "host.onlyActive": "This page is only available for active fiscal hosts",
   "host.organization.create": "Create an Organization",
   "Host.Plan": "Host Plan",
   "Host.Plan.AddedFunds.unlimited": "Unlimited added funds",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1287,6 +1287,7 @@
   "Host.Metrics.PlatformTips.description": "Total Platform Tips collected since the first of the month.",
   "Host.Metrics.TotalMoneyManages": "Total Money Managed",
   "Host.Metrics.TotalMoneyManages.description": "Total amount held in your bank account for the Host and its Collectives.",
+  "host.onlyActive": "This page is only available for active fiscal hosts",
   "host.organization.create": "Create an Organization",
   "Host.Plan": "Host Plan",
   "Host.Plan.AddedFunds.unlimited": "Unlimited added funds",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1287,6 +1287,7 @@
   "Host.Metrics.PlatformTips.description": "Total Platform Tips collected since the first of the month.",
   "Host.Metrics.TotalMoneyManages": "Total Money Managed",
   "Host.Metrics.TotalMoneyManages.description": "Total amount held in your bank account for the Host and its Collectives.",
+  "host.onlyActive": "This page is only available for active fiscal hosts",
   "host.organization.create": "Create an Organization",
   "Host.Plan": "Forfait d'hôte",
   "Host.Plan.AddedFunds.unlimited": "Fonds ajoutés illimités",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1287,6 +1287,7 @@
   "Host.Metrics.PlatformTips.description": "Total Platform Tips collected since the first of the month.",
   "Host.Metrics.TotalMoneyManages": "Total Money Managed",
   "Host.Metrics.TotalMoneyManages.description": "Total amount held in your bank account for the Host and its Collectives.",
+  "host.onlyActive": "This page is only available for active fiscal hosts",
   "host.organization.create": "Create an Organization",
   "Host.Plan": "Host Plan",
   "Host.Plan.AddedFunds.unlimited": "Unlimited added funds",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1287,6 +1287,7 @@
   "Host.Metrics.PlatformTips.description": "Total Platform Tips collected since the first of the month.",
   "Host.Metrics.TotalMoneyManages": "Total Money Managed",
   "Host.Metrics.TotalMoneyManages.description": "Total amount held in your bank account for the Host and its Collectives.",
+  "host.onlyActive": "This page is only available for active fiscal hosts",
   "host.organization.create": "Create an Organization",
   "Host.Plan": "Host Plan",
   "Host.Plan.AddedFunds.unlimited": "Unlimited added funds",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1287,6 +1287,7 @@
   "Host.Metrics.PlatformTips.description": "Total Platform Tips collected since the first of the month.",
   "Host.Metrics.TotalMoneyManages": "Total Money Managed",
   "Host.Metrics.TotalMoneyManages.description": "Total amount held in your bank account for the Host and its Collectives.",
+  "host.onlyActive": "This page is only available for active fiscal hosts",
   "host.organization.create": "Create an Organization",
   "Host.Plan": "호스트 플랜",
   "Host.Plan.AddedFunds.unlimited": "Unlimited added funds",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1287,6 +1287,7 @@
   "Host.Metrics.PlatformTips.description": "Total Platform Tips collected since the first of the month.",
   "Host.Metrics.TotalMoneyManages": "Total Money Managed",
   "Host.Metrics.TotalMoneyManages.description": "Total amount held in your bank account for the Host and its Collectives.",
+  "host.onlyActive": "This page is only available for active fiscal hosts",
   "host.organization.create": "Create an Organization",
   "Host.Plan": "Host Plan",
   "Host.Plan.AddedFunds.unlimited": "Unlimited added funds",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1287,6 +1287,7 @@
   "Host.Metrics.PlatformTips.description": "Gorjetas totais da plataforma coletadas desde o primeiro dia do mês.",
   "Host.Metrics.TotalMoneyManages": "Total de Dinheiro Gerenciado",
   "Host.Metrics.TotalMoneyManages.description": "Valor total mantido em sua conta bancária para o Host e seus Coletivos.",
+  "host.onlyActive": "This page is only available for active fiscal hosts",
   "host.organization.create": "Create an Organization",
   "Host.Plan": "Plano do Anfitrião",
   "Host.Plan.AddedFunds.unlimited": "Fundos adicionados ilimitados",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1287,6 +1287,7 @@
   "Host.Metrics.PlatformTips.description": "Total Platform Tips collected since the first of the month.",
   "Host.Metrics.TotalMoneyManages": "Total Money Managed",
   "Host.Metrics.TotalMoneyManages.description": "Total amount held in your bank account for the Host and its Collectives.",
+  "host.onlyActive": "This page is only available for active fiscal hosts",
   "host.organization.create": "Create an Organization",
   "Host.Plan": "Plano de Organização",
   "Host.Plan.AddedFunds.unlimited": "Fundos adicionados ilimitados",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1287,6 +1287,7 @@
   "Host.Metrics.PlatformTips.description": "Total Platform Tips collected since the first of the month.",
   "Host.Metrics.TotalMoneyManages": "Total Money Managed",
   "Host.Metrics.TotalMoneyManages.description": "Total amount held in your bank account for the Host and its Collectives.",
+  "host.onlyActive": "This page is only available for active fiscal hosts",
   "host.organization.create": "Create an Organization",
   "Host.Plan": "Host Plan",
   "Host.Plan.AddedFunds.unlimited": "Неограниченное количество добавленных средств",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -1287,6 +1287,7 @@
   "Host.Metrics.PlatformTips.description": "Total Platform Tips collected since the first of the month.",
   "Host.Metrics.TotalMoneyManages": "Всього отримано грошей",
   "Host.Metrics.TotalMoneyManages.description": "Total amount held in your bank account for the Host and its Collectives.",
+  "host.onlyActive": "This page is only available for active fiscal hosts",
   "host.organization.create": "Створити організацію",
   "Host.Plan": "Ціна скарбника",
   "Host.Plan.AddedFunds.unlimited": "Необмежене додавання коштів",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1287,6 +1287,7 @@
   "Host.Metrics.PlatformTips.description": "Total Platform Tips collected since the first of the month.",
   "Host.Metrics.TotalMoneyManages": "Total Money Managed",
   "Host.Metrics.TotalMoneyManages.description": "Total amount held in your bank account for the Host and its Collectives.",
+  "host.onlyActive": "This page is only available for active fiscal hosts",
   "host.organization.create": "创建组织",
   "Host.Plan": "托管计划",
   "Host.Plan.AddedFunds.unlimited": "Unlimited added funds",


### PR DESCRIPTION
Resolve https://sentry.io/organizations/open-collective/issues/2638657349

As per https://github.com/opencollective/opencollective-api/blob/15e2e1da9cc58325cceaf9aa5bcb31988dd3eaa4/server/models/Collective.js#L2981, host metrics are only available for active fiscal hosts. This PR prevents crashing on `/dashboard/reports` and `/edit/host-metrics` when the host is not active.

Also added error handling to both pages.

![image](https://user-images.githubusercontent.com/1556356/133599571-0ccadae0-5254-40dc-a53b-296bea98a273.png)
