### PR TITLE
Change missed `platformTipContributionAmount` to `platformTipAmount`

### DIFF
--- a/components/ContributionConfirmationModal.js
+++ b/components/ContributionConfirmationModal.js
@@ -30,7 +30,7 @@ const confirmContributionMutation = gqlV2/* GraphQL */ `
         currency
         valueInCents
       }
-      platformContributionAmount {
+      platformTipAmount {
         currency
         valueInCents
       }

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -1836,14 +1836,10 @@ type Order {
   paymentMethod: PaymentMethod
 
   """
-  Platform contribution attached to the Order.
-  """
-  platformContributionAmount: Amount @deprecated(reason: "2021-06-07: Please use platformTipAmount")
-
-  """
   Platform Tip attached to the Order.
   """
   platformTipAmount: Amount
+  platformTipEligible: Boolean
   tags: [String]!
   taxes: [OrderTax]!
 
@@ -9899,11 +9895,6 @@ input OrderCreateInput {
   The payment method used for this order
   """
   paymentMethod: PaymentMethodInput
-
-  """
-  Platform contribution attached to this order
-  """
-  platformContributionAmount: AmountInput @deprecated(reason: "2021-12-17: Use platformTipAmount")
 
   """
   Platform tip attached to this order


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/5052

Something I've missed changing in the previous PR where we migrated from `platformTipContributionAmount` to `platformTipAmount`