### PR TITLE
CollectivePage: Crash with connected account without host

### DIFF
--- a/components/collective-page/hero/Hero.js
+++ b/components/collective-page/hero/Hero.js
@@ -88,7 +88,7 @@ const Hero = ({ collective, host, isAdmin, onPrimaryColorChange }) => {
   const isFund = collective.type === CollectiveType.FUND;
   const parentIsHost = host && collective.parentCollective?.id === host.id;
   const firstConnectedAccount = first(collective.connectedTo);
-  const connectedAccountIsHost = firstConnectedAccount && firstConnectedAccount.collective.id === host.id;
+  const connectedAccountIsHost = firstConnectedAccount && host && firstConnectedAccount.collective.id === host.id;
 
   const handleHeroMessage = msg => {
     if (!msg) {


### PR DESCRIPTION
Fix a crash that happened on the collective page on profiles that had connected accounts but no host (only spotted on [this archived profile](https://opencollective.com/xr-namur)).