### PR TITLE
[Hotfix] formatCurrency: Add fallback for Safari

### DIFF
--- a/lib/currency-utils.js
+++ b/lib/currency-utils.js
@@ -31,13 +31,25 @@ export function formatCurrency(amount, currency = 'USD', options = {}) {
     minimumFractionDigits = options.precision;
     maximumFractionDigits = options.precision;
   }
-  return amount.toLocaleString(options.locale, {
-    style: 'currency',
-    currency,
-    minimumFractionDigits: minimumFractionDigits,
-    maximumFractionDigits: maximumFractionDigits,
-    currencyDisplay: 'narrowSymbol', // We manually add the exact currency (e.g. "$10 USD") in many places. This is to prevent showing the currency twice is some locales (10$US USD)
-  });
+
+  const formatAmount = currencyDisplay => {
+    return amount.toLocaleString(options.locale, {
+      style: 'currency',
+      currency,
+      minimumFractionDigits: minimumFractionDigits,
+      maximumFractionDigits: maximumFractionDigits,
+      currencyDisplay,
+    });
+  };
+
+  try {
+    // We manually add the exact currency (e.g. "$10 USD") in many places. This is to prevent
+    // showing the currency twice is some locales ($US10 USD)
+    return formatAmount('narrowSymbol');
+  } catch (e) {
+    // ... unfortunately, some old versions of Safari doesn't support it, so we need a fallback
+    return formatAmount('symbol');
+  }
 }
 
 export const formatValueAsCurrency = (value, options) =>


### PR DESCRIPTION
Fix https://sentry.io/organizations/open-collective/issues/2815153522
Fix https://sentry.io/organizations/open-collective/issues/2815150393
Fix https://sentry.io/organizations/open-collective/issues/2815269402
Fix https://sentry.io/organizations/open-collective/issues/2815224019
Fix https://sentry.io/organizations/open-collective/issues/2815246062
Fix https://sentry.io/organizations/open-collective/issues/2815269402

Unfortunately, this incompatibility was not listed on CanIUse (see https://github.com/mdn/browser-compat-data/issues/8985)