### PR TITLE
Add custom card name when assigning a virtual card

### DIFF
--- a/components/edit-collective/AssignVirtualCardModal.js
+++ b/components/edit-collective/AssignVirtualCardModal.js
@@ -14,6 +14,7 @@ import { Grid } from '../Grid';
 import CreditCard from '../icons/CreditCard';
 import StyledButton from '../StyledButton';
 import StyledHr from '../StyledHr';
+import StyledInput from '../StyledInput';
 import StyledInputField from '../StyledInputField';
 import StyledInputGroup from '../StyledInputGroup';
 import StyledInputMask from '../StyledInputMask';
@@ -29,6 +30,7 @@ const initialValues = {
   cvv: undefined,
   assignee: undefined,
   provider: undefined,
+  cardName: undefined,
 };
 
 const assignNewVirtualCardMutation = gqlV2/* GraphQL */ `
@@ -100,12 +102,13 @@ const AssignVirtualCardModal = ({ collective, host, virtualCard, onSuccess, onCl
             ...virtualCard.privateData,
             assignee: virtualCard.assignee,
             provider: virtualCard.provider,
+            cardName: virtualCard.name,
           }
         : initialValues),
       collective: collective || virtualCard?.account,
     },
     async onSubmit(values) {
-      const { collective, assignee, provider } = values;
+      const { collective, assignee, provider, cardName } = values;
       const privateData = {
         cardNumber: values.cardNumber.replace(/\s+/g, ''),
         cvv: values.cvv,
@@ -146,6 +149,7 @@ const AssignVirtualCardModal = ({ collective, host, virtualCard, onSuccess, onCl
               virtualCard: {
                 privateData,
                 provider,
+                name: cardName,
               },
               assignee: { id: assignee.id },
               account: typeof collective.id === 'string' ? { id: collective.id } : { legacyId: collective.id },
@@ -182,6 +186,9 @@ const AssignVirtualCardModal = ({ collective, host, virtualCard, onSuccess, onCl
       }
       if (!values.provider) {
         errors.provider = 'Required';
+      }
+      if (!values.cardName) {
+        errors.cardName = 'Required';
       }
       if (!values.assignee) {
         errors.assignee = 'Required';
@@ -307,6 +314,26 @@ const AssignVirtualCardModal = ({ collective, host, virtualCard, onSuccess, onCl
                   isSearchable={false}
                   disabled={isBusy || isEditing}
                   onChange={option => formik.setFieldValue('provider', option.value)}
+                />
+              )}
+            </StyledInputField>
+
+            <StyledInputField
+              gridColumn="1/3"
+              labelFontSize="13px"
+              label={<FormattedMessage defaultMessage="Card name" />}
+              htmlFor="cardName"
+              error={formik.touched.cardName && formik.errors.cardName}
+            >
+              {inputProps => (
+                <StyledInput
+                  {...inputProps}
+                  name="cardName"
+                  id="cardName"
+                  onChange={formik.handleChange}
+                  value={formik.values.cardName}
+                  disabled={isBusy || isEditing}
+                  guide={false}
                 />
               )}
             </StyledInputField>

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -12,6 +12,7 @@
   "7i6eHp": "Expire date",
   "7nUCu9": "Timezone",
   "7oAuzt": "Expense types",
+  "8oufoc": "Card name",
   "94IjMb": "Coordinated Universal Time",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
   "9kdoVP": "Local time: {localTime}{newLine}UTC time: {utcTime}",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -12,6 +12,7 @@
   "7i6eHp": "Expire date",
   "7nUCu9": "Timezone",
   "7oAuzt": "Expense types",
+  "8oufoc": "Card name",
   "94IjMb": "Coordinated Universal Time",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
   "9kdoVP": "Local time: {localTime}{newLine}UTC time: {utcTime}",

--- a/lang/de.json
+++ b/lang/de.json
@@ -12,6 +12,7 @@
   "7i6eHp": "Expire date",
   "7nUCu9": "Timezone",
   "7oAuzt": "Expense types",
+  "8oufoc": "Card name",
   "94IjMb": "Coordinated Universal Time",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
   "9kdoVP": "Local time: {localTime}{newLine}UTC time: {utcTime}",

--- a/lang/en.json
+++ b/lang/en.json
@@ -12,6 +12,7 @@
   "7i6eHp": "Expire date",
   "7nUCu9": "Timezone",
   "7oAuzt": "Expense types",
+  "8oufoc": "Card name",
   "94IjMb": "Coordinated Universal Time",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
   "9kdoVP": "Local time: {localTime}{newLine}UTC time: {utcTime}",

--- a/lang/es.json
+++ b/lang/es.json
@@ -12,6 +12,7 @@
   "7i6eHp": "Expire date",
   "7nUCu9": "Timezone",
   "7oAuzt": "Expense types",
+  "8oufoc": "Card name",
   "94IjMb": "Coordinated Universal Time",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
   "9kdoVP": "Local time: {localTime}{newLine}UTC time: {utcTime}",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -12,6 +12,7 @@
   "7i6eHp": "Expire date",
   "7nUCu9": "Fuseau horaire",
   "7oAuzt": "Expense types",
+  "8oufoc": "Card name",
   "94IjMb": "Temps universel coordonné",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
   "9kdoVP": "Heure locale: {localTime}{newLine}Heure UTC : {utcTime}",

--- a/lang/it.json
+++ b/lang/it.json
@@ -12,6 +12,7 @@
   "7i6eHp": "Expire date",
   "7nUCu9": "Fuso orario",
   "7oAuzt": "Expense types",
+  "8oufoc": "Card name",
   "94IjMb": "Tempo Universale Coordinato",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
   "9kdoVP": "Ora locale: {localTime}{newLine}ora UTC: {utcTime}",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -12,6 +12,7 @@
   "7i6eHp": "Expire date",
   "7nUCu9": "Timezone",
   "7oAuzt": "Expense types",
+  "8oufoc": "Card name",
   "94IjMb": "Coordinated Universal Time",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
   "9kdoVP": "Local time: {localTime}{newLine}UTC time: {utcTime}",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -12,6 +12,7 @@
   "7i6eHp": "Expire date",
   "7nUCu9": "Timezone",
   "7oAuzt": "Expense types",
+  "8oufoc": "Card name",
   "94IjMb": "Coordinated Universal Time",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
   "9kdoVP": "Local time: {localTime}{newLine}UTC time: {utcTime}",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -12,6 +12,7 @@
   "7i6eHp": "Expire date",
   "7nUCu9": "Timezone",
   "7oAuzt": "Expense types",
+  "8oufoc": "Card name",
   "94IjMb": "Coordinated Universal Time",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
   "9kdoVP": "Local time: {localTime}{newLine}UTC time: {utcTime}",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -12,6 +12,7 @@
   "7i6eHp": "Expire date",
   "7nUCu9": "Timezone",
   "7oAuzt": "Expense types",
+  "8oufoc": "Card name",
   "94IjMb": "Coordinated Universal Time",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
   "9kdoVP": "Local time: {localTime}{newLine}UTC time: {utcTime}",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -12,6 +12,7 @@
   "7i6eHp": "Expire date",
   "7nUCu9": "Timezone",
   "7oAuzt": "Expense types",
+  "8oufoc": "Card name",
   "94IjMb": "Coordinated Universal Time",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
   "9kdoVP": "Local time: {localTime}{newLine}UTC time: {utcTime}",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -12,6 +12,7 @@
   "7i6eHp": "Expire date",
   "7nUCu9": "Часовой пояс",
   "7oAuzt": "Expense types",
+  "8oufoc": "Card name",
   "94IjMb": "Универсальное скоординированное время",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
   "9kdoVP": "Локальное время: {localTime}{newLine}UTC время: {utcTime}",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -12,6 +12,7 @@
   "7i6eHp": "Expire date",
   "7nUCu9": "Часовий пояс",
   "7oAuzt": "Expense types",
+  "8oufoc": "Card name",
   "94IjMb": "Всесвітній координований час",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
   "9kdoVP": "Місцевий час: {localTime}{newLine}UTC: {utcTime}",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -12,6 +12,7 @@
   "7i6eHp": "Expire date",
   "7nUCu9": "时区",
   "7oAuzt": "Expense types",
+  "8oufoc": "Card name",
   "94IjMb": "世界标准时间（UTC）",
   "9DioA1": "{count, plural, one {# Recurring} other {# Recurring}}",
   "9kdoVP": "本地时间: {localTime}{newLine}UTC 时间: {utcTime}",


### PR DESCRIPTION
# Description

Add an input in the assign card modal to specify a custom name for the virtual card.
Replace the name from privacy or the last four digit when no name.