### PR TITLE
Add Contact Collective Modal to Actions Button When There is No Actions Dropdown

### DIFF
--- a/components/ContactCollectiveBtn.js
+++ b/components/ContactCollectiveBtn.js
@@ -1,0 +1,36 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { useRouter } from 'next/router';
+import { FormattedMessage } from 'react-intl';
+
+import ContactCollectiveModal from './ContactCollectiveModal';
+import StyledButton from './StyledButton';
+
+const ContactCollectiveBtn = ({ children, collective, LoggedInUser }) => {
+  const [showModal, setShowModal] = React.useState(false);
+  const router = useRouter();
+  return (
+    <Fragment>
+      {children({ onClick: () => (LoggedInUser ? setShowModal(true) : router.push(`/${collective.slug}/contact`)) })}
+      {showModal && <ContactCollectiveModal collective={collective} onClose={() => setShowModal(null)} />}
+    </Fragment>
+  );
+};
+
+ContactCollectiveBtn.propTypes = {
+  children: PropTypes.func.isRequired,
+  collective: PropTypes.object.isRequired,
+  LoggedInUser: PropTypes.object.isRequired,
+};
+
+const DefaultContactCollectiveButton = props => (
+  <StyledButton {...props}>
+    <FormattedMessage id="Contact" defaultMessage="Contact" />
+  </StyledButton>
+);
+
+ContactCollectiveBtn.defaultProps = {
+  children: DefaultContactCollectiveButton,
+};
+
+export default ContactCollectiveBtn;

--- a/components/collective-navbar/ActionsMenu.js
+++ b/components/collective-navbar/ActionsMenu.js
@@ -11,7 +11,6 @@ import { Dashboard } from '@styled-icons/material/Dashboard';
 import { Settings } from '@styled-icons/material/Settings';
 import { Stack } from '@styled-icons/remix-line/Stack';
 import { pickBy } from 'lodash';
-import { useRouter } from 'next/router';
 import { FormattedMessage } from 'react-intl';
 import styled, { css } from 'styled-components';
 
@@ -24,7 +23,7 @@ import ActionButton from '../ActionButton';
 import AddFundsBtn from '../AddFundsBtn';
 import ApplyToHostBtn from '../ApplyToHostBtn';
 import AssignVirtualCardBtn from '../AssignVirtualCardBtn';
-import ContactCollectiveModal from '../ContactCollectiveModal';
+import ContactCollectiveBtn from '../ContactCollectiveBtn';
 import Container from '../Container';
 import CreateVirtualCardBtn from '../CreateVirtualCardBtn';
 import { Box, Flex } from '../Grid';
@@ -183,8 +182,6 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction, hiddenActionFo
   const isEmpty = enabledCTAs.length < 1;
   const hasOnlyOneHiddenCTA = enabledCTAs.length === 1 && hiddenActionForNonMobile === enabledCTAs[0];
   const hasNewAdminPanel = parseToBoolean(getEnvVar('NEW_ADMIN_DASHBOARD'));
-  const [showContactModal, setShowContactModal] = React.useState(false);
-  const router = useRouter();
 
   // Do not render the menu if there are no available CTAs
   if (isEmpty) {
@@ -305,17 +302,14 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction, hiddenActionFo
                     )}
                     {callsToAction.hasContact && (
                       <MenuItem py={1} isHiddenOnMobile={hiddenActionForNonMobile === NAVBAR_ACTION_TYPE.CONTACT}>
-                        <StyledButton
-                          onClick={() =>
-                            LoggedInUser ? setShowContactModal(true) : router.push(`/${collective.slug}/contact`)
-                          }
-                          borderRadius={0}
-                          p={ITEM_PADDING}
-                          isBorderless
-                        >
-                          <Envelope size="20px" />
-                          <FormattedMessage id="Contact" defaultMessage="Contact" />
-                        </StyledButton>
+                        <ContactCollectiveBtn collective={collective} LoggedInUser={LoggedInUser}>
+                          {btnProps => (
+                            <StyledButton {...btnProps} borderRadius={0} p={ITEM_PADDING} isBorderless>
+                              <Envelope size="20px" />
+                              <FormattedMessage id="Contact" defaultMessage="Contact" />
+                            </StyledButton>
+                          )}
+                        </ContactCollectiveBtn>
                       </MenuItem>
                     )}
                     {callsToAction.hasApply && (
@@ -388,9 +382,6 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction, hiddenActionFo
           )}
         </ActionsDropdown>
       </Box>
-      {showContactModal && (
-        <ContactCollectiveModal collective={collective} onClose={() => setShowContactModal(false)} />
-      )}
     </Container>
   );
 };

--- a/components/collective-navbar/index.js
+++ b/components/collective-navbar/index.js
@@ -12,6 +12,7 @@ import { Settings } from '@styled-icons/material/Settings';
 import { Stack } from '@styled-icons/remix-line/Stack';
 import themeGet from '@styled-system/theme-get';
 import { get, pickBy, without } from 'lodash';
+import { useRouter } from 'next/router';
 import { FormattedMessage, useIntl } from 'react-intl';
 import styled, { createGlobalStyle, css } from 'styled-components';
 import { display } from 'styled-system';
@@ -30,6 +31,7 @@ import AddFundsBtn from '../AddFundsBtn';
 import ApplyToHostBtn from '../ApplyToHostBtn';
 import Avatar from '../Avatar';
 import { Dimensions, Sections } from '../collective-page/_constants';
+import ContactCollectiveModal from '../ContactCollectiveModal';
 import Container from '../Container';
 import { Box, Flex } from '../Grid';
 import Link from '../Link';
@@ -273,7 +275,7 @@ const getDefaultCallsToActions = (collective, sections, isAdmin, isAccountant, i
 /**
  * Returns the main CTA that should be displayed as a button outside of the action menu in this component.
  */
-const getMainAction = (collective, callsToAction, LoggedInUser) => {
+const getMainAction = (collective, callsToAction, LoggedInUser, setShowContactModal, router) => {
   if (!collective || !callsToAction) {
     return null;
   }
@@ -378,14 +380,15 @@ const getMainAction = (collective, callsToAction, LoggedInUser) => {
     return {
       type: NAVBAR_ACTION_TYPE.CONTACT,
       component: (
-        <Link href={`/${collective.slug}/contact`}>
-          <ActionButton tabIndex="-1">
-            <Envelope size="1em" />
-            <Span ml={2}>
-              <FormattedMessage id="Contact" defaultMessage="Contact" />
-            </Span>
-          </ActionButton>
-        </Link>
+        <ActionButton
+          tabIndex="-1"
+          onClick={() => (LoggedInUser ? setShowContactModal(true) : router.push(`/${collective.slug}/contact`))}
+        >
+          <Envelope size="1em" />
+          <Span ml={2}>
+            <FormattedMessage id="Contact" defaultMessage="Contact" />
+          </Span>
+        </ActionButton>
       ),
     };
   } else if (callsToAction.includes(NAVBAR_ACTION_TYPE.ADD_FUNDS) && collective.host) {
@@ -430,6 +433,8 @@ const CollectiveNavbar = ({
 }) => {
   const intl = useIntl();
   const [isExpanded, setExpanded] = React.useState(false);
+  const [showContactModal, setShowContactModal] = React.useState(false);
+  const router = useRouter();
   const { LoggedInUser } = useUser();
   const isAccountant = LoggedInUser?.hasRole(roles.ACCOUNTANT, collective);
   isAdmin = isAdmin || LoggedInUser?.canEditCollective(collective);
@@ -442,8 +447,10 @@ const CollectiveNavbar = ({
     ...callsToAction,
   };
   const actionsArray = Object.keys(pickBy(callsToAction, Boolean));
-  const mainAction = getMainAction(collective, actionsArray, LoggedInUser);
-  const secondAction = actionsArray.length === 2 && getMainAction(collective, without(actionsArray, mainAction?.type));
+  const mainAction = getMainAction(collective, actionsArray, LoggedInUser, setShowContactModal, router);
+  const secondAction =
+    actionsArray.length === 2 &&
+    getMainAction(collective, without(actionsArray, mainAction?.type), LoggedInUser, setShowContactModal, router);
   const navbarRef = useRef();
   const mainContainerRef = useRef();
 
@@ -605,6 +612,11 @@ const CollectiveNavbar = ({
           </Container>
         )}
       </NavbarContentContainer>
+      <ContactCollectiveModal
+        show={showContactModal}
+        collective={collective}
+        onClose={() => setShowContactModal(false)}
+      />
     </NavBarContainer>
   );
 };

--- a/components/collective-navbar/index.js
+++ b/components/collective-navbar/index.js
@@ -12,7 +12,6 @@ import { Settings } from '@styled-icons/material/Settings';
 import { Stack } from '@styled-icons/remix-line/Stack';
 import themeGet from '@styled-system/theme-get';
 import { get, pickBy, without } from 'lodash';
-import { useRouter } from 'next/router';
 import { FormattedMessage, useIntl } from 'react-intl';
 import styled, { createGlobalStyle, css } from 'styled-components';
 import { display } from 'styled-system';
@@ -31,7 +30,7 @@ import AddFundsBtn from '../AddFundsBtn';
 import ApplyToHostBtn from '../ApplyToHostBtn';
 import Avatar from '../Avatar';
 import { Dimensions, Sections } from '../collective-page/_constants';
-import ContactCollectiveModal from '../ContactCollectiveModal';
+import ContactCollectiveBtn from '../ContactCollectiveBtn';
 import Container from '../Container';
 import { Box, Flex } from '../Grid';
 import Link from '../Link';
@@ -275,7 +274,7 @@ const getDefaultCallsToActions = (collective, sections, isAdmin, isAccountant, i
 /**
  * Returns the main CTA that should be displayed as a button outside of the action menu in this component.
  */
-const getMainAction = (collective, callsToAction, LoggedInUser, setShowContactModal, router) => {
+const getMainAction = (collective, callsToAction, LoggedInUser) => {
   if (!collective || !callsToAction) {
     return null;
   }
@@ -380,15 +379,16 @@ const getMainAction = (collective, callsToAction, LoggedInUser, setShowContactMo
     return {
       type: NAVBAR_ACTION_TYPE.CONTACT,
       component: (
-        <ActionButton
-          tabIndex="-1"
-          onClick={() => (LoggedInUser ? setShowContactModal(true) : router.push(`/${collective.slug}/contact`))}
-        >
-          <Envelope size="1em" />
-          <Span ml={2}>
-            <FormattedMessage id="Contact" defaultMessage="Contact" />
-          </Span>
-        </ActionButton>
+        <ContactCollectiveBtn collective={collective} LoggedInUser={LoggedInUser}>
+          {btnProps => (
+            <ActionButton {...btnProps}>
+              <Envelope size="1em" />
+              <Span ml={2}>
+                <FormattedMessage id="Contact" defaultMessage="Contact" />
+              </Span>
+            </ActionButton>
+          )}
+        </ContactCollectiveBtn>
       ),
     };
   } else if (callsToAction.includes(NAVBAR_ACTION_TYPE.ADD_FUNDS) && collective.host) {
@@ -433,8 +433,6 @@ const CollectiveNavbar = ({
 }) => {
   const intl = useIntl();
   const [isExpanded, setExpanded] = React.useState(false);
-  const [showContactModal, setShowContactModal] = React.useState(false);
-  const router = useRouter();
   const { LoggedInUser } = useUser();
   const isAccountant = LoggedInUser?.hasRole(roles.ACCOUNTANT, collective);
   isAdmin = isAdmin || LoggedInUser?.canEditCollective(collective);
@@ -447,10 +445,9 @@ const CollectiveNavbar = ({
     ...callsToAction,
   };
   const actionsArray = Object.keys(pickBy(callsToAction, Boolean));
-  const mainAction = getMainAction(collective, actionsArray, LoggedInUser, setShowContactModal, router);
+  const mainAction = getMainAction(collective, actionsArray, LoggedInUser);
   const secondAction =
-    actionsArray.length === 2 &&
-    getMainAction(collective, without(actionsArray, mainAction?.type), LoggedInUser, setShowContactModal, router);
+    actionsArray.length === 2 && getMainAction(collective, without(actionsArray, mainAction?.type), LoggedInUser);
   const navbarRef = useRef();
   const mainContainerRef = useRef();
 
@@ -612,11 +609,6 @@ const CollectiveNavbar = ({
           </Container>
         )}
       </NavbarContentContainer>
-      <ContactCollectiveModal
-        show={showContactModal}
-        collective={collective}
-        onClose={() => setShowContactModal(false)}
-      />
     </NavBarContainer>
   );
 };

--- a/components/collective-page/hero/Hero.js
+++ b/components/collective-page/hero/Hero.js
@@ -8,7 +8,6 @@ import { Mail } from '@styled-icons/feather/Mail';
 import { Twitter } from '@styled-icons/feather/Twitter';
 import { first, get } from 'lodash';
 import dynamic from 'next/dynamic';
-import { useRouter } from 'next/router';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import styled from 'styled-components';
 
@@ -16,7 +15,7 @@ import { getCollectiveMainTag } from '../../../lib/collective.lib';
 import { CollectiveType } from '../../../lib/constants/collectives';
 import { githubProfileUrl, twitterProfileUrl } from '../../../lib/url-helpers';
 
-import ContactCollectiveModal from '../../ContactCollectiveModal';
+import ContactCollectiveBtn from '../../ContactCollectiveBtn';
 import Container from '../../Container';
 import DefinedTerm, { Terms } from '../../DefinedTerm';
 import { Box, Flex } from '../../Grid';
@@ -83,10 +82,8 @@ const StyledShortDescription = styled.h2`
 const Hero = ({ collective, host, isAdmin, onPrimaryColorChange }) => {
   const intl = useIntl();
   const { LoggedInUser } = useUser();
-  const router = useRouter();
   const [hasColorPicker, showColorPicker] = React.useState(false);
   const [isEditingCover, editCover] = React.useState(false);
-  const [showContactModal, setShowContactModal] = React.useState(false);
   const isEditing = hasColorPicker || isEditingCover;
   const isCollective = collective.type === CollectiveType.COLLECTIVE;
   const isEvent = collective.type === CollectiveType.EVENT;
@@ -173,17 +170,13 @@ const Hero = ({ collective, host, isAdmin, onPrimaryColorChange }) => {
               )}
               <Flex my={2}>
                 {collective.canContact && (
-                  <StyledRoundButton
-                    onClick={() =>
-                      LoggedInUser ? setShowContactModal(true) : router.push(`/${collective.slug}/contact`)
-                    }
-                    size={32}
-                    mr={3}
-                    title="Contact"
-                    aria-label="Contact"
-                  >
-                    <Mail size={12} />
-                  </StyledRoundButton>
+                  <ContactCollectiveBtn collective={collective} LoggedInUser={LoggedInUser}>
+                    {btnProps => (
+                      <StyledRoundButton {...btnProps} size={32} mr={3} title="Contact" aria-label="Contact">
+                        <Mail size={12} />
+                      </StyledRoundButton>
+                    )}
+                  </ContactCollectiveBtn>
                 )}
                 {collective.twitterHandle && (
                   <StyledLink
@@ -337,9 +330,6 @@ const Hero = ({ collective, host, isAdmin, onPrimaryColorChange }) => {
           )}
         </ContainerSectionContent>
       </Container>
-      {showContactModal && (
-        <ContactCollectiveModal collective={collective} onClose={() => setShowContactModal(false)} />
-      )}
     </Fragment>
   );
 };

--- a/components/collective-page/sections/OurTeam.js
+++ b/components/collective-page/sections/OurTeam.js
@@ -2,10 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Mail } from '@styled-icons/feather/Mail';
 import { get } from 'lodash';
-import { useRouter } from 'next/router';
 import { FormattedMessage } from 'react-intl';
 
-import ContactCollectiveModal from '../../ContactCollectiveModal';
+import ContactCollectiveBtn from '../../ContactCollectiveBtn';
 import Container from '../../Container';
 import ContributorCard from '../../ContributorCard';
 import StyledButton from '../../StyledButton';
@@ -19,8 +18,6 @@ const COLLECTIVE_CARD_WIDTH = 144;
  */
 const SectionOurTeam = ({ collective, coreContributors, LoggedInUser }) => {
   const loggedUserCollectiveId = get(LoggedInUser, 'CollectiveId');
-  const [showContactModal, setShowContactModal] = React.useState(false);
-  const router = useRouter();
 
   return (
     <ContainerSectionContent py={[3, 4]}>
@@ -45,22 +42,19 @@ const SectionOurTeam = ({ collective, coreContributors, LoggedInUser }) => {
         </Container>
         {collective.canContact && (
           <Container display="flex" flexDirection="column" alignItems="center">
-            <StyledButton
-              onClick={() => (LoggedInUser ? setShowContactModal(true) : router.push(`/${collective.slug}/contact`))}
-              buttonStyle="secondary"
-              mt={[3, 4]}
-            >
-              <Span mr="8px">
-                <Mail size={16} />
-              </Span>
-              <FormattedMessage defaultMessage="Contact Collective" />
-            </StyledButton>
+            <ContactCollectiveBtn collective={collective} LoggedInUser={LoggedInUser}>
+              {btnProps => (
+                <StyledButton {...btnProps} buttonStyle="secondary" mt={[3, 4]}>
+                  <Span mr="8px">
+                    <Mail size={16} />
+                  </Span>
+                  <FormattedMessage defaultMessage="Contact Collective" />
+                </StyledButton>
+              )}
+            </ContactCollectiveBtn>
           </Container>
         )}
       </Container>
-      {showContactModal && (
-        <ContactCollectiveModal collective={collective} onClose={() => setShowContactModal(false)} />
-      )}
     </ContainerSectionContent>
   );
 };


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/4760

Something we have missed previously is the case when there's not actions drop-down but the user is logged in. In this case we should still show the contact modal. 

![actions-dropdown-contact-modal](https://user-images.githubusercontent.com/12435965/146623870-dba7b107-370c-4802-ad23-d1f482530329.gif)

