### PR TITLE
Correct missed `e.g.` to `e.g,` refactoring

### DIFF
--- a/components/CreateCollectiveMiniForm.js
+++ b/components/CreateCollectiveMiniForm.js
@@ -100,7 +100,7 @@ const msg = defineMessages({
   },
   examples: {
     id: 'examples',
-    defaultMessage: 'e.g. {examples}',
+    defaultMessage: 'e.g., {examples}',
   },
 });
 


### PR DESCRIPTION
Related to https://opencollective.slack.com/archives/C0RMV6F8C/p1631797860084400; seems I've missed one translation here which was merged in the interim I think. 🤔 