### PR TITLE
Correct spacing issue with money managed section labels

### DIFF
--- a/components/host-dashboard/reports-section/TotalMoneyManagedSection.js
+++ b/components/host-dashboard/reports-section/TotalMoneyManagedSection.js
@@ -100,13 +100,13 @@ const TotalMoneyManagedSection = ({ currency, hostMetrics }) => {
         <Container mt={18} mb={12}>
           <FundAmounts>
             <Flex flexWrap="wrap">
-              <Box width={[1, 1, 1 / 2]}>
+              <Box width={[1, 1, 1 / 2]} pl="8px">
                 <TotalFundsLabel minWidth="210px" style={{ verticalAlign: 'middle' }}>
                   <Span fontWeight="700">{formatCurrency(totalCollectiveFunds, currency)}</Span> |{' '}
                   <FormattedMessage id="Collectives" defaultMessage="Collectives" />
                 </TotalFundsLabel>
               </Box>
-              <Box width={[1, 1, 1 / 2]} pt={['35px', '35px', 0]}>
+              <Box width={[1, 1, 1 / 2]} pt={['35px', '35px', 0]} pl="8px">
                 <TotalFundsLabel minWidth="230px" style={{ verticalAlign: 'middle' }}>
                   <Span fontWeight="700">{formatCurrency(totalHostFunds, currency)}</Span> |{' '}
                   <FormattedMessage id="TotalMoneyManagedSection.hostOrganization" defaultMessage="Host Organization" />


### PR DESCRIPTION
This was reported at https://opencollective.slack.com/archives/C020ZQSLM5M/p1633697604022000?thread_ts=1633632414.021400&cid=C020ZQSLM5M. The money managed section of the host dashboard reports have a slight spacing issue with the labels. This corrects it. 😄  

![image](https://user-images.githubusercontent.com/12435965/136974130-47f05842-8d8e-44f7-9083-597247fa4fd9.png)
