### PR TITLE
Contribution flow: Misc fixes on tip input

### DIFF
--- a/components/StyledAmountPicker.js
+++ b/components/StyledAmountPicker.js
@@ -5,14 +5,9 @@ import { isNil } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 
-import { getCurrencySymbol } from '../lib/currency-utils';
-
-import Container from './Container';
 import Currency from './Currency';
 import { Flex } from './Grid';
 import StyledButtonSet from './StyledButtonSet';
-import StyledInputAmount from './StyledInputAmount';
-import StyledInputField from './StyledInputField';
 
 const getButtonDisplay = (index, options, isSelected) => {
   if (index === 0 || index === options.length - 1 || isSelected) {
@@ -43,21 +38,13 @@ const ButtonText = styled.span(props =>
 
 export const OTHER_AMOUNT_KEY = 'other';
 
-const prepareButtonSetOptions = (presets, otherAmountDisplay) => {
-  if (otherAmountDisplay === 'button') {
-    return [...presets, OTHER_AMOUNT_KEY];
-  } else {
-    return presets;
-  }
-};
-
 /**
  * A money amount picker that shows a button set to pick between presets.
  */
-const StyledAmountPicker = ({ presets, currency, value, otherAmountDisplay, onChange }) => {
+const StyledAmountPicker = ({ presets, currency, value, onChange }) => {
   const [isOtherSelected, setOtherSelected] = React.useState(() => !isNil(value) && !presets?.includes(value));
   const hasPresets = presets?.length > 0;
-  const options = hasPresets ? prepareButtonSetOptions(presets, otherAmountDisplay) : [OTHER_AMOUNT_KEY];
+  const options = hasPresets ? [...presets, OTHER_AMOUNT_KEY] : [OTHER_AMOUNT_KEY];
 
   React.useEffect(() => {
     if (value && !presets?.includes(value) && !isOtherSelected) {
@@ -110,57 +97,6 @@ const StyledAmountPicker = ({ presets, currency, value, otherAmountDisplay, onCh
           }}
         </StyledButtonSet>
       )}
-      {otherAmountDisplay === 'input' && (
-        <Container minWidth={75} maxWidth={125} ml="-3px" height="100%">
-          <StyledInputField
-            htmlFor="custom-amount"
-            labelColor="black.600"
-            labelFontSize="14px"
-            labelProps={{ mb: 1, pt: '10px', lineHeight: '18px' }}
-            label={
-              hasPresets ? (
-                <FormattedMessage id="contribution.amount.other.label" defaultMessage="Other" />
-              ) : (
-                <FormattedMessage
-                  id="contribution.amount.currency.label"
-                  defaultMessage="Amount ({currency})"
-                  values={{ currency: `${getCurrencySymbol(currency)}${currency}` }}
-                />
-              )
-            }
-          >
-            {fieldProps => (
-              <StyledInputAmount
-                {...fieldProps}
-                type="number"
-                currency={currency}
-                value={value || null}
-                isEmpty={!isOtherSelected}
-                placeholder="---"
-                width={1}
-                fontSize={FONT_SIZES}
-                lineHeight={['21px', null, '26px']}
-                px="2px"
-                containerProps={{
-                  borderRadius: hasPresets ? '0 4px 4px 0' : '4px',
-                }}
-                prependProps={{
-                  pr: 1,
-                  bg: '#FFFFFF',
-                  fontSize: FONT_SIZES,
-                  lineHeight: ['21px', null, '26px'],
-                  color: isOtherSelected ? 'black.800' : 'black.400',
-                }}
-                onChange={value => {
-                  onChange(value);
-                  setOtherSelected(true);
-                }}
-                onBlur={() => setOtherSelected(!presets?.includes(value))}
-              />
-            )}
-          </StyledInputField>
-        </Container>
-      )}
     </Flex>
   );
 };
@@ -170,8 +106,6 @@ StyledAmountPicker.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   onChange: PropTypes.func,
   presets: PropTypes.arrayOf(PropTypes.number),
-  /** Whether to use a button rather than an input for "Other" */
-  otherAmountDisplay: PropTypes.oneOf(['none', 'input', 'button']),
 };
 
 export default StyledAmountPicker;

--- a/components/contribution-flow/ContributionSummary.js
+++ b/components/contribution-flow/ContributionSummary.js
@@ -99,7 +99,7 @@ const ContributionSummary = ({ collective, stepDetails, stepSummary, stepPayment
             </AmountLine>
           )}
           {Boolean(platformContribution) && (
-            <AmountLine color="black.700">
+            <AmountLine color="black.700" data-cy="ContributionSummary-Tip">
               <Label>
                 <FormattedMessage
                   id="SupportProject"
@@ -172,7 +172,7 @@ const ContributionSummary = ({ collective, stepDetails, stepSummary, stepPayment
         <Label fontWeight="500">
           <FormattedMessage id="TodaysCharge" defaultMessage="Today's charge" />
         </Label>
-        <Amount fontWeight="700">
+        <Amount fontWeight="700" data-cy="ContributionSummary-TodaysCharge">
           <FormattedMoneyAmount amount={totalAmount} currency={currency} amountStyles={null} isCrypto={isCrypto} />
         </Amount>
       </AmountLine>

--- a/components/contribution-flow/PlatformTipInput.js
+++ b/components/contribution-flow/PlatformTipInput.js
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import INTERVALS from '../../lib/constants/intervals';
 import { formatCurrency } from '../../lib/currency-utils';
 
+import Container from '../Container';
 import { Flex } from '../Grid';
 import StyledInputAmount from '../StyledInputAmount';
 import StyledSelect from '../StyledSelect';
@@ -34,13 +35,18 @@ const DEFAULT_PERCENTAGES = [0.1, 0.15, 0.2];
 
 const getOptionFromPercentage = (amount, currency, percentage) => {
   const feeAmount = isNaN(amount) ? 0 : Math.round(amount * percentage);
+  let label = `${feeAmount / 100} ${currency}`;
+  if (feeAmount) {
+    label += ` (${percentage * 100}%)`; // Don't show percentages of 0
+  }
+
   return {
     // Value must be unique, so we set a special key if feeAmount is 0
     value: feeAmount || `${percentage}%`,
     feeAmount,
     percentage,
     currency,
-    label: `${feeAmount / 100} ${currency} (${percentage * 100}%)`,
+    label,
   };
 };
 
@@ -60,7 +66,7 @@ const getOptions = (amount, currency, intl) => {
   ];
 };
 
-const FeesOnTopInput = ({ currency, amount, quantity, fees, onChange }) => {
+const PlatformTipInput = ({ currency, amount, quantity, fees, onChange }) => {
   const intl = useIntl();
   const orderAmount = amount * quantity;
   const options = React.useMemo(() => getOptions(orderAmount, currency, intl), [orderAmount, currency]);
@@ -69,7 +75,7 @@ const FeesOnTopInput = ({ currency, amount, quantity, fees, onChange }) => {
       return (
         <span>
           {formatCurrency(option.feeAmount, option.currency, { locale: intl.locale })}{' '}
-          <Span color="black.500">({option.percentage * 100}%)</Span>
+          {Boolean(option.feeAmount) && <Span color="black.500">({option.percentage * 100}%)</Span>}
         </span>
       );
     } else {
@@ -96,15 +102,15 @@ const FeesOnTopInput = ({ currency, amount, quantity, fees, onChange }) => {
       onChange(0);
     } else if (selectedOption.percentage) {
       const newOption = getOptionFromPercentage(orderAmount, currency, selectedOption.percentage);
-      if (newOption.value !== fees) {
-        onChange(newOption.value);
+      if (newOption.feeAmount !== fees) {
+        onChange(newOption.feeAmount);
         setSelectedOption(newOption);
       }
     }
   }, [selectedOption, orderAmount, isReady]);
 
   return (
-    <div>
+    <Container data-cy="PlatformTipInput" display={amount === 0 ? 'none' : 'block'}>
       <P fontWeight="400" fontSize="14px" lineHeight="21px" color="black.900" my={32}>
         <FormattedMessage
           id="platformFee.info"
@@ -130,18 +136,19 @@ const FeesOnTopInput = ({ currency, amount, quantity, fees, onChange }) => {
           onChange={setSelectedOption}
           formatOptionLabel={formatOptionLabel}
           value={selectedOption}
+          disabled={!amount} // Don't allow changing the platform tip if the amount is not set
         />
       </Flex>
       {selectedOption.value === 'CUSTOM' && (
         <Flex justifyContent="flex-end" mt={2}>
-          <StyledInputAmount id="feesOnTop" currency={currency} onChange={onChange} value={fees} />
+          <StyledInputAmount id="feesOnTop" name="platformTip" currency={currency} onChange={onChange} value={fees} />
         </Flex>
       )}
-    </div>
+    </Container>
   );
 };
 
-FeesOnTopInput.propTypes = {
+PlatformTipInput.propTypes = {
   currency: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   amount: PropTypes.number,
@@ -150,4 +157,4 @@ FeesOnTopInput.propTypes = {
   interval: PropTypes.oneOf(Object.values(INTERVALS)),
 };
 
-export default FeesOnTopInput;
+export default PlatformTipInput;

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -24,7 +24,7 @@ import { H5, P, Span } from '../Text';
 import { useUser } from '../UserProvider';
 
 import ChangeTierWarningModal from './ChangeTierWarningModal';
-import FeesOnTopInput from './FeesOnTopInput';
+import PlatformTipInput from './PlatformTipInput';
 import TierCustomFields from './TierCustomFields';
 import { getTotalAmount } from './utils';
 
@@ -95,7 +95,6 @@ const StepDetails = ({ onChange, data, collective, tier, showFeesOnTop, router }
           <StyledAmountPicker
             currency={currency}
             presets={presets}
-            otherAmountDisplay="button"
             value={isOtherAmountSelected ? OTHER_AMOUNT_KEY : data?.amount}
             onChange={value => {
               if (value === OTHER_AMOUNT_KEY) {
@@ -112,7 +111,7 @@ const StepDetails = ({ onChange, data, collective, tier, showFeesOnTop, router }
                 name="custom-amount"
                 type="number"
                 currency={currency}
-                value={data?.amount || null}
+                value={data?.amount}
                 width={1}
                 min={minAmount}
                 currencyDisplay="full"
@@ -211,9 +210,9 @@ const StepDetails = ({ onChange, data, collective, tier, showFeesOnTop, router }
           <StyledHr borderColor="black.300" mt={16} mb={32} />
         </React.Fragment>
       )}
-      {showFeesOnTop && data?.amount > 0 && (
+      {showFeesOnTop && (
         <Box mt={28}>
-          <FeesOnTopInput
+          <PlatformTipInput
             currency={currency}
             amount={data?.amount}
             fees={data?.platformContribution}

--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -530,11 +530,16 @@ class ContributionFlow extends React.Component {
   getTierMinAmount = memoizeOne(getTierMinAmount);
   getApplicableTaxes = memoizeOne(getApplicableTaxes);
 
-  canHaveFeesOnTop() {
-    if (!this.props.collective.platformContributionAvailable) {
+  canHavePlatformTips() {
+    const { tier, collective } = this.props;
+    if (!collective.platformContributionAvailable) {
       return false;
-    } else if (this.props.tier?.type === TierTypes.TICKET) {
+    } else if (!tier) {
+      return true;
+    } else if (tier.type === TierTypes.TICKET) {
       return false;
+    } else if (tier.amountType === 'FIXED' && !tier.amount.valueInCents) {
+      return false; // No platform tips for free tiers
     } else {
       return true;
     }
@@ -813,7 +818,7 @@ class ContributionFlow extends React.Component {
                     onChange={data => this.setState(data)}
                     step={currentStep}
                     isCrypto={isCrypto}
-                    showFeesOnTop={this.canHaveFeesOnTop()}
+                    showFeesOnTop={this.canHavePlatformTips()}
                     onNewCardFormReady={({ stripe, stripeElements }) => this.setState({ stripe, stripeElements })}
                     defaultProfileSlug={this.props.contributeAs}
                     defaultEmail={this.props.defaultEmail}

--- a/test/cypress/integration/13b-contributionFlow.contribute.platform-tip.test.js
+++ b/test/cypress/integration/13b-contributionFlow.contribute.platform-tip.test.js
@@ -1,0 +1,135 @@
+describe('Contribution Flow: contribute with platform tips', () => {
+  let collective;
+
+  before(() => {
+    cy.createHostedCollectiveV2({
+      testPayload: {
+        data: { platformTips: true },
+      },
+    }).then(c => (collective = c));
+  });
+
+  it('can edit the tip on a regular contribution', () => {
+    cy.visit(`/${collective.slug}/donate`);
+    cy.contains('[data-cy="amount-picker"] button', '$20').should('have.attr', 'aria-pressed', 'true');
+
+    // Register some aliases
+    cy.get('[data-cy="PlatformTipInput"] [data-cy="select"]').as('tipSelect');
+
+    // ---- Percentage based ----
+
+    // Defaults to 15%
+    cy.get('@tipSelect').should('contain', '$3.00 (15%)');
+    cy.getByDataCy('ContributionSummary-Tip').should('contain', '$3.00 USD');
+    cy.getByDataCy('ContributionSummary-TodaysCharge').should('contain', '$23.00 USD');
+
+    // Changing the amount changes the tip (because it's a percentage)
+    cy.contains('[data-cy="amount-picker"] button', '$50').click();
+    cy.get('@tipSelect').should('contain', '$7.50 (15%)');
+    cy.getByDataCy('ContributionSummary-Tip').should('contain', '$7.50 USD');
+    cy.getByDataCy('ContributionSummary-TodaysCharge').should('contain', '$57.50 USD');
+
+    // Switch to the 10% percentage preset
+    cy.get('@tipSelect').click();
+    cy.contains('[data-cy=select-option]', '$5.00 (10%)').click();
+    cy.get('@tipSelect').should('contain', '$5.00 (10%)');
+    cy.getByDataCy('ContributionSummary-Tip').should('contain', '$5.00 USD');
+    cy.getByDataCy('ContributionSummary-TodaysCharge').should('contain', '$55.00 USD');
+
+    // Changing the amount changes the tip
+    cy.contains('[data-cy="amount-picker"] button', '$10').click();
+    cy.get('@tipSelect').should('contain', '$1.00 (10%)');
+    cy.getByDataCy('ContributionSummary-Tip').should('contain', '$1.00 USD');
+    cy.getByDataCy('ContributionSummary-TodaysCharge').should('contain', '$11.00 USD');
+
+    // Use a custom amount
+    cy.contains('[data-cy="amount-picker"] button', 'Other').click();
+    cy.get('input[name="custom-amount"]').type('{backspace}{backspace}');
+    cy.get('@tipSelect').find('input').should('be.disabled'); // When empty, the tip input is disabled
+    cy.get('input[name="custom-amount"]').type('12');
+    cy.get('@tipSelect').should('contain', '$1.20 (10%)');
+    cy.getByDataCy('ContributionSummary-Tip').should('contain', '$1.20 USD');
+    cy.getByDataCy('ContributionSummary-TodaysCharge').should('contain', '$13.20 USD');
+
+    // Stays percentage-based when switching to a fixed amount
+    cy.contains('[data-cy="amount-picker"] button', '$10').click();
+    cy.get('@tipSelect').should('contain', '$1.00 (10%)');
+    cy.getByDataCy('ContributionSummary-Tip').should('contain', '$1.00 USD');
+    cy.getByDataCy('ContributionSummary-TodaysCharge').should('contain', '$11.00 USD');
+
+    // ---- Custom tip ----
+    cy.get('@tipSelect').click();
+    cy.contains('[data-cy=select-option]', 'Other').click();
+
+    // Can empty
+    cy.get('input[name="platformTip"]').type('{backspace}{backspace}{backspace}');
+    cy.get('@tipSelect').should('contain', 'Other');
+    cy.getByDataCy('ContributionSummary-Tip').should('not.exist');
+    cy.getByDataCy('ContributionSummary-TodaysCharge').should('contain', '$10.00 USD');
+
+    // Can set some amount
+    cy.get('input[name="platformTip"]').type('4.2');
+    cy.getByDataCy('ContributionSummary-Tip').should('contain', '$4.20 USD');
+    cy.getByDataCy('ContributionSummary-TodaysCharge').should('contain', '$14.20 USD');
+
+    // Custom tip stays when changing amount
+    cy.contains('[data-cy="amount-picker"] button', '$50').click();
+    cy.get('@tipSelect').should('contain', 'Other');
+    cy.getByDataCy('ContributionSummary-Tip').should('contain', '$4.20 USD');
+    cy.getByDataCy('ContributionSummary-TodaysCharge').should('contain', '$54.20 USD');
+
+    // Shows a warning if the tip is too high
+    const confirmStub = cy.stub();
+    confirmStub.returns(false); // Do not accept
+    cy.on('window:confirm', confirmStub);
+    cy.get('input[name="platformTip"]').type('{backspace}{backspace}{backspace}48');
+    cy.getByDataCy('cf-next-step')
+      .click()
+      .then(() => {
+        expect(confirmStub).to.be.calledOnce;
+        expect(confirmStub).to.be.calledWith(
+          'You are about to make a contribution of $50.00 to TestCollective, with a tip to the Open Collective platform of $48.00. The tip amount looks unusually high.\n\nAre you sure you want to do this?',
+        );
+      });
+
+    // ---- Opt out ----
+    cy.get('@tipSelect').click();
+    cy.contains('[data-cy=select-option]', 'No thank you').click();
+
+    // Removes the tip
+    cy.get('@tipSelect').should('contain', 'No thank you');
+    cy.getByDataCy('ContributionSummary-Tip').should('not.exist');
+    cy.getByDataCy('ContributionSummary-TodaysCharge').should('contain', '$50.00 USD');
+
+    // Stays opt-out when changing amount
+    cy.contains('[data-cy="amount-picker"] button', '$10').click();
+    cy.get('@tipSelect').should('contain', 'No thank you');
+    cy.getByDataCy('ContributionSummary-Tip').should('not.exist');
+    cy.getByDataCy('ContributionSummary-TodaysCharge').should('contain', '$10.00 USD');
+  });
+
+  it('Is not displayed when contribution amount is 0', () => {
+    // Create a special tier to allow free contributions
+    // TODO: Would be great to have that as a cypress command for that part, but there's no mutation to edit tiers on GQLV2 yet
+    cy.login({ redirect: `/${collective.slug}/admin/tiers` });
+    cy.get('[data-cy="tier-input-field-minimumAmount"]:first input').type('{backspace}{backspace}{backspace}0');
+    cy.contains('button[type=submit]', 'Save').click();
+    cy.visit(`/${collective.slug}/contribute`);
+    cy.get('[data-cy="contribute-btn"]:first').click();
+
+    // Register some aliases
+    cy.get('[data-cy="PlatformTipInput"] [data-cy="select"]').as('tipSelect');
+
+    // Displayed by default (because the amount is not 0)
+    cy.get('@tipSelect').should('contain', '$0.75 (15%)');
+    cy.getByDataCy('ContributionSummary-Tip').should('contain', '$0.75 USD');
+    cy.getByDataCy('ContributionSummary-TodaysCharge').should('contain', '$5.75 USD');
+
+    // But the tip disappears when the amount is 0
+    cy.contains('[data-cy="amount-picker"] button', 'Other').click();
+    cy.get('input[name="custom-amount"]').type('{backspace}{backspace}0');
+    cy.getByDataCy('PlatformTipInput').invoke('css', 'display').should('equal', 'none');
+    cy.getByDataCy('ContributionSummary-Tip').should('not.exist');
+    cy.getByDataCy('ContributionSummary-TodaysCharge').should('contain', '$0.00 USD');
+  });
+});


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-api/pull/6975
Addresses part of https://github.com/opencollective/opencollective/issues/5028
Implements a proper behavior for https://github.com/opencollective/opencollective/issues/4508
Fixes the regression introduced in https://github.com/opencollective/opencollective-frontend/pull/6711 that resulted in tip amounts being set to really small amounts whenever someone picked "Custom" for the contribution amount.

- [x] Add E2E test for platform tips
  - [x] Default percentages
  - [x] Custom tip amount
  - [x] Warning when tip is too high
  - [x] Opt-out from tip
  - [x] Contribution with free amount