### PR TITLE
Fixes & enhancements for host reports

### DIFF
--- a/components/ProportionalAreaChart.js
+++ b/components/ProportionalAreaChart.js
@@ -102,7 +102,7 @@ ProportionalAreaChart.propTypes = {
   areas: PropTypes.arrayOf(
     PropTypes.shape({
       key: PropTypes.string.isRequired,
-      label: PropTypes.node.isRequired,
+      label: PropTypes.node,
       /** How much space should be taken by this area. Defaults to proportional (100 / numberOfAreas)% */
       percentage: PropTypes.number,
       color: PropTypes.string,

--- a/components/host-dashboard/reports-section/HostFeesSection.js
+++ b/components/host-dashboard/reports-section/HostFeesSection.js
@@ -1,68 +1,29 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/client';
 import { ChevronDown } from '@styled-icons/fa-solid/ChevronDown/ChevronDown';
 import { ChevronUp } from '@styled-icons/fa-solid/ChevronUp/ChevronUp';
-import dynamic from 'next/dynamic';
-import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
-const Chart = dynamic(() => import('react-apexcharts'), { ssr: false });
-
-import { get, groupBy } from 'lodash';
+import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 
 import { CollectiveType } from '../../../lib/collective-sections';
 import { formatCurrency } from '../../../lib/currency-utils';
+import dayjs from '../../../lib/dayjs';
 import { API_V2_CONTEXT, gqlV2 } from '../../../lib/graphql/helpers';
-import { i18nTransactionSettlementStatus } from '../../../lib/i18n/transaction';
 
 import PeriodFilter from '../../budget/filters/PeriodFilter';
 import CollectivePickerAsync from '../../CollectivePickerAsync';
 import Container from '../../Container';
-import ContainerOverlay from '../../ContainerOverlay';
 import { Box, Flex } from '../../Grid';
 import Image from '../../Image';
 import Loading from '../../Loading';
 import StyledLinkButton from '../../StyledLinkButton';
-import { StyledSelectFilter } from '../../StyledSelectFilter';
-import StyledSpinner from '../../StyledSpinner';
 import { P, Span } from '../../Text';
 
-const hostFeeSectionQuery = gqlV2/* GraphQL */ `
-  query HostFeeSection($hostSlug: String!, $dateFrom: DateTime!, $dateTo: DateTime!) {
-    host(slug: $hostSlug) {
-      id
-      legacyId
-      createdAt
-      currency
-      hostMetricsTimeSeries(dateFrom: $dateFrom, dateTo: $dateTo, timeUnit: MONTH) {
-        hostFees {
-          nodes {
-            date
-            amount {
-              value
-              valueInCents
-              currency
-            }
-          }
-        }
-        hostFeeShare {
-          nodes {
-            date
-            settlementStatus
-            amount {
-              value
-              valueInCents
-              currency
-            }
-          }
-        }
-      }
-    }
-  }
-`;
+import { HostFeesSectionHistorical } from './HostFeesSectionHistorical';
 
-const hostFeeSectionTimeSeriesQuery = gqlV2/* GraphQL */ `
-  query HostFeeSectionTimeSeries(
+const hostFeeSectionQuery = gqlV2/* GraphQL */ `
+  query HostFeeSection(
     $hostSlug: String!
     $dateFrom: DateTime!
     $dateTo: DateTime!
@@ -84,23 +45,6 @@ const hostFeeSectionTimeSeriesQuery = gqlV2/* GraphQL */ `
   }
 `;
 
-const ChartWrapper = styled.div`
-  position: relative;
-
-  .apexcharts-legend-series {
-    background: white;
-    padding: 8px;
-    border-radius: 10px;
-    & > span {
-      vertical-align: middle;
-    }
-  }
-
-  .apexcharts-legend-marker {
-    margin-right: 8px;
-  }
-`;
-
 const FilterLabel = styled.label`
   font-weight: 500;
   text-transform: uppercase;
@@ -108,146 +52,30 @@ const FilterLabel = styled.label`
   color: #4e5052;
 `;
 
-const getChartOptions = (intl, hostCurrency) => ({
-  chart: {
-    id: 'chart-host-report-fees',
-    stacked: true,
-  },
-  legend: {
-    show: true,
-    showForSingleSeries: true,
-    horizontalAlign: 'left',
-    fontWeight: 'bold',
-    fontSize: '12px',
-    markers: {
-      width: 16,
-      height: 16,
-    },
-  },
-  dataLabels: { enabled: false },
-  grid: {
-    raw: { opacity: 0 },
-    column: { opacity: 0 },
-    xaxis: { lines: { show: true } },
-    yaxis: { lines: { show: false } },
-  },
-  plotOptions: {
-    bar: {
-      columnWidth: '50%',
-    },
-  },
-  colors: ['#46347F', '#95DDF4', '#F5C451', '#0EA755'], // TODO(HostReport): Use host primary colors
-  xaxis: {
-    categories: [...new Array(12)].map(
-      (_, idx) => `${intl.formatDate(new Date(0, idx), { month: 'short' }).toUpperCase()}`,
-    ),
-  },
-  yaxis: {
-    labels: {
-      minWidth: 38,
-      formatter: function (value) {
-        return value < 1000 ? value : `${Math.round(value / 1000)}k`;
-      },
-    },
-  },
-  tooltip: {
-    y: {
-      formatter: function (value) {
-        return formatCurrency(value * 100, hostCurrency);
-      },
-    },
-  },
-});
-
-const getHostFeesWithoutShare = (hostFeeNodes, hostFeeShareNodes) => {
-  const totalHostFeeSharePerMonthInCents = hostFeeShareNodes.reduce((result, node) => {
-    const monthKey = new Date(node.date).getMonth();
-    result[monthKey] = (result[monthKey] || 0) + node.amount.valueInCents;
-    return result;
-  }, {});
-
-  return hostFeeNodes.map(node => {
-    const monthKey = new Date(node.date).getMonth();
-    if (totalHostFeeSharePerMonthInCents[monthKey]) {
-      const valueInCents = node.amount.valueInCents - totalHostFeeSharePerMonthInCents[monthKey];
-      return { ...node, amount: { ...node.amount, valueInCents, value: valueInCents / 100 } };
-    } else {
-      return node;
-    }
-  });
-};
-
-const SERIES_NAMES = defineMessages({
-  hostRevenue: { defaultMessage: 'Host revenue' },
-  hostFeeShare: { id: 'Transaction.kind.HOST_FEE_SHARE', defaultMessage: 'Host fee share' },
-});
-
-const getSeriesFromData = (intl, timeSeries) => {
-  const dataToSeries = data => {
-    const series = new Array(12).fill(0); // = 12 months
-    data?.forEach(({ date, amount }) => (series[new Date(date).getMonth()] = amount.value));
-    return series;
-  };
-
-  const hostFeeNodes = get(timeSeries, 'hostFees.nodes', []);
-  const hostFeeShareNodes = get(timeSeries, 'hostFeeShare.nodes', []);
-  return [
-    {
-      name: intl.formatMessage(SERIES_NAMES.hostRevenue),
-      data: dataToSeries(getHostFeesWithoutShare(hostFeeNodes, hostFeeShareNodes)),
-    },
-    ...Object.entries(groupBy(hostFeeShareNodes, 'settlementStatus')).map(([status, nodes]) => ({
-      name: `${intl.formatMessage(SERIES_NAMES.hostFeeShare)} (${i18nTransactionSettlementStatus(intl, status)})`,
-      data: dataToSeries(nodes),
-    })),
-  ];
-};
-
-const getActiveYearsOptions = host => {
-  const currentYear = new Date().getFullYear();
-  const firstYear = host ? parseInt(host.createdAt.split('-')[0]) : currentYear;
-  const activeYears = [...Array(currentYear - firstYear + 1).keys()].map(year => year + firstYear);
-  return activeYears.map(year => ({ value: year, label: year }));
-};
-
-const getQueryVariables = (hostSlug, year) => {
+const getQueryVariables = (hostSlug, dateInterval, collectives) => {
   return {
+    dateFrom: dateInterval?.from ? new Date(dateInterval.from) : dayjs().startOf('month').toDate(),
+    dateTo: dateInterval?.to ? new Date(dateInterval.to) : dayjs().endOf('day').toDate(),
+    account: collectives,
     hostSlug,
-    dateFrom: `${year}-01-01T00:00:00Z`,
-    dateTo: `${year}-12-31T23:59:59Z`,
   };
 };
 
 const HostFeesSection = ({ hostSlug }) => {
-  const intl = useIntl();
-  const [selectedYear, setSelectedYear] = useState(() => new Date().getFullYear());
-  const variables = getQueryVariables(hostSlug, selectedYear);
+  const [dateInterval, setDateInterval] = useState(null);
+  const [collectives, setCollectives] = useState(null);
+  const variables = getQueryVariables(hostSlug, dateInterval, collectives);
   const { loading, data, previousData } = useQuery(hostFeeSectionQuery, { variables, context: API_V2_CONTEXT });
   const host = loading && !data ? previousData?.host : data?.host;
-  const timeSeries = host?.hostMetricsTimeSeries;
-  const series = useMemo(() => getSeriesFromData(intl, timeSeries), [timeSeries]);
-  const yearsOptions = useMemo(() => getActiveYearsOptions(host), [host]);
-  const chartOptions = useMemo(() => getChartOptions(intl, host?.currency), [host?.currency]);
-  const [dateInterval, setDateInterval] = useState(null);
   const [showHostFeeChart, setShowHostFeeChart] = useState(false);
-  const [collectives, setCollectives] = useState(null);
-  const { loading: loadingHostMetrics, data: hostMetricsData } = useQuery(hostFeeSectionTimeSeriesQuery, {
-    variables: {
-      dateFrom: dateInterval?.from ? new Date(dateInterval.from) : variables.dateFrom,
-      dateTo: dateInterval?.to ? new Date(dateInterval.to) : variables.dateTo,
-      account: collectives,
-      hostSlug,
-    },
-    context: API_V2_CONTEXT,
-  });
 
   if (loading && !host) {
     return <Loading />;
   }
 
   let totalHostFees, profit, sharedRevenue;
-  if (!loadingHostMetrics) {
-    const { hostFees, hostFeeShare } = hostMetricsData.host.hostMetrics;
+  if (!loading) {
+    const { hostFees, hostFeeShare } = data.host.hostMetrics;
     totalHostFees = hostFees.valueInCents;
     sharedRevenue = hostFeeShare.valueInCents;
     profit = totalHostFees - sharedRevenue;
@@ -285,7 +113,7 @@ const HostFeesSection = ({ hostSlug }) => {
           />
         </Container>
       </Flex>
-      {loadingHostMetrics ? (
+      {loading ? (
         <Loading />
       ) : (
         <Flex flexWrap="wrap">
@@ -374,31 +202,7 @@ const HostFeesSection = ({ hostSlug }) => {
           </StyledLinkButton>
         </Container>
       </Flex>
-      {showHostFeeChart && (
-        <Box py={3}>
-          <Flex alignItems="center" px={2} mb={2}>
-            <P fontSize="11px" fontWeight="700" mr={3} textTransform="uppercase">
-              <FormattedMessage id="HostFeesSection.Title" defaultMessage="Collected host fees per year" />
-            </P>
-            <StyledSelectFilter
-              inputId="host-report-host-fees-year-select"
-              options={yearsOptions}
-              defaultValue={{ value: selectedYear, label: selectedYear }}
-              onChange={({ value }) => setSelectedYear(value)}
-              isSearchable={false}
-              minWidth={100}
-            />
-          </Flex>
-          <ChartWrapper>
-            {loading && (
-              <ContainerOverlay>
-                <StyledSpinner size={64} />
-              </ContainerOverlay>
-            )}
-            <Chart type="bar" width="100%" height="250px" options={chartOptions} series={series} />
-          </ChartWrapper>
-        </Box>
-      )}
+      {showHostFeeChart && <HostFeesSectionHistorical collectives={collectives} hostSlug={hostSlug} />}
     </React.Fragment>
   );
 };

--- a/components/host-dashboard/reports-section/HostFeesSection.js
+++ b/components/host-dashboard/reports-section/HostFeesSection.js
@@ -290,12 +290,14 @@ const HostFeesSection = ({ hostSlug }) => {
       ) : (
         <Flex flexWrap="wrap">
           <Container flex="1 1 230px" px={3}>
-            <P fontSize="12px" fontWeight="500" textTransform="uppercase" mt="24px">
-              <Span mr={10}>
+            <Container mt="24px">
+              <Flex alignItems="center">
                 <Image width={14} height={7} src="/static/images/host-fees-timeline.svg" />
-              </Span>
-              <FormattedMessage defaultMessage="Total Host Fees" />
-            </P>
+                <Span ml="10px" fontSize="12px" fontWeight="500" textTransform="uppercase">
+                  <FormattedMessage defaultMessage="Total Host Fees" />
+                </Span>
+              </Flex>
+            </Container>
             <Box pt="12px" pb="10px" fontSize="18px" fontWeight="500">
               {formatCurrency(totalHostFees, host.currency)}
             </Box>
@@ -311,12 +313,14 @@ const HostFeesSection = ({ hostSlug }) => {
             mt="39px"
           />
           <Container flex="1 1 230px" px={3}>
-            <P fontSize="12px" fontWeight="500" textTransform="uppercase" mt="24px">
-              <Span mr={10}>
+            <Container mt="24px">
+              <Flex alignItems="center">
                 <Image width={6.5} height={12} mr={10} src="/static/images/host-fees-money-sign.svg" />
-              </Span>
-              <FormattedMessage defaultMessage="Your Profit" />
-            </P>
+                <Span ml="10px" fontSize="12px" fontWeight="500" textTransform="uppercase">
+                  <FormattedMessage defaultMessage="Your Profit" />
+                </Span>
+              </Flex>
+            </Container>
             <Box pt="12px" pb="10px" fontSize="18px" fontWeight="500">
               {formatCurrency(profit, host.currency)}
             </Box>
@@ -332,12 +336,14 @@ const HostFeesSection = ({ hostSlug }) => {
             mt="39px"
           />
           <Container flex="1 1 230px" px={3}>
-            <P fontSize="12px" fontWeight="500" textTransform="uppercase" mt="24px">
-              <Span mr={10}>
+            <Container mt="24px">
+              <Flex alignItems="center">
                 <Image width={9.42} height={12} mr={10} src="/static/images/host-fees-oc.svg" />
-              </Span>
-              <FormattedMessage defaultMessage="Shared Revenue" />
-            </P>
+                <Span ml="10px" fontSize="12px" fontWeight="500" textTransform="uppercase">
+                  <FormattedMessage defaultMessage="Shared Revenue" />
+                </Span>
+              </Flex>
+            </Container>
             <Box pt="12px" pb="10px" fontSize="18px" fontWeight="500">
               {formatCurrency(sharedRevenue, host.currency)}
             </Box>

--- a/components/host-dashboard/reports-section/HostFeesSectionHistorical.js
+++ b/components/host-dashboard/reports-section/HostFeesSectionHistorical.js
@@ -1,0 +1,222 @@
+import React, { useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { useQuery } from '@apollo/client';
+import dynamic from 'next/dynamic';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+const Chart = dynamic(() => import('react-apexcharts'), { ssr: false });
+
+import { get, groupBy } from 'lodash';
+import styled from 'styled-components';
+
+import { formatCurrency } from '../../../lib/currency-utils';
+import { API_V2_CONTEXT, gqlV2 } from '../../../lib/graphql/helpers';
+import { i18nTransactionSettlementStatus } from '../../../lib/i18n/transaction';
+
+import { Box, Flex } from '../../Grid';
+import LoadingPlaceholder from '../../LoadingPlaceholder';
+import { StyledSelectFilter } from '../../StyledSelectFilter';
+import { P } from '../../Text';
+
+const hostFeeSectionTimeSeriesQuery = gqlV2/* GraphQL */ `
+  query HostFeeSectionTimeSeries($hostSlug: String!, $dateFrom: DateTime!, $dateTo: DateTime!) {
+    host(slug: $hostSlug) {
+      id
+      legacyId
+      createdAt
+      currency
+      hostMetricsTimeSeries(dateFrom: $dateFrom, dateTo: $dateTo, timeUnit: MONTH) {
+        hostFees {
+          nodes {
+            date
+            amount {
+              value
+              valueInCents
+              currency
+            }
+          }
+        }
+        hostFeeShare {
+          nodes {
+            date
+            settlementStatus
+            amount {
+              value
+              valueInCents
+              currency
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const ChartWrapper = styled.div`
+  position: relative;
+
+  .apexcharts-legend-series {
+    background: white;
+    padding: 8px;
+    border-radius: 10px;
+    & > span {
+      vertical-align: middle;
+    }
+  }
+
+  .apexcharts-legend-marker {
+    margin-right: 8px;
+  }
+`;
+
+const getChartOptions = (intl, hostCurrency) => ({
+  chart: {
+    id: 'chart-host-report-fees',
+    stacked: true,
+  },
+  legend: {
+    show: true,
+    showForSingleSeries: true,
+    horizontalAlign: 'left',
+    fontWeight: 'bold',
+    fontSize: '12px',
+    markers: {
+      width: 16,
+      height: 16,
+    },
+  },
+  dataLabels: { enabled: false },
+  grid: {
+    raw: { opacity: 0 },
+    column: { opacity: 0 },
+    xaxis: { lines: { show: true } },
+    yaxis: { lines: { show: false } },
+  },
+  plotOptions: {
+    bar: {
+      columnWidth: '50%',
+    },
+  },
+  colors: ['#46347F', '#95DDF4', '#F5C451', '#0EA755'], // TODO(HostReport): Use host primary colors
+  xaxis: {
+    categories: [...new Array(12)].map(
+      (_, idx) => `${intl.formatDate(new Date(0, idx), { month: 'short' }).toUpperCase()}`,
+    ),
+  },
+  yaxis: {
+    labels: {
+      minWidth: 38,
+      formatter: function (value) {
+        return value < 1000 ? value : `${Math.round(value / 1000)}k`;
+      },
+    },
+  },
+  tooltip: {
+    y: {
+      formatter: function (value) {
+        return formatCurrency(value * 100, hostCurrency);
+      },
+    },
+  },
+});
+
+const SERIES_NAMES = defineMessages({
+  hostRevenue: { defaultMessage: 'Host revenue' },
+  hostFeeShare: { id: 'Transaction.kind.HOST_FEE_SHARE', defaultMessage: 'Host fee share' },
+});
+
+const getHostFeesWithoutShare = (hostFeeNodes, hostFeeShareNodes) => {
+  const totalHostFeeSharePerMonthInCents = hostFeeShareNodes.reduce((result, node) => {
+    const monthKey = new Date(node.date).getMonth();
+    result[monthKey] = (result[monthKey] || 0) + node.amount.valueInCents;
+    return result;
+  }, {});
+
+  return hostFeeNodes.map(node => {
+    const monthKey = new Date(node.date).getMonth();
+    if (totalHostFeeSharePerMonthInCents[monthKey]) {
+      const valueInCents = node.amount.valueInCents - totalHostFeeSharePerMonthInCents[monthKey];
+      return { ...node, amount: { ...node.amount, valueInCents, value: valueInCents / 100 } };
+    } else {
+      return node;
+    }
+  });
+};
+
+const getSeriesFromData = (intl, timeSeries) => {
+  const dataToSeries = data => {
+    const series = new Array(12).fill(0); // = 12 months
+    data?.forEach(({ date, amount }) => (series[new Date(date).getMonth()] = amount.value));
+    return series;
+  };
+
+  const hostFeeNodes = get(timeSeries, 'hostFees.nodes', []);
+  const hostFeeShareNodes = get(timeSeries, 'hostFeeShare.nodes', []);
+  return [
+    {
+      name: intl.formatMessage(SERIES_NAMES.hostRevenue),
+      data: dataToSeries(getHostFeesWithoutShare(hostFeeNodes, hostFeeShareNodes)),
+    },
+    ...Object.entries(groupBy(hostFeeShareNodes, 'settlementStatus')).map(([status, nodes]) => ({
+      name: `${intl.formatMessage(SERIES_NAMES.hostFeeShare)} (${i18nTransactionSettlementStatus(intl, status)})`,
+      data: dataToSeries(nodes),
+    })),
+  ];
+};
+
+const getActiveYearsOptions = host => {
+  const currentYear = new Date().getFullYear();
+  const firstYear = host ? parseInt(host.createdAt.split('-')[0]) : currentYear;
+  const activeYears = [...Array(currentYear - firstYear + 1).keys()].map(year => year + firstYear);
+  return activeYears.map(year => ({ value: year, label: year }));
+};
+
+const getQueryVariables = (hostSlug, year) => {
+  return {
+    hostSlug,
+    dateFrom: `${year}-01-01T00:00:00Z`,
+    dateTo: `${year}-12-31T23:59:59Z`,
+  };
+};
+
+export const HostFeesSectionHistorical = ({ hostSlug }) => {
+  const intl = useIntl();
+  const [selectedYear, setSelectedYear] = useState(() => new Date().getFullYear());
+  const variables = getQueryVariables(hostSlug, selectedYear);
+  const { loading, data } = useQuery(hostFeeSectionTimeSeriesQuery, { variables, context: API_V2_CONTEXT });
+  const host = data?.host;
+  const timeSeries = data?.host?.hostMetricsTimeSeries;
+  const series = useMemo(() => getSeriesFromData(intl, timeSeries), [timeSeries]);
+  const yearsOptions = useMemo(() => getActiveYearsOptions(host), [host]);
+  const chartOptions = useMemo(() => getChartOptions(intl, host?.currency), [host?.currency]);
+  return (
+    <Box py={3}>
+      <Flex alignItems="center" px={2} mb={2}>
+        <P fontSize="11px" fontWeight="700" mr={3} textTransform="uppercase">
+          <FormattedMessage id="HostFeesSection.Title" defaultMessage="Collected host fees per year" />
+        </P>
+        <StyledSelectFilter
+          inputId="host-report-host-fees-year-select"
+          options={yearsOptions}
+          defaultValue={{ value: selectedYear, label: selectedYear }}
+          onChange={({ value }) => setSelectedYear(value)}
+          isSearchable={false}
+          minWidth={100}
+          isLoading={loading}
+          disabled={loading}
+        />
+      </Flex>
+      {loading ? (
+        <LoadingPlaceholder height={250} />
+      ) : (
+        <ChartWrapper>
+          <Chart type="bar" width="100%" height="250px" options={chartOptions} series={series} />
+        </ChartWrapper>
+      )}
+    </Box>
+  );
+};
+
+HostFeesSectionHistorical.propTypes = {
+  collectives: PropTypes.arrayOf(PropTypes.object),
+  hostSlug: PropTypes.string.isRequired,
+};


### PR DESCRIPTION
I'm refactoring the whole `HostFeesSection`, we had some problems in there:
- There is some confusion around the query names and states. The one that loads the timeseries is called `HostFeeSection`, and the one that loads the general data is called `HostFeeSectionTimeSeries`
- The goal of having a collapsed view was to not load the data unless it's expanded, here we were triggering 2 queries while we could do 0 (just rely on the general data) + 1 when expended
- There is some confusion around the filters: the historical view is supposed to use the 'year' picker, not the date interval above