### PR TITLE
Fix layout issues on FiscalHosting page

### DIFF
--- a/components/StyledCarousel.js
+++ b/components/StyledCarousel.js
@@ -177,7 +177,7 @@ const StyledCarousel = props => {
       </Flex>
       <Container width={1} display="flex" alignItems="center" justifyContent={'center'}>
         {showArrowController && controllerPosition === 'bottom' && renderLeftController()}
-        <Flex mx={3} my={3} display={props.display}>
+        <Flex mx={3} my={3}>
           {Array.from({ length: children.length }, (_, i) => (
             <Indicator key={i} active={i === activeIndex} mx={1} onClick={() => handleOnClickIndicator(i)} />
           ))}

--- a/components/fiscal-hosting/WhoIsFiscalHostingForSection.js
+++ b/components/fiscal-hosting/WhoIsFiscalHostingForSection.js
@@ -200,7 +200,7 @@ const PotentialUsers = ({ users }) => {
     <Wrapper
       gridTemplateColumns={['100%', 'repeat(2, 1fr)', null, null, 'repeat(3, 1fr)']}
       placeItems="center"
-      alignItems="center"
+      alignItems="flex-start"
     >
       {users.map(user => (
         <PotentialUser key={user.id} id={user.id} />


### PR DESCRIPTION
Fix small issues reported in https://opencollective.slack.com/archives/CTMTYBWS1/p1637162419000900:
- Horizontal layout for navigation dots
- Alignments of the cards in "Who is fiscal hosting for?"