### PR TITLE
Use `donationMethod` instead of `paymentMethod` for crypto flow

### DIFF
--- a/components/contribution-flow/constants.js
+++ b/components/contribution-flow/constants.js
@@ -13,7 +13,7 @@ export const STEPS = {
   CHECKOUT: 'checkout',
 };
 
-export const DONATION_METHOD = {
+export const PAYMENT_FLOW = {
   CRYPTO: 'crypto',
 };
 

--- a/components/contribution-flow/constants.js
+++ b/components/contribution-flow/constants.js
@@ -13,6 +13,10 @@ export const STEPS = {
   CHECKOUT: 'checkout',
 };
 
+export const DONATION_METHOD = {
+  CRYPTO: 'crypto',
+};
+
 export const CRYPTO_CURRENCIES = [
   {
     label: (

--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -124,7 +124,7 @@ class ContributionFlow extends React.Component {
     redirect: PropTypes.string,
     tags: PropTypes.arrayOf(PropTypes.string),
     verb: PropTypes.string,
-    paymentMethod: PropTypes.string,
+    donationMethod: PropTypes.string,
     error: PropTypes.string,
     contributeAs: PropTypes.string,
     defaultEmail: PropTypes.string,
@@ -155,7 +155,7 @@ class ContributionFlow extends React.Component {
       stepDetails: {
         quantity: 1,
         interval: props.fixedInterval || getDefaultInterval(props.tier),
-        amount: props.paymentMethod === 'crypto' ? '' : props.fixedAmount || getDefaultTierAmount(props.tier),
+        amount: props.donationMethod === 'crypto' ? '' : props.fixedAmount || getDefaultTierAmount(props.tier),
         platformContribution: props.platformContribution,
         currency: CRYPTO_CURRENCIES[0],
       },
@@ -186,7 +186,7 @@ class ContributionFlow extends React.Component {
           order: {
             quantity: stepDetails.quantity,
             amount:
-              this.props.paymentMethod === 'crypto'
+              this.props.donationMethod === 'crypto'
                 ? { valueInCents: 100 } // Insert dummy value for crypto contribution until the transaction is reconciled
                 : { valueInCents: stepDetails.amount },
             frequency: getGQLV2FrequencyFromInterval(stepDetails.interval),
@@ -194,7 +194,7 @@ class ContributionFlow extends React.Component {
             fromAccount,
             toAccount: pick(this.props.collective, ['id']),
             customData:
-              this.props.paymentMethod === 'crypto'
+              this.props.donationMethod === 'crypto'
                 ? {
                     pledgeAmount: stepDetails.amount,
                     pledgeCurrency: stepDetails.currency.value,
@@ -231,7 +231,7 @@ class ContributionFlow extends React.Component {
 
     if (stripeError) {
       return this.handleStripeError(order, stripeError, email, guestToken);
-    } else if (this.props.paymentMethod === 'crypto') {
+    } else if (this.props.donationMethod === 'crypto') {
       this.setState({ isSubmitted: true, isSubmitting: false, createdOrder: order });
     } else {
       return this.handleSuccess(order);
@@ -450,7 +450,7 @@ class ContributionFlow extends React.Component {
     this.setState({ showSignIn: false });
     // To create an order we need a payment method to be set. This is normally set at final stage but for crypto flow we
     // need to set this before the final step of the flow
-    if (this.props.paymentMethod === 'crypto') {
+    if (this.props.donationMethod === 'crypto') {
       this.setState({
         stepPayment: {
           key: 'crypto',
@@ -517,7 +517,7 @@ class ContributionFlow extends React.Component {
     } else if (verb === 'contribute' || verb === 'new-contribute') {
       // Never use `contribute` as verb if not using a tier (would introduce a route conflict)
       route = `/${collective.slug}/donate/${step}`;
-    } else if (verb === 'donate' && this.props.paymentMethod === 'crypto') {
+    } else if (verb === 'donate' && this.props.donationMethod === 'crypto') {
       route = `/${collective.slug}/donate/crypto/${step}`;
     }
 
@@ -560,13 +560,13 @@ class ContributionFlow extends React.Component {
 
   /** Returns the steps list */
   getSteps() {
-    const { intl, fixedInterval, fixedAmount, collective, host, tier, LoggedInUser, paymentMethod } = this.props;
+    const { intl, fixedInterval, fixedAmount, collective, host, tier, LoggedInUser, donationMethod } = this.props;
     const { stepDetails, stepProfile, stepPayment, stepSummary } = this.state;
     const isFixedContribution = this.isFixedContribution(tier, fixedAmount, fixedInterval);
     const minAmount = this.getTierMinAmount(tier);
     const noPaymentRequired = minAmount === 0 && (isFixedContribution || stepDetails?.amount === 0);
     const isStepProfileCompleted = Boolean((stepProfile && LoggedInUser) || stepProfile?.isGuest);
-    const isCrypto = paymentMethod === 'crypto';
+    const isCrypto = donationMethod === 'crypto';
 
     const steps = [
       {
@@ -732,11 +732,11 @@ class ContributionFlow extends React.Component {
       loadingLoggedInUser,
       skipStepDetails,
       isEmbed,
-      paymentMethod,
+      donationMethod,
       error: backendError,
     } = this.props;
     const { error, isSubmitted, isSubmitting, stepDetails, stepSummary, stepProfile, stepPayment } = this.state;
-    const isCrypto = paymentMethod === 'crypto';
+    const isCrypto = donationMethod === 'crypto';
     const currency = isCrypto ? stepDetails.currency.value : tier?.amount.currency || collective.currency;
     const isLoading = isCrypto ? isSubmitting : isSubmitted || isSubmitting;
     const pastEvent = collective.type === CollectiveType.EVENT && isPastEvent(collective);

--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -41,7 +41,7 @@ import { withUser } from '../UserProvider';
 
 import { orderResponseFragment } from './graphql/fragments';
 import CollectiveTitleContainer from './CollectiveTitleContainer';
-import { CRYPTO_CURRENCIES, STEPS } from './constants';
+import { CRYPTO_CURRENCIES, DONATION_METHOD, STEPS } from './constants';
 import ContributionFlowButtons from './ContributionFlowButtons';
 import ContributionFlowHeader from './ContributionFlowHeader';
 import ContributionFlowStepContainer from './ContributionFlowStepContainer';
@@ -155,7 +155,8 @@ class ContributionFlow extends React.Component {
       stepDetails: {
         quantity: 1,
         interval: props.fixedInterval || getDefaultInterval(props.tier),
-        amount: props.donationMethod === 'crypto' ? '' : props.fixedAmount || getDefaultTierAmount(props.tier),
+        amount:
+          props.donationMethod === DONATION_METHOD.CRYPTO ? '' : props.fixedAmount || getDefaultTierAmount(props.tier),
         platformContribution: props.platformContribution,
         currency: CRYPTO_CURRENCIES[0],
       },
@@ -186,7 +187,7 @@ class ContributionFlow extends React.Component {
           order: {
             quantity: stepDetails.quantity,
             amount:
-              this.props.donationMethod === 'crypto'
+              this.props.donationMethod === DONATION_METHOD.CRYPTO
                 ? { valueInCents: 100 } // Insert dummy value for crypto contribution until the transaction is reconciled
                 : { valueInCents: stepDetails.amount },
             frequency: getGQLV2FrequencyFromInterval(stepDetails.interval),
@@ -194,7 +195,7 @@ class ContributionFlow extends React.Component {
             fromAccount,
             toAccount: pick(this.props.collective, ['id']),
             customData:
-              this.props.donationMethod === 'crypto'
+              this.props.donationMethod === DONATION_METHOD.CRYPTO
                 ? {
                     pledgeAmount: stepDetails.amount,
                     pledgeCurrency: stepDetails.currency.value,
@@ -231,7 +232,7 @@ class ContributionFlow extends React.Component {
 
     if (stripeError) {
       return this.handleStripeError(order, stripeError, email, guestToken);
-    } else if (this.props.donationMethod === 'crypto') {
+    } else if (this.props.donationMethod === DONATION_METHOD.CRYPTO) {
       this.setState({ isSubmitted: true, isSubmitting: false, createdOrder: order });
     } else {
       return this.handleSuccess(order);
@@ -450,7 +451,7 @@ class ContributionFlow extends React.Component {
     this.setState({ showSignIn: false });
     // To create an order we need a payment method to be set. This is normally set at final stage but for crypto flow we
     // need to set this before the final step of the flow
-    if (this.props.donationMethod === 'crypto') {
+    if (this.props.donationMethod === DONATION_METHOD.CRYPTO) {
       this.setState({
         stepPayment: {
           key: 'crypto',
@@ -517,7 +518,7 @@ class ContributionFlow extends React.Component {
     } else if (verb === 'contribute' || verb === 'new-contribute') {
       // Never use `contribute` as verb if not using a tier (would introduce a route conflict)
       route = `/${collective.slug}/donate/${step}`;
-    } else if (verb === 'donate' && this.props.donationMethod === 'crypto') {
+    } else if (verb === 'donate' && this.props.donationMethod === DONATION_METHOD.CRYPTO) {
       route = `/${collective.slug}/donate/crypto/${step}`;
     }
 
@@ -566,7 +567,7 @@ class ContributionFlow extends React.Component {
     const minAmount = this.getTierMinAmount(tier);
     const noPaymentRequired = minAmount === 0 && (isFixedContribution || stepDetails?.amount === 0);
     const isStepProfileCompleted = Boolean((stepProfile && LoggedInUser) || stepProfile?.isGuest);
-    const isCrypto = donationMethod === 'crypto';
+    const isCrypto = donationMethod === DONATION_METHOD.CRYPTO;
 
     const steps = [
       {
@@ -736,7 +737,7 @@ class ContributionFlow extends React.Component {
       error: backendError,
     } = this.props;
     const { error, isSubmitted, isSubmitting, stepDetails, stepSummary, stepProfile, stepPayment } = this.state;
-    const isCrypto = donationMethod === 'crypto';
+    const isCrypto = donationMethod === DONATION_METHOD.CRYPTO;
     const currency = isCrypto ? stepDetails.currency.value : tier?.amount.currency || collective.currency;
     const isLoading = isCrypto ? isSubmitting : isSubmitted || isSubmitting;
     const pastEvent = collective.type === CollectiveType.EVENT && isPastEvent(collective);

--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -41,7 +41,7 @@ import { withUser } from '../UserProvider';
 
 import { orderResponseFragment } from './graphql/fragments';
 import CollectiveTitleContainer from './CollectiveTitleContainer';
-import { CRYPTO_CURRENCIES, DONATION_METHOD, STEPS } from './constants';
+import { CRYPTO_CURRENCIES, PAYMENT_FLOW, STEPS } from './constants';
 import ContributionFlowButtons from './ContributionFlowButtons';
 import ContributionFlowHeader from './ContributionFlowHeader';
 import ContributionFlowStepContainer from './ContributionFlowStepContainer';
@@ -124,7 +124,7 @@ class ContributionFlow extends React.Component {
     redirect: PropTypes.string,
     tags: PropTypes.arrayOf(PropTypes.string),
     verb: PropTypes.string,
-    donationMethod: PropTypes.string,
+    paymentFlow: PropTypes.string,
     error: PropTypes.string,
     contributeAs: PropTypes.string,
     defaultEmail: PropTypes.string,
@@ -155,8 +155,7 @@ class ContributionFlow extends React.Component {
       stepDetails: {
         quantity: 1,
         interval: props.fixedInterval || getDefaultInterval(props.tier),
-        amount:
-          props.donationMethod === DONATION_METHOD.CRYPTO ? '' : props.fixedAmount || getDefaultTierAmount(props.tier),
+        amount: props.paymentFlow === PAYMENT_FLOW.CRYPTO ? '' : props.fixedAmount || getDefaultTierAmount(props.tier),
         platformContribution: props.platformContribution,
         currency: CRYPTO_CURRENCIES[0],
       },
@@ -187,7 +186,7 @@ class ContributionFlow extends React.Component {
           order: {
             quantity: stepDetails.quantity,
             amount:
-              this.props.donationMethod === DONATION_METHOD.CRYPTO
+              this.props.paymentFlow === PAYMENT_FLOW.CRYPTO
                 ? { valueInCents: 100 } // Insert dummy value for crypto contribution until the transaction is reconciled
                 : { valueInCents: stepDetails.amount },
             frequency: getGQLV2FrequencyFromInterval(stepDetails.interval),
@@ -195,7 +194,7 @@ class ContributionFlow extends React.Component {
             fromAccount,
             toAccount: pick(this.props.collective, ['id']),
             customData:
-              this.props.donationMethod === DONATION_METHOD.CRYPTO
+              this.props.paymentFlow === PAYMENT_FLOW.CRYPTO
                 ? {
                     pledgeAmount: stepDetails.amount,
                     pledgeCurrency: stepDetails.currency.value,
@@ -232,7 +231,7 @@ class ContributionFlow extends React.Component {
 
     if (stripeError) {
       return this.handleStripeError(order, stripeError, email, guestToken);
-    } else if (this.props.donationMethod === DONATION_METHOD.CRYPTO) {
+    } else if (this.props.paymentFlow === PAYMENT_FLOW.CRYPTO) {
       this.setState({ isSubmitted: true, isSubmitting: false, createdOrder: order });
     } else {
       return this.handleSuccess(order);
@@ -451,7 +450,7 @@ class ContributionFlow extends React.Component {
     this.setState({ showSignIn: false });
     // To create an order we need a payment method to be set. This is normally set at final stage but for crypto flow we
     // need to set this before the final step of the flow
-    if (this.props.donationMethod === DONATION_METHOD.CRYPTO) {
+    if (this.props.paymentFlow === PAYMENT_FLOW.CRYPTO) {
       this.setState({
         stepPayment: {
           key: 'crypto',
@@ -518,7 +517,7 @@ class ContributionFlow extends React.Component {
     } else if (verb === 'contribute' || verb === 'new-contribute') {
       // Never use `contribute` as verb if not using a tier (would introduce a route conflict)
       route = `/${collective.slug}/donate/${step}`;
-    } else if (verb === 'donate' && this.props.donationMethod === DONATION_METHOD.CRYPTO) {
+    } else if (verb === 'donate' && this.props.paymentFlow === PAYMENT_FLOW.CRYPTO) {
       route = `/${collective.slug}/donate/crypto/${step}`;
     }
 
@@ -561,13 +560,13 @@ class ContributionFlow extends React.Component {
 
   /** Returns the steps list */
   getSteps() {
-    const { intl, fixedInterval, fixedAmount, collective, host, tier, LoggedInUser, donationMethod } = this.props;
+    const { intl, fixedInterval, fixedAmount, collective, host, tier, LoggedInUser, paymentFlow } = this.props;
     const { stepDetails, stepProfile, stepPayment, stepSummary } = this.state;
     const isFixedContribution = this.isFixedContribution(tier, fixedAmount, fixedInterval);
     const minAmount = this.getTierMinAmount(tier);
     const noPaymentRequired = minAmount === 0 && (isFixedContribution || stepDetails?.amount === 0);
     const isStepProfileCompleted = Boolean((stepProfile && LoggedInUser) || stepProfile?.isGuest);
-    const isCrypto = donationMethod === DONATION_METHOD.CRYPTO;
+    const isCrypto = paymentFlow === PAYMENT_FLOW.CRYPTO;
 
     const steps = [
       {
@@ -733,11 +732,11 @@ class ContributionFlow extends React.Component {
       loadingLoggedInUser,
       skipStepDetails,
       isEmbed,
-      donationMethod,
+      paymentFlow,
       error: backendError,
     } = this.props;
     const { error, isSubmitted, isSubmitting, stepDetails, stepSummary, stepProfile, stepPayment } = this.state;
-    const isCrypto = donationMethod === DONATION_METHOD.CRYPTO;
+    const isCrypto = paymentFlow === PAYMENT_FLOW.CRYPTO;
     const currency = isCrypto ? stepDetails.currency.value : tier?.amount.currency || collective.currency;
     const isLoading = isCrypto ? isSubmitting : isSubmitted || isSubmitting;
     const pastEvent = collective.type === CollectiveType.EVENT && isPastEvent(collective);

--- a/lib/tier-utils.js
+++ b/lib/tier-utils.js
@@ -1,5 +1,7 @@
 import { get, isNil, min, orderBy, uniq } from 'lodash';
 
+import { DONATION_METHOD } from '../components/contribution-flow/constants';
+
 import { CollectiveType } from './constants/collectives';
 import INTERVALS from './constants/intervals';
 import { AmountTypes, TierTypes } from './constants/tiers-types';
@@ -98,7 +100,7 @@ export const sortTiers = (baseTiers, orderKeys, hasCustomContribution, hasCrypto
   }
 
   return orderBy(tiers, tier => {
-    const itemKey = tier === 'custom' || tier === 'crypto' ? tier : tier.id;
+    const itemKey = tier === 'custom' || tier === DONATION_METHOD.CRYPTO ? tier : tier.id;
     const index = orderKeys.findIndex(key => key === itemKey);
     return index === -1 ? Infinity : index; // put unsorted tiers at the end
   });

--- a/lib/tier-utils.js
+++ b/lib/tier-utils.js
@@ -1,6 +1,6 @@
 import { get, isNil, min, orderBy, uniq } from 'lodash';
 
-import { DONATION_METHOD } from '../components/contribution-flow/constants';
+import { PAYMENT_FLOW } from '../components/contribution-flow/constants';
 
 import { CollectiveType } from './constants/collectives';
 import INTERVALS from './constants/intervals';
@@ -100,7 +100,7 @@ export const sortTiers = (baseTiers, orderKeys, hasCustomContribution, hasCrypto
   }
 
   return orderBy(tiers, tier => {
-    const itemKey = tier === 'custom' || tier === DONATION_METHOD.CRYPTO ? tier : tier.id;
+    const itemKey = tier === 'custom' || tier === PAYMENT_FLOW.CRYPTO ? tier : tier.id;
     const index = orderKeys.findIndex(key => key === itemKey);
     return index === -1 ? Infinity : index; // put unsorted tiers at the end
   });

--- a/pages/contribute.js
+++ b/pages/contribute.js
@@ -24,7 +24,7 @@ import ContributeCustom from '../components/contribute-cards/ContributeCustom';
 import ContributeEvent from '../components/contribute-cards/ContributeEvent';
 import ContributeProject from '../components/contribute-cards/ContributeProject';
 import ContributeTier from '../components/contribute-cards/ContributeTier';
-import { DONATION_METHOD } from '../components/contribution-flow/constants';
+import { PAYMENT_FLOW } from '../components/contribution-flow/constants';
 import ErrorPage from '../components/ErrorPage';
 import Footer from '../components/Footer';
 import { Box, Flex, Grid } from '../components/Grid';
@@ -112,7 +112,7 @@ class TiersPage extends React.Component {
               stats: collective.stats.backers,
             },
           });
-        } else if (tier === DONATION_METHOD.CRYPTO) {
+        } else if (tier === PAYMENT_FLOW.CRYPTO) {
           waysToContribute.push({
             ContributeCardComponent: ContributeCrypto,
             key: 'contribute-tier-crypto',

--- a/pages/contribute.js
+++ b/pages/contribute.js
@@ -24,6 +24,7 @@ import ContributeCustom from '../components/contribute-cards/ContributeCustom';
 import ContributeEvent from '../components/contribute-cards/ContributeEvent';
 import ContributeProject from '../components/contribute-cards/ContributeProject';
 import ContributeTier from '../components/contribute-cards/ContributeTier';
+import { DONATION_METHOD } from '../components/contribution-flow/constants';
 import ErrorPage from '../components/ErrorPage';
 import Footer from '../components/Footer';
 import { Box, Flex, Grid } from '../components/Grid';
@@ -111,7 +112,7 @@ class TiersPage extends React.Component {
               stats: collective.stats.backers,
             },
           });
-        } else if (tier === 'crypto') {
+        } else if (tier === DONATION_METHOD.CRYPTO) {
           waysToContribute.push({
             ContributeCardComponent: ContributeCrypto,
             key: 'contribute-tier-crypto',

--- a/pages/contribution-flow.js
+++ b/pages/contribution-flow.js
@@ -11,7 +11,7 @@ import { floatAmountToCents } from '../lib/math';
 import { compose, parseToBoolean } from '../lib/utils';
 
 import Container from '../components/Container';
-import { DONATION_METHOD, STEPS } from '../components/contribution-flow/constants';
+import { PAYMENT_FLOW, STEPS } from '../components/contribution-flow/constants';
 import ContributionBlocker, {
   CONTRIBUTION_BLOCKER,
   getContributionBlocker,
@@ -63,7 +63,7 @@ class NewContributionFlowPage extends React.Component {
       description: query.description ? decodeURIComponent(query.description) : undefined,
       interval: query.interval,
       verb: query.verb,
-      donationMethod: query.donationMethod,
+      paymentFlow: query.paymentFlow,
       redirect: query.redirect,
       customData: query.data,
       skipStepDetails: query.skipStepDetails ? parseToBoolean(query.skipStepDetails) : false,
@@ -79,7 +79,7 @@ class NewContributionFlowPage extends React.Component {
   static propTypes = {
     collectiveSlug: PropTypes.string.isRequired,
     verb: PropTypes.string,
-    donationMethod: PropTypes.string,
+    paymentFlow: PropTypes.string,
     redirect: PropTypes.string,
     description: PropTypes.string,
     disabledPaymentMethodTypes: PropTypes.arrayOf(PropTypes.string),
@@ -130,9 +130,9 @@ class NewContributionFlowPage extends React.Component {
   }
 
   renderPageContent() {
-    const { data = {}, step, donationMethod, LoggedInUser, error } = this.props;
+    const { data = {}, step, paymentFlow, LoggedInUser, error } = this.props;
     const { account, tier } = data;
-    const isCrypto = donationMethod === DONATION_METHOD.CRYPTO;
+    const isCrypto = paymentFlow === PAYMENT_FLOW.CRYPTO;
 
     if (data.loading) {
       return (
@@ -164,7 +164,7 @@ class NewContributionFlowPage extends React.Component {
           tier={tier}
           step={step}
           verb={this.props.verb}
-          donationMethod={donationMethod}
+          paymentFlow={paymentFlow}
           redirect={this.props.redirect}
           description={this.props.description}
           defaultQuantity={this.props.quantity}

--- a/pages/contribution-flow.js
+++ b/pages/contribution-flow.js
@@ -63,7 +63,7 @@ class NewContributionFlowPage extends React.Component {
       description: query.description ? decodeURIComponent(query.description) : undefined,
       interval: query.interval,
       verb: query.verb,
-      paymentMethod: query.paymentMethod,
+      donationMethod: query.donationMethod,
       redirect: query.redirect,
       customData: query.data,
       skipStepDetails: query.skipStepDetails ? parseToBoolean(query.skipStepDetails) : false,
@@ -79,7 +79,7 @@ class NewContributionFlowPage extends React.Component {
   static propTypes = {
     collectiveSlug: PropTypes.string.isRequired,
     verb: PropTypes.string,
-    paymentMethod: PropTypes.string,
+    donationMethod: PropTypes.string,
     redirect: PropTypes.string,
     description: PropTypes.string,
     disabledPaymentMethodTypes: PropTypes.arrayOf(PropTypes.string),
@@ -130,9 +130,9 @@ class NewContributionFlowPage extends React.Component {
   }
 
   renderPageContent() {
-    const { data = {}, step, paymentMethod, LoggedInUser, error } = this.props;
+    const { data = {}, step, donationMethod, LoggedInUser, error } = this.props;
     const { account, tier } = data;
-    const isCrypto = paymentMethod === 'crypto';
+    const isCrypto = donationMethod === 'crypto';
 
     if (data.loading) {
       return (
@@ -164,7 +164,7 @@ class NewContributionFlowPage extends React.Component {
           tier={tier}
           step={step}
           verb={this.props.verb}
-          paymentMethod={this.props.paymentMethod}
+          donationMethod={donationMethod}
           redirect={this.props.redirect}
           description={this.props.description}
           defaultQuantity={this.props.quantity}

--- a/pages/contribution-flow.js
+++ b/pages/contribution-flow.js
@@ -11,7 +11,7 @@ import { floatAmountToCents } from '../lib/math';
 import { compose, parseToBoolean } from '../lib/utils';
 
 import Container from '../components/Container';
-import { STEPS } from '../components/contribution-flow/constants';
+import { DONATION_METHOD, STEPS } from '../components/contribution-flow/constants';
 import ContributionBlocker, {
   CONTRIBUTION_BLOCKER,
   getContributionBlocker,
@@ -132,7 +132,7 @@ class NewContributionFlowPage extends React.Component {
   renderPageContent() {
     const { data = {}, step, donationMethod, LoggedInUser, error } = this.props;
     const { account, tier } = data;
-    const isCrypto = donationMethod === 'crypto';
+    const isCrypto = donationMethod === DONATION_METHOD.CRYPTO;
 
     if (data.loading) {
       return (

--- a/pages/embed/contribution-flow.js
+++ b/pages/embed/contribution-flow.js
@@ -13,7 +13,7 @@ import { compose, parseToBoolean } from '../../lib/utils';
 
 import CollectiveThemeProvider from '../../components/CollectiveThemeProvider';
 import Container from '../../components/Container';
-import { STEPS } from '../../components/contribution-flow/constants';
+import { DONATION_METHOD, STEPS } from '../../components/contribution-flow/constants';
 import ContributionBlocker, { getContributionBlocker } from '../../components/contribution-flow/ContributionBlocker';
 import ContributionFlowSuccess from '../../components/contribution-flow/ContributionFlowSuccess';
 import {
@@ -148,7 +148,7 @@ class NewContributionFlowPage extends React.Component {
   renderPageContent() {
     const { data = {}, step, donationMethod, LoggedInUser } = this.props;
     const { account, tier } = data;
-    const isCrypto = donationMethod === 'crypto';
+    const isCrypto = donationMethod === DONATION_METHOD.CRYPTO;
 
     if (data.loading) {
       return (

--- a/pages/embed/contribution-flow.js
+++ b/pages/embed/contribution-flow.js
@@ -86,7 +86,7 @@ class NewContributionFlowPage extends React.Component {
 
   static propTypes = {
     collectiveSlug: PropTypes.string.isRequired,
-    paymentMethod: PropTypes.string,
+    donationMethod: PropTypes.string,
     verb: PropTypes.string,
     redirect: PropTypes.string,
     description: PropTypes.string,
@@ -146,9 +146,9 @@ class NewContributionFlowPage extends React.Component {
   }
 
   renderPageContent() {
-    const { data = {}, step, paymentMethod, LoggedInUser } = this.props;
+    const { data = {}, step, donationMethod, LoggedInUser } = this.props;
     const { account, tier } = data;
-    const isCrypto = paymentMethod === 'crypto';
+    const isCrypto = donationMethod === 'crypto';
 
     if (data.loading) {
       return (

--- a/pages/embed/contribution-flow.js
+++ b/pages/embed/contribution-flow.js
@@ -13,7 +13,7 @@ import { compose, parseToBoolean } from '../../lib/utils';
 
 import CollectiveThemeProvider from '../../components/CollectiveThemeProvider';
 import Container from '../../components/Container';
-import { DONATION_METHOD, STEPS } from '../../components/contribution-flow/constants';
+import { PAYMENT_FLOW, STEPS } from '../../components/contribution-flow/constants';
 import ContributionBlocker, { getContributionBlocker } from '../../components/contribution-flow/ContributionBlocker';
 import ContributionFlowSuccess from '../../components/contribution-flow/ContributionFlowSuccess';
 import {
@@ -86,7 +86,7 @@ class NewContributionFlowPage extends React.Component {
 
   static propTypes = {
     collectiveSlug: PropTypes.string.isRequired,
-    donationMethod: PropTypes.string,
+    paymentFlow: PropTypes.string,
     verb: PropTypes.string,
     redirect: PropTypes.string,
     description: PropTypes.string,
@@ -146,9 +146,9 @@ class NewContributionFlowPage extends React.Component {
   }
 
   renderPageContent() {
-    const { data = {}, step, donationMethod, LoggedInUser } = this.props;
+    const { data = {}, step, paymentFlow, LoggedInUser } = this.props;
     const { account, tier } = data;
-    const isCrypto = donationMethod === DONATION_METHOD.CRYPTO;
+    const isCrypto = paymentFlow === PAYMENT_FLOW.CRYPTO;
 
     if (data.loading) {
       return (

--- a/rewrites.js
+++ b/rewrites.js
@@ -219,7 +219,7 @@ exports.REWRITES = [
   },
   // New Routes -> New flow
   {
-    source: `/:collectiveSlug/:verb(donate)/:donationMethod(crypto)?/:step(${contributionFlowSteps})?`,
+    source: `/:collectiveSlug/:verb(donate)/:paymentFlow(crypto)?/:step(${contributionFlowSteps})?`,
     destination: createOrderPage,
   },
   {
@@ -239,7 +239,7 @@ exports.REWRITES = [
   },
   // Embed
   {
-    source: `/embed/:collectiveSlug/:verb(donate)/:paymentMethod(crypto)?/:step(${contributionFlowSteps})?`,
+    source: `/embed/:collectiveSlug/:verb(donate)/:paymentFlow(crypto)?/:step(${contributionFlowSteps})?`,
     destination: '/embed/contribution-flow',
   },
   {

--- a/rewrites.js
+++ b/rewrites.js
@@ -219,7 +219,7 @@ exports.REWRITES = [
   },
   // New Routes -> New flow
   {
-    source: `/:collectiveSlug/:verb(donate)/:paymentMethod(crypto)?/:step(${contributionFlowSteps})?`,
+    source: `/:collectiveSlug/:verb(donate)/:donationMethod(crypto)?/:step(${contributionFlowSteps})?`,
     destination: createOrderPage,
   },
   {


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective-frontend/pull/6851#pullrequestreview-767935694

This is with related to the above comment. Here I've renamed the `paymentMethod` to `donationMethod` to avoid any confusion with the other `paymentMethod` variables. 