### PR TITLE
Don't toggle checkboxes when clicking label links

### DIFF
--- a/components/ApplyToHostModal.js
+++ b/components/ApplyToHostModal.js
@@ -403,6 +403,7 @@ const ApplyToHostModal = ({ hostSlug, collective, onClose, onSuccess, router, ..
                                       href: host.termsUrl,
                                       openInNewTabNoFollow: true,
                                       ...(isOCFHost && { color: '#396C6F' }),
+                                      onClick: e => e.stopPropagation(), // don't check the checkbox when clicking on the link
                                     }),
                                   }}
                                 />

--- a/components/create-collective/CreateCollectiveForm.js
+++ b/components/create-collective/CreateCollectiveForm.js
@@ -341,7 +341,11 @@ class CreateCollectiveForm extends React.Component {
                                     defaultMessage="I agree with the <TOSLink>terms of service</TOSLink> of {hostName}"
                                     values={{
                                       hostName: host.name,
-                                      TOSLink: getI18nLink({ href: host.termsUrl, openInNewTabNoFollow: true }),
+                                      TOSLink: getI18nLink({
+                                        href: host.termsUrl,
+                                        openInNewTabNoFollow: true,
+                                        onClick: e => e.stopPropagation(), // don't check the checkbox when clicking on the link
+                                      }),
                                     }}
                                   />
                                 }

--- a/components/ocf-host-application/ApplicationForm.js
+++ b/components/ocf-host-application/ApplicationForm.js
@@ -574,6 +574,7 @@ const ApplicationForm = ({
                                         TOSLink: getI18nLink({
                                           href: '/tos',
                                           openInNewTab: true,
+                                          onClick: e => e.stopPropagation(), // don't check the checkbox when clicking on the link
                                         }),
                                       }}
                                     />

--- a/components/ocf-host-application/TermsOfFiscalSponsorship.js
+++ b/components/ocf-host-application/TermsOfFiscalSponsorship.js
@@ -63,6 +63,7 @@ const TermsOfFiscalSponsorship = ({ checked, onChecked }) => (
                     TOSLink: getI18nLink({
                       href: 'https://docs.opencollective.foundation/about/our-terms-and-conditions',
                       openInNewTabNoFollow: true,
+                      onClick: e => e.stopPropagation(), // don't check the checkbox when clicking on the link
                     }),
                   }}
                 />


### PR DESCRIPTION
Not covering all of them, just the ones using `getI18nLink`. I just wanted to push a quick enhancement for the easy ones.