### PR TITLE
Add support for maxCollapsedHeight in HTMLContent.js

### DIFF
--- a/components/HTMLContent.js
+++ b/components/HTMLContent.js
@@ -75,12 +75,16 @@ const HTMLContent = styled(({ content, collapsable = false, maxCollapsedHeight =
 
   return (
     <div>
-      <DisplayBox
-        ref={contentRef}
-        maxHeight={maxCollapsedHeight}
-        dangerouslySetInnerHTML={{ __html: content }}
-        {...props}
-      />
+      {!isCollapsed || isOpen ? (
+        <InlineDisplayBox ref={contentRef} dangerouslySetInnerHTML={{ __html: content }} {...props} />
+      ) : (
+        <DisplayBox
+          ref={contentRef}
+          maxHeight={maxCollapsedHeight}
+          dangerouslySetInnerHTML={{ __html: content }}
+          {...props}
+        />
+      )}
       {!isOpen && isCollapsed && (
         <ReadFullLink
           onClick={() => setOpen(true)}


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4875 and Resolve https://github.com/opencollective/opencollective/issues/4238

![max-collapsable-height](https://user-images.githubusercontent.com/12435965/139123734-5e9d882f-3504-4164-8656-105ef84fe399.gif)


