### PR TITLE
Host Balance Correction in Host Dashboard Reports Section

### DIFF
--- a/components/host-dashboard/HostDashboardReports.js
+++ b/components/host-dashboard/HostDashboardReports.js
@@ -48,7 +48,7 @@ const hostReportPageQuery = gqlV2/* GraphQL */ `
       hostFeePercent
       isTrustedHost
       stats {
-        balance(dateFrom: $dateFrom, dateTo: $dateTo) {
+        balance {
           valueInCents
           currency
         }

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -9921,7 +9921,7 @@ input PaypalPaymentInput {
   data: JSON
   orderId: String
   subscriptionId: String
-  isNewApi: Boolean
+  isNewApi: Boolean @deprecated(reason: "2021-07-30: Not used anymore")
 }
 
 """


### PR DESCRIPTION
This is with related to the slack discussion, https://opencollective.slack.com/archives/C02C146LFCP/p1637764114003400

The balance should not change when filtered on a date since the `totalMoneyManaged` is not computed at an interval. 

Resolve https://github.com/opencollective/opencollective/issues/4994