### PR TITLE
Make sure account details are loaded after initial render

### DIFF
--- a/components/expenses/PayoutBankInformationForm.js
+++ b/components/expenses/PayoutBankInformationForm.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/client';
 import { Info } from '@styled-icons/feather/Info';
@@ -237,6 +237,10 @@ const DetailsForm = ({ disabled, getFieldName, formik, host, currency }) => {
     //      * The Collective Host doesn't have Wise configured and `host` is already switched to the Platform account
     variables: { slug: host ? host.slug : TW_API_COLLECTIVE_SLUG, currency },
   });
+
+  useEffect(() => {
+    refetch({ accountDetails: get(formik.values, getFieldName('data')) });
+  }, []);
 
   if (loading && !data) {
     return <StyledSpinner />;

--- a/components/expenses/PayoutBankInformationForm.js
+++ b/components/expenses/PayoutBankInformationForm.js
@@ -238,6 +238,9 @@ const DetailsForm = ({ disabled, getFieldName, formik, host, currency }) => {
     variables: { slug: host ? host.slug : TW_API_COLLECTIVE_SLUG, currency },
   });
 
+  // Make sure we load the form data on initial load. Otherwise certain form fields such
+  // as the state field in the "Recipient's Address" section might not be visible on first load
+  // and only be visible after the user reselect the country.
   useEffect(() => {
     refetch({ accountDetails: get(formik.values, getFieldName('data')) });
   }, []);


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4838

![account-details](https://user-images.githubusercontent.com/12435965/142466885-34842be8-066e-4c81-8387-0d38c23e58fe.gif)


