### PR TITLE
Simplify function prototype for checking `isGrants` to only need `collective/account`

### DIFF
--- a/components/collective-navbar/index.js
+++ b/components/collective-navbar/index.js
@@ -247,9 +247,8 @@ const getDefaultCallsToActions = (collective, sections, isAdmin, isHostAdmin, Lo
     return {};
   }
 
-  const { features, settings, host } = collective;
+  const { features, host } = collective;
   const isProjectOrFund = [CollectiveType.FUND, CollectiveType.PROJECT].includes(collective.type);
-  const hostSettings = host ? host.settings : null;
   return {
     hasContribute: getHasContribute(collective, sections, isAdmin),
     hasContact: isFeatureAvailable(collective, 'CONTACT_FORM'),
@@ -259,8 +258,7 @@ const getDefaultCallsToActions = (collective, sections, isAdmin, isHostAdmin, Lo
     hasManageSubscriptions: isAdmin && get(features, 'RECURRING_CONTRIBUTIONS') === 'ACTIVE',
     hasDashboard: isAdmin && isFeatureAvailable(collective, 'HOST_DASHBOARD'),
     hasRequestGrant:
-      (accountSupportsGrants(settings, hostSettings) || isProjectOrFund) &&
-      expenseSubmissionAllowed(collective, LoggedInUser),
+      (accountSupportsGrants(collective) || isProjectOrFund) && expenseSubmissionAllowed(collective, LoggedInUser),
     addFunds: isHostAdmin,
     assignVirtualCard: isHostAdmin && isFeatureAvailable(host, 'VIRTUAL_CARDS'),
     requestVirtualCard: isAdmin && isFeatureAvailable(collective, 'REQUEST_VIRTUAL_CARDS'),

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -373,7 +373,7 @@ const ExpenseFormBody = ({
           value={values.type}
           options={{
             fundingRequest:
-              accountSupportsGrants(collective.settings, collective?.host?.settings) ||
+              accountSupportsGrants(collective) ||
               [CollectiveType.FUND, CollectiveType.PROJECT].includes(collective.type),
           }}
         />

--- a/components/host-dashboard/CollectiveSettingsModal.js
+++ b/components/host-dashboard/CollectiveSettingsModal.js
@@ -70,9 +70,7 @@ const CollectiveSettingsModal = ({ host, collective, ...props }) => {
     hostFeePercent === host.hostFeePercent ? HOST_FEE_STRUCTURE.DEFAULT : HOST_FEE_STRUCTURE.CUSTOM_FEE,
   );
   const isProjectOrFund = [CollectiveType.FUND, CollectiveType.PROJECT].includes(collective.type);
-  const [hasGrant, setHasGrant] = useState(
-    accountSupportsGrants(collective?.settings, host?.settings) || isProjectOrFund,
-  );
+  const [hasGrant, setHasGrant] = useState(accountSupportsGrants(collective, host) || isProjectOrFund);
   const [submitFeesStructure, { loading, error }] = useMutation(editAccountSettingsMutation, {
     context: API_V2_CONTEXT,
   });

--- a/lib/collective.lib.js
+++ b/lib/collective.lib.js
@@ -232,6 +232,6 @@ export const isSelfHostedAccount = c => c.isHost === true && c.type === 'COLLECT
 export const isIndividualAccount = account => ['USER', 'INDIVIDUAL'].includes(account.type);
 
 /* Checks whether an account supports grants */
-export const accountSupportsGrants = (collectiveSettings, hostSettings) => {
-  return get(collectiveSettings, 'expenseTypes.hasGrant', !get(hostSettings, 'disableGrantsByDefault', false));
+export const accountSupportsGrants = (collective, host = collective.host) => {
+  return get(collective.settings, 'expenseTypes.hasGrant', !get(host?.settings, 'disableGrantsByDefault', false));
 };


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective-frontend/pull/7090#discussion_r749371204

This simplifies the function prototype of the `accountSupportsGrants` method to only need the `account`. 