### PR TITLE
lint: add plugin 'jsx'

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": ["opencollective", "plugin:styled-components-a11y/recommended"],
   "env": { "jest": true },
-  "plugins": ["graphql", "react-hooks", "simple-import-sort", "formatjs", "styled-components-a11y"],
+  "plugins": ["graphql", "react-hooks", "simple-import-sort", "formatjs", "styled-components-a11y", "jsx"],
   "rules": {
     "no-console": "warn",
     "require-atomic-updates": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22046,6 +22046,31 @@
         }
       }
     },
+    "eslint-plugin-jsx": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx/-/eslint-plugin-jsx-0.1.0.tgz",
+      "integrity": "sha512-278HIClJgb3Gp1b89wbva7AGS7cxQzBNgKFysy6aEB44Acso2M8ARdoaLUnN7VTWf0vnSvtwugCmc/B8MSzY5g==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-react": "3.4.2",
+        "html-tags": "1",
+        "svg-tags": "1"
+      },
+      "dependencies": {
+        "eslint-plugin-react": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-3.4.2.tgz",
+          "integrity": "sha1-nm74qAVPisO4e5cjbnuEnlg13Gw=",
+          "dev": true
+        },
+        "html-tags": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-1.2.0.tgz",
+          "integrity": "sha1-x43mW1Zjqll5id0rerSSANfk25g=",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-jsx-a11y": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.4.1.tgz",
@@ -37217,6 +37242,12 @@
           }
         }
       }
+    },
+    "svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
+      "dev": true
     },
     "svg.draggable.js": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
     "eslint-plugin-formatjs": "^2.18.0",
     "eslint-plugin-graphql": "^4.0.0",
     "eslint-plugin-import": "^2.25.2",
+    "eslint-plugin-jsx": "^0.1.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-react": "^7.27.0",
     "eslint-plugin-react-hooks": "^4.2.0",


### PR DESCRIPTION
# Description

This PR adds plugin 'jsx' to ESLint, to avoid error 'Parsing error: This experimental syntax requires enabling one of the following parser plugin(s): 'jsx, flow, typescript' (1:1)eslint' in VSCode (and probably other IDEs that depend on `.eslintrc.json`).

# Screenshots

![](https://i.postimg.cc/zf6FwX07/image.png)
