### PR TITLE
ExpenseItemForm: use a simplified version for rich text editor

### DIFF
--- a/components/expenses/ExpenseItemForm.js
+++ b/components/expenses/ExpenseItemForm.js
@@ -158,7 +158,13 @@ const ExpenseItemForm = ({
           >
             {inputProps =>
               isRichText ? (
-                <Field as={RichTextEditor} {...inputProps} inputName={inputProps.name} withBorders />
+                <Field
+                  as={RichTextEditor}
+                  {...inputProps}
+                  inputName={inputProps.name}
+                  withBorders
+                  version="simplified"
+                />
               ) : (
                 <Field as={StyledInput} {...inputProps} />
               )


### PR DESCRIPTION
Fix to prevent issues like https://opencollective.freshdesk.com/a/tickets/39263 to happen in the future, by not allowing users to upload images.