### PR TITLE
Move Collective budget Stats to GraphQL V2

### DIFF
--- a/components/collective-page/BudgetStats.js
+++ b/components/collective-page/BudgetStats.js
@@ -8,6 +8,7 @@ import styled, { css } from 'styled-components';
 
 import { CollectiveType } from '../../lib/constants/collectives';
 import { formatCurrency, getCurrencySymbol } from '../../lib/currency-utils';
+import { AmountPropTypeShape } from '../../lib/prop-types';
 
 import Container from '../Container';
 import DefinedTerm, { Terms } from '../DefinedTerm';
@@ -76,7 +77,7 @@ const BudgetStats = ({ collective, stats }) => {
           </Container>
           <FormattedMessage id="CollectivePage.SectionBudget.Balance" defaultMessage="Today’s balance" />
         </StatTitle>
-        <StatAmount amount={stats.balance} currency={collective.currency} />
+        <StatAmount amount={stats.balance.valueInCents} currency={collective.currency} />
       </StatContainer>
       <StatContainer>
         <StatTitle>
@@ -91,20 +92,25 @@ const BudgetStats = ({ collective, stats }) => {
                 <FormattedMessage
                   id="budgetSection-raised-total"
                   defaultMessage="Total contributed before fees: {amount}"
-                  values={{ amount: formatCurrency(stats?.totalAmountRaised || 0, collective.currency, { locale }) }}
+                  values={{
+                    amount: formatCurrency(stats?.totalAmountRaised.valueInCents || 0, collective.currency, { locale }),
+                  }}
                 />
               </Box>
             }
           />
         </StatTitle>
-        <StatAmount amount={stats.totalNetAmountRaised} currency={collective.currency} />
+        <StatAmount amount={stats.totalNetAmountRaised.valueInCents} currency={collective.currency} />
       </StatContainer>
       <StatContainer>
         <StatTitle>
           <Expand size="12px" />
           <FormattedMessage id="budgetSection-disbursed" defaultMessage="Total disbursed" />
         </StatTitle>
-        <StatAmount amount={stats.totalNetAmountRaised - stats.balance} currency={collective.currency} />
+        <StatAmount
+          amount={stats.totalNetAmountRaised.valueInCents - stats.balance.valueInCents}
+          currency={collective.currency}
+        />
       </StatContainer>
       {!isFund && !isProject && (
         <StatContainer data-cy="budgetSection-estimated-budget" $isMain>
@@ -126,14 +132,16 @@ const BudgetStats = ({ collective, stats }) => {
                     id="CollectivePage.SectionBudget.TotalAmountReceived"
                     defaultMessage="Total received in the last 12 months: {amount}"
                     values={{
-                      amount: formatCurrency(stats?.totalAmountReceived || 0, collective.currency, { locale }),
+                      amount: formatCurrency(stats?.totalAmountReceived.valueInCents || 0, collective.currency, {
+                        locale,
+                      }),
                     }}
                   />
                 </Box>
               }
             />
           </StatTitle>
-          <StatAmount amount={stats.yearlyBudget} currency={collective.currency} />
+          <StatAmount amount={stats.yearlyBudget.valueInCents} currency={collective.currency} />
         </StatContainer>
       )}
     </Fragment>
@@ -154,12 +162,12 @@ BudgetStats.propTypes = {
 
   /** Stats */
   stats: PropTypes.shape({
-    balance: PropTypes.number.isRequired,
-    yearlyBudget: PropTypes.number.isRequired,
+    balance: AmountPropTypeShape.isRequired,
+    yearlyBudget: AmountPropTypeShape.isRequired,
     activeRecurringContributions: PropTypes.object,
-    totalAmountReceived: PropTypes.number,
-    totalAmountRaised: PropTypes.number,
-    totalNetAmountRaised: PropTypes.number,
+    totalAmountReceived: AmountPropTypeShape,
+    totalAmountRaised: AmountPropTypeShape,
+    totalNetAmountRaised: AmountPropTypeShape,
   }),
 
   isLoading: PropTypes.bool,

--- a/components/collective-page/graphql/queries.js
+++ b/components/collective-page/graphql/queries.js
@@ -215,6 +215,31 @@ export const budgetSectionQuery = gqlV2/* GraphQL */ `
         ...ExpensesListFieldsFragment
       }
     }
+    account(slug: $slug) {
+      stats {
+        balance {
+          valueInCents
+          currency
+        }
+        yearlyBudget {
+          valueInCents
+          currency
+        }
+        activeRecurringContributions
+        totalAmountReceived(periodInMonths: 12) {
+          valueInCents
+          currency
+        }
+        totalAmountRaised: totalAmountReceived {
+          valueInCents
+          currency
+        }
+        totalNetAmountRaised: totalNetAmountReceived {
+          valueInCents
+          currency
+        }
+      }
+    }
   }
   ${transactionsQueryCollectionFragment}
   ${expensesListFieldsFragment}

--- a/components/collective-page/index.js
+++ b/components/collective-page/index.js
@@ -187,7 +187,6 @@ class CollectivePage extends Component {
             collective={this.props.collective}
             transactions={this.props.transactions}
             expenses={this.props.expenses}
-            stats={this.props.stats}
           />
         );
       case Sections.TRANSACTIONS:

--- a/components/collective-page/sections/Budget.js
+++ b/components/collective-page/sections/Budget.js
@@ -48,6 +48,31 @@ export const budgetSectionWithHostQuery = gqlV2/* GraphQL */ `
         ...ExpensesListFieldsFragment
       }
     }
+    account(slug: $slug) {
+      stats {
+        balance {
+          valueInCents
+          currency
+        }
+        yearlyBudget {
+          valueInCents
+          currency
+        }
+        activeRecurringContributions
+        totalAmountReceived(periodInMonths: 12) {
+          valueInCents
+          currency
+        }
+        totalAmountRaised: totalAmountReceived {
+          valueInCents
+          currency
+        }
+        totalNetAmountRaised: totalNetAmountReceived {
+          valueInCents
+          currency
+        }
+      }
+    }
   }
   ${transactionsQueryCollectionFragment}
   ${expensesListFieldsFragment}
@@ -129,7 +154,7 @@ ViewAllLink.propTypes = {
  * The budget section. Shows the expenses, the latests transactions and some statistics
  * abut the global budget of the collective.
  */
-const SectionBudget = ({ collective, stats, LoggedInUser }) => {
+const SectionBudget = ({ collective, LoggedInUser }) => {
   const [filter, setFilter] = React.useState('all');
   const budgetQuery = collective.host ? budgetSectionWithHostQuery : budgetSectionQuery;
   const budgetQueryResult = useQuery(budgetQuery, {
@@ -221,7 +246,11 @@ const SectionBudget = ({ collective, stats, LoggedInUser }) => {
           mb={2}
           mx={[null, null, 3]}
         >
-          <BudgetStats collective={collective} stats={stats} />
+          {isLoading ? (
+            <LoadingPlaceholder height={300} />
+          ) : (
+            <BudgetStats collective={collective} stats={data?.account?.stats} />
+          )}
         </StyledCard>
       </Flex>
     </ContainerSectionContent>
@@ -238,15 +267,6 @@ SectionBudget.propTypes = {
     isArchived: PropTypes.bool,
     settings: PropTypes.object,
     host: PropTypes.object,
-  }),
-
-  /** Stats */
-  stats: PropTypes.shape({
-    balance: PropTypes.number.isRequired,
-    yearlyBudget: PropTypes.number.isRequired,
-    activeRecurringContributions: PropTypes.object,
-    totalAmountReceived: PropTypes.number,
-    totalAmountRaised: PropTypes.number,
   }),
 
   LoggedInUser: PropTypes.object,

--- a/lib/graphql/schema.graphql
+++ b/lib/graphql/schema.graphql
@@ -257,7 +257,7 @@ type UserDetails {
   id: Int
   CollectiveId: Int
   collective: CollectiveInterface
-  username: String
+  username: String @deprecated(reason: "2022-01-13: Not used anymore. Will be ignored")
   name: String
   image: String
   email: String
@@ -4035,7 +4035,7 @@ input UserInputType {
   name: String
   company: String
   image: String
-  username: String
+  username: String @deprecated(reason: "2022-01-13: Not used anymore. Will be ignored")
   description: String
   twitterHandle: String
   githubHandle: String

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -2863,6 +2863,11 @@ type AccountStats {
     Calculate total amount received after this date
     """
     dateFrom: DateTime
+
+    """
+    Computes contributions from the last x months. Cannot be used with startDate/endDate
+    """
+    periodInMonths: Int
   ): Amount!
 
   """
@@ -2891,6 +2896,12 @@ type AccountStats {
   ): Amount!
   yearlyBudget: Amount!
   yearlyBudgetManaged: Amount!
+
+  """
+  Total net amount received
+  """
+  totalNetAmountReceived: Amount!
+  activeRecurringContributions: JSON
 }
 
 """

--- a/lib/prop-types.js
+++ b/lib/prop-types.js
@@ -1,0 +1,7 @@
+import PropTypes from 'prop-types';
+
+export const AmountPropTypeShape = PropTypes.shape({
+  value: PropTypes.number,
+  valueInCents: PropTypes.number,
+  currency: PropTypes.string,
+});


### PR DESCRIPTION
Fixes: https://github.com/opencollective/opencollective/issues/4449
Requires: https://github.com/opencollective/opencollective-api/pull/7077

It turns out this was being stuck because of how Next.JS server-side rendering and navigation works.
I didn't want to mess with that because I think that related to how the rest of the page is rendering this is optimal.
In the end, I just updated the Budget component to load that information dynamically using GQL V2 API as we do it for transactions.