### PR TITLE
Fix conditions for grants

### DIFF
--- a/components/collective-navbar/index.js
+++ b/components/collective-navbar/index.js
@@ -247,9 +247,7 @@ const getDefaultCallsToActions = (collective, sections, isAdmin, isHostAdmin, Lo
     return {};
   }
 
-  const { features, settings, host } = collective;
-  const isProjectOrFund = [CollectiveType.FUND, CollectiveType.PROJECT].includes(collective.type);
-  const hostSettings = host ? host.settings : null;
+  const { features, host } = collective;
   return {
     hasContribute: getHasContribute(collective, sections, isAdmin),
     hasContact: isFeatureAvailable(collective, 'CONTACT_FORM'),
@@ -258,9 +256,7 @@ const getDefaultCallsToActions = (collective, sections, isAdmin, isHostAdmin, Lo
       isFeatureAvailable(collective, 'RECEIVE_EXPENSES') && expenseSubmissionAllowed(collective, LoggedInUser),
     hasManageSubscriptions: isAdmin && get(features, 'RECURRING_CONTRIBUTIONS') === 'ACTIVE',
     hasDashboard: isAdmin && isFeatureAvailable(collective, 'HOST_DASHBOARD'),
-    hasRequestGrant:
-      (accountSupportsGrants(settings, hostSettings) || isProjectOrFund) &&
-      expenseSubmissionAllowed(collective, LoggedInUser),
+    hasRequestGrant: accountSupportsGrants(collective, host) && expenseSubmissionAllowed(collective, LoggedInUser),
     addFunds: isHostAdmin,
     assignVirtualCard: isHostAdmin && isFeatureAvailable(host, 'VIRTUAL_CARDS'),
     requestVirtualCard: isAdmin && isFeatureAvailable(collective, 'REQUEST_VIRTUAL_CARDS'),

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -7,7 +7,6 @@ import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import styled from 'styled-components';
 
 import { accountSupportsGrants } from '../../lib/collective.lib';
-import { CollectiveType } from '../../lib/collective-sections';
 import expenseStatus from '../../lib/constants/expense-status';
 import expenseTypes from '../../lib/constants/expenseTypes';
 import { PayoutMethodType } from '../../lib/constants/payout-method';
@@ -379,9 +378,7 @@ const ExpenseFormBody = ({
           }}
           value={values.type}
           options={{
-            fundingRequest:
-              accountSupportsGrants(collective.settings, collective?.host?.settings) ||
-              [CollectiveType.FUND, CollectiveType.PROJECT].includes(collective.type),
+            fundingRequest: accountSupportsGrants(collective, collective?.host),
           }}
         />
       )}

--- a/components/host-dashboard/CollectiveSettingsModal.js
+++ b/components/host-dashboard/CollectiveSettingsModal.js
@@ -5,7 +5,6 @@ import { clamp, isNil, round } from 'lodash';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
 import { accountSupportsGrants } from '../../lib/collective.lib';
-import { CollectiveType } from '../../lib/constants/collectives';
 import { HOST_FEE_STRUCTURE } from '../../lib/constants/host-fee-structure';
 import { API_V2_CONTEXT, gqlV2 } from '../../lib/graphql/helpers';
 
@@ -69,10 +68,7 @@ const CollectiveSettingsModal = ({ host, collective, ...props }) => {
   const [selectedOption, setSelectedOption] = useState(
     hostFeePercent === host.hostFeePercent ? HOST_FEE_STRUCTURE.DEFAULT : HOST_FEE_STRUCTURE.CUSTOM_FEE,
   );
-  const isProjectOrFund = [CollectiveType.FUND, CollectiveType.PROJECT].includes(collective.type);
-  const [hasGrant, setHasGrant] = useState(
-    accountSupportsGrants(collective?.settings, host?.settings) || isProjectOrFund,
-  );
+  const [hasGrant, setHasGrant] = useState(() => accountSupportsGrants(collective, host));
   const [submitFeesStructure, { loading, error }] = useMutation(editAccountSettingsMutation, {
     context: API_V2_CONTEXT,
   });

--- a/lib/collective.lib.js
+++ b/lib/collective.lib.js
@@ -1,4 +1,4 @@
-import { get, trim } from 'lodash';
+import { get, isBoolean, trim } from 'lodash';
 import slugify from 'slugify';
 
 import {
@@ -233,9 +233,10 @@ export const isIndividualAccount = account => ['USER', 'INDIVIDUAL'].includes(ac
 
 /* Checks whether an account supports grants */
 export const accountSupportsGrants = (account, host) => {
-  if (get(account, 'settings.expenseTypes.hasGrant')) {
-    // If the opt-in flag in ON, always allow grants
-    return true;
+  const accountHasGrantFlag = get(account, 'settings.expenseTypes.hasGrant');
+  if (isBoolean(accountHasGrantFlag)) {
+    // If the account's feature flag is set, use it as the main source of truth
+    return accountHasGrantFlag;
   } else if (get(host, 'settings.disableGrantsByDefault')) {
     // If the host has configured grants to be opt-in, the previous flag (`hasGrant`) **must** be set
     return false;

--- a/lib/collective.lib.js
+++ b/lib/collective.lib.js
@@ -232,6 +232,14 @@ export const isSelfHostedAccount = c => c.isHost === true && c.type === 'COLLECT
 export const isIndividualAccount = account => ['USER', 'INDIVIDUAL'].includes(account.type);
 
 /* Checks whether an account supports grants */
-export const accountSupportsGrants = (collectiveSettings, hostSettings) => {
-  return get(collectiveSettings, 'expenseTypes.hasGrant', !get(hostSettings, 'disableGrantsByDefault', false));
+export const accountSupportsGrants = (account, host) => {
+  if (get(account, 'settings.expenseTypes.hasGrant')) {
+    // If the opt-in flag in ON, always allow grants
+    return true;
+  } else if (get(host, 'settings.disableGrantsByDefault')) {
+    // If the host has configured grants to be opt-in, the previous flag (`hasGrant`) **must** be set
+    return false;
+  } else {
+    return [CollectiveType.FUND, CollectiveType.PROJECT].includes(account?.type);
+  }
 };


### PR DESCRIPTION
Followup on https://github.com/opencollective/opencollective-frontend/pull/7090

Grants were enabled by default for all account types in the previous PR, which is not what we wanted (it's only ON by default for funds and projects). Also refactored `accountSupportsGrants` to match what was proposed in https://github.com/opencollective/opencollective-frontend/pull/7090#discussion_r745337346 and reduce code duplication.