### PR TITLE
Wise: Load availableCurrencies only on Expense pages

### DIFF
--- a/components/expenses/graphql/fragments.js
+++ b/components/expenses/graphql/fragments.js
@@ -105,10 +105,6 @@ export const expenseHostFields = gqlV2/* GraphQL */ `
     plan {
       id
     }
-    transferwise {
-      id
-      availableCurrencies
-    }
   }
 `;
 
@@ -237,6 +233,10 @@ export const expensePageExpenseFieldsFragment = gqlV2/* GraphQL */ `
         isApproved
         host {
           ...ExpenseHostFields
+          transferwise {
+            id
+            availableCurrencies
+          }
         }
       }
 
@@ -247,6 +247,10 @@ export const expensePageExpenseFieldsFragment = gqlV2/* GraphQL */ `
         isActive
         host {
           ...ExpenseHostFields
+          transferwise {
+            id
+            availableCurrencies
+          }
         }
       }
 


### PR DESCRIPTION
Due to fragment reusability, we were unnecessarily loading Wise's available currencies every time we loaded the Collective page.
This fixes that, enforcing the correct behaviour that is pre-loading that information only on the expense page.