### PR TITLE
Fix PDF downlad error handling

### DIFF
--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -121,20 +121,17 @@ export const saveInvoice = async ({
     createdAt,
   });
   const getParams = { format: 'blob', allowExternal: invoiceServiceURL };
-  let response;
+  let blob;
   try {
-    response = await fetch(invoiceUrl, getParams);
+    blob = await fetch(invoiceUrl, getParams);
   } catch {
     throw createError(ERROR.NETWORK);
   }
 
-  const content = response && (await response.text());
-  if (!response?.ok) {
-    throw createError(ERROR.UNKNOWN, { message: content });
+  if (blob?.type !== 'application/pdf') {
+    throw createError(ERROR.UNKNOWN);
   }
 
-  return saveAs(
-    response,
-    getFilename({ fromCollectiveSlug, toCollectiveSlug, transactionUuid, dateFrom, dateTo, createdAt }),
-  );
+  const filename = getFilename({ fromCollectiveSlug, toCollectiveSlug, transactionUuid, dateFrom, dateTo, createdAt });
+  return saveAs(blob, filename);
 };


### PR DESCRIPTION
I copy-pasted the `fetch` error handling from the download CSV feature, but I missed that we're downloading it as a blob here, which produces different kind of errors.