### PR TITLE
Add Terms Page for Fiscal hosts to Directly Access Their Terms of Sponsorship

### DIFF
--- a/pages/terms-of-fiscal-sponsorship.js
+++ b/pages/terms-of-fiscal-sponsorship.js
@@ -1,0 +1,39 @@
+import PropTypes from 'prop-types';
+import { useQuery } from '@apollo/client';
+import { useRouter } from 'next/router';
+
+import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
+
+const hostTermsQuery = gqlV2/* GraphQL */ `
+  query HostTermsQuery($hostCollectiveSlug: String!) {
+    host(slug: $hostCollectiveSlug) {
+      id
+      settings
+    }
+  }
+`;
+
+const TermsOfFiscalSponsorship = ({ hostCollectiveSlug }) => {
+  const router = useRouter();
+  const { data, loading } = useQuery(hostTermsQuery, {
+    variables: { hostCollectiveSlug },
+    context: API_V2_CONTEXT,
+    skip: !hostCollectiveSlug,
+  });
+
+  if (!loading && data.host.settings.tos) {
+    router.push({ pathname: '/external-redirect', query: { url: data.host.settings.tos } });
+  }
+
+  return null;
+};
+
+export const getServerSideProps = async ({ query }) => {
+  return { props: { hostCollectiveSlug: query.hostCollectiveSlug } };
+};
+
+TermsOfFiscalSponsorship.propTypes = {
+  hostCollectiveSlug: PropTypes.string,
+};
+
+export default TermsOfFiscalSponsorship;

--- a/rewrites.js
+++ b/rewrites.js
@@ -326,4 +326,9 @@ exports.REWRITES = [
     source: '/opencollective/root-actions',
     destination: '/root-actions',
   },
+  // Terms of services for the host
+  {
+    source: '/:hostCollectiveSlug/terms',
+    destination: '/terms-of-fiscal-sponsorship',
+  },
 ];


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2757
![fiscal-host-terms](https://user-images.githubusercontent.com/12435965/133911571-735bd126-272c-457c-aaff-b51dcab4e291.gif)


