### PR TITLE
Remove unnecessary `@` sign when inviting users to submit an expense

### DIFF
--- a/components/expenses/ExpensePayeeDetails.js
+++ b/components/expenses/ExpensePayeeDetails.js
@@ -98,7 +98,7 @@ const ExpensePayeeDetails = ({ expense, host, isLoading, borderless, isLoadingLo
                   payee.organization?.name || payee.name,
                 )}
               </Span>
-              {payee.type !== CollectiveType.VENDOR && (
+              {payee.type !== CollectiveType.VENDOR && (payee.organization?.slug || payee.slug) && (
                 <Span color="black.900" fontSize="11px" truncateOverflow>
                   @{payee.organization?.slug || payee.slug}
                 </Span>


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4795

![image](https://user-images.githubusercontent.com/12435965/136617073-f7b41659-2f84-4d72-b941-67b60bf81a31.png)
