### PR TITLE
Set `startsAt` when Creating An Event without Changing Defaults

### DIFF
--- a/components/EditEventForm.js
+++ b/components/EditEventForm.js
@@ -9,6 +9,10 @@ import InputField from './InputField';
 import StyledButton from './StyledButton';
 import TimezonePicker from './TimezonePicker';
 
+const defaultStartsAt = new Date();
+defaultStartsAt.setHours(19);
+defaultStartsAt.setMinutes(0);
+
 class EditEventForm extends React.Component {
   static propTypes = {
     event: PropTypes.object,
@@ -61,6 +65,10 @@ class EditEventForm extends React.Component {
         defaultMessage: 'These instructions will be provided by email to the participants.',
       },
     });
+  }
+
+  componentDidMount() {
+    this.handleChange('startsAt', defaultStartsAt);
   }
 
   componentDidUpdate(prevProps) {
@@ -120,9 +128,6 @@ class EditEventForm extends React.Component {
 
     const isNew = !(event && event.id);
     const submitBtnLabel = loading ? 'loading' : isNew ? 'Create Event' : 'Save';
-    const defaultStartsAt = new Date();
-    defaultStartsAt.setHours(19);
-    defaultStartsAt.setMinutes(0);
 
     this.fields = [
       {


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/5011

![event-default-times](https://user-images.githubusercontent.com/12435965/144523775-a61a5421-3837-4e7f-8242-6167cac3adc8.gif)


