### PR TITLE
RichTextEditor: Improve scrollbar display

### DIFF
--- a/components/RichTextEditor.js
+++ b/components/RichTextEditor.js
@@ -6,6 +6,7 @@ import { v4 as uuid } from 'uuid';
 import { isURL } from 'validator';
 
 import { uploadImageWithXHR } from '../lib/api';
+import { CustomScrollbarCSS } from '../lib/styled-components-shared-styles';
 import { stripHTML } from '../lib/utils';
 
 import Container from './Container';
@@ -30,7 +31,11 @@ const TrixEditorContainer = styled.div`
     margin-top: 8px;
     padding-top: 8px;
     outline-offset: 0.5em;
-    overflow-y: scroll;
+    ${CustomScrollbarCSS}
+    &::-webkit-scrollbar {
+      width: 8px;
+    }
+    ${props => Boolean(props.editorMaxHeight) && css({ overflowY: 'scroll' })}
 
     // Outline (only when there's no border)
     ${props =>


### PR DESCRIPTION
Quick fix for https://github.com/opencollective/opencollective/issues/4481#issuecomment-933404243

1. Hide scrollbar if no minHeight is set
2. Use our custom styles for the scrollbar

![image](https://user-images.githubusercontent.com/1556356/135851438-ba6febdb-b435-4737-942e-adf431bb612a.png)
