### PR TITLE
ContributionFlowHeader: show amount already contributed in the header

### DIFF
--- a/components/contribution-flow/ContributionFlowHeader.js
+++ b/components/contribution-flow/ContributionFlowHeader.js
@@ -36,7 +36,7 @@ class NewContributionFlowHeader extends React.Component {
   };
 
   render() {
-    const { collective, isEmbed, loggedInAccount, LoggedInUser } = this.props;
+    const { collective, isEmbed, loggedInAccount } = this.props;
     const contributors = collective.contributors?.nodes;
     let loggedInUserTotalDonations = 0;
 

--- a/components/contribution-flow/ContributionFlowHeader.js
+++ b/components/contribution-flow/ContributionFlowHeader.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { truncate } from 'lodash';
 import { FormattedMessage, injectIntl } from 'react-intl';
 
+import FormattedMoneyAmount from '../../components/FormattedMoneyAmount';
+
 import Avatar, { ContributorAvatar } from '../Avatar';
 import Container from '../Container';
 import { Box, Flex } from '../Grid';
@@ -27,14 +29,20 @@ class NewContributionFlowHeader extends React.Component {
         ),
       }),
     }).isRequired,
+    loggedInAccount: PropTypes.object,
     LoggedInUser: PropTypes.object,
     intl: PropTypes.object,
     isEmbed: PropTypes.bool,
   };
 
   render() {
-    const { collective, isEmbed } = this.props;
+    const { collective, isEmbed, loggedInAccount, LoggedInUser } = this.props;
     const contributors = collective.contributors?.nodes;
+    let loggedInUserTotalDonations = 0;
+
+    if (loggedInAccount?.memberOf?.nodes?.length > 0) {
+      loggedInUserTotalDonations = loggedInAccount.memberOf.nodes[0].totalDonations.value * 100;
+    }
 
     return (
       <Flex flexDirection={['column', null, 'row']} alignItems="center" maxWidth={500}>
@@ -57,27 +65,48 @@ class NewContributionFlowHeader extends React.Component {
               />
             </H1>
           </CollectiveTitleContainer>
-          {contributors?.length > 0 && (
+          {loggedInUserTotalDonations > 0 ? (
+            <P py={2}>
+              <FormattedMessage
+                defaultMessage="You have contributed {amount} to {collective} so far. Keep it going!"
+                values={{
+                  collective: collective.name,
+                  amount: (
+                    <FormattedMoneyAmount
+                      precision={2}
+                      amount={loggedInUserTotalDonations}
+                      currency={collective.currency}
+                      amountStyles={{ fontWeight: 'bold', color: 'black.900' }}
+                    />
+                  ),
+                }}
+              />
+            </P>
+          ) : (
             <Fragment>
-              <P fontSize="16px" lineHeight="24px" fontWeight={400} color="black.500" py={2}>
-                <FormattedMessage
-                  id="NewContributionFlow.Join"
-                  defaultMessage="Join {numberOfContributors} other fellow contributors"
-                  values={{ numberOfContributors: collective.contributors.totalCount }}
-                />
-              </P>
-              <Flex alignItems="center">
-                {contributors.map(contributor => (
-                  <Box key={contributor.id} mx={1}>
-                    <ContributorAvatar contributor={contributor} radius={24} />
-                  </Box>
-                ))}
-                {collective.contributors.totalCount > contributors.length && (
-                  <Container fontSize="12px" color="black.600">
-                    + {collective.contributors.totalCount - contributors.length}
-                  </Container>
-                )}
-              </Flex>
+              {contributors?.length > 0 && (
+                <Fragment>
+                  <P fontSize="16px" lineHeight="24px" fontWeight={400} color="black.500" py={2}>
+                    <FormattedMessage
+                      id="NewContributionFlow.Join"
+                      defaultMessage="Join {numberOfContributors} other fellow contributors"
+                      values={{ numberOfContributors: collective.contributors.totalCount }}
+                    />
+                  </P>
+                  <Flex alignItems="center">
+                    {contributors.map(contributor => (
+                      <Box key={contributor.id} mx={1}>
+                        <ContributorAvatar contributor={contributor} radius={24} />
+                      </Box>
+                    ))}
+                    {collective.contributors.totalCount > contributors.length && (
+                      <Container fontSize="12px" color="black.600">
+                        + {collective.contributors.totalCount - contributors.length}
+                      </Container>
+                    )}
+                  </Flex>
+                </Fragment>
+              )}
             </Fragment>
           )}
         </Flex>

--- a/components/contribution-flow/graphql/queries.js
+++ b/components/contribution-flow/graphql/queries.js
@@ -16,6 +16,16 @@ export const contributionFlowAccountWithTierQuery = gqlV2/* GraphQL */ `
     account(slug: $collectiveSlug, throwIfMissing: false) {
       ...ContributionFlowAccountFields
     }
+    loggedInAccount {
+      memberOf(account: { slug: $collectiveSlug }) {
+        nodes {
+          id
+          totalDonations {
+            value
+          }
+        }
+      }
+    }
     tier(tier: $tier, throwIfMissing: false) {
       id
       legacyId

--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -104,6 +104,7 @@ class ContributionFlow extends React.Component {
       }),
     }).isRequired,
     host: PropTypes.object.isRequired,
+    loggedInAccount: PropTypes.object,
     tier: PropTypes.object,
     intl: PropTypes.object,
     createOrder: PropTypes.func.isRequired,
@@ -707,6 +708,7 @@ class ContributionFlow extends React.Component {
     const {
       collective,
       host,
+      loggedInAccount,
       tier,
       LoggedInUser,
       loadingLoggedInUser,
@@ -753,7 +755,7 @@ class ContributionFlow extends React.Component {
           >
             {!this.props.hideHeader && (
               <Box px={[2, 3]} mb={4}>
-                <ContributionFlowHeader collective={collective} isEmbed={isEmbed} />
+                <ContributionFlowHeader collective={collective} loggedInAccount={loggedInAccount} isEmbed={isEmbed} />
               </Box>
             )}
             <StepsProgressBox mb={3} width={[1.0, 0.8]}>

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -755,6 +755,7 @@
   "DropZone.UploadBox": "Drag and drop one or multiple files or <i18n-link>click here to select</i18n-link>.",
   "DrU2Pu": "The profit as an organization resulting of the host fees you collect without the shared revenue for the use of the platform.",
   "Du12dj": "Error creating virtual card: {error}",
+  "eB/3mQ": "You have contributed {amount} to {collective} so far. Keep it going!",
   "Edit": "Edit",
   "editCollective.fiscalHosting": "Fiscal Hosting",
   "EditCollective.GSTNumber": "GST number",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -755,6 +755,7 @@
   "DropZone.UploadBox": "Drag and drop one or multiple files or <i18n-link>click here to select</i18n-link>.",
   "DrU2Pu": "The profit as an organization resulting of the host fees you collect without the shared revenue for the use of the platform.",
   "Du12dj": "Error creating virtual card: {error}",
+  "eB/3mQ": "You have contributed {amount} to {collective} so far. Keep it going!",
   "Edit": "Upravit",
   "editCollective.fiscalHosting": "Fiskální hostování",
   "EditCollective.GSTNumber": "GST number",

--- a/lang/de.json
+++ b/lang/de.json
@@ -755,6 +755,7 @@
   "DropZone.UploadBox": "Drag and drop one or multiple files or <i18n-link>click here to select</i18n-link>.",
   "DrU2Pu": "The profit as an organization resulting of the host fees you collect without the shared revenue for the use of the platform.",
   "Du12dj": "Error creating virtual card: {error}",
+  "eB/3mQ": "You have contributed {amount} to {collective} so far. Keep it going!",
   "Edit": "Bearbeiten",
   "editCollective.fiscalHosting": "Träger",
   "EditCollective.GSTNumber": "GST number",

--- a/lang/en.json
+++ b/lang/en.json
@@ -755,6 +755,7 @@
   "DropZone.UploadBox": "Drag and drop one or multiple files or <i18n-link>click here to select</i18n-link>.",
   "DrU2Pu": "The profit as an organization resulting of the host fees you collect without the shared revenue for the use of the platform.",
   "Du12dj": "Error creating virtual card: {error}",
+  "eB/3mQ": "You have contributed {amount} to {collective} so far. Keep it going!",
   "Edit": "Edit",
   "editCollective.fiscalHosting": "Fiscal Hosting",
   "EditCollective.GSTNumber": "GST number",

--- a/lang/es.json
+++ b/lang/es.json
@@ -755,6 +755,7 @@
   "DropZone.UploadBox": "Arrastra y suelta uno o más archivos o <i18n-link>haz clic aquí para seleccionar</i18n-link>.",
   "DrU2Pu": "The profit as an organization resulting of the host fees you collect without the shared revenue for the use of the platform.",
   "Du12dj": "Error creating virtual card: {error}",
+  "eB/3mQ": "You have contributed {amount} to {collective} so far. Keep it going!",
   "Edit": "Editar",
   "editCollective.fiscalHosting": "Fiscal Hosting",
   "EditCollective.GSTNumber": "Número GST",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -755,6 +755,7 @@
   "DropZone.UploadBox": "Glissez et déposez un ou plusieurs fichiers ou <i18n-link>cliquez ici pour sélectionner</i18n-link>.",
   "DrU2Pu": "The profit as an organization resulting of the host fees you collect without the shared revenue for the use of the platform.",
   "Du12dj": "Error creating virtual card: {error}",
+  "eB/3mQ": "You have contributed {amount} to {collective} so far. Keep it going!",
   "Edit": "Éditer",
   "editCollective.fiscalHosting": "Hébergement Fiscal",
   "EditCollective.GSTNumber": "Numéro GST",

--- a/lang/it.json
+++ b/lang/it.json
@@ -755,6 +755,7 @@
   "DropZone.UploadBox": "Trascina e rilascia uno o più file o <i18n-link>clicca qui per selezionare</i18n-link>.",
   "DrU2Pu": "The profit as an organization resulting of the host fees you collect without the shared revenue for the use of the platform.",
   "Du12dj": "Error creating virtual card: {error}",
+  "eB/3mQ": "You have contributed {amount} to {collective} so far. Keep it going!",
   "Edit": "Modifica",
   "editCollective.fiscalHosting": "Fiscal Hosting",
   "EditCollective.GSTNumber": "GST number",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -755,6 +755,7 @@
   "DropZone.UploadBox": "Drag and drop one or multiple files or <i18n-link>click here to select</i18n-link>.",
   "DrU2Pu": "The profit as an organization resulting of the host fees you collect without the shared revenue for the use of the platform.",
   "Du12dj": "Error creating virtual card: {error}",
+  "eB/3mQ": "You have contributed {amount} to {collective} so far. Keep it going!",
   "Edit": "編集",
   "editCollective.fiscalHosting": "Fiscal Hosting",
   "EditCollective.GSTNumber": "GST number",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -755,6 +755,7 @@
   "DropZone.UploadBox": "Drag and drop one or multiple files or <i18n-link>click here to select</i18n-link>.",
   "DrU2Pu": "The profit as an organization resulting of the host fees you collect without the shared revenue for the use of the platform.",
   "Du12dj": "Error creating virtual card: {error}",
+  "eB/3mQ": "You have contributed {amount} to {collective} so far. Keep it going!",
   "Edit": "편집",
   "editCollective.fiscalHosting": "재정 호스트",
   "EditCollective.GSTNumber": "상품서비스세 식별 번호 (GSTIN)",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -755,6 +755,7 @@
   "DropZone.UploadBox": "Drag and drop one or multiple files or <i18n-link>click here to select</i18n-link>.",
   "DrU2Pu": "The profit as an organization resulting of the host fees you collect without the shared revenue for the use of the platform.",
   "Du12dj": "Error creating virtual card: {error}",
+  "eB/3mQ": "You have contributed {amount} to {collective} so far. Keep it going!",
   "Edit": "Edit",
   "editCollective.fiscalHosting": "Fiscal Hosting",
   "EditCollective.GSTNumber": "GST number",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -755,6 +755,7 @@
   "DropZone.UploadBox": "Arraste e solte um ou vários arquivos ou <i18n-link>clique aqui para selecionar</i18n-link>.",
   "DrU2Pu": "The profit as an organization resulting of the host fees you collect without the shared revenue for the use of the platform.",
   "Du12dj": "Error creating virtual card: {error}",
+  "eB/3mQ": "You have contributed {amount} to {collective} so far. Keep it going!",
   "Edit": "Editar",
   "editCollective.fiscalHosting": "Hospedagem Fiscal",
   "EditCollective.GSTNumber": "Número GST",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -755,6 +755,7 @@
   "DropZone.UploadBox": "Arraste e solte um ou vários arquivos ou <i18n-link>clique aqui para selecionar</i18n-link>.",
   "DrU2Pu": "The profit as an organization resulting of the host fees you collect without the shared revenue for the use of the platform.",
   "Du12dj": "Error creating virtual card: {error}",
+  "eB/3mQ": "You have contributed {amount} to {collective} so far. Keep it going!",
   "Edit": "Editar",
   "editCollective.fiscalHosting": "Fiscal Hosting",
   "EditCollective.GSTNumber": "GST number",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -755,6 +755,7 @@
   "DropZone.UploadBox": "Drag and drop one or multiple files or <i18n-link>click here to select</i18n-link>.",
   "DrU2Pu": "The profit as an organization resulting of the host fees you collect without the shared revenue for the use of the platform.",
   "Du12dj": "Error creating virtual card: {error}",
+  "eB/3mQ": "You have contributed {amount} to {collective} so far. Keep it going!",
   "Edit": "Редактировать",
   "editCollective.fiscalHosting": "Фискальное Представительство",
   "EditCollective.GSTNumber": "Номер GST",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -755,6 +755,7 @@
   "DropZone.UploadBox": "Перетягніть один або кілька файлів або ж <i18n-link>клацніть тут, щоб вибрати</i18n-link>.",
   "DrU2Pu": "The profit as an organization resulting of the host fees you collect without the shared revenue for the use of the platform.",
   "Du12dj": "Error creating virtual card: {error}",
+  "eB/3mQ": "You have contributed {amount} to {collective} so far. Keep it going!",
   "Edit": "Змінити",
   "editCollective.fiscalHosting": "Фіскальні вузли",
   "EditCollective.GSTNumber": "Номер GST",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -755,6 +755,7 @@
   "DropZone.UploadBox": "拖放一个或多个文件或 <i18n-link>点击这里选择</i18n-link>。",
   "DrU2Pu": "The profit as an organization resulting of the host fees you collect without the shared revenue for the use of the platform.",
   "Du12dj": "Error creating virtual card: {error}",
+  "eB/3mQ": "You have contributed {amount} to {collective} so far. Keep it going!",
   "Edit": "编辑",
   "editCollective.fiscalHosting": "财政托管",
   "EditCollective.GSTNumber": "GST 号码",

--- a/pages/contribution-flow.js
+++ b/pages/contribution-flow.js
@@ -20,7 +20,6 @@ import ContributionFlowSuccess from '../components/contribution-flow/Contributio
 import {
   contributionFlowAccountQuery,
   contributionFlowAccountWithTierQuery,
-  isLoggedInUserContributorQuery,
 } from '../components/contribution-flow/graphql/queries';
 import ContributionFlowContainer from '../components/contribution-flow/index';
 import { getContributionFlowMetadata } from '../components/contribution-flow/utils';

--- a/pages/contribution-flow.js
+++ b/pages/contribution-flow.js
@@ -20,6 +20,7 @@ import ContributionFlowSuccess from '../components/contribution-flow/Contributio
 import {
   contributionFlowAccountQuery,
   contributionFlowAccountWithTierQuery,
+  isLoggedInUserContributorQuery,
 } from '../components/contribution-flow/graphql/queries';
 import ContributionFlowContainer from '../components/contribution-flow/index';
 import { getContributionFlowMetadata } from '../components/contribution-flow/utils';
@@ -133,7 +134,7 @@ class NewContributionFlowPage extends React.Component {
 
   renderPageContent() {
     const { data = {}, step, paymentFlow, LoggedInUser, error } = this.props;
-    const { account, tier } = data;
+    const { account, loggedInAccount, tier } = data;
     const isCrypto = paymentFlow === PAYMENT_FLOW.CRYPTO;
 
     if (data.loading) {
@@ -162,6 +163,7 @@ class NewContributionFlowPage extends React.Component {
       return (
         <ContributionFlowContainer
           collective={account}
+          loggedInAccount={loggedInAccount}
           host={account.host}
           tier={tier}
           step={step}


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/3478

# Description

show amount already contributed in the header

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots

## When contributed before

<img width="560" alt="Screenshot 2021-11-15 at 8 34 46 AM" src="https://user-images.githubusercontent.com/46647141/141716297-915c6202-8911-462d-aed9-7022ed94a099.png">

## When new contribution
<img width="566" alt="Screenshot 2021-11-15 at 8 34 56 AM" src="https://user-images.githubusercontent.com/46647141/141716308-53a7e7be-d29d-4053-bd75-6e2c2ef96590.png">

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
