### PR TITLE
ExpenseForm: Handle null payout data

### DIFF
--- a/components/expenses/ExpenseFormPayeeStep.js
+++ b/components/expenses/ExpenseFormPayeeStep.js
@@ -256,7 +256,7 @@ const ExpenseFormPayeeStep = ({
                   mt={3}
                 >
                   <StyledInput value={values.payee.legalName} disabled />
-                  {values.payoutMethod?.data.accountHolderName &&
+                  {values.payoutMethod?.data?.accountHolderName &&
                     values.payee.legalName &&
                     !compareNames(values.payoutMethod.data.accountHolderName, values.payee.legalName) && (
                       <MessageBox mt={2} fontSize="12px" type="warning" withIcon>


### PR DESCRIPTION
Fix https://sentry.io/organizations/open-collective/issues/2770386832