### PR TITLE
Authorize HostReports for accountants

### DIFF
--- a/components/ProfileMenuMemberships.js
+++ b/components/ProfileMenuMemberships.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Plus } from '@styled-icons/boxicons-regular';
 import { Settings } from '@styled-icons/feather/Settings';
 import { groupBy, isEmpty, uniqBy } from 'lodash';
-import { defineMessage, defineMessages, FormattedMessage, useIntl } from 'react-intl';
+import { defineMessage, FormattedMessage, useIntl } from 'react-intl';
 import styled from 'styled-components';
 
 import { CollectiveType } from '../lib/constants/collectives';
@@ -20,13 +20,6 @@ import StyledHr from './StyledHr';
 import StyledLink from './StyledLink';
 import StyledRoundButton from './StyledRoundButton';
 import { P } from './Text';
-
-const messages = defineMessages({
-  settings: {
-    id: 'Settings',
-    defaultMessage: 'Settings',
-  },
-});
 
 const CollectiveListItem = styled(ListItem)`
   @media (hover: hover) {
@@ -58,13 +51,13 @@ const MembershipLine = ({ user, membership }) => {
           </Flex>
         </Flex>
       </Link>
-      {Boolean(user?.canEditCollective(membership.collective)) && (
+      {Boolean(user?.canSeeAdminPanel(membership.collective)) && (
         <StyledLink
           as={Link}
           href={getSettingsRoute(membership.collective, null, user)}
           ml={1}
           color="black.500"
-          title={intl.formatMessage(messages.settings)}
+          title={intl.formatMessage({ id: 'AdminPanel.button', defaultMessage: 'Admin' })}
         >
           <Settings opacity="0" size="1.2em" />
         </StyledLink>

--- a/components/admin-panel/AdminPanelContext.js
+++ b/components/admin-panel/AdminPanelContext.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import { ALL_SECTIONS } from './constants';
+
+export const AdminPanelContext = React.createContext({
+  selectedSection: ALL_SECTIONS.INFO,
+});

--- a/components/admin-panel/AdminPanelSection.js
+++ b/components/admin-panel/AdminPanelSection.js
@@ -70,7 +70,7 @@ const AdminPanelSection = ({ collective, isLoading, section }) => {
             <Title>{formatMessage(SECTION_LABELS[section])}</Title>
           </Box>
         )}
-        <AccountSettings account={collective} />
+        <AccountSettings account={collective} section={section} />
       </Container>
     );
   }

--- a/components/admin-panel/Menu.js
+++ b/components/admin-panel/Menu.js
@@ -20,29 +20,38 @@ import { MenuGroup, MenuLink, MenuSectionHeader, useSubmenu } from './MenuCompon
 
 const { USER, ORGANIZATION, COLLECTIVE, FUND, EVENT, PROJECT } = CollectiveType;
 
-const OrganizationSettingsMenuLinks = ({ collective }) => {
+const OrganizationSettingsMenuLinks = ({ collective, isAccountantOnly }) => {
   return (
     <React.Fragment>
-      <MenuLink collective={collective} section={ABOUT_ORG_SECTIONS.INFO} />
-      <MenuLink collective={collective} section={ABOUT_ORG_SECTIONS.COLLECTIVE_PAGE} />
-      <MenuLink collective={collective} section={ABOUT_ORG_SECTIONS.CONNECTED_ACCOUNTS} />
-      <MenuLink collective={collective} section={ABOUT_ORG_SECTIONS.TEAM} />
-      <MenuLink collective={collective} section={ORG_BUDGET_SECTIONS.PAYMENT_METHODS} />
+      {!isAccountantOnly && (
+        <React.Fragment>
+          <MenuLink collective={collective} section={ABOUT_ORG_SECTIONS.INFO} />
+          <MenuLink collective={collective} section={ABOUT_ORG_SECTIONS.COLLECTIVE_PAGE} />
+          <MenuLink collective={collective} section={ABOUT_ORG_SECTIONS.CONNECTED_ACCOUNTS} />
+          <MenuLink collective={collective} section={ABOUT_ORG_SECTIONS.TEAM} />
+          <MenuLink collective={collective} section={ORG_BUDGET_SECTIONS.PAYMENT_METHODS} />
+        </React.Fragment>
+      )}
       <MenuLink collective={collective} section={ORG_BUDGET_SECTIONS.PAYMENT_RECEIPTS} />
-      <MenuLink collective={collective} section={ORG_BUDGET_SECTIONS.TIERS} />
-      <MenuLink collective={collective} section={ORG_BUDGET_SECTIONS.GIFT_CARDS} />
-      <MenuLink collective={collective} section={ALL_SECTIONS.WEBHOOKS} />
-      <MenuLink collective={collective} section={ALL_SECTIONS.ADVANCED} />
-      {!isHostAccount(collective) && <MenuLink collective={collective} section={ALL_SECTIONS.FISCAL_HOSTING} />}
+      {!isAccountantOnly && (
+        <React.Fragment>
+          <MenuLink collective={collective} section={ORG_BUDGET_SECTIONS.TIERS} />
+          <MenuLink collective={collective} section={ORG_BUDGET_SECTIONS.GIFT_CARDS} />
+          <MenuLink collective={collective} section={ALL_SECTIONS.WEBHOOKS} />
+          <MenuLink collective={collective} section={ALL_SECTIONS.ADVANCED} />
+          {!isHostAccount(collective) && <MenuLink collective={collective} section={ALL_SECTIONS.FISCAL_HOSTING} />}
+        </React.Fragment>
+      )}
     </React.Fragment>
   );
 };
 
 OrganizationSettingsMenuLinks.propTypes = {
   collective: PropTypes.object,
+  isAccountantOnly: PropTypes.boolean,
 };
 
-const Menu = ({ collective }) => {
+const Menu = ({ collective, isAccountantOnly }) => {
   const { formatMessage } = useIntl();
   const isHost = isHostAccount(collective);
   const isIndividual = isIndividualAccount(collective);
@@ -58,10 +67,10 @@ const Menu = ({ collective }) => {
           <MenuSectionHeader>
             <FormattedMessage id="HostDashboard" defaultMessage="Host Dashboard" />
           </MenuSectionHeader>
-          <MenuLink collective={collective} section={HOST_SECTIONS.EXPENSES} />
-          <MenuLink collective={collective} section={HOST_SECTIONS.FINANCIAL_CONTRIBUTIONS} />
-          <MenuLink collective={collective} section={HOST_SECTIONS.PENDING_APPLICATIONS} />
-          <MenuLink collective={collective} section={HOST_SECTIONS.HOSTED_COLLECTIVES} />
+          <MenuLink collective={collective} section={HOST_SECTIONS.EXPENSES} if={!isAccountantOnly} />
+          <MenuLink collective={collective} section={HOST_SECTIONS.FINANCIAL_CONTRIBUTIONS} if={!isAccountantOnly} />
+          <MenuLink collective={collective} section={HOST_SECTIONS.PENDING_APPLICATIONS} if={!isAccountantOnly} />
+          <MenuLink collective={collective} section={HOST_SECTIONS.HOSTED_COLLECTIVES} if={!isAccountantOnly} />
           <MenuLink collective={collective} section={HOST_SECTIONS.REPORTS} isBeta />
         </MenuGroup>
         <MenuGroup if={isHost || isType(collective, ORGANIZATION)}>
@@ -72,11 +81,11 @@ const Menu = ({ collective }) => {
             label={formatMessage(PAGE_TITLES[getCollectiveTypeKey(collective.type)])}
             if={isType(collective, ORGANIZATION) && isHost}
           >
-            <OrganizationSettingsMenuLinks collective={collective} />
+            <OrganizationSettingsMenuLinks collective={collective} isAccountantOnly={isAccountantOnly} />
           </SubMenu>
           <SubMenu
             label={<FormattedMessage id="AdminPanel.FiscalHostSettings" defaultMessage="Fiscal Host Settings" />}
-            if={isHost}
+            if={isHost && !isAccountantOnly}
           >
             <MenuLink collective={collective} section={FISCAL_HOST_SECTIONS.FISCAL_HOSTING} />
             <MenuGroup if={isHost}>
@@ -110,11 +119,11 @@ const Menu = ({ collective }) => {
 
         {/** General non-host organization settings (hosts organizations have a dedicated sub-menu) */}
         <MenuGroup if={isSimpleOrg}>
-          <OrganizationSettingsMenuLinks collective={collective} />
+          <OrganizationSettingsMenuLinks collective={collective} isAccountantOnly={isAccountantOnly} />
         </MenuGroup>
 
         {/** General settings for everyone except organizations */}
-        <MenuGroup if={!isType(collective, ORGANIZATION)}>
+        <MenuGroup if={!isType(collective, ORGANIZATION) && !isAccountantOnly}>
           <MenuLink collective={collective} section={COLLECTIVE_SECTIONS.INFO} />
           <MenuLink collective={collective} section={COLLECTIVE_SECTIONS.COLLECTIVE_PAGE} />
           <MenuLink
@@ -173,7 +182,7 @@ const Menu = ({ collective }) => {
           <MenuLink collective={collective} section={COLLECTIVE_SECTIONS.TWO_FACTOR_AUTH} if={isIndividual} />
           <MenuLink collective={collective} section={COLLECTIVE_SECTIONS.ADVANCED} />
         </MenuGroup>
-        <MenuGroup if={isSelfHostedAccount(collective)} mt={24}>
+        <MenuGroup if={isSelfHostedAccount(collective) && !isAccountantOnly} mt={24}>
           <MenuLink collective={collective} section={FISCAL_HOST_SECTIONS.INVOICES_RECEIPTS} />
           <MenuLink collective={collective} section={FISCAL_HOST_SECTIONS.RECEIVING_MONEY} />
           <MenuLink collective={collective} section={FISCAL_HOST_SECTIONS.SENDING_MONEY} />
@@ -190,6 +199,7 @@ const Menu = ({ collective }) => {
 };
 
 Menu.propTypes = {
+  isAccountantOnly: PropTypes.bool,
   collective: PropTypes.shape({
     slug: PropTypes.string,
     name: PropTypes.string,

--- a/components/admin-panel/MenuComponents.js
+++ b/components/admin-panel/MenuComponents.js
@@ -1,16 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useRouter } from 'next/router';
 import { FormattedMessage, useIntl } from 'react-intl';
 import styled, { css } from 'styled-components';
 
 import { getSettingsRoute } from '../../lib/url-helpers';
 
-import { getDefaultSectionForAccount } from '../../pages/admin-panel';
 import { Box } from '../Grid';
 import Link from '../Link';
 import StyledLink from '../StyledLink';
 
+import { AdminPanelContext } from './AdminPanelContext';
 import { SECTION_LABELS } from './constants';
 
 const MenuLinkContainer = styled.li`
@@ -49,13 +48,12 @@ const MenuLinkContainer = styled.li`
 `;
 
 export const MenuLink = ({ collective, section, children, onClick, isSelected, isStrong, if: conditional, isBeta }) => {
-  const router = useRouter();
+  const { selectedSection } = React.useContext(AdminPanelContext);
   const { formatMessage } = useIntl();
   if (conditional === false) {
     return null;
   }
 
-  const selectedSection = router.query?.section || getDefaultSectionForAccount(collective);
   if (!children && SECTION_LABELS[section]) {
     children = formatMessage(SECTION_LABELS[section]);
   }

--- a/components/admin-panel/SideBar.js
+++ b/components/admin-panel/SideBar.js
@@ -12,7 +12,7 @@ import { H1 } from '../Text';
 import Menu from './Menu';
 import { MenuContainer } from './MenuComponents';
 
-const AdminPanelSideBar = ({ collective, isLoading, selectedSection, onRoute, ...props }) => {
+const AdminPanelSideBar = ({ collective, isAccountantOnly, isLoading, selectedSection, onRoute, ...props }) => {
   const pageUrl = getCollectivePageRoute(collective);
   return (
     <Box {...props}>
@@ -41,7 +41,7 @@ const AdminPanelSideBar = ({ collective, isLoading, selectedSection, onRoute, ..
             </li>
           ))
         ) : (
-          <Menu {...{ collective, selectedSection, onRoute }} />
+          <Menu {...{ collective, selectedSection, onRoute, isAccountantOnly }} />
         )}
       </MenuContainer>
     </Box>
@@ -57,6 +57,7 @@ AdminPanelSideBar.propTypes = {
     type: PropTypes.string,
     isHost: PropTypes.bool,
   }),
+  isAccountantOnly: PropTypes.bool,
   onRoute: PropTypes.func,
 };
 

--- a/components/admin-panel/constants.js
+++ b/components/admin-panel/constants.js
@@ -80,6 +80,8 @@ export const ALL_SECTIONS = {
   ...HOST_DASHBOARD_SECTIONS,
 };
 
+export const SECTIONS_ACCESSIBLE_TO_ACCOUNTANTS = [ALL_SECTIONS.REPORTS, ALL_SECTIONS.PAYMENT_RECEIPTS];
+
 export const PAGE_TITLES = defineMessages({
   [USER]: { id: 'AdminPanel.UserSettings', defaultMessage: 'User Settings' },
   [ORGANIZATION]: { id: 'AdminPanel.OrganizationSettings', defaultMessage: 'Organization Settings' },

--- a/components/admin-panel/sections/AccountSettings.js
+++ b/components/admin-panel/sections/AccountSettings.js
@@ -17,7 +17,7 @@ import Loading from '../../Loading';
 import { TOAST_TYPE, useToasts } from '../../ToastProvider';
 import { useUser } from '../../UserProvider';
 
-const AccountSettings = ({ account }) => {
+const AccountSettings = ({ account, section }) => {
   const { LoggedInUser, refetchLoggedInUser } = useUser();
   const router = useRouter();
   const [state, setState] = React.useState({ status: undefined, result: undefined });
@@ -150,12 +150,14 @@ const AccountSettings = ({ account }) => {
       onSubmit={handleEditCollective}
       status={state.status}
       contentOnly={true}
+      section={section}
     />
   );
 };
 
 AccountSettings.propTypes = {
   account: PropTypes.object,
+  section: PropTypes.string,
 };
 
 export default AccountSettings;

--- a/components/collective-navbar/index.js
+++ b/components/collective-navbar/index.js
@@ -19,6 +19,7 @@ import { display } from 'styled-system';
 import { accountSupportsGrants, expenseSubmissionAllowed, getContributeRoute } from '../../lib/collective.lib';
 import { getFilteredSectionsForCollective, isSectionEnabled, NAVBAR_CATEGORIES } from '../../lib/collective-sections';
 import { CollectiveType } from '../../lib/constants/collectives';
+import roles from '../../lib/constants/roles';
 import { getEnvVar } from '../../lib/env-utils';
 import useGlobalBlur from '../../lib/hooks/useGlobalBlur';
 import { getSettingsRoute } from '../../lib/url-helpers';
@@ -242,7 +243,7 @@ const getHasContribute = (collective, sections, isAdmin) => {
   );
 };
 
-const getDefaultCallsToActions = (collective, sections, isAdmin, isHostAdmin, LoggedInUser) => {
+const getDefaultCallsToActions = (collective, sections, isAdmin, isAccountant, isHostAdmin, LoggedInUser) => {
   if (!collective) {
     return {};
   }
@@ -260,7 +261,7 @@ const getDefaultCallsToActions = (collective, sections, isAdmin, isHostAdmin, Lo
     addFunds: isHostAdmin,
     assignVirtualCard: isHostAdmin && isFeatureAvailable(host, 'VIRTUAL_CARDS'),
     requestVirtualCard: isAdmin && isFeatureAvailable(collective, 'REQUEST_VIRTUAL_CARDS'),
-    hasSettings: isAdmin,
+    hasSettings: isAdmin || isAccountant,
   };
 };
 
@@ -425,13 +426,14 @@ const CollectiveNavbar = ({
   const intl = useIntl();
   const [isExpanded, setExpanded] = React.useState(false);
   const { LoggedInUser } = useUser();
+  const isAccountant = LoggedInUser?.hasRole(roles.ACCOUNTANT, collective);
   isAdmin = isAdmin || LoggedInUser?.canEditCollective(collective);
   const isHostAdmin = LoggedInUser?.isHostAdmin(collective);
   const sections = React.useMemo(() => {
     return sectionsFromParent || getFilteredSectionsForCollective(collective, isAdmin, isHostAdmin);
   }, [sectionsFromParent, collective, isAdmin, isHostAdmin]);
   callsToAction = {
-    ...getDefaultCallsToActions(collective, sections, isAdmin, isHostAdmin, LoggedInUser),
+    ...getDefaultCallsToActions(collective, sections, isAdmin, isAccountant, isHostAdmin, LoggedInUser),
     ...callsToAction,
   };
   const actionsArray = Object.keys(pickBy(callsToAction, Boolean));

--- a/components/edit-collective/Form.js
+++ b/components/edit-collective/Form.js
@@ -59,6 +59,7 @@ class EditCollectiveForm extends React.Component {
   static propTypes = {
     collective: PropTypes.object,
     status: PropTypes.string, // loading, saved
+    section: PropTypes.string,
     onSubmit: PropTypes.func,
     LoggedInUser: PropTypes.object.isRequired,
     router: PropTypes.object, // from withRouter
@@ -634,7 +635,7 @@ class EditCollectiveForm extends React.Component {
   render() {
     const { collective, status, intl, router, contentOnly } = this.props;
 
-    const section = get(router, 'query.section', 'info');
+    const section = this.props.section || get(router, 'query.section', 'info');
 
     const isNew = !(collective && collective.id);
     let submitBtnMessageId = isNew ? 'event.create.btn' : 'save';

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -14,6 +14,7 @@
   "7oAuzt": "Expense types",
   "94IjMb": "Coordinated Universal Time",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
+  "9FWGOh": "You need to be logged in as an admin or accountant to view this page",
   "9kdoVP": "Local time: {localTime}{newLine}UTC time: {utcTime}",
   "9MpOZn": "Support the event or buy tickets.",
   "9sbPks": "By default, all dates are filtered and displayed using your local timezone. You can switch to UTC to indicate that the dates provided above use the Coordinated Universal Time format, which matches how email reports are generated",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -14,6 +14,7 @@
   "7oAuzt": "Expense types",
   "94IjMb": "Coordinated Universal Time",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
+  "9FWGOh": "You need to be logged in as an admin or accountant to view this page",
   "9kdoVP": "Local time: {localTime}{newLine}UTC time: {utcTime}",
   "9MpOZn": "Support the event or buy tickets.",
   "9sbPks": "By default, all dates are filtered and displayed using your local timezone. You can switch to UTC to indicate that the dates provided above use the Coordinated Universal Time format, which matches how email reports are generated",

--- a/lang/de.json
+++ b/lang/de.json
@@ -14,6 +14,7 @@
   "7oAuzt": "Expense types",
   "94IjMb": "Coordinated Universal Time",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
+  "9FWGOh": "You need to be logged in as an admin or accountant to view this page",
   "9kdoVP": "Local time: {localTime}{newLine}UTC time: {utcTime}",
   "9MpOZn": "Support the event or buy tickets.",
   "9sbPks": "By default, all dates are filtered and displayed using your local timezone. You can switch to UTC to indicate that the dates provided above use the Coordinated Universal Time format, which matches how email reports are generated",

--- a/lang/en.json
+++ b/lang/en.json
@@ -14,6 +14,7 @@
   "7oAuzt": "Expense types",
   "94IjMb": "Coordinated Universal Time",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
+  "9FWGOh": "You need to be logged in as an admin or accountant to view this page",
   "9kdoVP": "Local time: {localTime}{newLine}UTC time: {utcTime}",
   "9MpOZn": "Support the event or buy tickets.",
   "9sbPks": "By default, all dates are filtered and displayed using your local timezone. You can switch to UTC to indicate that the dates provided above use the Coordinated Universal Time format, which matches how email reports are generated",

--- a/lang/es.json
+++ b/lang/es.json
@@ -14,6 +14,7 @@
   "7oAuzt": "Expense types",
   "94IjMb": "Coordinated Universal Time",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
+  "9FWGOh": "You need to be logged in as an admin or accountant to view this page",
   "9kdoVP": "Local time: {localTime}{newLine}UTC time: {utcTime}",
   "9MpOZn": "Support the event or buy tickets.",
   "9sbPks": "By default, all dates are filtered and displayed using your local timezone. You can switch to UTC to indicate that the dates provided above use the Coordinated Universal Time format, which matches how email reports are generated",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -14,6 +14,7 @@
   "7oAuzt": "Expense types",
   "94IjMb": "Temps universel coordonné",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
+  "9FWGOh": "You need to be logged in as an admin or accountant to view this page",
   "9kdoVP": "Heure locale: {localTime}{newLine}Heure UTC : {utcTime}",
   "9MpOZn": "Support the event or buy tickets.",
   "9sbPks": "By default, all dates are filtered and displayed using your local timezone. You can switch to UTC to indicate that the dates provided above use the Coordinated Universal Time format, which matches how email reports are generated",

--- a/lang/it.json
+++ b/lang/it.json
@@ -14,6 +14,7 @@
   "7oAuzt": "Expense types",
   "94IjMb": "Tempo Universale Coordinato",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
+  "9FWGOh": "You need to be logged in as an admin or accountant to view this page",
   "9kdoVP": "Ora locale: {localTime}{newLine}ora UTC: {utcTime}",
   "9MpOZn": "Support the event or buy tickets.",
   "9sbPks": "Per impostazione predefinita, tutte le date sono filtrate e visualizzate utilizzando il fuso orario locale. È possibile passare a UTC per indicare che le date fornite sopra utilizzare il formato Coordinated Universal Time, che corrisponde a come vengono generati i report di posta elettronica",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -14,6 +14,7 @@
   "7oAuzt": "Expense types",
   "94IjMb": "Coordinated Universal Time",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
+  "9FWGOh": "You need to be logged in as an admin or accountant to view this page",
   "9kdoVP": "Local time: {localTime}{newLine}UTC time: {utcTime}",
   "9MpOZn": "Support the event or buy tickets.",
   "9sbPks": "By default, all dates are filtered and displayed using your local timezone. You can switch to UTC to indicate that the dates provided above use the Coordinated Universal Time format, which matches how email reports are generated",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -14,6 +14,7 @@
   "7oAuzt": "Expense types",
   "94IjMb": "Coordinated Universal Time",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
+  "9FWGOh": "You need to be logged in as an admin or accountant to view this page",
   "9kdoVP": "Local time: {localTime}{newLine}UTC time: {utcTime}",
   "9MpOZn": "Support the event or buy tickets.",
   "9sbPks": "By default, all dates are filtered and displayed using your local timezone. You can switch to UTC to indicate that the dates provided above use the Coordinated Universal Time format, which matches how email reports are generated",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -14,6 +14,7 @@
   "7oAuzt": "Expense types",
   "94IjMb": "Coordinated Universal Time",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
+  "9FWGOh": "You need to be logged in as an admin or accountant to view this page",
   "9kdoVP": "Local time: {localTime}{newLine}UTC time: {utcTime}",
   "9MpOZn": "Support the event or buy tickets.",
   "9sbPks": "By default, all dates are filtered and displayed using your local timezone. You can switch to UTC to indicate that the dates provided above use the Coordinated Universal Time format, which matches how email reports are generated",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -14,6 +14,7 @@
   "7oAuzt": "Expense types",
   "94IjMb": "Coordinated Universal Time",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
+  "9FWGOh": "You need to be logged in as an admin or accountant to view this page",
   "9kdoVP": "Local time: {localTime}{newLine}UTC time: {utcTime}",
   "9MpOZn": "Support the event or buy tickets.",
   "9sbPks": "By default, all dates are filtered and displayed using your local timezone. You can switch to UTC to indicate that the dates provided above use the Coordinated Universal Time format, which matches how email reports are generated",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -14,6 +14,7 @@
   "7oAuzt": "Expense types",
   "94IjMb": "Coordinated Universal Time",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
+  "9FWGOh": "You need to be logged in as an admin or accountant to view this page",
   "9kdoVP": "Local time: {localTime}{newLine}UTC time: {utcTime}",
   "9MpOZn": "Support the event or buy tickets.",
   "9sbPks": "By default, all dates are filtered and displayed using your local timezone. You can switch to UTC to indicate that the dates provided above use the Coordinated Universal Time format, which matches how email reports are generated",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -14,6 +14,7 @@
   "7oAuzt": "Expense types",
   "94IjMb": "Универсальное скоординированное время",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
+  "9FWGOh": "You need to be logged in as an admin or accountant to view this page",
   "9kdoVP": "Локальное время: {localTime}{newLine}UTC время: {utcTime}",
   "9MpOZn": "Support the event or buy tickets.",
   "9sbPks": "By default, all dates are filtered and displayed using your local timezone. You can switch to UTC to indicate that the dates provided above use the Coordinated Universal Time format, which matches how email reports are generated",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -14,6 +14,7 @@
   "7oAuzt": "Expense types",
   "94IjMb": "Всесвітній координований час",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
+  "9FWGOh": "You need to be logged in as an admin or accountant to view this page",
   "9kdoVP": "Місцевий час: {localTime}{newLine}UTC: {utcTime}",
   "9MpOZn": "Support the event or buy tickets.",
   "9sbPks": "By default, all dates are filtered and displayed using your local timezone. You can switch to UTC to indicate that the dates provided above use the Coordinated Universal Time format, which matches how email reports are generated",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -14,6 +14,7 @@
   "7oAuzt": "Expense types",
   "94IjMb": "世界标准时间（UTC）",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
+  "9FWGOh": "You need to be logged in as an admin or accountant to view this page",
   "9kdoVP": "本地时间: {localTime}{newLine}UTC 时间: {utcTime}",
   "9MpOZn": "Support the event or buy tickets.",
   "9sbPks": "页面上所有时间的处理和显示默认根据您本地的时区，而电子邮件的报告是以世界标准时间（UTC）来生成的。您可以切换页面时间至 UTC 来和邮件的时间保持一致",

--- a/lib/LoggedInUser.js
+++ b/lib/LoggedInUser.js
@@ -59,6 +59,13 @@ LoggedInUser.prototype.canEditCollective = function (collective) {
 };
 
 /**
+ * Has access to admin panel if admin or accountant
+ */
+LoggedInUser.prototype.canSeeAdminPanel = function (collective) {
+  return this.hasRole([ROLES.ADMIN, ROLES.ACCOUNTANT], collective);
+};
+
+/**
  * CanEditComment if LoggedInUser is
  * - creator of the comment
  * - is admin or host of the collective

--- a/pages/admin-panel.js
+++ b/pages/admin-panel.js
@@ -4,10 +4,12 @@ import { useRouter } from 'next/router';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
 import { isHostAccount } from '../lib/collective.lib';
+import roles from '../lib/constants/roles';
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
 
+import { AdminPanelContext } from '../components/admin-panel/AdminPanelContext';
 import AdminPanelSection from '../components/admin-panel/AdminPanelSection';
-import { ALL_SECTIONS } from '../components/admin-panel/constants';
+import { ALL_SECTIONS, SECTIONS_ACCESSIBLE_TO_ACCOUNTANTS } from '../components/admin-panel/constants';
 import AdminPanelSideBar from '../components/admin-panel/SideBar';
 import AdminPanelTopBar from '../components/admin-panel/TopBar';
 import { collectiveNavbarFieldsFragment } from '../components/collective-page/graphql/fragments';
@@ -74,8 +76,19 @@ const messages = defineMessages({
   },
 });
 
-export const getDefaultSectionForAccount = account => {
-  return account && isHostAccount(account) ? ALL_SECTIONS.EXPENSES : ALL_SECTIONS.INFO;
+const getDefaultSectionForAccount = (account, loggedInUser) => {
+  if (!account) {
+    return ALL_SECTIONS.INFO;
+  }
+
+  const isAdmin = loggedInUser?.canEditCollective(account);
+  const isAccountant = loggedInUser?.hasRole(roles.ACCOUNTANT, account);
+  const isAccountantOnly = !isAdmin && isAccountant;
+  if (isHostAccount(account)) {
+    return isAccountantOnly ? ALL_SECTIONS.REPORTS : ALL_SECTIONS.EXPENSES;
+  } else {
+    return isAccountantOnly ? ALL_SECTIONS.PAYMENT_RECEIPTS : ALL_SECTIONS.INFO;
+  }
 };
 
 const getNotification = (intl, account) => {
@@ -99,76 +112,91 @@ const getNotification = (intl, account) => {
   }
 };
 
-function getBlocker(LoggedInUser, account) {
+function getBlocker(LoggedInUser, account, section) {
   if (!LoggedInUser) {
     return <FormattedMessage id="mustBeLoggedIn" defaultMessage="You must be logged in to see this page" />;
   } else if (!account) {
     return <FormattedMessage defaultMessage="This account doesn't exist" />;
   } else if (account.isIncognito) {
     return <FormattedMessage defaultMessage="You cannot edit this collective" />;
-  } else if (!LoggedInUser.canEditCollective(account)) {
+  }
+
+  // Check permissions
+  const isAdmin = LoggedInUser.canEditCollective(account);
+  if (SECTIONS_ACCESSIBLE_TO_ACCOUNTANTS.includes(section)) {
+    if (!isAdmin && !LoggedInUser.hasRole(roles.ACCOUNTANT, account)) {
+      return <FormattedMessage defaultMessage="You need to be logged in as an admin or accountant to view this page" />;
+    }
+  } else if (!isAdmin) {
     return <FormattedMessage defaultMessage="You need to be logged in as an admin" />;
   }
 }
 
+const getIsAccountantOnly = (LoggedInUser, account) => {
+  return LoggedInUser && !LoggedInUser.canEditCollective(account) && LoggedInUser.hasRole(roles.ACCOUNTANT, account);
+};
+
 const AdminPanelPage = () => {
   const router = useRouter();
-  const { slug } = router.query;
+  const { slug, section } = router.query;
   const intl = useIntl();
   const { LoggedInUser, loadingLoggedInUser } = useUser();
   const { data, loading } = useQuery(adminPanelQuery, { context: API_V2_CONTEXT, variables: { slug } });
 
   const account = data?.account;
   const notification = getNotification(intl, account);
-  const section = router.query.section || getDefaultSectionForAccount(account);
+  const selectedSection = section || getDefaultSectionForAccount(account, LoggedInUser);
   const isLoading = loading || loadingLoggedInUser;
-  const blocker = !isLoading && getBlocker(LoggedInUser, account);
+  const blocker = !isLoading && getBlocker(LoggedInUser, account, selectedSection);
   return (
-    <Page>
-      {!blocker && (
-        <AdminPanelTopBar
-          isLoading={isLoading}
-          collective={data?.account}
-          collectiveSlug={slug}
-          selectedSection={section}
-          display={['flex', null, 'none']}
-        />
-      )}
-      {Boolean(notification) && (
-        <NotificationBar
-          status={notification.status}
-          title={notification.title}
-          description={notification.description}
-        />
-      )}
-      {blocker ? (
-        <Flex flexDirection="column" alignItems="center" my={6}>
-          <MessageBox type="warning" mb={4} maxWidth={400} withIcon>
-            {blocker}
-          </MessageBox>
-          {!LoggedInUser && <SignInOrJoinFree form="signin" disableSignup />}
-        </Flex>
-      ) : (
-        <Grid
-          gridTemplateColumns={['1fr', null, '208px 1fr']}
-          maxWidth={1280}
-          minHeight={600}
-          gridGap={56}
-          m="0 auto"
-          px={3}
-          py={4}
-        >
-          <AdminPanelSideBar
+    <AdminPanelContext.Provider value={{ selectedSection }}>
+      <Page>
+        {!blocker && (
+          <AdminPanelTopBar
             isLoading={isLoading}
-            collective={account}
-            selectedSection={section}
-            display={['none', null, 'block']}
+            collective={data?.account}
+            collectiveSlug={slug}
+            selectedSection={selectedSection}
+            display={['flex', null, 'none']}
           />
-          <AdminPanelSection section={section} isLoading={isLoading} collective={account} />
-        </Grid>
-      )}
-      ;
-    </Page>
+        )}
+        {Boolean(notification) && (
+          <NotificationBar
+            status={notification.status}
+            title={notification.title}
+            description={notification.description}
+          />
+        )}
+        {blocker ? (
+          <Flex flexDirection="column" alignItems="center" my={6}>
+            <MessageBox type="warning" mb={4} maxWidth={400} withIcon>
+              {blocker}
+            </MessageBox>
+            {!LoggedInUser && <SignInOrJoinFree form="signin" disableSignup />}
+          </Flex>
+        ) : (
+          <Grid
+            gridTemplateColumns={['1fr', null, '208px 1fr']}
+            maxWidth={1280}
+            minHeight={600}
+            gridGap={56}
+            m="0 auto"
+            px={3}
+            py={4}
+          >
+            <AdminPanelSideBar
+              isLoading={isLoading}
+              collective={account}
+              selectedSection={selectedSection}
+              display={['none', null, 'block']}
+              isAccountantOnly={getIsAccountantOnly(LoggedInUser, account)}
+            />
+            <AdminPanelSection section={selectedSection} isLoading={isLoading} collective={account} />
+          </Grid>
+        )}
+        ;
+      </Page>
+    </AdminPanelContext.Provider>
   );
 };
 


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-api/pull/6839

- [x] Authorize the reports page
- [x] Authorize the payment receipts page
- [x] Adapt menu for accountants (hide everything they don't have access to)
- [x] Make reports the default section for accountants when they arrive on `/host/admin`
- [x] Show `Admin` button on profiles for accountants
- [x] Show admin cog icon in the user menu for accountants