### PR TITLE
fix: handle bank details correctly for independent collective

### DIFF
--- a/components/accept-financial-contributions/AcceptContributionsOurselvesOrOrg.js
+++ b/components/accept-financial-contributions/AcceptContributionsOurselvesOrOrg.js
@@ -124,7 +124,7 @@ class AcceptContributionsOurselvesOrOrg extends React.Component {
   submitBankAccountInformation = async payoutMethodData => {
     // prepare objects
     const account = {
-      legacyId: this.state.organization ? this.state.organization.id : this.props.LoggedInUser.CollectiveId,
+      legacyId: this.state.organization ? this.state.organization.id : this.props.collective.id,
     };
 
     // try mutation


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/4909

# Description

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

`CreatePayoutMethod` and `EditBankAccount` should target the `collective` itself, not the `authenticated` user.
