### PR TITLE
feat(ExpenseForm): add a button to reset the expense form

### DIFF
--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Undo } from '@styled-icons/fa-solid/Undo';
 import { Field, FieldArray, Form, Formik } from 'formik';
 import { first, isEmpty, omit, pick } from 'lodash';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
@@ -67,10 +68,15 @@ const msg = defineMessages({
     id: 'ExpenseForm.StepExpenseFundingRequest',
     defaultMessage: 'Set grant details',
   },
-
   stepPayee: {
     id: 'ExpenseForm.StepPayeeInvoice',
     defaultMessage: 'Payee information',
+  },
+  resetExpense: {
+    defaultMessage: 'Reset Form',
+  },
+  confirmResetExpense: {
+    defaultMessage: 'Do you really want to reset the expense form?',
   },
 });
 
@@ -195,7 +201,7 @@ const ExpenseFormBody = ({
   const intl = useIntl();
   const { formatMessage } = intl;
   const formRef = React.useRef();
-  const { values, handleChange, errors, setValues, dirty, touched, setErrors } = formik;
+  const { values, handleChange, handleReset, errors, setValues, dirty, touched, setErrors } = formik;
   const hasBaseFormFieldsCompleted = values.type && values.description;
   const isInvite = values.payee?.isInvite;
   const isNewUser = !values.payee?.id;
@@ -570,6 +576,29 @@ const ExpenseFormBody = ({
                     {errors.payoutMethod.data.currency.toString()}
                   </Box>
                 )}
+                <StyledHr flex="1" borderColor="#ffffff" mx={2} />
+                <StyledButton
+                  type="button"
+                  buttonStyle="borderless"
+                  width={['100%', 'auto']}
+                  color="red.500"
+                  mt={1}
+                  mx={[2, 0]}
+                  mr={[null, 3]}
+                  whiteSpace="nowrap"
+                  onClick={() => {
+                    if (window.confirm(formatMessage(msg.confirmResetExpense))) {
+                      handleReset();
+                      setStep(STEPS.PAYEE);
+                      if (formPersister) {
+                        formPersister.clearValues();
+                      }
+                    }
+                  }}
+                >
+                  <Undo size={11} />
+                  <Span mx={1}>{formatMessage(msg.resetExpense)}</Span>
+                </StyledButton>
               </Flex>
             </HiddenFragment>
           </HiddenFragment>

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -592,6 +592,7 @@ const ExpenseFormBody = ({
                       setStep(STEPS.PAYEE);
                       if (formPersister) {
                         formPersister.clearValues();
+                        window.scrollTo(0, 0);
                       }
                     }
                   }}

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -190,6 +190,7 @@ const ExpenseFormBody = ({
   formik,
   payoutProfiles,
   collective,
+  expense,
   autoFocusTitle,
   onCancel,
   formPersister,
@@ -587,12 +588,10 @@ const ExpenseFormBody = ({
                     body={formatMessage(msg.confirmResetExpense)}
                     continueHandler={() => {
                       setStep(STEPS.PAYEE);
+                      resetForm({ values: expense || getDefaultExpense(collective) });
                       if (formPersister) {
-                        resetForm({ values: {} });
                         formPersister.clearValues();
                         window.scrollTo(0, 0);
-                      } else {
-                        resetForm();
                       }
                       setShowModal(false);
                     }}
@@ -652,6 +651,18 @@ ExpenseFormBody.propTypes = {
     settings: PropTypes.object,
     isApproved: PropTypes.bool,
   }).isRequired,
+  expense: PropTypes.shape({
+    type: PropTypes.oneOf(Object.values(expenseTypes)),
+    description: PropTypes.string,
+    status: PropTypes.string,
+    payee: PropTypes.object,
+    draft: PropTypes.object,
+    items: PropTypes.arrayOf(
+      PropTypes.shape({
+        url: PropTypes.string,
+      }),
+    ),
+  }),
 };
 
 /**
@@ -661,6 +672,7 @@ const ExpenseForm = ({
   onSubmit,
   collective,
   expense,
+  originalExpense,
   payoutProfiles,
   autoFocusTitle,
   onCancel,
@@ -702,6 +714,7 @@ const ExpenseForm = ({
           formik={formik}
           payoutProfiles={payoutProfiles}
           collective={collective}
+          expense={originalExpense}
           autoFocusTitle={autoFocusTitle}
           onCancel={onCancel}
           formPersister={formPersister}
@@ -741,6 +754,19 @@ ExpenseForm.propTypes = {
   }).isRequired,
   /** If editing */
   expense: PropTypes.shape({
+    type: PropTypes.oneOf(Object.values(expenseTypes)),
+    description: PropTypes.string,
+    status: PropTypes.string,
+    payee: PropTypes.object,
+    draft: PropTypes.object,
+    items: PropTypes.arrayOf(
+      PropTypes.shape({
+        url: PropTypes.string,
+      }),
+    ),
+  }),
+  /** To reset form */
+  originalExpense: PropTypes.shape({
     type: PropTypes.oneOf(Object.values(expenseTypes)),
     description: PropTypes.string,
     status: PropTypes.string,

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -576,7 +576,7 @@ const ExpenseFormBody = ({
                     {errors.payoutMethod.data.currency.toString()}
                   </Box>
                 )}
-                <StyledHr flex="1" borderColor="#ffffff" mx={2} />
+                <StyledHr flex="1" borderColor="white.full" mx={2} />
                 <StyledButton
                   type="button"
                   buttonStyle="borderless"

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -584,7 +584,7 @@ const ExpenseFormBody = ({
                   <ConfirmationModal
                     show
                     onClose={() => setShowModal(false)}
-                    header={<FormattedMessage defaultMessage="Reset form" />}
+                    header={formatMessage(msg.resetExpense)}
                     body={formatMessage(msg.confirmResetExpense)}
                     continueHandler={() => {
                       setStep(STEPS.PAYEE);

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -77,7 +77,7 @@ const msg = defineMessages({
     defaultMessage: 'Reset Form',
   },
   confirmResetExpense: {
-    defaultMessage: 'Do you really want to reset the expense form?',
+    defaultMessage: 'Are you sure you want to reset the expense form?',
   },
 });
 

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -13,6 +13,7 @@ import { PayoutMethodType } from '../../lib/constants/payout-method';
 import { requireFields } from '../../lib/form-utils';
 import { flattenObjectDeep } from '../../lib/utils';
 
+import ConfirmationModal from '../ConfirmationModal';
 import { Box, Flex } from '../Grid';
 import { serializeAddress } from '../I18nAddressFields';
 import PrivateInfoIcon from '../icons/PrivateInfoIcon';
@@ -201,7 +202,7 @@ const ExpenseFormBody = ({
   const intl = useIntl();
   const { formatMessage } = intl;
   const formRef = React.useRef();
-  const { values, handleChange, handleReset, errors, setValues, dirty, touched, setErrors } = formik;
+  const { values, handleChange, errors, setValues, dirty, touched, resetForm, setErrors } = formik;
   const hasBaseFormFieldsCompleted = values.type && values.description;
   const isInvite = values.payee?.isInvite;
   const isNewUser = !values.payee?.id;
@@ -219,6 +220,7 @@ const ExpenseFormBody = ({
   const [step, setStep] = React.useState(stepOneCompleted || isCreditCardCharge ? STEPS.EXPENSE : STEPS.PAYEE);
   // Only true when logged in and drafting the expense
   const [isOnBehalf, setOnBehalf] = React.useState(false);
+  const [showModal, setShowModal] = React.useState(false);
 
   // Scroll to top when step changes
   React.useEffect(() => {
@@ -577,29 +579,40 @@ const ExpenseFormBody = ({
                   </Box>
                 )}
                 <StyledHr flex="1" borderColor="white.full" mx={2} />
-                <StyledButton
-                  type="button"
-                  buttonStyle="borderless"
-                  width={['100%', 'auto']}
-                  color="red.500"
-                  mt={1}
-                  mx={[2, 0]}
-                  mr={[null, 3]}
-                  whiteSpace="nowrap"
-                  onClick={() => {
-                    if (window.confirm(formatMessage(msg.confirmResetExpense))) {
-                      handleReset();
+                {showModal ? (
+                  <ConfirmationModal
+                    show
+                    onClose={() => setShowModal(false)}
+                    header={<FormattedMessage defaultMessage="Reset form" />}
+                    body={formatMessage(msg.confirmResetExpense)}
+                    continueHandler={() => {
                       setStep(STEPS.PAYEE);
                       if (formPersister) {
+                        resetForm({ values: {} });
                         formPersister.clearValues();
                         window.scrollTo(0, 0);
+                      } else {
+                        resetForm();
                       }
-                    }
-                  }}
-                >
-                  <Undo size={11} />
-                  <Span mx={1}>{formatMessage(msg.resetExpense)}</Span>
-                </StyledButton>
+                      setShowModal(false);
+                    }}
+                  />
+                ) : (
+                  <StyledButton
+                    type="button"
+                    buttonStyle="borderless"
+                    width={['100%', 'auto']}
+                    color="red.500"
+                    mt={1}
+                    mx={[2, 0]}
+                    mr={[null, 3]}
+                    whiteSpace="nowrap"
+                    onClick={() => setShowModal(true)}
+                  >
+                    <Undo size={11} />
+                    <Span mx={1}>{formatMessage(msg.resetExpense)}</Span>
+                  </StyledButton>
+                )}
               </Flex>
             </HiddenFragment>
           </HiddenFragment>

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -221,7 +221,7 @@ const ExpenseFormBody = ({
   const [step, setStep] = React.useState(stepOneCompleted || isCreditCardCharge ? STEPS.EXPENSE : STEPS.PAYEE);
   // Only true when logged in and drafting the expense
   const [isOnBehalf, setOnBehalf] = React.useState(false);
-  const [showModal, setShowModal] = React.useState(false);
+  const [showResetModal, setShowResetModal] = React.useState(false);
 
   // Scroll to top when step changes
   React.useEffect(() => {
@@ -580,10 +580,10 @@ const ExpenseFormBody = ({
                   </Box>
                 )}
                 <StyledHr flex="1" borderColor="white.full" mx={2} />
-                {showModal ? (
+                {showResetModal ? (
                   <ConfirmationModal
                     show
-                    onClose={() => setShowModal(false)}
+                    onClose={() => setShowResetModal(false)}
                     header={formatMessage(msg.resetExpense)}
                     body={formatMessage(msg.confirmResetExpense)}
                     continueHandler={() => {
@@ -593,7 +593,7 @@ const ExpenseFormBody = ({
                         formPersister.clearValues();
                         window.scrollTo(0, 0);
                       }
-                      setShowModal(false);
+                      setShowResetModal(false);
                     }}
                   />
                 ) : (
@@ -606,7 +606,7 @@ const ExpenseFormBody = ({
                     mx={[2, 0]}
                     mr={[null, 3]}
                     whiteSpace="nowrap"
-                    onClick={() => setShowModal(true)}
+                    onClick={() => setShowResetModal(true)}
                   >
                     <Undo size={11} />
                     <Span mx={1}>{formatMessage(msg.resetExpense)}</Span>

--- a/components/expenses/ExpenseSummary.js
+++ b/components/expenses/ExpenseSummary.js
@@ -68,7 +68,6 @@ const ExpenseSummary = ({
   const createdByAccount = expense?.requestedByAccount || expense?.createdByAccount || {};
   const expenseItems = expense?.items.length > 0 ? expense.items : expense?.draft?.items || [];
 
-  console.log('exp', expense);
   return (
     <StyledCard
       p={borderless ? 0 : [16, 24, 32]}

--- a/components/expenses/ExpenseSummary.js
+++ b/components/expenses/ExpenseSummary.js
@@ -68,6 +68,7 @@ const ExpenseSummary = ({
   const createdByAccount = expense?.requestedByAccount || expense?.createdByAccount || {};
   const expenseItems = expense?.items.length > 0 ? expense.items : expense?.draft?.items || [];
 
+  console.log('exp', expense);
   return (
     <StyledCard
       p={borderless ? 0 : [16, 24, 32]}

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1914,6 +1914,7 @@
   "Success": "Success",
   "Summary": "Summary",
   "SupportProject": "Support {projectName}",
+  "t+ZzuJ": "Reset Form",
   "table.head.grow": "Grow",
   "table.head.scale": "Scale",
   "table.head.start": "Start",
@@ -2190,5 +2191,6 @@
   "WM71Ho": "Discover Collectives to Support",
   "YearlyBudget": "Pressupost anual",
   "yes": "Sí",
+  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -2189,8 +2189,8 @@
   "widget.contributeOnOpenCollective": "Contribute on Open Collective",
   "withColon": "{item}:",
   "WM71Ho": "Discover Collectives to Support",
+  "wtrPbi": "Are you sure you want to reset the expense form?",
   "YearlyBudget": "Pressupost anual",
   "yes": "Sí",
-  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1914,6 +1914,7 @@
   "Success": "Success",
   "Summary": "Summary",
   "SupportProject": "Support {projectName}",
+  "t+ZzuJ": "Reset Form",
   "table.head.grow": "Grow",
   "table.head.scale": "Scale",
   "table.head.start": "Start",
@@ -2190,5 +2191,6 @@
   "WM71Ho": "Discover Collectives to Support",
   "YearlyBudget": "Roční rozpočet",
   "yes": "Ano",
+  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -2189,8 +2189,8 @@
   "widget.contributeOnOpenCollective": "Přispějte na Open Collective",
   "withColon": "{item}:",
   "WM71Ho": "Discover Collectives to Support",
+  "wtrPbi": "Are you sure you want to reset the expense form?",
   "YearlyBudget": "Roční rozpočet",
   "yes": "Ano",
-  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -2189,8 +2189,8 @@
   "widget.contributeOnOpenCollective": "Contribute on Open Collective",
   "withColon": "{item}:",
   "WM71Ho": "Discover Collectives to Support",
+  "wtrPbi": "Are you sure you want to reset the expense form?",
   "YearlyBudget": "Jährliches Budget",
   "yes": "Ja",
-  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -1914,6 +1914,7 @@
   "Success": "Success",
   "Summary": "Summary",
   "SupportProject": "Support {projectName}",
+  "t+ZzuJ": "Reset Form",
   "table.head.grow": "Grow",
   "table.head.scale": "Scale",
   "table.head.start": "Start",
@@ -2190,5 +2191,6 @@
   "WM71Ho": "Discover Collectives to Support",
   "YearlyBudget": "Jährliches Budget",
   "yes": "Ja",
+  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -1914,6 +1914,7 @@
   "Success": "Success",
   "Summary": "Summary",
   "SupportProject": "Support {projectName}",
+  "t+ZzuJ": "Reset Form",
   "table.head.grow": "Grow",
   "table.head.scale": "Scale",
   "table.head.start": "Start",
@@ -2190,5 +2191,6 @@
   "WM71Ho": "Discover Collectives to Support",
   "YearlyBudget": "Yearly budget",
   "yes": "Yes",
+  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -2189,8 +2189,8 @@
   "widget.contributeOnOpenCollective": "Contribute on Open Collective",
   "withColon": "{item}:",
   "WM71Ho": "Discover Collectives to Support",
+  "wtrPbi": "Are you sure you want to reset the expense form?",
   "YearlyBudget": "Yearly budget",
   "yes": "Yes",
-  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -1914,6 +1914,7 @@
   "Success": "Success",
   "Summary": "Resumen",
   "SupportProject": "Support {projectName}",
+  "t+ZzuJ": "Reset Form",
   "table.head.grow": "Grow",
   "table.head.scale": "Scale",
   "table.head.start": "Start",
@@ -2190,5 +2191,6 @@
   "WM71Ho": "Discover Collectives to Support",
   "YearlyBudget": "Presupuesto anual",
   "yes": "Sí",
+  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -2189,8 +2189,8 @@
   "widget.contributeOnOpenCollective": "Contribuir en Open Collective",
   "withColon": "{item}:",
   "WM71Ho": "Discover Collectives to Support",
+  "wtrPbi": "Are you sure you want to reset the expense form?",
   "YearlyBudget": "Presupuesto anual",
   "yes": "Sí",
-  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2189,8 +2189,8 @@
   "widget.contributeOnOpenCollective": "Contribuer sur Open Collective",
   "withColon": "{item} :",
   "WM71Ho": "Discover Collectives to Support",
+  "wtrPbi": "Are you sure you want to reset the expense form?",
   "YearlyBudget": "Budget annuel",
   "yes": "Oui",
-  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1914,6 +1914,7 @@
   "Success": "Succès",
   "Summary": "Résumé",
   "SupportProject": "Soutenir {projectName}",
+  "t+ZzuJ": "Reset Form",
   "table.head.grow": "Grandir",
   "table.head.scale": "Scale",
   "table.head.start": "Démarrer",
@@ -2190,5 +2191,6 @@
   "WM71Ho": "Discover Collectives to Support",
   "YearlyBudget": "Budget annuel",
   "yes": "Oui",
+  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/it.json
+++ b/lang/it.json
@@ -2189,8 +2189,8 @@
   "widget.contributeOnOpenCollective": "Contribute on Open Collective",
   "withColon": "{item}:",
   "WM71Ho": "Discover Collectives to Support",
+  "wtrPbi": "Are you sure you want to reset the expense form?",
   "YearlyBudget": "Budget annuale",
   "yes": "Yes",
-  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/it.json
+++ b/lang/it.json
@@ -1914,6 +1914,7 @@
   "Success": "Success",
   "Summary": "Summary",
   "SupportProject": "Support {projectName}",
+  "t+ZzuJ": "Reset Form",
   "table.head.grow": "Grow",
   "table.head.scale": "Scale",
   "table.head.start": "Start",
@@ -2190,5 +2191,6 @@
   "WM71Ho": "Discover Collectives to Support",
   "YearlyBudget": "Budget annuale",
   "yes": "Yes",
+  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1914,6 +1914,7 @@
   "Success": "Success",
   "Summary": "Summary",
   "SupportProject": "Support {projectName}",
+  "t+ZzuJ": "Reset Form",
   "table.head.grow": "Grow",
   "table.head.scale": "Scale",
   "table.head.start": "Start",
@@ -2190,5 +2191,6 @@
   "WM71Ho": "Discover Collectives to Support",
   "YearlyBudget": "Yearly budget",
   "yes": "Yes",
+  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -2189,8 +2189,8 @@
   "widget.contributeOnOpenCollective": "Contribute on Open Collective",
   "withColon": "{item}:",
   "WM71Ho": "Discover Collectives to Support",
+  "wtrPbi": "Are you sure you want to reset the expense form?",
   "YearlyBudget": "Yearly budget",
   "yes": "Yes",
-  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -2189,8 +2189,8 @@
   "widget.contributeOnOpenCollective": "Contribute on Open Collective",
   "withColon": "{item}:",
   "WM71Ho": "Discover Collectives to Support",
+  "wtrPbi": "Are you sure you want to reset the expense form?",
   "YearlyBudget": "연간 예산",
   "yes": "예",
-  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1914,6 +1914,7 @@
   "Success": "성공",
   "Summary": "요약",
   "SupportProject": "Support {projectName}",
+  "t+ZzuJ": "Reset Form",
   "table.head.grow": "성장",
   "table.head.scale": "크기",
   "table.head.start": "시작",
@@ -2190,5 +2191,6 @@
   "WM71Ho": "Discover Collectives to Support",
   "YearlyBudget": "연간 예산",
   "yes": "예",
+  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1914,6 +1914,7 @@
   "Success": "Success",
   "Summary": "Summary",
   "SupportProject": "Support {projectName}",
+  "t+ZzuJ": "Reset Form",
   "table.head.grow": "Grow",
   "table.head.scale": "Scale",
   "table.head.start": "Start",
@@ -2190,5 +2191,6 @@
   "WM71Ho": "Discover Collectives to Support",
   "YearlyBudget": "Yearly budget",
   "yes": "Yes",
+  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -2189,8 +2189,8 @@
   "widget.contributeOnOpenCollective": "Contribute on Open Collective",
   "withColon": "{item}:",
   "WM71Ho": "Discover Collectives to Support",
+  "wtrPbi": "Are you sure you want to reset the expense form?",
   "YearlyBudget": "Yearly budget",
   "yes": "Yes",
-  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -2189,8 +2189,8 @@
   "widget.contributeOnOpenCollective": "Contribuir com a Open Collective",
   "withColon": "{item}:",
   "WM71Ho": "Discover Collectives to Support",
+  "wtrPbi": "Are you sure you want to reset the expense form?",
   "YearlyBudget": "Orçamento anual",
   "yes": "Sim",
-  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1914,6 +1914,7 @@
   "Success": "Sucesso",
   "Summary": "Resumo",
   "SupportProject": "Apoie {projectName}",
+  "t+ZzuJ": "Reset Form",
   "table.head.grow": "Crescer",
   "table.head.scale": "Escalar",
   "table.head.start": "Iniciar",
@@ -2190,5 +2191,6 @@
   "WM71Ho": "Discover Collectives to Support",
   "YearlyBudget": "Orçamento anual",
   "yes": "Sim",
+  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -2189,8 +2189,8 @@
   "widget.contributeOnOpenCollective": "Contribua no Open Collective",
   "withColon": "{item}:",
   "WM71Ho": "Discover Collectives to Support",
+  "wtrPbi": "Are you sure you want to reset the expense form?",
   "YearlyBudget": "Orçamento anual",
   "yes": "Sim",
-  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1914,6 +1914,7 @@
   "Success": "Success",
   "Summary": "Summary",
   "SupportProject": "Support {projectName}",
+  "t+ZzuJ": "Reset Form",
   "table.head.grow": "Grow",
   "table.head.scale": "Scale",
   "table.head.start": "Start",
@@ -2190,5 +2191,6 @@
   "WM71Ho": "Discover Collectives to Support",
   "YearlyBudget": "Orçamento anual",
   "yes": "Sim",
+  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -2189,8 +2189,8 @@
   "widget.contributeOnOpenCollective": "Внести свой вклад на Open Collective",
   "withColon": "{item}:",
   "WM71Ho": "Discover Collectives to Support",
+  "wtrPbi": "Are you sure you want to reset the expense form?",
   "YearlyBudget": "Годовой бюджет",
   "yes": "Да",
-  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1914,6 +1914,7 @@
   "Success": "Успешно",
   "Summary": "Краткое описание",
   "SupportProject": "Поддержка {projectName}",
+  "t+ZzuJ": "Reset Form",
   "table.head.grow": "Увеличить",
   "table.head.scale": "Scale",
   "table.head.start": "Стартовый",
@@ -2190,5 +2191,6 @@
   "WM71Ho": "Discover Collectives to Support",
   "YearlyBudget": "Годовой бюджет",
   "yes": "Да",
+  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -2189,8 +2189,8 @@
   "widget.contributeOnOpenCollective": "Допомогти на Open Collective",
   "withColon": "{item}:",
   "WM71Ho": "Discover Collectives to Support",
+  "wtrPbi": "Are you sure you want to reset the expense form?",
   "YearlyBudget": "Річний бюджет",
   "yes": "Так",
-  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -1914,6 +1914,7 @@
   "Success": "Вдалося",
   "Summary": "Підсумок",
   "SupportProject": "Підтримка {projectName}",
+  "t+ZzuJ": "Reset Form",
   "table.head.grow": "Зростання",
   "table.head.scale": "Масштаб",
   "table.head.start": "Початок",
@@ -2190,5 +2191,6 @@
   "WM71Ho": "Discover Collectives to Support",
   "YearlyBudget": "Річний бюджет",
   "yes": "Так",
+  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1914,6 +1914,7 @@
   "Success": "成功",
   "Summary": "摘要",
   "SupportProject": "支持 {projectName}",
+  "t+ZzuJ": "Reset Form",
   "table.head.grow": "增长",
   "table.head.scale": "规模",
   "table.head.start": "开始",
@@ -2190,5 +2191,6 @@
   "WM71Ho": "Discover Collectives to Support",
   "YearlyBudget": "年度预算",
   "yes": "是的",
+  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -2189,8 +2189,8 @@
   "widget.contributeOnOpenCollective": "Contribute on Open Collective",
   "withColon": "{item}：",
   "WM71Ho": "Discover Collectives to Support",
+  "wtrPbi": "Are you sure you want to reset the expense form?",
   "YearlyBudget": "年度预算",
   "yes": "是的",
-  "zuys7h": "Do you really want to reset the expense form?",
   "zWgbGg": "Today"
 }

--- a/pages/expense.js
+++ b/pages/expense.js
@@ -635,6 +635,7 @@ class ExpensePage extends React.Component {
                     collective={collective}
                     loading={data.loading || loadingLoggedInUser || isRefetchingDataForUser}
                     expense={editedExpense || expense}
+                    originalExpense={expense}
                     expensesTags={this.getSuggestedTags(collective)}
                     payoutProfiles={payoutProfiles}
                     loggedInAccount={loggedInAccount}


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/4625

# Description

add a button to reset the expense form

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Demo

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->

## Editing an expense

https://user-images.githubusercontent.com/46647141/135701512-d5483cb5-af30-41f4-95f4-928e4ab8b0d7.mp4


## Submitting a new expense


https://user-images.githubusercontent.com/46647141/135702050-3a727f2c-e39e-4dad-8e90-15be3c09b288.mp4


