### PR TITLE
Not Show Legal Name Info Section for Non Host Admins

### DIFF
--- a/components/edit-collective/Form.js
+++ b/components/edit-collective/Form.js
@@ -650,7 +650,7 @@ class EditCollectiveForm extends React.Component {
             examples: isUser ? 'Maria Gracia' : 'Salesforce, Inc., Airbnb, Inc.',
           }),
           maxLength: 255,
-          when: () => isUser || collective.type === CollectiveType.ORGANIZATION,
+          when: () => isUser || collective.type === CollectiveType.ORGANIZATION || collective.isHost,
           isPrivate: true,
         },
         {

--- a/components/edit-collective/sections/Host.js
+++ b/components/edit-collective/sections/Host.js
@@ -111,6 +111,7 @@ class Host extends React.Component {
     const hostMembership = get(collective, 'members', []).find(m => m.role === 'HOST');
 
     const closeModal = () => this.setState({ showModal: false });
+    const isHostAdmin = LoggedInUser?.isHostAdmin(collective);
 
     if (get(collective, 'host.id') === collective.id) {
       return (
@@ -145,7 +146,7 @@ class Host extends React.Component {
               </p>
             </Fragment>
           )}
-          <Container>{this.renderLegalNameSetInfoMessage(collective)}</Container>
+          {isHostAdmin && <Container>{this.renderLegalNameSetInfoMessage(collective)}</Container>}
           {collective.stats.balance === 0 && (
             <Fragment>
               <p>
@@ -263,7 +264,7 @@ class Host extends React.Component {
                       </Fineprint>
                     </Fragment>
                   )}
-                  <Container mt={4}>{this.renderLegalNameSetInfoMessage(collective)}</Container>
+                  {isHostAdmin && <Container mt={4}>{this.renderLegalNameSetInfoMessage(collective)}</Container>}
                 </Fragment>
               )}
             </Box>


### PR DESCRIPTION
This is related to the discussion https://opencollective.slack.com/archives/G46PNRCGP/p1631881231305700. We show the legal name info section for all collectives. This should only be shown to host admins. Also here I've added a condition to show the legal name field in the settings info section for self hosted collectives. 

Resolve https://github.com/opencollective/opencollective/issues/4698

![legal-name-host](https://user-images.githubusercontent.com/12435965/133818810-856f28f1-9e75-4db3-bf59-32aa7dddbec3.gif)


