### PR TITLE
Show Contribution Blocker at Beginning of Flow when Host has No Payment Methods

### DIFF
--- a/components/contribution-flow/ContributionBlocker.js
+++ b/components/contribution-flow/ContributionBlocker.js
@@ -74,7 +74,16 @@ export const getContributionBlocker = (loggedInUser, account, tier, shouldHaveTi
     return { reason: CONTRIBUTION_BLOCKER.NO_CRYPTO_CONTRIBUTION, type: 'warning', showOtherWaysToContribute: true };
   } else if (account.settings.disableCustomContributions && !isCrypto && !tier) {
     return { reason: CONTRIBUTION_BLOCKER.NO_CUSTOM_CONTRIBUTION, type: 'warning', showOtherWaysToContribute: true };
-  } else if (tierHasFixedInterval(tier) && !canContributeRecurring(account, loggedInUser)) {
+    /*
+     * The no payment warning is shown if,
+     * a) The host has no payment methods configured.
+     * b) If this tier has a fixed interval but the collective doesn't support recurring contributions (i.e: say the
+     *    collective has only bank transfer payment method).
+     */
+  } else if (
+    account.host.supportedPaymentMethods?.length === 0 ||
+    (tierHasFixedInterval(tier) && !canContributeRecurring(account, loggedInUser))
+  ) {
     return {
       reason: CONTRIBUTION_BLOCKER.NO_PAYMENT_PROVIDER,
       type: 'warning',


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/4669 specifically the comment https://github.com/opencollective/opencollective/issues/4669#issuecomment-932841111

![contribution-blocker](https://user-images.githubusercontent.com/12435965/135778128-efd4593f-be68-4d28-8ab9-fdde4469eb43.gif)

Here I have made sure the contribution flow is blocked when there's no payment methods configured on the host side. 🙂 


