### PR TITLE
Fix canContributeRecurring condition for cross-collective contributions

### DIFF
--- a/lib/collective.lib.js
+++ b/lib/collective.lib.js
@@ -8,6 +8,7 @@ import {
   OPENSOURCE_COLLECTIVE_ID,
 } from './constants/collectives';
 import { ProvidersWithRecurringPaymentSupport } from './constants/payment-methods';
+import MEMBER_ROLE from './constants/roles';
 
 /**
  * For a given host and/or a list of tags, returns the main tag for the category of the
@@ -157,9 +158,21 @@ export const getSuggestedTags = collective => {
 
 /** Checks if recurring contributions are allowed for the user for a given collective **/
 export const canContributeRecurring = (collective, user) => {
-  return (
-    collective.host.supportedPaymentMethods.some(paymentMethod =>
-      ProvidersWithRecurringPaymentSupport.includes(paymentMethod),
-    ) || user?.memberOf.some(member => member.collective?.host?.id === collective.host.legacyId)
+  // If the host has a a payment method that supports recurring payments (PayPal, Credit Card, etc.)
+  const paymentProviderSupportRecurring = pm => ProvidersWithRecurringPaymentSupport.includes(pm);
+  if (collective.host.supportedPaymentMethods.some(paymentProviderSupportRecurring)) {
+    return true;
+  }
+
+  // Otherwise the only other option to contribute recurring is if the user is an admin of another collective under the same host
+  const hostId = collective.host.legacyId;
+  const collectiveId = collective.legacyId;
+  return Boolean(
+    user?.memberOf.some(
+      member =>
+        member.collective?.host?.id === hostId && // Must be under the same host
+        member.collective.id !== collectiveId && // Must not be the same collective
+        member.role === MEMBER_ROLE.ADMIN,
+    ),
   );
 };


### PR DESCRIPTION
Implements the fix described in https://github.com/opencollective/opencollective/issues/4669#issuecomment-920799739

- Make sure `canContributeRecurring` only returns true for cross-collective contributions if there's **another** collective under the same host (we used to return true whenever the user was a member of the collective we were contributing to).
- Make sure we check the role, as users can only contribute with the profile when they're admins (being a `BACKER`, for example, does not allow you to do so)