### PR TITLE
AdminPanel: Event form data load

### DIFF
--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -166,6 +166,9 @@ export const editCollectivePageFieldsFragment = gql`
     slug
     isActive
     isIncognito
+    startsAt
+    endsAt
+    timezone
     host {
       id
       createdAt
@@ -252,6 +255,10 @@ export const editCollectivePageFieldsFragment = gql`
       currency
       maxQuantity
       button
+      stats {
+        id
+        availableQuantity
+      }
     }
     members(roles: ["ADMIN", "MEMBER", "HOST"]) {
       id
@@ -318,6 +325,10 @@ export const editCollectivePageFieldsFragment = gql`
       id
       slug
       name
+      currency
+      imageUrl
+      backgroundImage
+      settings
     }
     features {
       ...NavbarFields

--- a/pages/admin-panel.js
+++ b/pages/admin-panel.js
@@ -172,4 +172,10 @@ const AdminPanelPage = () => {
   );
 };
 
+AdminPanelPage.getInitialProps = () => {
+  return {
+    scripts: { googleMaps: true }, // TODO: This should be enabled only for events
+  };
+};
+
 export default AdminPanelPage;


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/4865#issuecomment-952752581

Events data was not preloaded in the new admin panel