### PR TITLE
Fixes & enhancements for period filter

### DIFF
--- a/components/budget/filters/PeriodFilter.js
+++ b/components/budget/filters/PeriodFilter.js
@@ -129,8 +129,9 @@ const TriggerContainer = styled(StyledButton)`
   }
 `;
 
-const PeriodFilter = ({ onChange, value, inputId, ...props }) => {
+const PeriodFilter = ({ onChange, value, inputId, minDate, ...props }) => {
   const [dateInterval, setDateInterval] = React.useState(() => getDefaultState(value));
+  const formattedMin = formatDate(minDate, true);
   const setDate = (type, date) => {
     setDateInterval(value => ({
       ...value,
@@ -171,6 +172,7 @@ const PeriodFilter = ({ onChange, value, inputId, ...props }) => {
                 lineHeight={1}
                 fontSize="13px"
                 defaultValue={formatDate(dateInterval.from, true)}
+                min={formattedMin}
                 onChange={e => setDate('from', e.target.value)}
               />
             )}
@@ -191,6 +193,7 @@ const PeriodFilter = ({ onChange, value, inputId, ...props }) => {
                 lineHeight={1}
                 fontSize="13px"
                 defaultValue={formatDate(dateInterval.to, true)}
+                min={formattedMin}
                 onChange={e => setDate('to', e.target.value)}
               />
             )}
@@ -228,6 +231,7 @@ PeriodFilter.propTypes = {
   onChange: PropTypes.func.isRequired,
   value: PropTypes.string,
   inputId: PropTypes.string,
+  minDate: PropTypes.string,
 };
 
 export default PeriodFilter;

--- a/components/budget/filters/PeriodFilter.js
+++ b/components/budget/filters/PeriodFilter.js
@@ -13,11 +13,24 @@ import StyledButton from '../../StyledButton';
 import StyledInput from '../../StyledInput';
 import StyledInputField from '../../StyledInputField';
 
-const normalizeDate = date => {
-  return new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+const normalizeDate = (date, isEndOfDay = false) => {
+  const resultDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  if (isEndOfDay) {
+    resultDate.setHours(23, 59, 59, 999);
+  }
+
+  return resultDate;
 };
 
-const formatDate = date => (!date ? '' : dayjs(date).format('YYYY-MM-DD'));
+const formatDate = (date, stripTime) => {
+  if (!date) {
+    return '';
+  } else if (stripTime) {
+    return dayjs(date).format('YYYY-MM-DD');
+  } else {
+    return dayjs(date).toISOString();
+  }
+};
 
 /**
  * Parse `strValue` and returns an array like [dateFrom, dateTo]. Each value in the array
@@ -36,7 +49,7 @@ export const getDateRangeFromPeriod = strValue => {
     return [dateAddFunc(now, -value), now];
   }
 
-  // New format (dateFrom-dateTo)
+  // New format (dateFrom→dateTo)
   const parsedValue = strValue?.match(/([^→]+)(→(.+))?/);
   if (parsedValue) {
     const parseDate = dateStr => (!dateStr || dateStr === 'all' ? undefined : new Date(dateStr));
@@ -119,7 +132,10 @@ const TriggerContainer = styled(StyledButton)`
 const PeriodFilter = ({ onChange, value, inputId, ...props }) => {
   const [dateInterval, setDateInterval] = React.useState(() => getDefaultState(value));
   const setDate = (type, date) => {
-    setDateInterval(value => ({ ...value, [type]: !date ? null : normalizeDate(new Date(date)) }));
+    setDateInterval(value => ({
+      ...value,
+      [type]: !date ? null : normalizeDate(new Date(date), type === 'to'),
+    }));
   };
 
   return (
@@ -154,7 +170,7 @@ const PeriodFilter = ({ onChange, value, inputId, ...props }) => {
                 closeOnSelect
                 lineHeight={1}
                 fontSize="13px"
-                defaultValue={formatDate(dateInterval.from)}
+                defaultValue={formatDate(dateInterval.from, true)}
                 onChange={e => setDate('from', e.target.value)}
               />
             )}
@@ -174,7 +190,7 @@ const PeriodFilter = ({ onChange, value, inputId, ...props }) => {
                 closeOnSelect
                 lineHeight={1}
                 fontSize="13px"
-                defaultValue={formatDate(dateInterval.to)}
+                defaultValue={formatDate(dateInterval.to, true)}
                 onChange={e => setDate('to', e.target.value)}
               />
             )}

--- a/components/budget/filters/PeriodFilter.js
+++ b/components/budget/filters/PeriodFilter.js
@@ -14,7 +14,7 @@ import StyledInput from '../../StyledInput';
 import StyledInputField from '../../StyledInputField';
 
 const normalizeDate = date => {
-  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  return new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
 };
 
 const formatDate = date => (!date ? '' : dayjs(date).format('YYYY-MM-DD'));

--- a/components/budget/filters/PeriodFilter.js
+++ b/components/budget/filters/PeriodFilter.js
@@ -134,15 +134,23 @@ const TriggerContainer = styled(StyledButton)`
   }
 `;
 
+const getNewInterval = (interval, changeField, newValue) => {
+  const newInterval = { ...interval };
+  newInterval[changeField] = normalizeDate(newValue, changeField === 'to');
+
+  // Reset interval in case fromDate is after toDate
+  if (newInterval.from && newInterval.to && newInterval.from > newInterval.to) {
+    const fieldToReset = changeField === 'from' ? 'to' : 'from';
+    newInterval[fieldToReset] = '';
+  }
+
+  return newInterval;
+};
+
 const PeriodFilter = ({ onChange, value, inputId, minDate, ...props }) => {
   const [dateInterval, setDateInterval] = React.useState(() => getDefaultState(value));
   const formattedMin = stripTime(minDate);
-  const setDate = (type, date) => {
-    setDateInterval(value => ({
-      ...value,
-      [type]: normalizeDate(date, type === 'to'),
-    }));
-  };
+  const setDate = (changeField, date) => setDateInterval(getNewInterval(dateInterval, changeField, date));
 
   return (
     <PopupMenu
@@ -176,7 +184,7 @@ const PeriodFilter = ({ onChange, value, inputId, minDate, ...props }) => {
                 closeOnSelect
                 lineHeight={1}
                 fontSize="13px"
-                defaultValue={stripTime(dateInterval.from)}
+                value={stripTime(dateInterval.from)}
                 min={formattedMin}
                 onChange={e => setDate('from', e.target.value)}
               />
@@ -197,8 +205,9 @@ const PeriodFilter = ({ onChange, value, inputId, minDate, ...props }) => {
                 closeOnSelect
                 lineHeight={1}
                 fontSize="13px"
-                defaultValue={stripTime(dateInterval.to)}
+                value={stripTime(dateInterval.to)}
                 min={formattedMin}
+                max={stripTime(new Date())}
                 onChange={e => setDate('to', e.target.value)}
               />
             )}

--- a/components/expenses/ExpensesFilters.js
+++ b/components/expenses/ExpensesFilters.js
@@ -55,7 +55,7 @@ const ExpensesFilters = ({ collective, filters, onChange }) => {
         <FilterLabel htmlFor="expenses-filter-period">
           <FormattedMessage id="Period" defaultMessage="Period" />
         </FilterLabel>
-        <PeriodFilter {...getFilterProps('period')} />
+        <PeriodFilter {...getFilterProps('period')} minDate={collective.createdAt} />
       </FilterContainer>
       <FilterContainer>
         <FilterLabel htmlFor="expenses-filter-amount">
@@ -78,6 +78,7 @@ ExpensesFilters.propTypes = {
   filters: PropTypes.object,
   collective: PropTypes.shape({
     currency: PropTypes.string.isRequired,
+    createdAt: PropTypes.string,
   }).isRequired,
 };
 

--- a/components/host-dashboard/HostDashboardExpenses.js
+++ b/components/host-dashboard/HostDashboardExpenses.js
@@ -76,6 +76,7 @@ const hostDashboardExpensesQuery = gqlV2/* GraphQL */ `
           id
           name
           slug
+          createdAt
           currency
           type
           stats {

--- a/components/transactions/TransactionsFilters.js
+++ b/components/transactions/TransactionsFilters.js
@@ -44,7 +44,7 @@ const TransactionsFilters = ({ collective, filters, kinds, onChange }) => {
         <FilterLabel htmlFor="transactions-filter-period">
           <FormattedMessage id="Period" defaultMessage="Period" />
         </FilterLabel>
-        <PeriodFilter {...getFilterProps('period')} />
+        <PeriodFilter {...getFilterProps('period')} minDate={collective.createdAt} />
       </FilterContainer>
       <FilterContainer mr={[0, '8px']} mb={['8px', 0]} flexGrow={1}>
         <FilterLabel htmlFor="transactions-filter-amount">
@@ -68,6 +68,7 @@ TransactionsFilters.propTypes = {
   kinds: PropTypes.array,
   collective: PropTypes.shape({
     currency: PropTypes.string.isRequired,
+    createdAt: PropTypes.string,
   }).isRequired,
 };
 

--- a/pages/expenses.js
+++ b/pages/expenses.js
@@ -342,6 +342,7 @@ const expensesPageQuery = gqlV2/* GraphQL */ `
       currency
       isArchived
       settings
+      createdAt
       expensesTags {
         id
         tag

--- a/pages/transactions.js
+++ b/pages/transactions.js
@@ -59,6 +59,7 @@ const transactionsPageQuery = gqlV2/* GraphQL */ `
       slug
       name
       type
+      createdAt
       imageUrl(height: 256)
       currency
       features {

--- a/stories/design-system/ContributorsFilter.stories.mdx
+++ b/stories/design-system/ContributorsFilter.stories.mdx
@@ -1,7 +1,7 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
 import ContributorsFilter from '../../components/ContributorsFilter';
 
-<Meta title="Design system/ContributorsFilter" component={ContributorsFilter} />
+<Meta title="Filters/ContributorsFilter" component={ContributorsFilter} />
 
 <Canvas>
   <Story name="Default">

--- a/stories/filters/PeriodFilter.stories.mdx
+++ b/stories/filters/PeriodFilter.stories.mdx
@@ -1,0 +1,24 @@
+import { ArgsTable, Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import PeriodFilter from '../../components/budget/filters/PeriodFilter';
+
+<Meta
+  title="Filters/PeriodFilter"
+  component={PeriodFilter}
+  argTypes={{
+    value: { control: { disable: true } },
+    minDate: { control: { type: 'date' } },
+  }}
+  parameters={{
+    actions: {
+      handles: ['onChange'],
+    },
+  }}
+/>
+
+## Default
+
+export const DefaultStory = props => <PeriodFilter {...props} />;
+
+<Story name="Default">{DefaultStory.bind({})}</Story>
+
+<ArgsTable story="Default" />


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/4424
Resolve https://github.com/opencollective/opencollective/issues/4502

- Added support for setting a `minDate`, defaults to `account.createdAt` for transactions and expenses pages (simplifies the UX)
- Added a [Storybook story](https://opencollective-styleguide-ml9snzrrq-opencollective.vercel.app/?path=/story/filters-periodfilter--default-story) for the component