### PR TITLE
Fix: Missing fields when editing BankAccount expenses validation bug

### DIFF
--- a/components/expenses/graphql/fragments.js
+++ b/components/expenses/graphql/fragments.js
@@ -106,6 +106,7 @@ export const expenseHostFields = gqlV2/* GraphQL */ `
     }
     transferwise {
       id
+      availableCurrencies
     }
   }
 `;


### PR DESCRIPTION
This bug was informed by JF through Slack.

It turns out we were always requesting required fields using the platform account when editing an expense, this could cause inconsistency between the fields that were presented when creating an expense and the ones presented when editing that expense.
This happened because `host.transferwise.availableCurrencies` is only pre-loaded in the create expense page. I'm tweaking a bit the logic in _PayoutBankInformationForm_ to always use the host's Wise account when it is available and only fall back to the platform account if required because `availableCurrencies` and `requiredFields` vary with the account.