### PR TITLE
Add parent collective part in URL for events and projects

### DIFF
--- a/components/LinkCollective.js
+++ b/components/LinkCollective.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
-import { CollectiveType } from '../lib/constants/collectives';
 import { getCollectivePageRoute } from '../lib/url-helpers';
 
 import Link from './Link';
@@ -30,17 +29,8 @@ const LinkCollective = ({ target, title, noTitle, collective, children, ...props
   if (type === 'USER' && (!name || isIncognito || !slug)) {
     return children || <FormattedMessage id="profile.incognito" defaultMessage="Incognito" />;
   }
-  return ![CollectiveType.EVENT, CollectiveType.PROJECT].includes(type) ? (
-    <Link href={`/${slug}`} {...props} title={noTitle ? null : title || name} target={target}>
-      {children || name || slug}
-    </Link>
-  ) : (
-    <Link
-      href={`${getCollectivePageRoute(collective)}`}
-      title={noTitle ? null : title || name}
-      target={target}
-      {...props}
-    >
+  return (
+    <Link href={getCollectivePageRoute(collective)} title={noTitle ? null : title || name} target={target} {...props}>
       {children || name || slug}
     </Link>
   );

--- a/components/LinkCollective.js
+++ b/components/LinkCollective.js
@@ -2,16 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
-import Link from './Link';
+import { CollectiveType } from '../lib/constants/collectives';
+import { getCollectivePageRoute } from '../lib/url-helpers';
 
-/**
- * Returns event's parent collective slug. If the parent is not available,
- * fallback on `collective` slug which will result in a valid URL: parent
- * collective slug is only used to generate pretty URLs.
- */
-const getEventParentCollectiveSlug = parentCollective => {
-  return parentCollective && parentCollective.slug ? parentCollective.slug : 'collective';
-};
+import Link from './Link';
 
 /**
  * Create a `Link` to the collective based on collective type.
@@ -32,17 +26,17 @@ const LinkCollective = ({ target, title, noTitle, collective, children, ...props
     return children || collective.name;
   }
 
-  const { type, slug, name, parentCollective, isIncognito } = collective;
+  const { type, slug, name, isIncognito } = collective;
   if (type === 'USER' && (!name || isIncognito || !slug)) {
     return children || <FormattedMessage id="profile.incognito" defaultMessage="Incognito" />;
   }
-  return type !== 'EVENT' ? (
+  return ![CollectiveType.EVENT, CollectiveType.PROJECT].includes(type) ? (
     <Link href={`/${slug}`} {...props} title={noTitle ? null : title || name} target={target}>
       {children || name || slug}
     </Link>
   ) : (
     <Link
-      href={`/${getEventParentCollectiveSlug(parentCollective)}/events/${slug}`}
+      href={`${getCollectivePageRoute(collective)}`}
       title={noTitle ? null : title || name}
       target={target}
       {...props}

--- a/components/StyledUpdate.js
+++ b/components/StyledUpdate.js
@@ -9,6 +9,7 @@ import styled from 'styled-components';
 import { borders } from 'styled-system';
 
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
+import { getCollectivePageRoute } from '../lib/url-helpers';
 import { compose, formatDate } from '../lib/utils';
 
 import EmojiReactionPicker from './conversations/EmojiReactionPicker';
@@ -226,7 +227,7 @@ class StyledUpdate extends Component {
     const { mode } = this.state;
     if (mode === 'summary') {
       return (
-        <Link href={`/${collective.slug}/updates/${update.slug}`}>
+        <Link href={`${getCollectivePageRoute(collective)}/updates/${update.slug}`}>
           <H5 data-cy="updateTitle">{update.title}</H5>
         </Link>
       );
@@ -348,7 +349,7 @@ class StyledUpdate extends Component {
         </UpdateWrapper>
         {update.publishedAt && mode === 'details' && (
           <Flex my={3} justifyContent={['center', 'flex-start']}>
-            <Link href={`/${collective.slug}/updates`}>
+            <Link href={`${getCollectivePageRoute(collective)}/updates`}>
               <StyledButton ml={[0, 5]}>{intl.formatMessage(this.messages['viewLatestUpdates'])}</StyledButton>
             </Link>
           </Flex>

--- a/components/UpdatesWithData.js
+++ b/components/UpdatesWithData.js
@@ -5,6 +5,7 @@ import { cloneDeep } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
+import { getCollectivePageRoute } from '../lib/url-helpers';
 
 import UpdateFilters from './updates/UpdateFilters';
 import Container from './Container';
@@ -68,7 +69,7 @@ class UpdatesWithData extends React.Component {
               </P>
             </Container>
             {LoggedInUser?.canEditCollective(collective) && (
-              <Link href={`/${collective.slug}/updates/new`}>
+              <Link href={`${getCollectivePageRoute(collective)}/updates/new`}>
                 <StyledButton buttonStyle="primary" m={2}>
                   <FormattedMessage id="sections.update.new" defaultMessage="Create an Update" />
                 </StyledButton>

--- a/components/budget/ExpenseBudgetItem.js
+++ b/components/budget/ExpenseBudgetItem.js
@@ -9,6 +9,7 @@ import styled from 'styled-components';
 import expenseStatus from '../../lib/constants/expense-status';
 import expenseTypes from '../../lib/constants/expenseTypes';
 import { toPx } from '../../lib/theme/helpers';
+import { getCollectivePageRoute } from '../../lib/url-helpers';
 
 import AutosizeText from '../AutosizeText';
 import Avatar from '../Avatar';
@@ -121,7 +122,11 @@ const ExpenseBudgetItem = ({
                 content={<FormattedMessage id="Expense.GoToPage" defaultMessage="Go to expense page" />}
                 delayHide={0}
               >
-                <StyledLink as={Link} underlineOnHover href={`/${expense.account.slug}/expenses/${expense.legacyId}`}>
+                <StyledLink
+                  as={Link}
+                  underlineOnHover
+                  href={`${getCollectivePageRoute(expense.account)}/expenses/${expense.legacyId}`}
+                >
                   <AutosizeText
                     value={expense.description}
                     maxLength={255}

--- a/components/collective-navbar/ActionsMenu.js
+++ b/components/collective-navbar/ActionsMenu.js
@@ -233,7 +233,7 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction, hiddenActionFo
                     )}
                     {callsToAction.hasDashboard && !hasNewAdminPanel && (
                       <MenuItem isHiddenOnMobile={hiddenActionForNonMobile === NAVBAR_ACTION_TYPE.DASHBOARD}>
-                        <StyledLink as={Link} href={`/${getCollectivePageRoute(collective)}/dashboard`}>
+                        <StyledLink as={Link} href={`/${collective.slug}/dashboard`}>
                           <Container p={ITEM_PADDING}>
                             <Dashboard size="20px" />
                             <FormattedMessage id="host.dashboard" defaultMessage="Dashboard" />

--- a/components/collective-navbar/ActionsMenu.js
+++ b/components/collective-navbar/ActionsMenu.js
@@ -17,7 +17,7 @@ import styled, { css } from 'styled-components';
 
 import { getContributeRoute } from '../../lib/collective.lib';
 import { getEnvVar } from '../../lib/env-utils';
-import { getSettingsRoute } from '../../lib/url-helpers';
+import { getCollectivePageRoute, getSettingsRoute } from '../../lib/url-helpers';
 import { parseToBoolean } from '../../lib/utils';
 
 import ActionButton from '../ActionButton';
@@ -233,7 +233,7 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction, hiddenActionFo
                     )}
                     {callsToAction.hasDashboard && !hasNewAdminPanel && (
                       <MenuItem isHiddenOnMobile={hiddenActionForNonMobile === NAVBAR_ACTION_TYPE.DASHBOARD}>
-                        <StyledLink as={Link} href={`/${collective.slug}/dashboard`}>
+                        <StyledLink as={Link} href={`/${getCollectivePageRoute(collective)}/dashboard`}>
                           <Container p={ITEM_PADDING}>
                             <Dashboard size="20px" />
                             <FormattedMessage id="host.dashboard" defaultMessage="Dashboard" />
@@ -243,7 +243,7 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction, hiddenActionFo
                     )}
                     {callsToAction.hasSubmitExpense && (
                       <MenuItem isHiddenOnMobile={hiddenActionForNonMobile === NAVBAR_ACTION_TYPE.SUBMIT_EXPENSE}>
-                        <StyledLink as={Link} href={`/${collective.slug}/expenses/new`}>
+                        <StyledLink as={Link} href={`${getCollectivePageRoute(collective)}/expenses/new`}>
                           <Container p={ITEM_PADDING}>
                             <Receipt size="20px" />
                             <FormattedMessage id="ExpenseForm.Submit" defaultMessage="Submit expense" />
@@ -253,7 +253,7 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction, hiddenActionFo
                     )}
                     {callsToAction.hasRequestGrant && (
                       <MenuItem py={1} isHiddenOnMobile={hiddenActionForNonMobile === NAVBAR_ACTION_TYPE.REQUEST_GRANT}>
-                        <StyledLink as={Link} href={`/${collective.slug}/expenses/new`}>
+                        <StyledLink as={Link} href={`${getCollectivePageRoute(collective)}/expenses/new`}>
                           <Container p={ITEM_PADDING}>
                             <MoneyCheckAlt size="20px" />
                             <FormattedMessage id="ExpenseForm.Type.Request" defaultMessage="Request Grant" />
@@ -263,7 +263,7 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction, hiddenActionFo
                     )}
                     {callsToAction.hasManageSubscriptions && (
                       <MenuItem isHiddenOnMobile={hiddenActionForNonMobile === NAVBAR_ACTION_TYPE.MANAGE_SUBSCRIPTIONS}>
-                        <StyledLink as={Link} href={`/${collective.slug}/recurring-contributions`}>
+                        <StyledLink as={Link} href={`/${getCollectivePageRoute(collective)}/recurring-contributions`}>
                           <Container p={ITEM_PADDING}>
                             <Stack size="20px" />
                             <span>

--- a/components/collective-navbar/ActionsMenu.js
+++ b/components/collective-navbar/ActionsMenu.js
@@ -263,7 +263,7 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction, hiddenActionFo
                     )}
                     {callsToAction.hasManageSubscriptions && (
                       <MenuItem isHiddenOnMobile={hiddenActionForNonMobile === NAVBAR_ACTION_TYPE.MANAGE_SUBSCRIPTIONS}>
-                        <StyledLink as={Link} href={`/${getCollectivePageRoute(collective)}/recurring-contributions`}>
+                        <StyledLink as={Link} href={`${getCollectivePageRoute(collective)}/recurring-contributions`}>
                           <Container p={ITEM_PADDING}>
                             <Stack size="20px" />
                             <span>

--- a/components/collective-navbar/index.js
+++ b/components/collective-navbar/index.js
@@ -470,7 +470,7 @@ const CollectiveNavbar = ({
               {showBackButton && (
                 <Container display={['none', null, null, null, 'block']} position="absolute" left={-30}>
                   {collective && (
-                    <Link href={`${getCollectivePageRoute(collective)}`}>
+                    <Link href={getCollectivePageRoute(collective)}>
                       <StyledButton px={1} isBorderless>
                         &larr;
                       </StyledButton>

--- a/components/collective-navbar/index.js
+++ b/components/collective-navbar/index.js
@@ -22,7 +22,7 @@ import { CollectiveType } from '../../lib/constants/collectives';
 import roles from '../../lib/constants/roles';
 import { getEnvVar } from '../../lib/env-utils';
 import useGlobalBlur from '../../lib/hooks/useGlobalBlur';
-import { getSettingsRoute } from '../../lib/url-helpers';
+import { getCollectivePageRoute, getSettingsRoute } from '../../lib/url-helpers';
 import { parseToBoolean } from '../../lib/utils';
 
 import ActionButton from '../ActionButton';
@@ -470,7 +470,7 @@ const CollectiveNavbar = ({
               {showBackButton && (
                 <Container display={['none', null, null, null, 'block']} position="absolute" left={-30}>
                   {collective && (
-                    <Link href={`/${collective.slug}`}>
+                    <Link href={`${getCollectivePageRoute(collective)}`}>
                       <StyledButton px={1} isBorderless>
                         &larr;
                       </StyledButton>

--- a/components/collective-navbar/menu.js
+++ b/components/collective-navbar/menu.js
@@ -3,6 +3,7 @@ import { defineMessages } from 'react-intl';
 import hasFeature, { FEATURES } from '../../lib/allowed-features';
 import { hasSection, NAVBAR_CATEGORIES } from '../../lib/collective-sections';
 import i18nCollectivePageSection from '../../lib/i18n-collective-page-section';
+import { getCollectivePageRoute } from '../../lib/url-helpers';
 
 import { Sections } from '../collective-page/_constants';
 
@@ -70,7 +71,7 @@ const addSectionLink = (intl, links, collective, sections, section) => {
  */
 const getCategoryMenuLinks = (intl, collective, sections, category) => {
   const links = [];
-  const collectiveSlug = collective.slug;
+  const collectiveSlug = getCollectivePageRoute(collective);
 
   if (category === NAVBAR_CATEGORIES.ABOUT) {
     // About
@@ -81,28 +82,28 @@ const getCategoryMenuLinks = (intl, collective, sections, category) => {
     // Contribute
     if (hasFeature(collective, FEATURES.RECEIVE_FINANCIAL_CONTRIBUTIONS) && hasSection(sections, Sections.CONTRIBUTE)) {
       links.push({
-        route: `/${collectiveSlug}/contribute`,
+        route: `${collectiveSlug}/contribute`,
         title: intl.formatMessage(titles.CONTRIBUTE),
       });
     }
 
     if (hasFeature(collective, FEATURES.EVENTS) && hasSection(sections, Sections.EVENTS)) {
       links.push({
-        route: `/${collectiveSlug}/events`,
+        route: `${collectiveSlug}/events`,
         title: intl.formatMessage(titles.EVENTS),
       });
     }
 
     if (hasFeature(collective, FEATURES.PROJECTS) && hasSection(sections, Sections.PROJECTS)) {
       links.push({
-        route: `/${collectiveSlug}/projects`,
+        route: `${collectiveSlug}/projects`,
         title: intl.formatMessage(titles.PROJECTS),
       });
     }
 
     if (hasFeature(collective, FEATURES.CONNECTED_ACCOUNTS) && hasSection(sections, Sections.CONNECTED_COLLECTIVES)) {
       links.push({
-        route: `/${collectiveSlug}/connected-collectives`,
+        route: `${collectiveSlug}/connected-collectives`,
         title: intl.formatMessage(titles.CONNECTED_COLLECTIVES),
       });
     }
@@ -111,13 +112,13 @@ const getCategoryMenuLinks = (intl, collective, sections, category) => {
   } else if (category === NAVBAR_CATEGORIES.BUDGET) {
     // Budget
     links.push({
-      route: `/${collectiveSlug}/transactions`,
+      route: `${collectiveSlug}/transactions`,
       title: intl.formatMessage(titles.TRANSACTIONS),
     });
 
     if (hasFeature(collective, FEATURES.RECEIVE_EXPENSES)) {
       links.push({
-        route: `/${collectiveSlug}/expenses`,
+        route: `${collectiveSlug}/expenses`,
         title: intl.formatMessage(titles.EXPENSES),
       });
     }
@@ -125,13 +126,13 @@ const getCategoryMenuLinks = (intl, collective, sections, category) => {
     // Connect
     if (hasFeature(collective, FEATURES.UPDATES) && hasSection(sections, Sections.UPDATES)) {
       links.push({
-        route: `/${collectiveSlug}/updates`,
+        route: `${collectiveSlug}/updates`,
         title: intl.formatMessage(titles.UPDATES),
       });
     }
     if (hasFeature(collective, FEATURES.CONVERSATIONS) && hasSection(sections, Sections.CONVERSATIONS)) {
       links.push({
-        route: `/${collectiveSlug}/conversations`,
+        route: `${collectiveSlug}/conversations`,
         title: intl.formatMessage(titles.CONVERSATIONS),
       });
     }

--- a/components/collective-navbar/menu.js
+++ b/components/collective-navbar/menu.js
@@ -71,7 +71,7 @@ const addSectionLink = (intl, links, collective, sections, section) => {
  */
 const getCategoryMenuLinks = (intl, collective, sections, category) => {
   const links = [];
-  const collectiveSlug = getCollectivePageRoute(collective);
+  const collectivePageRoute = getCollectivePageRoute(collective);
 
   if (category === NAVBAR_CATEGORIES.ABOUT) {
     // About
@@ -82,28 +82,28 @@ const getCategoryMenuLinks = (intl, collective, sections, category) => {
     // Contribute
     if (hasFeature(collective, FEATURES.RECEIVE_FINANCIAL_CONTRIBUTIONS) && hasSection(sections, Sections.CONTRIBUTE)) {
       links.push({
-        route: `${collectiveSlug}/contribute`,
+        route: `${collectivePageRoute}/contribute`,
         title: intl.formatMessage(titles.CONTRIBUTE),
       });
     }
 
     if (hasFeature(collective, FEATURES.EVENTS) && hasSection(sections, Sections.EVENTS)) {
       links.push({
-        route: `${collectiveSlug}/events`,
+        route: `${collectivePageRoute}/events`,
         title: intl.formatMessage(titles.EVENTS),
       });
     }
 
     if (hasFeature(collective, FEATURES.PROJECTS) && hasSection(sections, Sections.PROJECTS)) {
       links.push({
-        route: `${collectiveSlug}/projects`,
+        route: `${collectivePageRoute}/projects`,
         title: intl.formatMessage(titles.PROJECTS),
       });
     }
 
     if (hasFeature(collective, FEATURES.CONNECTED_ACCOUNTS) && hasSection(sections, Sections.CONNECTED_COLLECTIVES)) {
       links.push({
-        route: `${collectiveSlug}/connected-collectives`,
+        route: `${collectivePageRoute}/connected-collectives`,
         title: intl.formatMessage(titles.CONNECTED_COLLECTIVES),
       });
     }
@@ -112,13 +112,13 @@ const getCategoryMenuLinks = (intl, collective, sections, category) => {
   } else if (category === NAVBAR_CATEGORIES.BUDGET) {
     // Budget
     links.push({
-      route: `${collectiveSlug}/transactions`,
+      route: `${collectivePageRoute}/transactions`,
       title: intl.formatMessage(titles.TRANSACTIONS),
     });
 
     if (hasFeature(collective, FEATURES.RECEIVE_EXPENSES)) {
       links.push({
-        route: `${collectiveSlug}/expenses`,
+        route: `${collectivePageRoute}/expenses`,
         title: intl.formatMessage(titles.EXPENSES),
       });
     }
@@ -126,13 +126,13 @@ const getCategoryMenuLinks = (intl, collective, sections, category) => {
     // Connect
     if (hasFeature(collective, FEATURES.UPDATES) && hasSection(sections, Sections.UPDATES)) {
       links.push({
-        route: `${collectiveSlug}/updates`,
+        route: `${collectivePageRoute}/updates`,
         title: intl.formatMessage(titles.UPDATES),
       });
     }
     if (hasFeature(collective, FEATURES.CONVERSATIONS) && hasSection(sections, Sections.CONVERSATIONS)) {
       links.push({
-        route: `${collectiveSlug}/conversations`,
+        route: `${collectivePageRoute}/conversations`,
         title: intl.formatMessage(titles.CONVERSATIONS),
       });
     }

--- a/components/collective-page/sections/Budget.js
+++ b/components/collective-page/sections/Budget.js
@@ -7,6 +7,7 @@ import styled, { css } from 'styled-components';
 
 import { EMPTY_ARRAY } from '../../../lib/constants/utils';
 import { API_V2_CONTEXT, gqlV2 } from '../../../lib/graphql/helpers';
+import { getCollectivePageRoute } from '../../../lib/url-helpers';
 
 import { DebitItem } from '../../budget/DebitCreditList';
 import ExpenseBudgetItem from '../../budget/ExpenseBudgetItem';
@@ -100,7 +101,7 @@ const ViewAllLink = ({ collective, filter, hasExpenses, hasTransactions }) => {
   const isFilterAll = filter === 'all';
   if (filter === 'expenses' || (isFilterAll && hasExpenses && !hasTransactions)) {
     return (
-      <Link href={`/${collective.slug}/expenses`} data-cy="view-all-expenses-link">
+      <Link href={`${getCollectivePageRoute(collective)}/expenses`} data-cy="view-all-expenses-link">
         <span>
           <FormattedMessage id="CollectivePage.SectionBudget.ViewAllExpenses" defaultMessage="View all expenses" />{' '}
           &rarr;
@@ -109,7 +110,7 @@ const ViewAllLink = ({ collective, filter, hasExpenses, hasTransactions }) => {
     );
   } else if (filter === 'transactions' || (isFilterAll && hasTransactions && !hasExpenses)) {
     return (
-      <Link href={`/${collective.slug}/transactions`} data-cy="view-all-transactions-link">
+      <Link href={`${getCollectivePageRoute(collective)}/transactions`} data-cy="view-all-transactions-link">
         <FormattedMessage id="CollectivePage.SectionBudget.ViewAll" defaultMessage="View all transactions" /> &rarr;
       </Link>
     );

--- a/components/collective-page/sections/Updates.js
+++ b/components/collective-page/sections/Updates.js
@@ -174,7 +174,11 @@ class SectionUpdates extends React.PureComponent {
                         <Container>
                           <HTMLContent style={{ display: 'inline' }} content={update.summary} />
                           {` `}
-                          <StyledLink as={Link} fontSize="12px" href={`/${collective.slug}/updates/${update.slug}`}>
+                          <StyledLink
+                            as={Link}
+                            fontSize="12px"
+                            href={`${getCollectivePageRoute(collective)}/updates/${update.slug}`}
+                          >
                             <FormattedMessage id="ContributeCard.ReadMore" defaultMessage="Read more" />
                           </StyledLink>
                         </Container>

--- a/components/collective-page/sections/Updates.js
+++ b/components/collective-page/sections/Updates.js
@@ -165,7 +165,7 @@ class SectionUpdates extends React.PureComponent {
                       </LinkCollective>
                     </Box>
                     <Flex flexDirection="column" justifyContent="space-between">
-                      <Link href={`/${collective.slug}/updates/${update.slug}`}>
+                      <Link href={`${getCollectivePageRoute(collective)}/updates/${update.slug}`}>
                         <P color="black.900" fontWeight="600" mb={2}>
                           {update.title}
                         </P>

--- a/components/collective-page/sections/Updates.js
+++ b/components/collective-page/sections/Updates.js
@@ -7,6 +7,7 @@ import { get, isEmpty } from 'lodash';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import styled from 'styled-components';
 
+import { getCollectivePageRoute } from '../../../lib/url-helpers';
 import { formatDate } from '../../../lib/utils';
 
 import Avatar from '../../Avatar';
@@ -127,7 +128,7 @@ class SectionUpdates extends React.PureComponent {
             <FormattedMessage id="section.updates.subtitle" defaultMessage="Updates on our activities and progress." />
           </P>
           {isAdmin && (
-            <Link href={`/${collective.slug}/updates/new`}>
+            <Link href={`${getCollectivePageRoute(collective)}/updates/new`}>
               <StyledButton data-cy="create-new-update-btn" buttonStyle="primary" my={[2, 0]}>
                 <Span fontSize="16px" fontWeight="bold" mr={2}>
                   +
@@ -237,7 +238,7 @@ class SectionUpdates extends React.PureComponent {
               ))}
             </StyledCard>
             {updates.length > 0 && (
-              <Link href={`/${collective.slug}/updates`}>
+              <Link href={`${getCollectivePageRoute(collective)}/updates`}>
                 <StyledButton data-cy="view-all-updates-btn" mt={4} width={1} buttonSize="small" fontSize="14px">
                   <FormattedMessage id="CollectivePage.SectionUpdates.ViewAll" defaultMessage="View all updates" /> →
                 </StyledButton>

--- a/components/expenses/graphql/fragments.js
+++ b/components/expenses/graphql/fragments.js
@@ -344,6 +344,12 @@ export const expensesListFieldsFragment = gqlV2/* GraphQL */ `
           currency
         }
       }
+      ... on AccountWithParent {
+        parent {
+          id
+          slug
+        }
+      }
     }
     permissions {
       id

--- a/components/recurring-contributions/graphql/queries.js
+++ b/components/recurring-contributions/graphql/queries.js
@@ -14,6 +14,12 @@ export const recurringContributionsQuery = gqlV2/* GraphQL */ `
       features {
         ...NavbarFields
       }
+      ... on AccountWithParent {
+        parent {
+          id
+          slug
+        }
+      }
       orders(filter: OUTGOING, onlySubscriptions: true, includeIncognito: true) {
         totalCount
         nodes {

--- a/lib/graphql/schema.graphql
+++ b/lib/graphql/schema.graphql
@@ -257,7 +257,7 @@ type UserDetails {
   id: Int
   CollectiveId: Int
   collective: CollectiveInterface
-  username: String
+  username: String @deprecated(reason: "2022-01-13: Not used anymore. Will be ignored")
   name: String
   image: String
   email: String
@@ -1019,6 +1019,11 @@ enum UpdateAudienceTypeEnum {
   Will be sent to financial contributors
   """
   FINANCIAL_CONTRIBUTORS
+
+  """
+  Will be sent to no one
+  """
+  NO_ONE
 }
 
 """
@@ -4030,7 +4035,7 @@ input UserInputType {
   name: String
   company: String
   image: String
-  username: String
+  username: String @deprecated(reason: "2022-01-13: Not used anymore. Will be ignored")
   description: String
   twitterHandle: String
   githubHandle: String

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -2978,6 +2978,11 @@ enum UpdateAudience {
   Will be sent to financial contributors
   """
   FINANCIAL_CONTRIBUTORS
+
+  """
+  Will be sent to no one
+  """
+  NO_ONE
 }
 
 """
@@ -6389,6 +6394,7 @@ type Mutation {
   addFunds(
     fromAccount: AccountReferenceInput!
     account: AccountReferenceInput!
+    tier: TierReferenceInput
     amount: AmountInput!
     description: String!
     hostFeePercent: Float!
@@ -9750,6 +9756,14 @@ input ExpenseInvitee {
   name: String
   email: String
   isInvite: Boolean
+  organization: ExpenseInviteeOrganizationInput
+}
+
+input ExpenseInviteeOrganizationInput {
+  description: String
+  name: String
+  slug: String
+  website: String
 }
 
 type EmojiReactionResponse {

--- a/lib/url-helpers.js
+++ b/lib/url-helpers.js
@@ -145,9 +145,13 @@ export const getSettingsRoute = (account, section, LoggedInUserOrHasNewAdmin) =>
   }
 };
 
+export const getCanonicalURL = account => {
+  return process.env.WEBSITE_URL + getCollectivePageRoute(account);
+};
+
 export const getCollectivePageRoute = account => {
   if (!account) {
-    return '#';
+    return '';
   } else if (account.type === CollectiveType.EVENT) {
     const parent = account.parentCollective || account.parent;
     return `/${parent?.slug || 'collective'}/events/${account.slug}`;

--- a/lib/url-helpers.js
+++ b/lib/url-helpers.js
@@ -145,7 +145,7 @@ export const getSettingsRoute = (account, section, LoggedInUserOrHasNewAdmin) =>
   }
 };
 
-export const getCanonicalURL = account => {
+export const getCollectivePageCanonicalURL = account => {
   return process.env.WEBSITE_URL + getCollectivePageRoute(account);
 };
 
@@ -176,10 +176,10 @@ export const isTrustedRedirectHost = host => {
   });
 };
 
-export const addParentToURLIfMissing = (router, account, url) => {
+export const addParentToURLIfMissing = (router, account, url = '', queryParams) => {
   const query = router.query;
-  const urlWithParent = getCollectivePageRoute(account) + url;
   if ([CollectiveType.EVENT, CollectiveType.PROJECT].includes(account?.type) && !query.parentCollectiveSlug) {
-    router.push(urlWithParent, undefined, { shallow: true });
+    const urlWithParent = getCollectivePageRoute(account) + url;
+    router.push({ pathname: urlWithParent, query: queryParams }, null, { shallow: true });
   }
 };

--- a/lib/url-helpers.js
+++ b/lib/url-helpers.js
@@ -175,3 +175,11 @@ export const isTrustedRedirectHost = host => {
     return host === domain || host.endsWith(`.${domain}`);
   });
 };
+
+export const addParentToURLIfMissing = (router, account, url) => {
+  const query = router.query;
+  const urlWithParent = getCollectivePageRoute(account) + url;
+  if ([CollectiveType.EVENT, CollectiveType.PROJECT].includes(account?.type) && !query.parentCollectiveSlug) {
+    router.push(urlWithParent, undefined, { shallow: true });
+  }
+};

--- a/lib/url-helpers.js
+++ b/lib/url-helpers.js
@@ -10,7 +10,7 @@ export const invoiceServiceURL = process.env.PDF_SERVICE_URL;
 // ---- Utils ----
 
 /**
- * Transorm an object into a query string. Strips undefined values.
+ * Transform an object into a query string. Strips undefined values.
  *
  * ## Example
  *
@@ -126,17 +126,19 @@ export const getSettingsRoute = (account, section, LoggedInUserOrHasNewAdmin) =>
     const adminPath = section ? `${account.slug}/admin/${section}` : `${account.slug}/admin`;
 
     if (parent) {
-      if (account.type === 'EVENT') {
+      if (account.type === CollectiveType.EVENT) {
         return `/${parent?.slug || 'collective'}/events/${adminPath}`;
-      } else if (account.type === 'PROJECT') {
+      } else if (account.type === CollectiveType.PROJECT) {
         return `/${parent?.slug || 'collective'}/projects/${adminPath}`;
       }
     }
 
     return `/${adminPath}`;
   } else {
-    if (account.type === 'EVENT') {
+    if (account.type === CollectiveType.EVENT) {
       return `/${parent?.slug || 'collective'}/events/${account.slug}/admin`;
+    } else if (account.type === CollectiveType.PROJECT) {
+      return `/${parent?.slug || 'collective'}/projects/${account.slug}/admin`;
     } else {
       return `/${account.slug}/admin`;
     }
@@ -149,6 +151,9 @@ export const getCollectivePageRoute = account => {
   } else if (account.type === CollectiveType.EVENT) {
     const parent = account.parentCollective || account.parent;
     return `/${parent?.slug || 'collective'}/events/${account.slug}`;
+  } else if (account.type === CollectiveType.PROJECT) {
+    const parent = account.parentCollective || account.parent;
+    return `/${parent?.slug || 'collective'}/projects/${account.slug}`;
   } else {
     return `/${account.slug}`;
   }

--- a/pages/collective-page.js
+++ b/pages/collective-page.js
@@ -6,9 +6,8 @@ import dynamic from 'next/dynamic';
 import { withRouter } from 'next/router';
 import { createGlobalStyle } from 'styled-components';
 
-import { CollectiveType } from '../lib/constants/collectives';
 import { generateNotFoundError } from '../lib/errors';
-import { getCanonicalURL, getCollectivePageRoute } from '../lib/url-helpers';
+import { addParentToURLIfMissing, getCollectivePageCanonicalURL } from '../lib/url-helpers';
 
 import CollectivePageContent from '../components/collective-page';
 import CollectiveNotificationBar from '../components/collective-page/CollectiveNotificationBar';
@@ -96,6 +95,7 @@ class CollectivePage extends React.Component {
     data: PropTypes.shape({
       loading: PropTypes.bool,
       error: PropTypes.any,
+      account: PropTypes.object,
       Collective: PropTypes.shape({
         name: PropTypes.string,
         type: PropTypes.string.isRequired,
@@ -137,11 +137,8 @@ class CollectivePage extends React.Component {
     this.setState({ smooth: true });
 
     const { router, data } = this.props;
-    const query = router.query;
     const collective = data?.Collective;
-    if ([CollectiveType.EVENT, CollectiveType.PROJECT].includes(collective?.type) && !query.parentCollectiveSlug) {
-      router.push(getCollectivePageRoute(collective), undefined, { shallow: true });
-    }
+    addParentToURLIfMissing(router, collective);
   }
 
   getPageMetaData(collective) {
@@ -199,7 +196,7 @@ class CollectivePage extends React.Component {
     }
 
     return (
-      <Page canonicalURL={getCanonicalURL(collective)} {...this.getPageMetaData(collective)}>
+      <Page canonicalURL={getCollectivePageCanonicalURL(collective)} {...this.getPageMetaData(collective)}>
         <GlobalStyles smooth={this.state.smooth} />
         {loading ? (
           <Container py={[5, 6]}>

--- a/pages/collective-page.js
+++ b/pages/collective-page.js
@@ -8,7 +8,7 @@ import { createGlobalStyle } from 'styled-components';
 
 import { CollectiveType } from '../lib/constants/collectives';
 import { generateNotFoundError } from '../lib/errors';
-import { getCollectivePageRoute } from '../lib/url-helpers';
+import { getCanonicalURL, getCollectivePageRoute } from '../lib/url-helpers';
 
 import CollectivePageContent from '../components/collective-page';
 import CollectiveNotificationBar from '../components/collective-page/CollectiveNotificationBar';
@@ -140,7 +140,7 @@ class CollectivePage extends React.Component {
     const query = router.query;
     const collective = data?.Collective;
     if ([CollectiveType.EVENT, CollectiveType.PROJECT].includes(collective?.type) && !query.parentCollectiveSlug) {
-      router.push(`${getCollectivePageRoute(collective)}`, undefined, { shallow: true });
+      router.push(getCollectivePageRoute(collective), undefined, { shallow: true });
     }
   }
 
@@ -171,10 +171,6 @@ class CollectivePage extends React.Component {
     this.setState({ showOnboardingModal: bool });
   };
 
-  getCanonicalURL(collective) {
-    return `${process.env.WEBSITE_URL}/${getCollectivePageRoute(collective)}`;
-  }
-
   render() {
     const { slug, data, LoggedInUser, status, step, mode, action } = this.props;
     const { showOnboardingModal } = this.state;
@@ -203,7 +199,7 @@ class CollectivePage extends React.Component {
     }
 
     return (
-      <Page canonicalURL={this.getCanonicalURL(collective)} {...this.getPageMetaData(collective)}>
+      <Page canonicalURL={getCanonicalURL(collective)} {...this.getPageMetaData(collective)}>
         <GlobalStyles smooth={this.state.smooth} />
         {loading ? (
           <Container py={[5, 6]}>

--- a/pages/createUpdate.js
+++ b/pages/createUpdate.js
@@ -8,6 +8,7 @@ import styled from 'styled-components';
 
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
 import { addCollectiveNavbarData } from '../lib/graphql/queries';
+import { getCollectivePageRoute } from '../lib/url-helpers';
 import { compose } from '../lib/utils';
 
 import Body from '../components/Body';
@@ -103,7 +104,7 @@ class CreateUpdatePage extends React.Component {
         ],
       });
       this.setState({ isModified: false });
-      return this.props.router.push(`/${account.slug}/updates/${res.data.createUpdate.slug}`);
+      return this.props.router.push(`${getCollectivePageRoute(account)}/updates/${res.data.createUpdate.slug}`);
     } catch (e) {
       this.setState({ status: 'error', error: e.message });
     }

--- a/pages/expense.js
+++ b/pages/expense.js
@@ -9,13 +9,13 @@ import { withRouter } from 'next/router';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 
 import { getCollectiveTypeForUrl, getSuggestedTags } from '../lib/collective.lib';
-import { CollectiveType, NAVBAR_CATEGORIES } from '../lib/collective-sections';
+import { NAVBAR_CATEGORIES } from '../lib/collective-sections';
 import expenseStatus from '../lib/constants/expense-status';
 import expenseTypes from '../lib/constants/expenseTypes';
 import { formatErrorMessage, generateNotFoundError, getErrorFromGraphqlException } from '../lib/errors';
 import { getPayoutProfiles } from '../lib/expenses';
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
-import { getCanonicalURL, getCollectivePageRoute } from '../lib/url-helpers';
+import { addParentToURLIfMissing, getCanonicalURL } from '../lib/url-helpers';
 
 import CollectiveNavbar from '../components/collective-navbar';
 import { Sections } from '../components/collective-page/_constants';
@@ -212,11 +212,8 @@ class ExpensePage extends React.Component {
 
   componentDidMount() {
     const { router, data, legacyExpenseId } = this.props;
-    const query = router.query;
     const account = data?.account;
-    if ([CollectiveType.EVENT, CollectiveType.PROJECT].includes(account?.type) && !query.parentCollectiveSlug) {
-      router.push(`${getCollectivePageRoute(account)}/expenses/${legacyExpenseId}`, undefined, { shallow: true });
-    }
+    addParentToURLIfMissing(router, account, `/expenses/${legacyExpenseId}`);
 
     const shouldEditDraft = this.props.data.expense?.status === expenseStatus.DRAFT && this.props.draftKey;
     if (shouldEditDraft) {
@@ -494,7 +491,11 @@ class ExpensePage extends React.Component {
     }
 
     return (
-      <Page collective={collective} canonicalURL={getCanonicalURL(collective)} {...this.getPageMetaData(expense)}>
+      <Page
+        collective={collective}
+        canonicalURL={`${getCanonicalURL(collective)}/expense`}
+        {...this.getPageMetaData(expense)}
+      >
         <CollectiveNavbar
           collective={collective}
           isLoading={!collective}

--- a/pages/expense.js
+++ b/pages/expense.js
@@ -9,12 +9,13 @@ import { withRouter } from 'next/router';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 
 import { getCollectiveTypeForUrl, getSuggestedTags } from '../lib/collective.lib';
-import { NAVBAR_CATEGORIES } from '../lib/collective-sections';
+import { CollectiveType, NAVBAR_CATEGORIES } from '../lib/collective-sections';
 import expenseStatus from '../lib/constants/expense-status';
 import expenseTypes from '../lib/constants/expenseTypes';
 import { formatErrorMessage, generateNotFoundError, getErrorFromGraphqlException } from '../lib/errors';
 import { getPayoutProfiles } from '../lib/expenses';
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
+import { getCollectivePageRoute } from '../lib/url-helpers';
 
 import CollectiveNavbar from '../components/collective-navbar';
 import { Sections } from '../components/collective-page/_constants';
@@ -210,6 +211,13 @@ class ExpensePage extends React.Component {
   }
 
   componentDidMount() {
+    const { router, data, legacyExpenseId } = this.props;
+    const query = router.query;
+    const account = data?.account;
+    if ([CollectiveType.EVENT, CollectiveType.PROJECT].includes(account?.type) && !query.parentCollectiveSlug) {
+      router.push(`${getCollectivePageRoute(account)}/expenses/${legacyExpenseId}`, undefined, { shallow: true });
+    }
+
     const shouldEditDraft = this.props.data.expense?.status === expenseStatus.DRAFT && this.props.draftKey;
     if (shouldEditDraft) {
       this.setState(() => ({
@@ -219,7 +227,7 @@ class ExpensePage extends React.Component {
       }));
     }
 
-    const expense = this.props.data?.expense;
+    const expense = data?.expense;
     if (
       expense?.status === expenseStatus.UNVERIFIED &&
       expense?.permissions?.canEdit &&

--- a/pages/expense.js
+++ b/pages/expense.js
@@ -15,7 +15,7 @@ import expenseTypes from '../lib/constants/expenseTypes';
 import { formatErrorMessage, generateNotFoundError, getErrorFromGraphqlException } from '../lib/errors';
 import { getPayoutProfiles } from '../lib/expenses';
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
-import { addParentToURLIfMissing, getCanonicalURL } from '../lib/url-helpers';
+import { addParentToURLIfMissing, getCollectivePageCanonicalURL } from '../lib/url-helpers';
 
 import CollectiveNavbar from '../components/collective-navbar';
 import { Sections } from '../components/collective-page/_constants';
@@ -493,7 +493,7 @@ class ExpensePage extends React.Component {
     return (
       <Page
         collective={collective}
-        canonicalURL={`${getCanonicalURL(collective)}/expense`}
+        canonicalURL={`${getCollectivePageCanonicalURL(collective)}/expense`}
         {...this.getPageMetaData(expense)}
       >
         <CollectiveNavbar

--- a/pages/expense.js
+++ b/pages/expense.js
@@ -15,7 +15,7 @@ import expenseTypes from '../lib/constants/expenseTypes';
 import { formatErrorMessage, generateNotFoundError, getErrorFromGraphqlException } from '../lib/errors';
 import { getPayoutProfiles } from '../lib/expenses';
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
-import { getCollectivePageRoute } from '../lib/url-helpers';
+import { getCanonicalURL, getCollectivePageRoute } from '../lib/url-helpers';
 
 import CollectiveNavbar from '../components/collective-navbar';
 import { Sections } from '../components/collective-page/_constants';
@@ -494,7 +494,7 @@ class ExpensePage extends React.Component {
     }
 
     return (
-      <Page collective={collective} {...this.getPageMetaData(expense)}>
+      <Page collective={collective} canonicalURL={getCanonicalURL(collective)} {...this.getPageMetaData(expense)}>
         <CollectiveNavbar
           collective={collective}
           isLoading={!collective}

--- a/pages/expenses.js
+++ b/pages/expenses.js
@@ -16,7 +16,7 @@ import { PayoutMethodType } from '../lib/constants/payout-method';
 import { parseDateInterval } from '../lib/date-utils';
 import { generateNotFoundError } from '../lib/errors';
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
-import { getCanonicalURL, getCollectivePageRoute } from '../lib/url-helpers';
+import { addParentToURLIfMissing, getCanonicalURL } from '../lib/url-helpers';
 
 import { parseAmountRange } from '../components/budget/filters/AmountFilter';
 import CollectiveNavbar from '../components/collective-navbar';
@@ -132,11 +132,8 @@ class ExpensePage extends React.Component {
 
   componentDidMount() {
     const { router, data } = this.props;
-    const query = router.query;
     const account = data?.account;
-    if ([CollectiveType.EVENT, CollectiveType.PROJECT].includes(account?.type) && !query.parentCollectiveSlug) {
-      router.push(`${getCollectivePageRoute(account)}/expenses`, undefined, { shallow: true });
-    }
+    addParentToURLIfMissing(router, account, '/expenses');
   }
 
   componentDidUpdate(oldProps) {
@@ -214,7 +211,7 @@ class ExpensePage extends React.Component {
     return (
       <Page
         collective={data.account}
-        canonicalURL={getCanonicalURL(data.account)}
+        canonicalURL={`${getCanonicalURL(data.account)}/expenses`}
         {...this.getPageMetaData(data.account)}
       >
         <CollectiveNavbar

--- a/pages/expenses.js
+++ b/pages/expenses.js
@@ -16,7 +16,7 @@ import { PayoutMethodType } from '../lib/constants/payout-method';
 import { parseDateInterval } from '../lib/date-utils';
 import { generateNotFoundError } from '../lib/errors';
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
-import { getCollectivePageRoute } from '../lib/url-helpers';
+import { getCanonicalURL, getCollectivePageRoute } from '../lib/url-helpers';
 
 import { parseAmountRange } from '../components/budget/filters/AmountFilter';
 import CollectiveNavbar from '../components/collective-navbar';
@@ -212,7 +212,11 @@ class ExpensePage extends React.Component {
     }
 
     return (
-      <Page collective={data.account} {...this.getPageMetaData(data.account)}>
+      <Page
+        collective={data.account}
+        canonicalURL={getCanonicalURL(data.account)}
+        {...this.getPageMetaData(data.account)}
+      >
         <CollectiveNavbar
           collective={data.account}
           isLoading={!data.account}

--- a/pages/expenses.js
+++ b/pages/expenses.js
@@ -9,13 +9,14 @@ import styled from 'styled-components';
 
 import hasFeature, { FEATURES } from '../lib/allowed-features';
 import { getSuggestedTags } from '../lib/collective.lib';
-import { isSectionForAdminsOnly, NAVBAR_CATEGORIES } from '../lib/collective-sections';
+import { CollectiveType, isSectionForAdminsOnly, NAVBAR_CATEGORIES } from '../lib/collective-sections';
 import expenseStatus from '../lib/constants/expense-status';
 import expenseTypes from '../lib/constants/expenseTypes';
 import { PayoutMethodType } from '../lib/constants/payout-method';
 import { parseDateInterval } from '../lib/date-utils';
 import { generateNotFoundError } from '../lib/errors';
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
+import { getCollectivePageRoute } from '../lib/url-helpers';
 
 import { parseAmountRange } from '../components/budget/filters/AmountFilter';
 import CollectiveNavbar from '../components/collective-navbar';
@@ -114,6 +115,7 @@ class ExpensePage extends React.Component {
         isHost: PropTypes.bool,
         host: PropTypes.object,
         expensesTags: PropTypes.array,
+        type: PropTypes.oneOf(Object.keys(CollectiveType)),
       }),
       expenses: PropTypes.shape({
         nodes: PropTypes.array,
@@ -127,6 +129,15 @@ class ExpensePage extends React.Component {
     }),
     router: PropTypes.object,
   };
+
+  componentDidMount() {
+    const { router, data } = this.props;
+    const query = router.query;
+    const account = data?.account;
+    if ([CollectiveType.EVENT, CollectiveType.PROJECT].includes(account?.type) && !query.parentCollectiveSlug) {
+      router.push(`${getCollectivePageRoute(account)}/expenses`, undefined, { shallow: true });
+    }
+  }
 
   componentDidUpdate(oldProps) {
     const { LoggedInUser, data } = this.props;

--- a/pages/transactions.js
+++ b/pages/transactions.js
@@ -13,7 +13,7 @@ import roles from '../lib/constants/roles';
 import { parseDateInterval } from '../lib/date-utils';
 import { getErrorFromGraphqlException } from '../lib/errors';
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
-import { getCollectivePageRoute } from '../lib/url-helpers';
+import { getCanonicalURL, getCollectivePageRoute } from '../lib/url-helpers';
 
 import Body from '../components/Body';
 import { parseAmountRange } from '../components/budget/filters/AmountFilter';
@@ -271,6 +271,7 @@ class TransactionsPage extends React.Component {
         <Header
           collective={collective}
           LoggedInUser={LoggedInUser}
+          canonicalURL={getCanonicalURL(collective)}
           noRobots={['USER', 'INDIVIDUAL'].includes(collective.type) && !collective.isHost}
         />
         <Body>

--- a/pages/transactions.js
+++ b/pages/transactions.js
@@ -69,6 +69,12 @@ const transactionsPageQuery = gqlV2/* GraphQL */ `
       features {
         ...NavbarFields
       }
+      ... on AccountWithParent {
+        parent {
+          id
+          slug
+        }
+      }
     }
     transactions(
       account: { slug: $slug }

--- a/pages/transactions.js
+++ b/pages/transactions.js
@@ -271,7 +271,7 @@ class TransactionsPage extends React.Component {
         <Header
           collective={collective}
           LoggedInUser={LoggedInUser}
-          canonicalURL={getCanonicalURL(collective)}
+          canonicalURL={`${getCanonicalURL(collective)}/transactions`}
           noRobots={['USER', 'INDIVIDUAL'].includes(collective.type) && !collective.isHost}
         />
         <Body>

--- a/pages/transactions.js
+++ b/pages/transactions.js
@@ -13,6 +13,7 @@ import roles from '../lib/constants/roles';
 import { parseDateInterval } from '../lib/date-utils';
 import { getErrorFromGraphqlException } from '../lib/errors';
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
+import { getCollectivePageRoute } from '../lib/url-helpers';
 
 import Body from '../components/Body';
 import { parseAmountRange } from '../components/budget/filters/AmountFilter';
@@ -165,9 +166,13 @@ class TransactionsPage extends React.Component {
   }
 
   async componentDidMount() {
-    const { data } = this.props;
+    const { router, data } = this.props;
     const Collective = (data && data.account) || this.state.collective;
+    const query = router.query;
     this.setState({ Collective });
+    if ([CollectiveType.EVENT, CollectiveType.PROJECT].includes(Collective.type) && !query.parentCollectiveSlug) {
+      router.push(`${getCollectivePageRoute(Collective)}/transactions`, undefined, { shallow: true });
+    }
   }
 
   componentDidUpdate(oldProps) {

--- a/pages/update.js
+++ b/pages/update.js
@@ -7,7 +7,7 @@ import { withRouter } from 'next/router';
 import { NAVBAR_CATEGORIES } from '../lib/collective-sections';
 import { ERROR } from '../lib/errors';
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
-import { addParentToURLIfMissing, getCanonicalURL } from '../lib/url-helpers';
+import { addParentToURLIfMissing, getCollectivePageCanonicalURL } from '../lib/url-helpers';
 import { stripHTML } from '../lib/utils';
 
 import CollectiveNavbar from '../components/collective-navbar';
@@ -130,7 +130,7 @@ class UpdatePage extends React.Component {
         collective={account}
         title={update.title}
         description={stripHTML(update.summary)}
-        canonicalURL={`${getCanonicalURL(account)}/update`}
+        canonicalURL={`${getCollectivePageCanonicalURL(account)}/update`}
         metaTitle={`${update.title} - ${account.name}`}
       >
         <CollectiveNavbar

--- a/pages/update.js
+++ b/pages/update.js
@@ -4,10 +4,10 @@ import { graphql, withApollo } from '@apollo/client/react/hoc';
 import { cloneDeep, get, uniqBy, update } from 'lodash';
 import { withRouter } from 'next/router';
 
-import { CollectiveType, NAVBAR_CATEGORIES } from '../lib/collective-sections';
+import { NAVBAR_CATEGORIES } from '../lib/collective-sections';
 import { ERROR } from '../lib/errors';
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
-import { getCanonicalURL, getCollectivePageRoute } from '../lib/url-helpers';
+import { addParentToURLIfMissing, getCanonicalURL } from '../lib/url-helpers';
 import { stripHTML } from '../lib/utils';
 
 import CollectiveNavbar from '../components/collective-navbar';
@@ -47,11 +47,8 @@ class UpdatePage extends React.Component {
 
   componentDidMount() {
     const { router, data, updateSlug } = this.props;
-    const query = router.query;
     const account = data?.account;
-    if ([CollectiveType.EVENT, CollectiveType.PROJECT].includes(account?.type) && !query.parentCollectiveSlug) {
-      router.push(`${getCollectivePageRoute(account)}/updates/${updateSlug}`, undefined, { shallow: true });
-    }
+    addParentToURLIfMissing(router, account, `/updates/${updateSlug}`);
   }
 
   async componentDidUpdate(oldProps) {
@@ -133,7 +130,7 @@ class UpdatePage extends React.Component {
         collective={account}
         title={update.title}
         description={stripHTML(update.summary)}
-        canonicalURL={getCanonicalURL(account)}
+        canonicalURL={`${getCanonicalURL(account)}/update`}
         metaTitle={`${update.title} - ${account.name}`}
       >
         <CollectiveNavbar

--- a/pages/update.js
+++ b/pages/update.js
@@ -7,7 +7,7 @@ import { withRouter } from 'next/router';
 import { CollectiveType, NAVBAR_CATEGORIES } from '../lib/collective-sections';
 import { ERROR } from '../lib/errors';
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
-import { getCollectivePageRoute } from '../lib/url-helpers';
+import { getCanonicalURL, getCollectivePageRoute } from '../lib/url-helpers';
 import { stripHTML } from '../lib/utils';
 
 import CollectiveNavbar from '../components/collective-navbar';
@@ -133,6 +133,7 @@ class UpdatePage extends React.Component {
         collective={account}
         title={update.title}
         description={stripHTML(update.summary)}
+        canonicalURL={getCanonicalURL(account)}
         metaTitle={`${update.title} - ${account.name}`}
       >
         <CollectiveNavbar

--- a/pages/update.js
+++ b/pages/update.js
@@ -2,10 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql, withApollo } from '@apollo/client/react/hoc';
 import { cloneDeep, get, uniqBy, update } from 'lodash';
+import { withRouter } from 'next/router';
 
-import { NAVBAR_CATEGORIES } from '../lib/collective-sections';
+import { CollectiveType, NAVBAR_CATEGORIES } from '../lib/collective-sections';
 import { ERROR } from '../lib/errors';
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
+import { getCollectivePageRoute } from '../lib/url-helpers';
 import { stripHTML } from '../lib/utils';
 
 import CollectiveNavbar from '../components/collective-navbar';
@@ -32,6 +34,7 @@ class UpdatePage extends React.Component {
     updateSlug: PropTypes.string,
     LoggedInUser: PropTypes.object, // from withUser
     client: PropTypes.object, // from withApollo
+    router: PropTypes.object, // from withRouter
     data: PropTypes.shape({
       account: PropTypes.object,
       update: PropTypes.object,
@@ -41,6 +44,15 @@ class UpdatePage extends React.Component {
   };
 
   state = { isReloadingData: false };
+
+  componentDidMount() {
+    const { router, data, updateSlug } = this.props;
+    const query = router.query;
+    const account = data?.account;
+    if ([CollectiveType.EVENT, CollectiveType.PROJECT].includes(account?.type) && !query.parentCollectiveSlug) {
+      router.push(`${getCollectivePageRoute(account)}/updates/${updateSlug}`, undefined, { shallow: true });
+    }
+  }
 
   async componentDidUpdate(oldProps) {
     // Refetch data when use logs in
@@ -246,4 +258,4 @@ const getUpdate = graphql(updateQuery, {
   },
 });
 
-export default withUser(getUpdate(withApollo(UpdatePage)));
+export default withRouter(withUser(getUpdate(withApollo(UpdatePage))));

--- a/pages/update.js
+++ b/pages/update.js
@@ -193,6 +193,7 @@ const updateQuery = gqlV2/* GraphQL */ `
       ... on Collective {
         isApproved
       }
+      type
       ... on AccountWithParent {
         parent {
           id

--- a/pages/updates.js
+++ b/pages/updates.js
@@ -5,7 +5,7 @@ import { withRouter } from 'next/router';
 
 import { CollectiveType, NAVBAR_CATEGORIES } from '../lib/collective-sections';
 import { addCollectiveNavbarData } from '../lib/graphql/queries';
-import { getCollectivePageRoute } from '../lib/url-helpers';
+import { getCanonicalURL, getCollectivePageRoute } from '../lib/url-helpers';
 
 import Body from '../components/Body';
 import CollectiveNavbar from '../components/collective-navbar';
@@ -57,7 +57,7 @@ class UpdatesPage extends React.Component {
 
     return (
       <div className="UpdatesPage">
-        <Header collective={collective} LoggedInUser={LoggedInUser} />
+        <Header collective={collective} LoggedInUser={LoggedInUser} canonicalURL={getCanonicalURL(collective)} />
 
         <Body>
           <CollectiveNavbar

--- a/pages/updates.js
+++ b/pages/updates.js
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import { omitBy } from 'lodash';
 import { withRouter } from 'next/router';
 
-import { NAVBAR_CATEGORIES } from '../lib/collective-sections';
+import { CollectiveType, NAVBAR_CATEGORIES } from '../lib/collective-sections';
 import { addCollectiveNavbarData } from '../lib/graphql/queries';
+import { getCollectivePageRoute } from '../lib/url-helpers';
 
 import Body from '../components/Body';
 import CollectiveNavbar from '../components/collective-navbar';
@@ -29,6 +30,15 @@ class UpdatesPage extends React.Component {
     LoggedInUser: PropTypes.object, // from withUser
     router: PropTypes.object,
   };
+
+  componentDidMount() {
+    const { router, data } = this.props;
+    const query = router.query;
+    const account = data?.account;
+    if ([CollectiveType.EVENT, CollectiveType.PROJECT].includes(account?.type) && !query.parentCollectiveSlug) {
+      router.push(`${getCollectivePageRoute(account)}/updates`, undefined, { shallow: true });
+    }
+  }
 
   updateQuery = (router, newParams) => {
     const query = omitBy({ ...router.query, ...newParams }, (value, key) => !value || ROUTE_PARAMS.includes(key));

--- a/pages/updates.js
+++ b/pages/updates.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import { omitBy } from 'lodash';
 import { withRouter } from 'next/router';
 
-import { CollectiveType, NAVBAR_CATEGORIES } from '../lib/collective-sections';
+import { NAVBAR_CATEGORIES } from '../lib/collective-sections';
 import { addCollectiveNavbarData } from '../lib/graphql/queries';
-import { getCanonicalURL, getCollectivePageRoute } from '../lib/url-helpers';
+import { addParentToURLIfMissing, getCanonicalURL } from '../lib/url-helpers';
 
 import Body from '../components/Body';
 import CollectiveNavbar from '../components/collective-navbar';
@@ -33,11 +33,8 @@ class UpdatesPage extends React.Component {
 
   componentDidMount() {
     const { router, data } = this.props;
-    const query = router.query;
     const account = data?.account;
-    if ([CollectiveType.EVENT, CollectiveType.PROJECT].includes(account?.type) && !query.parentCollectiveSlug) {
-      router.push(`${getCollectivePageRoute(account)}/updates`, undefined, { shallow: true });
-    }
+    addParentToURLIfMissing(router, account, '/updates');
   }
 
   updateQuery = (router, newParams) => {
@@ -57,7 +54,11 @@ class UpdatesPage extends React.Component {
 
     return (
       <div className="UpdatesPage">
-        <Header collective={collective} LoggedInUser={LoggedInUser} canonicalURL={getCanonicalURL(collective)} />
+        <Header
+          collective={collective}
+          LoggedInUser={LoggedInUser}
+          canonicalURL={`${getCanonicalURL(collective)}/updates`}
+        />
 
         <Body>
           <CollectiveNavbar

--- a/pages/updates.js
+++ b/pages/updates.js
@@ -5,7 +5,7 @@ import { withRouter } from 'next/router';
 
 import { NAVBAR_CATEGORIES } from '../lib/collective-sections';
 import { addCollectiveNavbarData } from '../lib/graphql/queries';
-import { addParentToURLIfMissing, getCanonicalURL } from '../lib/url-helpers';
+import { addParentToURLIfMissing, getCollectivePageCanonicalURL } from '../lib/url-helpers';
 
 import Body from '../components/Body';
 import CollectiveNavbar from '../components/collective-navbar';
@@ -57,7 +57,7 @@ class UpdatesPage extends React.Component {
         <Header
           collective={collective}
           LoggedInUser={LoggedInUser}
-          canonicalURL={`${getCanonicalURL(collective)}/updates`}
+          canonicalURL={`${getCollectivePageCanonicalURL(collective)}/updates`}
         />
 
         <Body>

--- a/rewrites.js
+++ b/rewrites.js
@@ -43,15 +43,15 @@ exports.REWRITES = [
     destination: '/createOrganization',
   },
   {
-    source: '/:collectiveSlug/updates',
+    source: '/:parentCollectiveSlug?/:collectiveType(events|projects)?/:collectiveSlug/updates',
     destination: '/updates',
   },
   {
-    source: '/:collectiveSlug/updates/new',
+    source: '/:parentCollectiveSlug?/:collectiveType(events|projects)?/:collectiveSlug/updates/new',
     destination: '/createUpdate',
   },
   {
-    source: '/:collectiveSlug/updates/:updateSlug',
+    source: '/:parentCollectiveSlug?/:collectiveType(events|projects)?/:collectiveSlug/updates/:updateSlug',
     destination: '/update',
   },
   {

--- a/rewrites.js
+++ b/rewrites.js
@@ -268,11 +268,11 @@ exports.REWRITES = [
   },
   // New recurring contributions page
   {
-    source: '/:slug/recurring-contributions',
+    source: '/:parentCollectiveSlug?/:collectiveType(events|projects)?/:slug/recurring-contributions',
     destination: '/recurring-contributions',
   },
   {
-    source: '/:slug/subscriptions',
+    source: '/:parentCollectiveSlug?/:collectiveType(events|projects)?/:slug/subscriptions',
     destination: '/recurring-contributions',
   },
   // Path routing: all the rewrites below are ready to be removed as soon as we


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4587

![url-sync-events-and-projects](https://user-images.githubusercontent.com/12435965/148181482-9bc976d8-02d0-4945-8077-2ca2e1eb966a.gif)

### Redirecting to `canonicalURL`

![redirect-urls](https://user-images.githubusercontent.com/12435965/148292937-eb14c033-9764-4e27-ad76-07f41273465a.gif)


