### PR TITLE
change button to say remove

### DIFF
--- a/components/edit-collective/sections/EditMemberModal.js
+++ b/components/edit-collective/sections/EditMemberModal.js
@@ -98,10 +98,10 @@ const EditMemberModal = props => {
     context: API_V2_CONTEXT,
   });
 
-  const [
-    editMemberInvitationAccount,
-    { loading: isEditingMemberInvitation },
-  ] = useMutation(editMemberInvitationMutation, { context: API_V2_CONTEXT });
+  const [editMemberInvitationAccount, { loading: isEditingMemberInvitation }] = useMutation(
+    editMemberInvitationMutation,
+    { context: API_V2_CONTEXT },
+  );
 
   const [removeMemberAccount] = useMutation(removeMemberMutation, {
     context: API_V2_CONTEXT,

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1403,7 +1403,7 @@
   "Members.DefinedInParent": "Team members are defined in the settings of {parentName}",
   "members.edit.description": "Note: Only Collective Admins can edit this Collective and approve expenses.",
   "members.pending.details": "This person has not accepted their invitation yet",
-  "members.remove": "Delete Member",
+  "members.remove": "Remove",
   "members.remove.cantRemoveLast": "The last admin cannot be removed. Please add another admin first.",
   "members.remove.confirm": "Do you really want to remove {name} @{slug} {hasEmail, select, 1 {({email})} other {}}?",
   "members.role.label": "Role",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1403,7 +1403,7 @@
   "Members.DefinedInParent": "Team members are defined in the settings of {parentName}",
   "members.edit.description": "Note: Only Collective Admins can edit this Collective and approve expenses.",
   "members.pending.details": "This person has not accepted their invitation yet",
-  "members.remove": "Delete Member",
+  "members.remove": "Remove",
   "members.remove.cantRemoveLast": "The last admin cannot be removed. Please add another admin first.",
   "members.remove.confirm": "Do you really want to remove {name} @{slug} {hasEmail, select, 1 {({email})} other {}}?",
   "members.role.label": "Role",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1403,7 +1403,7 @@
   "Members.DefinedInParent": "Team members are defined in the settings of {parentName}",
   "members.edit.description": "Note: Only Collective Admins can edit this Collective and approve expenses.",
   "members.pending.details": "This person has not accepted their invitation yet",
-  "members.remove": "Delete Member",
+  "members.remove": "Remove",
   "members.remove.cantRemoveLast": "The last admin cannot be removed. Please add another admin first.",
   "members.remove.confirm": "Do you really want to remove {name} @{slug} {hasEmail, select, 1 {({email})} other {}}?",
   "members.role.label": "Role",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1403,7 +1403,7 @@
   "Members.DefinedInParent": "Team members are defined in the settings of {parentName}",
   "members.edit.description": "Note: Only Collective Admins can edit this Collective and approve expenses.",
   "members.pending.details": "This person has not accepted their invitation yet",
-  "members.remove": "Delete Member",
+  "members.remove": "Remove",
   "members.remove.cantRemoveLast": "The last admin cannot be removed. Please add another admin first.",
   "members.remove.confirm": "Do you really want to remove {name} @{slug} {hasEmail, select, 1 {({email})} other {}}?",
   "members.role.label": "Role",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1403,7 +1403,7 @@
   "Members.DefinedInParent": "Los miembros del equipo están definidos en la configuración de {parentName}",
   "members.edit.description": "Nota: solo los administradores del Colectivo pueden editar este Colectivo y aprobar gastos.",
   "members.pending.details": "Esta persona no ha aceptado su invitación aún",
-  "members.remove": "Delete Member",
+  "members.remove": "Remove",
   "members.remove.cantRemoveLast": "No se puede eliminar el último administrador. Por favor, añade otro administrador primero.",
   "members.remove.confirm": "¿Estás seguro que quieres eliminar a {name} @{slug} {hasEmail, select, 1 {({email})} other {}}?",
   "members.role.label": "Role",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1403,7 +1403,7 @@
   "Members.DefinedInParent": "Team members are defined in the settings of {parentName}",
   "members.edit.description": "Note: Only Collective Admins can edit this Collective and approve expenses.",
   "members.pending.details": "This person has not accepted their invitation yet",
-  "members.remove": "Delete Member",
+  "members.remove": "Remove",
   "members.remove.cantRemoveLast": "The last admin cannot be removed. Please add another admin first.",
   "members.remove.confirm": "Voulez-vous vraiment enlever {name} @{slug} {hasEmail, select, 1 {({email})} other {}}?",
   "members.role.label": "Role",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1403,7 +1403,7 @@
   "Members.DefinedInParent": "Team members are defined in the settings of {parentName}",
   "members.edit.description": "Note: Only Collective Admins can edit this Collective and approve expenses.",
   "members.pending.details": "This person has not accepted their invitation yet",
-  "members.remove": "Delete Member",
+  "members.remove": "Remove",
   "members.remove.cantRemoveLast": "The last admin cannot be removed. Please add another admin first.",
   "members.remove.confirm": "Do you really want to remove {name} @{slug} {hasEmail, select, 1 {({email})} other {}}?",
   "members.role.label": "Role",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1403,7 +1403,7 @@
   "Members.DefinedInParent": "Team members are defined in the settings of {parentName}",
   "members.edit.description": "Note: Only Collective Admins can edit this Collective and approve expenses.",
   "members.pending.details": "This person has not accepted their invitation yet",
-  "members.remove": "Delete Member",
+  "members.remove": "Remove",
   "members.remove.cantRemoveLast": "The last admin cannot be removed. Please add another admin first.",
   "members.remove.confirm": "Do you really want to remove {name} @{slug} {hasEmail, select, 1 {({email})} other {}}?",
   "members.role.label": "Role",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1403,7 +1403,7 @@
   "Members.DefinedInParent": "Team members are defined in the settings of {parentName}",
   "members.edit.description": "Note: Only Collective Admins can edit this Collective and approve expenses.",
   "members.pending.details": "This person has not accepted their invitation yet",
-  "members.remove": "Delete Member",
+  "members.remove": "Remove",
   "members.remove.cantRemoveLast": "The last admin cannot be removed. Please add another admin first.",
   "members.remove.confirm": "Do you really want to remove {name} @{slug} {hasEmail, select, 1 {({email})} other {}}?",
   "members.role.label": "Role",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1403,7 +1403,7 @@
   "Members.DefinedInParent": "Team members are defined in the settings of {parentName}",
   "members.edit.description": "Note: Only Collective Admins can edit this Collective and approve expenses.",
   "members.pending.details": "This person has not accepted their invitation yet",
-  "members.remove": "Delete Member",
+  "members.remove": "Remove",
   "members.remove.cantRemoveLast": "The last admin cannot be removed. Please add another admin first.",
   "members.remove.confirm": "Do you really want to remove {name} @{slug} {hasEmail, select, 1 {({email})} other {}}?",
   "members.role.label": "Role",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1403,7 +1403,7 @@
   "Members.DefinedInParent": "Os membros da equipe são definidos nas configurações de {parentName}",
   "members.edit.description": "Nota: Somente administradores do Coletivo podem editar este Coletivo e aprovar as despesas.",
   "members.pending.details": "Esta pessoa ainda não aceitou o convite",
-  "members.remove": "Delete Member",
+  "members.remove": "Remove",
   "members.remove.cantRemoveLast": "O último administrador não pode ser removido. Por favor, adicione outro administrador antes.",
   "members.remove.confirm": "Você realmente quer remover {name} @{slug} {hasEmail, select, 1 {({email})} other {}}?",
   "members.role.label": "Role",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1403,7 +1403,7 @@
   "Members.DefinedInParent": "Team members are defined in the settings of {parentName}",
   "members.edit.description": "Note: Only Collective Admins can edit this Collective and approve expenses.",
   "members.pending.details": "This person has not accepted their invitation yet",
-  "members.remove": "Delete Member",
+  "members.remove": "Remove",
   "members.remove.cantRemoveLast": "The last admin cannot be removed. Please add another admin first.",
   "members.remove.confirm": "Do you really want to remove {name} @{slug} {hasEmail, select, 1 {({email})} other {}}?",
   "members.role.label": "Role",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1403,7 +1403,7 @@
   "Members.DefinedInParent": "Team members are defined in the settings of {parentName}",
   "members.edit.description": "Note: Only Collective Admins can edit this Collective and approve expenses.",
   "members.pending.details": "This person has not accepted their invitation yet",
-  "members.remove": "Delete Member",
+  "members.remove": "Remove",
   "members.remove.cantRemoveLast": "The last admin cannot be removed. Please add another admin first.",
   "members.remove.confirm": "Do you really want to remove {name} @{slug} {hasEmail, select, 1 {({email})} other {}}?",
   "members.role.label": "Role",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -1403,7 +1403,7 @@
   "Members.DefinedInParent": "Team members are defined in the settings of {parentName}",
   "members.edit.description": "Note: Only Collective Admins can edit this Collective and approve expenses.",
   "members.pending.details": "This person has not accepted their invitation yet",
-  "members.remove": "Delete Member",
+  "members.remove": "Remove",
   "members.remove.cantRemoveLast": "The last admin cannot be removed. Please add another admin first.",
   "members.remove.confirm": "Do you really want to remove {name} @{slug} {hasEmail, select, 1 {({email})} other {}}?",
   "members.role.label": "Role",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1403,7 +1403,7 @@
   "Members.DefinedInParent": "Team members are defined in the settings of {parentName}",
   "members.edit.description": "Note: Only Collective Admins can edit this Collective and approve expenses.",
   "members.pending.details": "This person has not accepted their invitation yet",
-  "members.remove": "Delete Member",
+  "members.remove": "Remove",
   "members.remove.cantRemoveLast": "The last admin cannot be removed. Please add another admin first.",
   "members.remove.confirm": "Do you really want to remove {name} @{slug} {hasEmail, select, 1 {({email})} other {}}?",
   "members.role.label": "Role",


### PR DESCRIPTION
I think saying `delete member` implies you're deleting this person, when it's supposed to indicate removing them from your team.