### PR TITLE
LazyPaginatedGraphQL: Memoize nodes

### DIFF
--- a/lib/hooks/useLazyGraphQLPaginatedResults.js
+++ b/lib/hooks/useLazyGraphQLPaginatedResults.js
@@ -15,6 +15,7 @@ export const useLazyGraphQLPaginatedResults = (query, key, options = DEFAULT_OPT
   const results = query?.data?.[key];
   const nbItemsDisplayed = limit * allOptions.percentageDisplayed;
   const resultsCount = results?.nodes?.length || 0;
+  const nodes = React.useMemo(() => results?.nodes?.slice(0, nbItemsDisplayed) || [], [results, nbItemsDisplayed]);
 
   // Refetch when the number of items go below the threshold
   React.useEffect(() => {
@@ -25,7 +26,7 @@ export const useLazyGraphQLPaginatedResults = (query, key, options = DEFAULT_OPT
 
   if (!results) {
     return {
-      nodes: [],
+      nodes,
       totalCount: 0,
       offset: 0,
       limit: nbItemsDisplayed,
@@ -36,6 +37,6 @@ export const useLazyGraphQLPaginatedResults = (query, key, options = DEFAULT_OPT
     offset: query.variables.offset,
     limit: nbItemsDisplayed,
     totalCount: results.totalCount,
-    nodes: results.nodes.slice(0, nbItemsDisplayed),
+    nodes,
   };
 };


### PR DESCRIPTION
A tiny enhancement that will make sure components dependants on this always get the same reference to `nodes` if it doesn't change, making it possible to have more granular update rules (with pure components or memoization).