### PR TITLE
Fix limit display on collective virtual cards

### DIFF
--- a/components/edit-collective/sections/virtual-cards/VirtualCards.js
+++ b/components/edit-collective/sections/virtual-cards/VirtualCards.js
@@ -66,6 +66,8 @@ const virtualCardsQuery = gqlV2/* GraphQL */ `
           data
           privateData
           createdAt
+          spendingLimitAmount
+          spendingLimitInterval
           account {
             id
             name


### PR DESCRIPTION
# Description

Virtual cards limits where not correctly displayed on the admin collective page, showing "no limit" instead of the actual limit.

<img width="414" alt="Screenshot 2021-11-26 at 15 36 12" src="https://user-images.githubusercontent.com/4048371/143856195-a7f53ee4-36ca-4b07-b1fa-36b6995974fa.png">

