### PR TITLE
Implement extra env on frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .next
 .env
+.env.*
 node_modules
 npm-debug.log.*
 ./report.*.json

--- a/env.js
+++ b/env.js
@@ -1,7 +1,18 @@
 const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
 
 const debug = require('debug');
 const dotenv = require('dotenv');
+const lodash = require('lodash');
+
+// Load extra env file on demand
+// e.g. `npm run dev production` -> `.env.production`
+const extraEnv = process.env.EXTRA_ENV || lodash.last(process.argv);
+const extraEnvPath = path.join(__dirname, `.env.${extraEnv}`);
+if (fs.existsSync(extraEnvPath)) {
+  dotenv.config({ path: extraEnvPath });
+}
 
 dotenv.config();
 debug.enable(process.env.DEBUG);

--- a/server/index.js
+++ b/server/index.js
@@ -36,6 +36,10 @@ const desiredServiceLevel = Number(process.env.SERVICE_LEVEL) || 100;
 
 const start = id =>
   nextApp.prepare().then(() => {
+    logger.info(
+      `Starting with NODE_ENV=${process.env.NODE_ENV} OC_ENV=${process.env.OC_ENV} API_URL=${process.env.API_URL}`,
+    );
+
     // Not much documentation on this,
     // but we should ensure this goes to the default Next.js handler
     app.get('/__nextjs_original-stack-frame', nextApp.getRequestHandler());


### PR DESCRIPTION
Similar to https://github.com/opencollective/opencollective-api/pull/6624

Except that we're loading the extra file first (as dotenv is NOT overloading environment variables). We should also change that in our API implementation.

Be aware that next.js will always load a file named `.env.local` at the end if it exists. So, don't use `.env.local` to avoid conflicts. https://github.com/vercel/next.js/blob/canary/packages/next-env/index.ts

