### PR TITLE
Fix pricing page crash with intl key

### DIFF
--- a/components/pricing/ForFiscalHostCard.js
+++ b/components/pricing/ForFiscalHostCard.js
@@ -88,11 +88,11 @@ const Card = styled(Container)`
 `;
 
 const messages = defineMessages({
-  HostDashboard: {
+  'pricing.dashboard': {
     id: 'HostDashboard',
     defaultMessage: 'Host Dashboard',
   },
-  'HostDashboard.description': {
+  'pricing.dashboard.description': {
     id: 'HostDashboard.description',
     defaultMessage:
       'A host dashboard to easily manage budgets and expenses across all your Collectives, including one-click payouts via Paypal and TransferWise.',


### PR DESCRIPTION
Introduced in https://github.com/opencollective/opencollective-frontend/pull/6881/files#diff-5b7129eaceb693950e3943065f78aa524724d56bb53efdf9ae626e3225a2f848

While it was a good approach to rename the `id` to avoid duplicates, the object key shouldn't have been renamed.