### PR TITLE
Use fragments between the collective and contribute pages

### DIFF
--- a/components/collective-page/graphql/fragments.js
+++ b/components/collective-page/graphql/fragments.js
@@ -75,3 +75,131 @@ export const collectiveNavbarFieldsFragment = gql`
     REQUEST_VIRTUAL_CARDS
   }
 `;
+
+const contributeCardContributorFieldsFragment = gql`
+  fragment ContributeCardContributorFields on Contributor {
+    id
+    image(height: 64)
+    collectiveSlug
+    name
+    type
+    isGuest
+  }
+`;
+
+export const contributeCardTierFieldsFragment = gql`
+  fragment ContributeCardTierFields on Tier {
+    id
+    name
+    slug
+    description
+    useStandalonePage
+    goal
+    interval
+    currency
+    amount
+    minimumAmount
+    button
+    amountType
+    endsAt
+    type
+    maxQuantity
+    stats {
+      id
+      availableQuantity
+      totalDonated
+      totalRecurringDonations
+      contributors {
+        id
+        all
+        users
+        organizations
+      }
+    }
+    contributors(limit: $nbContributorsPerContributeCard) {
+      ...ContributeCardContributorFields
+    }
+  }
+  ${contributeCardContributorFieldsFragment}
+`;
+
+export const contributeCardEventFieldsFragment = gql`
+  fragment ContributeCardEventFields on Event {
+    id
+    slug
+    name
+    description
+    image
+    isActive
+    startsAt
+    endsAt
+    backgroundImageUrl(height: 208)
+    tiers {
+      id
+      type
+    }
+    contributors(limit: $nbContributorsPerContributeCard, roles: [BACKER, ATTENDEE]) {
+      ...ContributeCardContributorFields
+    }
+    stats {
+      id
+      backers {
+        id
+        all
+        users
+        organizations
+      }
+    }
+  }
+  ${contributeCardContributorFieldsFragment}
+`;
+
+export const contributeCardProjectFieldsFragment = gql`
+  fragment ContributeCardProjectFields on Project {
+    id
+    slug
+    name
+    description
+    image
+    isActive
+    isArchived
+    backgroundImageUrl(height: 208)
+    contributors(limit: $nbContributorsPerContributeCard, roles: [BACKER]) {
+      ...ContributeCardContributorFields
+    }
+    stats {
+      id
+      backers {
+        id
+        all
+        users
+        organizations
+      }
+    }
+  }
+  ${contributeCardContributorFieldsFragment}
+`;
+
+export const contributeCardConnectedCollectiveFieldsFragment = gql`
+  fragment ContributeCardConnectedCollectiveFields on Collective {
+    id
+    slug
+    name
+    type
+    description
+    backgroundImageUrl(height: 208)
+    stats {
+      id
+      backers {
+        id
+        all
+        users
+        organizations
+      }
+    }
+    contributors(limit: $nbContributorsPerContributeCard) {
+      ...ContributeCardContributorFields
+    }
+  }
+  ${contributeCardContributorFieldsFragment}
+`;

--- a/components/collective-page/graphql/queries.js
+++ b/components/collective-page/graphql/queries.js
@@ -8,6 +8,8 @@ import { transactionsQueryCollectionFragment } from '../../transactions/graphql/
 
 import * as fragments from './fragments';
 
+// We have to disable the linter because it's not able to detect that `nbContributorsPerContributeCard` is used in fragments
+/* eslint-disable graphql/template-strings */
 export const collectivePageQuery = gql`
   query CollectivePage($slug: String!, $nbContributorsPerContributeCard: Int) {
     Collective(slug: $slug, throwIfMissing: false) {
@@ -113,121 +115,18 @@ export const collectivePageQuery = gql`
         ...ContributorsFields
       }
       tiers {
-        id
-        name
-        slug
-        description
-        useStandalonePage
-        goal
-        interval
-        currency
-        amount
-        minimumAmount
-        button
-        amountType
-        endsAt
-        type
-        maxQuantity
-        stats {
-          id
-          availableQuantity
-          totalDonated
-          totalRecurringDonations
-          contributors {
-            id
-            all
-            users
-            organizations
-          }
-        }
-        contributors(limit: $nbContributorsPerContributeCard) {
-          id
-          image
-          collectiveSlug
-          name
-          type
-          isGuest
-        }
+        ...ContributeCardTierFields
       }
       events(includePastEvents: true, includeInactive: true) {
-        id
-        slug
-        name
-        description
-        image
-        isActive
-        startsAt
-        endsAt
-        backgroundImageUrl(height: 208)
-        contributors(limit: $nbContributorsPerContributeCard, roles: [BACKER, ATTENDEE]) {
-          id
-          image
-          collectiveSlug
-          name
-          type
-          isGuest
-        }
-        stats {
-          id
-          backers {
-            id
-            all
-            users
-            organizations
-          }
-        }
+        ...ContributeCardEventFields
       }
       projects {
-        id
-        slug
-        name
-        description
-        image
-        isActive
-        isArchived
-        backgroundImageUrl(height: 208)
-        contributors(limit: $nbContributorsPerContributeCard, roles: [BACKER]) {
-          id
-          name
-          image
-          collectiveSlug
-          type
-        }
-        stats {
-          id
-          backers {
-            id
-            all
-            users
-            organizations
-          }
-        }
+        ...ContributeCardProjectFields
       }
       connectedCollectives: members(role: "CONNECTED_COLLECTIVE") {
         id
         collective: member {
-          id
-          slug
-          name
-          type
-          description
-          backgroundImageUrl(height: 208)
-          stats {
-            id
-            backers {
-              id
-              all
-              users
-              organizations
-            }
-          }
-          contributors(limit: $nbContributorsPerContributeCard) {
-            id
-            image
-            collectiveSlug
-            name
-            type
-          }
+          ...ContributeCardConnectedCollectiveFields
         }
       }
       updates(limit: 3, onlyPublishedUpdates: true) {
@@ -282,7 +181,12 @@ export const collectivePageQuery = gql`
   ${fragments.updatesFieldsFragment}
   ${fragments.contributorsFieldsFragment}
   ${fragments.collectiveNavbarFieldsFragment}
+  ${fragments.contributeCardTierFieldsFragment}
+  ${fragments.contributeCardEventFieldsFragment}
+  ${fragments.contributeCardProjectFieldsFragment}
+  ${fragments.contributeCardConnectedCollectiveFieldsFragment}
 `;
+/* eslint-enable graphql/template-strings */
 
 export const budgetSectionQuery = gqlV2/* GraphQL */ `
   query BudgetSection($slug: String!, $limit: Int!, $kind: [TransactionKind]) {

--- a/pages/contribute.js
+++ b/pages/contribute.js
@@ -14,7 +14,7 @@ import { sortTiersForCollective } from '../lib/tier-utils';
 import Body from '../components/Body';
 import CollectiveNavbar from '../components/collective-navbar';
 import { Sections } from '../components/collective-page/_constants';
-import { collectiveNavbarFieldsFragment } from '../components/collective-page/graphql/fragments';
+import * as fragments from '../components/collective-page/graphql/fragments';
 import CollectiveThemeProvider from '../components/CollectiveThemeProvider';
 import Container from '../components/Container';
 import { MAX_CONTRIBUTORS_PER_CONTRIBUTE_CARD } from '../components/contribute-cards/Contribute';
@@ -339,6 +339,8 @@ class TiersPage extends React.Component {
   }
 }
 
+// We have to disable the linter because it's not able to detect that `nbContributorsPerContributeCard` is used in fragments
+/* eslint-disable graphql/template-strings */
 const contributePageQuery = gql`
   query ContributePage($slug: String!, $nbContributorsPerContributeCard: Int) {
     Collective(slug: $slug) {
@@ -393,128 +395,29 @@ const contributePageQuery = gql`
         tiersIds
       }
       tiers {
-        id
-        name
-        slug
-        description
-        goal
-        interval
-        currency
-        amount
-        minimumAmount
-        button
-        amountType
-        endsAt
-        maxQuantity
-        type
-        stats {
-          id
-          totalDonated
-          totalRecurringDonations
-          availableQuantity
-          contributors {
-            id
-            all
-            users
-            organizations
-          }
-        }
-        contributors(limit: $nbContributorsPerContributeCard) {
-          id
-          image
-          collectiveSlug
-          name
-          type
-        }
+        ...ContributeCardTierFields
       }
       events(includePastEvents: true, includeInactive: true) {
-        id
-        slug
-        name
-        description
-        image
-        isActive
-        startsAt
-        endsAt
-        backgroundImageUrl(height: 208)
-        tiers {
-          id
-          type
-        }
-        contributors(limit: $nbContributorsPerContributeCard, roles: [BACKER, ATTENDEE]) {
-          id
-          image
-          collectiveSlug
-          name
-          type
-        }
-        stats {
-          id
-          backers {
-            id
-            all
-            users
-            organizations
-          }
-        }
+        ...ContributeCardEventFields
       }
       projects {
-        id
-        slug
-        name
-        description
-        image
-        isActive
-        isArchived
-        backgroundImageUrl(height: 208)
-        contributors(limit: $nbContributorsPerContributeCard, roles: [BACKER]) {
-          id
-          name
-          image
-          collectiveSlug
-          type
-        }
-        stats {
-          id
-          backers {
-            id
-            all
-            users
-            organizations
-          }
-        }
+        ...ContributeCardProjectFields
       }
       connectedCollectives: members(role: "CONNECTED_COLLECTIVE") {
         id
         collective: member {
-          id
-          slug
-          name
-          type
-          description
-          backgroundImageUrl(height: 208)
-          stats {
-            id
-            backers {
-              id
-              all
-              users
-              organizations
-            }
-          }
-          contributors(limit: $nbContributorsPerContributeCard) {
-            id
-            image
-            collectiveSlug
-            name
-            type
-          }
+          ...ContributeCardConnectedCollectiveFields
         }
       }
     }
   }
-  ${collectiveNavbarFieldsFragment}
+  ${fragments.collectiveNavbarFieldsFragment}
+  ${fragments.contributeCardTierFieldsFragment}
+  ${fragments.contributeCardEventFieldsFragment}
+  ${fragments.contributeCardProjectFieldsFragment}
+  ${fragments.contributeCardConnectedCollectiveFieldsFragment}
 `;
+/* eslint-enable graphql/template-strings */
 
 const addContributePageData = graphql(contributePageQuery, {
   options: props => ({


### PR DESCRIPTION
Will resolve the issue reported in https://opencollective.slack.com/archives/C6JTTA4SK/p1642101849011800 by using common fragments between the two pages. This change will:
- Prevent inconsistencies on the contribute cards between the collective page and `/contribute`
- Facilitate new developments as there's now only one place to update