### PR TITLE
Fix progress stats for flexible tiers on tier page

### DIFF
--- a/components/tier-page/index.js
+++ b/components/tier-page/index.js
@@ -166,7 +166,9 @@ class TierPage extends Component {
   render() {
     const { collective, tier, contributors, contributorsStats, redirect, LoggedInUser } = this.props;
     const canEdit = LoggedInUser && LoggedInUser.canEditCollective(collective);
-    const amountRaised = tier.interval ? tier.stats.totalRecurringDonations : tier.stats.totalDonated;
+    const isFlexibleInterval = tier.interval === INTERVALS.flexible;
+    const amountRaisedKey = tier.interval && !isFlexibleInterval ? 'totalRecurringDonations' : 'totalDonated';
+    const amountRaised = tier.stats?.[amountRaisedKey] || 0;
     const shareBlock = this.renderShareBlock();
     const isPassed = isTierExpired(tier);
 


### PR DESCRIPTION
Fix https://opencollective.freshdesk.com/a/tickets/45554

The way to compute progress implemented in https://github.com/opencollective/opencollective-frontend/pull/6047 was not applied to the tier page.