### PR TITLE
Legal Name Info Section Appears only if Legal Name is Not Set

### DIFF
--- a/components/edit-collective/sections/Host.js
+++ b/components/edit-collective/sections/Host.js
@@ -94,9 +94,10 @@ class Host extends React.Component {
       <MessageBox type="info" fontSize="13px" withIcon>
         <FormattedMessage
           id="collective.edit.host.legalName.info"
-          defaultMessage="Please set the legal name of the host in the Info section under <SettingsLink>your settings</SettingsLink>. This is required if your legal name is different than your display name for tax and accounting purposes."
+          defaultMessage="Please set the legal name {isSelfHosted, select, false {of the host} other {}} in the Info section of <SettingsLink>the settings</SettingsLink>. This is required if the legal name is different than the display name for tax and accounting purposes."
           values={{
             SettingsLink: getI18nLink({ href: `/${collective.host?.slug}/edit` }),
+            isSelfHosted: collective.id === collective.host?.id,
           }}
         />
       </MessageBox>
@@ -111,7 +112,7 @@ class Host extends React.Component {
     const hostMembership = get(collective, 'members', []).find(m => m.role === 'HOST');
 
     const closeModal = () => this.setState({ showModal: false });
-    const isHostAdmin = LoggedInUser?.isHostAdmin(collective);
+    const showLegalNameInfoBox = LoggedInUser?.isHostAdmin(collective) && !collective?.host?.legalName;
 
     if (get(collective, 'host.id') === collective.id) {
       return (
@@ -146,7 +147,7 @@ class Host extends React.Component {
               </p>
             </Fragment>
           )}
-          {isHostAdmin && <Container>{this.renderLegalNameSetInfoMessage(collective)}</Container>}
+          {showLegalNameInfoBox && <Container>{this.renderLegalNameSetInfoMessage(collective)}</Container>}
           {collective.stats.balance === 0 && (
             <Fragment>
               <p>
@@ -264,7 +265,9 @@ class Host extends React.Component {
                       </Fineprint>
                     </Fragment>
                   )}
-                  {isHostAdmin && <Container mt={4}>{this.renderLegalNameSetInfoMessage(collective)}</Container>}
+                  {showLegalNameInfoBox && (
+                    <Container mt={4}>{this.renderLegalNameSetInfoMessage(collective)}</Container>
+                  )}
                 </Fragment>
               )}
             </Box>

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -270,7 +270,7 @@
   "collective.edit.backToProfile": "mostra la pàgina {type}",
   "collective.edit.host.findHost.description": "You won't need to hold funds or set up a legal entity and bank account for your project. The Fiscal Host will take care of accounting, invoices, taxes, admin, payments, and liability. Most hosts charge a fee for this service (which you can review before choosing a Host).",
   "collective.edit.host.findHost.title": "Apply to an existing Fiscal Host",
-  "collective.edit.host.legalName.info": "Please set the legal name of the host in the Info section under <SettingsLink>your settings</SettingsLink>. This is required if your legal name is different than your display name for tax and accounting purposes.",
+  "collective.edit.host.legalName.info": "Please set the legal name {isSelfHosted, select, false {of the host} other {}} in the Info section of <SettingsLink>the settings</SettingsLink>. This is required if the legal name is different than the display name for tax and accounting purposes.",
   "collective.edit.host.noHost.description": "You can't receive financial contributions or use the budget features. You can still edit your profile page, submit expenses to be paid later, and post updates.",
   "collective.edit.host.noHost.title": "No one",
   "collective.edit.host.selfHost.description": "Simply connect a bank account for a single Collective. You will be responsible for accounting, taxes, payments, and liability.",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -270,7 +270,7 @@
   "collective.edit.backToProfile": "zobrazit {type} stránku",
   "collective.edit.host.findHost.description": "You won't need to hold funds or set up a legal entity and bank account for your project. The Fiscal Host will take care of accounting, invoices, taxes, admin, payments, and liability. Most hosts charge a fee for this service (which you can review before choosing a Host).",
   "collective.edit.host.findHost.title": "Apply to an existing Fiscal Host",
-  "collective.edit.host.legalName.info": "Please set the legal name of the host in the Info section under <SettingsLink>your settings</SettingsLink>. This is required if your legal name is different than your display name for tax and accounting purposes.",
+  "collective.edit.host.legalName.info": "Please set the legal name {isSelfHosted, select, false {of the host} other {}} in the Info section of <SettingsLink>the settings</SettingsLink>. This is required if the legal name is different than the display name for tax and accounting purposes.",
   "collective.edit.host.noHost.description": "You can't receive financial contributions or use the budget features. You can still edit your profile page, submit expenses to be paid later, and post updates.",
   "collective.edit.host.noHost.title": "No one",
   "collective.edit.host.selfHost.description": "Simply connect a bank account for a single Collective. You will be responsible for accounting, taxes, payments, and liability.",

--- a/lang/de.json
+++ b/lang/de.json
@@ -270,7 +270,7 @@
   "collective.edit.backToProfile": "{type} Seite anzeigen",
   "collective.edit.host.findHost.description": "Sie müssen für Ihr Projekt weder Gelder halten noch eine juristische Person und kein Bankkonto einrichten. Der Fiscal Host kümmert sich um Buchhaltung, Rechnungen, Steuern, Verwaltung, Zahlungen und Haftung. Die meisten Gastgeber berechnen für diesen Service eine Gebühr (die Sie überprüfen können, bevor Sie sich für einen Gastgeber entscheiden).",
   "collective.edit.host.findHost.title": "Bei einem bestehenden Träger bewerben",
-  "collective.edit.host.legalName.info": "Please set the legal name of the host in the Info section under <SettingsLink>your settings</SettingsLink>. This is required if your legal name is different than your display name for tax and accounting purposes.",
+  "collective.edit.host.legalName.info": "Please set the legal name {isSelfHosted, select, false {of the host} other {}} in the Info section of <SettingsLink>the settings</SettingsLink>. This is required if the legal name is different than the display name for tax and accounting purposes.",
   "collective.edit.host.noHost.description": "Sie können keine Finanzbeiträge erhalten oder die Budgetfunktionen nutzen. Sie können Ihre Profilseite weiterhin bearbeiten, später zu zahlende Ausgaben einreichen und Aktualisierungen veröffentlichen.",
   "collective.edit.host.noHost.title": "Niemand",
   "collective.edit.host.selfHost.description": "Verbinden Sie einfach ein Bankkonto für ein einzelnes Kollektiv. Sie sind verantwortlich für Buchhaltung, Steuern, Zahlungen und Haftung.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -270,7 +270,7 @@
   "collective.edit.backToProfile": "view {type} page",
   "collective.edit.host.findHost.description": "You won't need to hold funds or set up a legal entity and bank account for your project. The Fiscal Host will take care of accounting, invoices, taxes, admin, payments, and liability. Most hosts charge a fee for this service (which you can review before choosing a Host).",
   "collective.edit.host.findHost.title": "Apply to an existing Fiscal Host",
-  "collective.edit.host.legalName.info": "Please set the legal name of the host in the Info section under <SettingsLink>your settings</SettingsLink>. This is required if your legal name is different than your display name for tax and accounting purposes.",
+  "collective.edit.host.legalName.info": "Please set the legal name {isSelfHosted, select, false {of the host} other {}} in the Info section of <SettingsLink>the settings</SettingsLink>. This is required if the legal name is different than the display name for tax and accounting purposes.",
   "collective.edit.host.noHost.description": "You can't receive financial contributions or use the budget features. You can still edit your profile page, submit expenses to be paid later, and post updates.",
   "collective.edit.host.noHost.title": "No one",
   "collective.edit.host.selfHost.description": "Simply connect a bank account for a single Collective. You will be responsible for accounting, taxes, payments, and liability.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -270,7 +270,7 @@
   "collective.edit.backToProfile": "ver página {type}",
   "collective.edit.host.findHost.description": "You won't need to hold funds or set up a legal entity and bank account for your project. The Fiscal Host will take care of accounting, invoices, taxes, admin, payments, and liability. Most hosts charge a fee for this service (which you can review before choosing a Host).",
   "collective.edit.host.findHost.title": "Aplicar para un sponsor fiscal existente",
-  "collective.edit.host.legalName.info": "Please set the legal name of the host in the Info section under <SettingsLink>your settings</SettingsLink>. This is required if your legal name is different than your display name for tax and accounting purposes.",
+  "collective.edit.host.legalName.info": "Please set the legal name {isSelfHosted, select, false {of the host} other {}} in the Info section of <SettingsLink>the settings</SettingsLink>. This is required if the legal name is different than the display name for tax and accounting purposes.",
   "collective.edit.host.noHost.description": "No puedes recibir contribuciones económicas si usar las características de presupuesto. Aún así, puedes editar la página de tu perfil, enviar gastos para ser pagados luego y publicar actualizaciones.",
   "collective.edit.host.noHost.title": "Nadie",
   "collective.edit.host.selfHost.description": "Simplemente conecte una cuenta bancaria para un solo Colectivo. Serás responsable de la contabilidad, los impuestos, los pagos y las obligaciones.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -270,7 +270,7 @@
   "collective.edit.backToProfile": "voir la page {type}",
   "collective.edit.host.findHost.description": "You won't need to hold funds or set up a legal entity and bank account for your project. The Fiscal Host will take care of accounting, invoices, taxes, admin, payments, and liability. Most hosts charge a fee for this service (which you can review before choosing a Host).",
   "collective.edit.host.findHost.title": "Candidater à un hôte fiscal existant",
-  "collective.edit.host.legalName.info": "Please set the legal name of the host in the Info section under <SettingsLink>your settings</SettingsLink>. This is required if your legal name is different than your display name for tax and accounting purposes.",
+  "collective.edit.host.legalName.info": "Please set the legal name {isSelfHosted, select, false {of the host} other {}} in the Info section of <SettingsLink>the settings</SettingsLink>. This is required if the legal name is different than the display name for tax and accounting purposes.",
   "collective.edit.host.noHost.description": "You can't receive financial contributions or use the budget features. You can still edit your profile page, submit expenses to be paid later, and post updates.",
   "collective.edit.host.noHost.title": "Aucun hôte",
   "collective.edit.host.selfHost.description": "Simply connect a bank account for a single Collective. You will be responsible for accounting, taxes, payments, and liability.",

--- a/lang/it.json
+++ b/lang/it.json
@@ -270,7 +270,7 @@
   "collective.edit.backToProfile": "vedi {type} pagina",
   "collective.edit.host.findHost.description": "You won't need to hold funds or set up a legal entity and bank account for your project. The Fiscal Host will take care of accounting, invoices, taxes, admin, payments, and liability. Most hosts charge a fee for this service (which you can review before choosing a Host).",
   "collective.edit.host.findHost.title": "Apply to an existing Fiscal Host",
-  "collective.edit.host.legalName.info": "Please set the legal name of the host in the Info section under <SettingsLink>your settings</SettingsLink>. This is required if your legal name is different than your display name for tax and accounting purposes.",
+  "collective.edit.host.legalName.info": "Please set the legal name {isSelfHosted, select, false {of the host} other {}} in the Info section of <SettingsLink>the settings</SettingsLink>. This is required if the legal name is different than the display name for tax and accounting purposes.",
   "collective.edit.host.noHost.description": "You can't receive financial contributions or use the budget features. You can still edit your profile page, submit expenses to be paid later, and post updates.",
   "collective.edit.host.noHost.title": "No one",
   "collective.edit.host.selfHost.description": "Simply connect a bank account for a single Collective. You will be responsible for accounting, taxes, payments, and liability.",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -270,7 +270,7 @@
   "collective.edit.backToProfile": "{type} ページに戻る",
   "collective.edit.host.findHost.description": "You won't need to hold funds or set up a legal entity and bank account for your project. The Fiscal Host will take care of accounting, invoices, taxes, admin, payments, and liability. Most hosts charge a fee for this service (which you can review before choosing a Host).",
   "collective.edit.host.findHost.title": "Apply to an existing Fiscal Host",
-  "collective.edit.host.legalName.info": "Please set the legal name of the host in the Info section under <SettingsLink>your settings</SettingsLink>. This is required if your legal name is different than your display name for tax and accounting purposes.",
+  "collective.edit.host.legalName.info": "Please set the legal name {isSelfHosted, select, false {of the host} other {}} in the Info section of <SettingsLink>the settings</SettingsLink>. This is required if the legal name is different than the display name for tax and accounting purposes.",
   "collective.edit.host.noHost.description": "You can't receive financial contributions or use the budget features. You can still edit your profile page, submit expenses to be paid later, and post updates.",
   "collective.edit.host.noHost.title": "No one",
   "collective.edit.host.selfHost.description": "Simply connect a bank account for a single Collective. You will be responsible for accounting, taxes, payments, and liability.",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -270,7 +270,7 @@
   "collective.edit.backToProfile": "{type} 페이지 보기",
   "collective.edit.host.findHost.description": "You won't need to hold funds or set up a legal entity and bank account for your project. The Fiscal Host will take care of accounting, invoices, taxes, admin, payments, and liability. Most hosts charge a fee for this service (which you can review before choosing a Host).",
   "collective.edit.host.findHost.title": "Apply to an existing Fiscal Host",
-  "collective.edit.host.legalName.info": "Please set the legal name of the host in the Info section under <SettingsLink>your settings</SettingsLink>. This is required if your legal name is different than your display name for tax and accounting purposes.",
+  "collective.edit.host.legalName.info": "Please set the legal name {isSelfHosted, select, false {of the host} other {}} in the Info section of <SettingsLink>the settings</SettingsLink>. This is required if the legal name is different than the display name for tax and accounting purposes.",
   "collective.edit.host.noHost.description": "You can't receive financial contributions or use the budget features. You can still edit your profile page, submit expenses to be paid later, and post updates.",
   "collective.edit.host.noHost.title": "아무도 없음",
   "collective.edit.host.selfHost.description": "Simply connect a bank account for a single Collective. You will be responsible for accounting, taxes, payments, and liability.",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -270,7 +270,7 @@
   "collective.edit.backToProfile": "bekijk {type} pagina",
   "collective.edit.host.findHost.description": "You won't need to hold funds or set up a legal entity and bank account for your project. The Fiscal Host will take care of accounting, invoices, taxes, admin, payments, and liability. Most hosts charge a fee for this service (which you can review before choosing a Host).",
   "collective.edit.host.findHost.title": "Apply to an existing Fiscal Host",
-  "collective.edit.host.legalName.info": "Please set the legal name of the host in the Info section under <SettingsLink>your settings</SettingsLink>. This is required if your legal name is different than your display name for tax and accounting purposes.",
+  "collective.edit.host.legalName.info": "Please set the legal name {isSelfHosted, select, false {of the host} other {}} in the Info section of <SettingsLink>the settings</SettingsLink>. This is required if the legal name is different than the display name for tax and accounting purposes.",
   "collective.edit.host.noHost.description": "You can't receive financial contributions or use the budget features. You can still edit your profile page, submit expenses to be paid later, and post updates.",
   "collective.edit.host.noHost.title": "No one",
   "collective.edit.host.selfHost.description": "Simply connect a bank account for a single Collective. You will be responsible for accounting, taxes, payments, and liability.",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -270,7 +270,7 @@
   "collective.edit.backToProfile": "ver página {type}",
   "collective.edit.host.findHost.description": "Você não precisará manter fundos ou configurar uma entidade jurídica e uma conta bancária para o seu projeto. O administrador fiscal cuidará da contabilidade, faturas, impostos, administradores, pagamentos e responsabilidades. A maioria dos administradores cobram uma taxa para esse serviço (que você pode rever antes de escolher um administrador).",
   "collective.edit.host.findHost.title": "Aplicar para uma posição existende de Administrador Fiscal",
-  "collective.edit.host.legalName.info": "Please set the legal name of the host in the Info section under <SettingsLink>your settings</SettingsLink>. This is required if your legal name is different than your display name for tax and accounting purposes.",
+  "collective.edit.host.legalName.info": "Please set the legal name {isSelfHosted, select, false {of the host} other {}} in the Info section of <SettingsLink>the settings</SettingsLink>. This is required if the legal name is different than the display name for tax and accounting purposes.",
   "collective.edit.host.noHost.description": "Você não pode receber contribuições financeiras ou usar os recursos do orçamento. Você ainda pode editar a sua página de perfil, enviar despesas para serem pagas posteriormente e publicar atualizações.",
   "collective.edit.host.noHost.title": "Ninguém",
   "collective.edit.host.selfHost.description": "Basta conectar uma conta bancária para um único Coletivo. Você será responsável pela contabilidade, impostos, pagamentos e responsabilidade.",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -270,7 +270,7 @@
   "collective.edit.backToProfile": "ver página de {type}",
   "collective.edit.host.findHost.description": "You won't need to hold funds or set up a legal entity and bank account for your project. The Fiscal Host will take care of accounting, invoices, taxes, admin, payments, and liability. Most hosts charge a fee for this service (which you can review before choosing a Host).",
   "collective.edit.host.findHost.title": "Apply to an existing Fiscal Host",
-  "collective.edit.host.legalName.info": "Please set the legal name of the host in the Info section under <SettingsLink>your settings</SettingsLink>. This is required if your legal name is different than your display name for tax and accounting purposes.",
+  "collective.edit.host.legalName.info": "Please set the legal name {isSelfHosted, select, false {of the host} other {}} in the Info section of <SettingsLink>the settings</SettingsLink>. This is required if the legal name is different than the display name for tax and accounting purposes.",
   "collective.edit.host.noHost.description": "You can't receive financial contributions or use the budget features. You can still edit your profile page, submit expenses to be paid later, and post updates.",
   "collective.edit.host.noHost.title": "No one",
   "collective.edit.host.selfHost.description": "Simply connect a bank account for a single Collective. You will be responsible for accounting, taxes, payments, and liability.",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -270,7 +270,7 @@
   "collective.edit.backToProfile": "посмотреть страницу {type}",
   "collective.edit.host.findHost.description": "You won't need to hold funds or set up a legal entity and bank account for your project. The Fiscal Host will take care of accounting, invoices, taxes, admin, payments, and liability. Most hosts charge a fee for this service (which you can review before choosing a Host).",
   "collective.edit.host.findHost.title": "Применить к существующему Фискальному Представителю",
-  "collective.edit.host.legalName.info": "Please set the legal name of the host in the Info section under <SettingsLink>your settings</SettingsLink>. This is required if your legal name is different than your display name for tax and accounting purposes.",
+  "collective.edit.host.legalName.info": "Please set the legal name {isSelfHosted, select, false {of the host} other {}} in the Info section of <SettingsLink>the settings</SettingsLink>. This is required if the legal name is different than the display name for tax and accounting purposes.",
   "collective.edit.host.noHost.description": "You can't receive financial contributions or use the budget features. You can still edit your profile page, submit expenses to be paid later, and post updates.",
   "collective.edit.host.noHost.title": "Никого",
   "collective.edit.host.selfHost.description": "Simply connect a bank account for a single Collective. You will be responsible for accounting, taxes, payments, and liability.",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -270,7 +270,7 @@
   "collective.edit.backToProfile": "переглянути сторінку {type}",
   "collective.edit.host.findHost.description": "Вам не потрібно буде утримувати кошти або налаштувати юридичну організацію і банківський рахунок для вашого проєкту. Скарбник піклуватиметься про бухгалтерський облік, рахунки, податки, управляння, платежі та відповідальність. Більшість скарбників отримують платню за цю послугу (яку можна переглянути, перш ніж вибрати скарбника).",
   "collective.edit.host.findHost.title": "Застосувати до наявного скарбника",
-  "collective.edit.host.legalName.info": "Please set the legal name of the host in the Info section under <SettingsLink>your settings</SettingsLink>. This is required if your legal name is different than your display name for tax and accounting purposes.",
+  "collective.edit.host.legalName.info": "Please set the legal name {isSelfHosted, select, false {of the host} other {}} in the Info section of <SettingsLink>the settings</SettingsLink>. This is required if the legal name is different than the display name for tax and accounting purposes.",
   "collective.edit.host.noHost.description": "Ви не можете отримати фінансовий внесок або використовувати бюджетні можливості. Ви досі можете редагувати сторінку профілю, затверджувати витрати, які будуть оплачені пізніше і публікувати оновлення.",
   "collective.edit.host.noHost.title": "Ніхто",
   "collective.edit.host.selfHost.description": "Simply connect a bank account for a single Collective. You will be responsible for accounting, taxes, payments, and liability.",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -270,7 +270,7 @@
   "collective.edit.backToProfile": "查看 {type} 页",
   "collective.edit.host.findHost.description": "You won't need to hold funds or set up a legal entity and bank account for your project. The Fiscal Host will take care of accounting, invoices, taxes, admin, payments, and liability. Most hosts charge a fee for this service (which you can review before choosing a Host).",
   "collective.edit.host.findHost.title": "适用于现有的财务托管人",
-  "collective.edit.host.legalName.info": "Please set the legal name of the host in the Info section under <SettingsLink>your settings</SettingsLink>. This is required if your legal name is different than your display name for tax and accounting purposes.",
+  "collective.edit.host.legalName.info": "Please set the legal name {isSelfHosted, select, false {of the host} other {}} in the Info section of <SettingsLink>the settings</SettingsLink>. This is required if the legal name is different than the display name for tax and accounting purposes.",
   "collective.edit.host.noHost.description": "You can't receive financial contributions or use the budget features. You can still edit your profile page, submit expenses to be paid later, and post updates.",
   "collective.edit.host.noHost.title": "无人",
   "collective.edit.host.selfHost.description": "Simply connect a bank account for a single Collective. You will be responsible for accounting, taxes, payments, and liability.",

--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -172,6 +172,7 @@ export const editCollectivePageFieldsFragment = gql`
       createdAt
       slug
       name
+      legalName
       currency
       settings
       description


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4712

- Make sure legal name info section appears only if legal name is not set

- Make sure the message is aligned with self hosted collectives

![legal-name-fixes](https://user-images.githubusercontent.com/12435965/134016529-5b85b35b-d8ac-444e-b521-e13b7a727545.gif)

