### PR TITLE
Revert  #7019 ("Make Sure `accountDetails` are Initially Loaded when `DetailsForm` renders")

### DIFF
--- a/components/expenses/PayoutBankInformationForm.js
+++ b/components/expenses/PayoutBankInformationForm.js
@@ -229,11 +229,7 @@ const DetailsForm = ({ disabled, getFieldName, formik, host, currency }) => {
     // B) If `host` is set, we expect to be in 2 cases:
     //      * The Collective Host has Wise configured and we should be able to fetch `requiredFields` from it
     //      * The Collective Host doesn't have Wise configured and `host` is already switched to the Platform account
-    variables: {
-      slug: host ? host.slug : TW_API_COLLECTIVE_SLUG,
-      currency,
-      accountDetails: get(formik.values, getFieldName('data')),
-    },
+    variables: { slug: host ? host.slug : TW_API_COLLECTIVE_SLUG, currency },
   });
 
   if (loading && !data) {


### PR DESCRIPTION
Reverts opencollective/opencollective-frontend#7019
Reopens https://github.com/opencollective/opencollective/issues/4838
Resolve https://github.com/opencollective/opencollective/issues/4959

opencollective/opencollective-frontend#7019 introduced this bug, since `accountDetails` is a JSON containing all the info it changes on each keystroke and therefore the query `variables` will change each time, triggering a new query. We need to find a better way to solve https://github.com/opencollective/opencollective/issues/4838.