### PR TITLE
Fix image props on HomePage

### DIFF
--- a/components/home/HomeNextIllustration.js
+++ b/components/home/HomeNextIllustration.js
@@ -8,10 +8,10 @@ import Image from '../Image';
  * Illustrations that use the next/image component.
  */
 
-function NextIllustration(props) {
+function NextIllustration({ display, ...props }) {
   return (
-    <Box display={props.display}>
-      <Image src={props.src} width={props.width} height={props.height} />
+    <Box display={display}>
+      <Image {...props} />
     </Box>
   );
 }


### PR DESCRIPTION
Props were not passed down to Next images on homepage/static pages. As a result:
- We were missing many `alt` props (for accessibility)
- We were missing some props like the `loading="eager"` from https://github.com/opencollective/opencollective-frontend/blob/c002c036aa71112b8f16cc2b4c9736f12263e264/components/home/sections/Features.js#L246, so the behavior was not what was described by the code