### PR TITLE
PeriodFilter: Use generic function to parse period

### DIFF
--- a/components/edit-collective/sections/virtual-cards/VirtualCards.js
+++ b/components/edit-collective/sections/virtual-cards/VirtualCards.js
@@ -5,6 +5,7 @@ import { omit, omitBy } from 'lodash';
 import { useRouter } from 'next/router';
 import { FormattedMessage } from 'react-intl';
 
+import { parseDateInterval } from '../../../../lib/date-utils';
 import { API_V2_CONTEXT, gqlV2 } from '../../../../lib/graphql/helpers';
 
 import Collapse from '../../../Collapse';
@@ -97,7 +98,7 @@ const VirtualCards = props => {
   const routerQuery = omit(router.query, ['slug', 'section']);
   const offset = parseInt(routerQuery.offset) || 0;
   const { state, merchant, period } = routerQuery;
-
+  const { from: dateFrom, to: dateTo } = parseDateInterval(period);
   const { loading, data } = useQuery(virtualCardsQuery, {
     context: API_V2_CONTEXT,
     variables: {
@@ -106,8 +107,8 @@ const VirtualCards = props => {
       offset,
       state,
       merchantAccount: { slug: merchant },
-      dateFrom: period?.split('→')[0],
-      dateTo: period?.split('→')[1] !== 'all' ? period?.split('→')[1] : null,
+      dateFrom: dateFrom,
+      dateTo: dateTo,
     },
   });
 

--- a/components/transactions/TransactionsDownloadCSV.js
+++ b/components/transactions/TransactionsDownloadCSV.js
@@ -6,6 +6,7 @@ import dayjs from 'dayjs';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { fetchCSVFileFromRESTService } from '../../lib/api';
+import { parseDateInterval } from '../../lib/date-utils';
 import { formatErrorMessage, i18nGraphqlException } from '../../lib/errors';
 import { exportFile } from '../../lib/export_file';
 import { transactionsQuery } from '../../lib/graphql/queries';
@@ -82,10 +83,8 @@ const TransactionsDownloadCSV = ({ collective, client, query }) => {
   const { addToast } = useToasts();
   let dateFrom, dateTo;
   if (query.period) {
-    [dateFrom, dateTo] = query.period.split('→');
+    ({ from: dateFrom, to: dateTo } = parseDateInterval(query.period));
   }
-  dateFrom = dateFrom === 'all' ? null : dateFrom;
-  dateTo = dateTo === 'all' ? null : dateTo;
 
   const type = query.type;
 
@@ -98,8 +97,7 @@ const TransactionsDownloadCSV = ({ collective, client, query }) => {
         query: transactionsQuery,
         variables: {
           dateFrom: dateFrom,
-          // Extend to end of day
-          dateTo: dateTo && dayjs(dateTo).set('hour', 23).set('minute', 59).set('second', 59).toISOString(),
+          dateTo: dateTo,
           CollectiveId: collective.legacyId,
           type: type,
           kinds: kinds,


### PR DESCRIPTION
Uses the latest changes from https://github.com/opencollective/opencollective-frontend/pull/6931

While updating the period filter, I missed that two places were manually parsing the period string instead of relying on the standard helper.