### PR TITLE
update to tax form banner text

### DIFF
--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1030,7 +1030,7 @@
   "ExpenseForm.Type.Request": "Request Grant",
   "ExpenseFormAttachments.TotalAmount": "Total amount:",
   "expenseNeedsTaxForm.hover": "We can't pay until we receive your tax info. Check your inbox for an email from HelloWorks. Need help? Contact support@opencollective.com",
-  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email from HelloWorks saying Open Collective is requesting you fill out a form. This is required by the IRS (US tax agency) for everyone who invoices $600 or more per year. We also require one for grant recipients for our records. If you have not received the email within 24 hours, or you have any questions, please contact <I18nSupportLink></I18nSupportLink>. For more info, see our <Link>help docs about taxes</Link>.",
+  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email with a link to fill out a form. If you have not received the email within 24 hours, check your spam, then contact <I18nSupportLink></I18nSupportLink>. Questions? See <Link>help docs about taxes</Link>.",
   "ExpensePage.title": "{title} · Expense #{id}",
   "ExpensePolicies": "Expense policies",
   "ExpenseReceiptImagePreview.Alt": "Expense receipt preview",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1030,7 +1030,7 @@
   "ExpenseForm.Type.Request": "Request Grant",
   "ExpenseFormAttachments.TotalAmount": "Celková částka:",
   "expenseNeedsTaxForm.hover": "We can't pay until we receive your tax info. Check your inbox for an email from HelloWorks. Need help? Contact support@opencollective.com",
-  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email from HelloWorks saying Open Collective is requesting you fill out a form. This is required by the IRS (US tax agency) for everyone who invoices $600 or more per year. We also require one for grant recipients for our records. If you have not received the email within 24 hours, or you have any questions, please contact <I18nSupportLink></I18nSupportLink>. For more info, see our <Link>help docs about taxes</Link>.",
+  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email with a link to fill out a form. If you have not received the email within 24 hours, check your spam, then contact <I18nSupportLink></I18nSupportLink>. Questions? See <Link>help docs about taxes</Link>.",
   "ExpensePage.title": "{title} · Expense #{id}",
   "ExpensePolicies": "Expense policies",
   "ExpenseReceiptImagePreview.Alt": "Expense receipt preview",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1030,7 +1030,7 @@
   "ExpenseForm.Type.Request": "Request Grant",
   "ExpenseFormAttachments.TotalAmount": "Total amount:",
   "expenseNeedsTaxForm.hover": "We can't pay until we receive your tax info. Check your inbox for an email from HelloWorks. Need help? Contact support@opencollective.com",
-  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email from HelloWorks saying Open Collective is requesting you fill out a form. This is required by the IRS (US tax agency) for everyone who invoices $600 or more per year. We also require one for grant recipients for our records. If you have not received the email within 24 hours, or you have any questions, please contact <I18nSupportLink></I18nSupportLink>. For more info, see our <Link>help docs about taxes</Link>.",
+  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email with a link to fill out a form. If you have not received the email within 24 hours, check your spam, then contact <I18nSupportLink></I18nSupportLink>. Questions? See <Link>help docs about taxes</Link>.",
   "ExpensePage.title": "{title} · Expense #{id}",
   "ExpensePolicies": "Expense policies",
   "ExpenseReceiptImagePreview.Alt": "Expense receipt preview",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1030,7 +1030,7 @@
   "ExpenseForm.Type.Request": "Request Grant",
   "ExpenseFormAttachments.TotalAmount": "Total amount:",
   "expenseNeedsTaxForm.hover": "We can't pay until we receive your tax info. Check your inbox for an email from HelloWorks. Need help? Contact support@opencollective.com",
-  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email from HelloWorks saying Open Collective is requesting you fill out a form. This is required by the IRS (US tax agency) for everyone who invoices $600 or more per year. We also require one for grant recipients for our records. If you have not received the email within 24 hours, or you have any questions, please contact <I18nSupportLink></I18nSupportLink>. For more info, see our <Link>help docs about taxes</Link>.",
+  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email with a link to fill out a form. If you have not received the email within 24 hours, check your spam, then contact <I18nSupportLink></I18nSupportLink>. Questions? See <Link>help docs about taxes</Link>.",
   "ExpensePage.title": "{title} · Expense #{id}",
   "ExpensePolicies": "Expense policies",
   "ExpenseReceiptImagePreview.Alt": "Expense receipt preview",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1030,7 +1030,7 @@
   "ExpenseForm.Type.Request": "Request Grant",
   "ExpenseFormAttachments.TotalAmount": "Importe total:",
   "expenseNeedsTaxForm.hover": "No podemos pagar hasta que recibamos tu información de impuestos. Revisa tu bandeja de entrada y busca un correo electrónico de HelloWorks. Si necesitas ayuda puedes enviarnos un correo electrónico a support@opencollective.com",
-  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email from HelloWorks saying Open Collective is requesting you fill out a form. This is required by the IRS (US tax agency) for everyone who invoices $600 or more per year. We also require one for grant recipients for our records. If you have not received the email within 24 hours, or you have any questions, please contact <I18nSupportLink></I18nSupportLink>. For more info, see our <Link>help docs about taxes</Link>.",
+  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email with a link to fill out a form. If you have not received the email within 24 hours, check your spam, then contact <I18nSupportLink></I18nSupportLink>. Questions? See <Link>help docs about taxes</Link>.",
   "ExpensePage.title": "{title} · Gasto #{id}",
   "ExpensePolicies": "Políticas de gastos",
   "ExpenseReceiptImagePreview.Alt": "Vista previa del recibo de gasto",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1030,7 +1030,7 @@
   "ExpenseForm.Type.Request": "Demande d'autorisation",
   "ExpenseFormAttachments.TotalAmount": "Montant total :",
   "expenseNeedsTaxForm.hover": "We can't pay until we receive your tax info. Check your inbox for an email from HelloWorks. Need help? Contact support@opencollective.com",
-  "expenseNeedsTaxFormMessage.msg": "Nous avons besoin de vos renseignements fiscaux avant de pouvoir vous payer. Vous recevrez un e-mail de HelloWorks, disant qu'Open Collective vous demande de remplir un formulaire. Ceci est requis par l’IRS (agence fiscale américaine) pour tous ceux qui facturent 600 $ ou plus par an. Nous en avons également besoin pour les bénéficiaires de subventions pour notre comptabilité. Si vous n'avez pas reçu l'e-mail dans les 24 heures, ou si vous avez des questions, veuillez contacter <I18nSupportLink></I18nSupportLink>. Pour plus d'informations, consultez notre <Link>documentation d'aide sur les impôts</Link>.",
+  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email with a link to fill out a form. If you have not received the email within 24 hours, check your spam, then contact <I18nSupportLink></I18nSupportLink>. Questions? See <Link>help docs about taxes</Link>.",
   "ExpensePage.title": "{title} · Dépense #{id}",
   "ExpensePolicies": "Politique de remboursement",
   "ExpenseReceiptImagePreview.Alt": "Aperçu du reçu",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1030,7 +1030,7 @@
   "ExpenseForm.Type.Request": "Request Grant",
   "ExpenseFormAttachments.TotalAmount": "Importo totale:",
   "expenseNeedsTaxForm.hover": "We can't pay until we receive your tax info. Check your inbox for an email from HelloWorks. Need help? Contact support@opencollective.com",
-  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email from HelloWorks saying Open Collective is requesting you fill out a form. This is required by the IRS (US tax agency) for everyone who invoices $600 or more per year. We also require one for grant recipients for our records. If you have not received the email within 24 hours, or you have any questions, please contact <I18nSupportLink></I18nSupportLink>. For more info, see our <Link>help docs about taxes</Link>.",
+  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email with a link to fill out a form. If you have not received the email within 24 hours, check your spam, then contact <I18nSupportLink></I18nSupportLink>. Questions? See <Link>help docs about taxes</Link>.",
   "ExpensePage.title": "{title} · Spesa #{id}",
   "ExpensePolicies": "Politiche di spesa",
   "ExpenseReceiptImagePreview.Alt": "Anteprima ricevuta spesa",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1030,7 +1030,7 @@
   "ExpenseForm.Type.Request": "Request Grant",
   "ExpenseFormAttachments.TotalAmount": "総額:",
   "expenseNeedsTaxForm.hover": "We can't pay until we receive your tax info. Check your inbox for an email from HelloWorks. Need help? Contact support@opencollective.com",
-  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email from HelloWorks saying Open Collective is requesting you fill out a form. This is required by the IRS (US tax agency) for everyone who invoices $600 or more per year. We also require one for grant recipients for our records. If you have not received the email within 24 hours, or you have any questions, please contact <I18nSupportLink></I18nSupportLink>. For more info, see our <Link>help docs about taxes</Link>.",
+  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email with a link to fill out a form. If you have not received the email within 24 hours, check your spam, then contact <I18nSupportLink></I18nSupportLink>. Questions? See <Link>help docs about taxes</Link>.",
   "ExpensePage.title": "{title} · Expense #{id}",
   "ExpensePolicies": "Expense policies",
   "ExpenseReceiptImagePreview.Alt": "Expense receipt preview",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1030,7 +1030,7 @@
   "ExpenseForm.Type.Request": "Request Grant",
   "ExpenseFormAttachments.TotalAmount": "Total amount:",
   "expenseNeedsTaxForm.hover": "We can't pay until we receive your tax info. Check your inbox for an email from HelloWorks. Need help? Contact support@opencollective.com",
-  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email from HelloWorks saying Open Collective is requesting you fill out a form. This is required by the IRS (US tax agency) for everyone who invoices $600 or more per year. We also require one for grant recipients for our records. If you have not received the email within 24 hours, or you have any questions, please contact <I18nSupportLink></I18nSupportLink>. For more info, see our <Link>help docs about taxes</Link>.",
+  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email with a link to fill out a form. If you have not received the email within 24 hours, check your spam, then contact <I18nSupportLink></I18nSupportLink>. Questions? See <Link>help docs about taxes</Link>.",
   "ExpensePage.title": "{title} · Expense #{id}",
   "ExpensePolicies": "Expense policies",
   "ExpenseReceiptImagePreview.Alt": "Expense receipt preview",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1030,7 +1030,7 @@
   "ExpenseForm.Type.Request": "Request Grant",
   "ExpenseFormAttachments.TotalAmount": "Total amount:",
   "expenseNeedsTaxForm.hover": "We can't pay until we receive your tax info. Check your inbox for an email from HelloWorks. Need help? Contact support@opencollective.com",
-  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email from HelloWorks saying Open Collective is requesting you fill out a form. This is required by the IRS (US tax agency) for everyone who invoices $600 or more per year. We also require one for grant recipients for our records. If you have not received the email within 24 hours, or you have any questions, please contact <I18nSupportLink></I18nSupportLink>. For more info, see our <Link>help docs about taxes</Link>.",
+  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email with a link to fill out a form. If you have not received the email within 24 hours, check your spam, then contact <I18nSupportLink></I18nSupportLink>. Questions? See <Link>help docs about taxes</Link>.",
   "ExpensePage.title": "{title} · Expense #{id}",
   "ExpensePolicies": "Expense policies",
   "ExpenseReceiptImagePreview.Alt": "Expense receipt preview",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -1030,7 +1030,7 @@
   "ExpenseForm.Type.Request": "Wniosek o dotację",
   "ExpenseFormAttachments.TotalAmount": "Łączna kwota:",
   "expenseNeedsTaxForm.hover": "Nie możemy zapłacić dopóki nie otrzymamy informacji o Twoim rozliczeniu podatkowym. Sprawdź swoją skrzynkę odbiorczą w poszukiwaniu wiadomości e-mail od HelloWorks. Potrzebujesz pomocy? Skontaktuj się z support@opencollective.com",
-  "expenseNeedsTaxFormMessage.msg": "Zanim będziemy mogli Ci zapłacić, potrzebujemy Twoich danych podatkowych. Otrzymasz e-mail od HelloWorks z informacją, że Open Collective prosi Cię o wypełnienie formularza. Jest to wymagane przez IRS (amerykańska agencja podatkowa) dla każdego, kto wystawia fakturę na kwotę 600 USD lub więcej rocznie. Wymagamy go również od odbiorców dotacji do naszej dokumentacji. Jeśli nie otrzymałeś emaila w ciągu 24 godzin, lub masz jakiekolwiek pytania, prosimy o kontakt z <I18nSupportLink></I18nSupportLink>. Aby uzyskać więcej informacji, zobacz nasze <Link>dokumenty pomocy na temat podatków</Link>.",
+  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email with a link to fill out a form. If you have not received the email within 24 hours, check your spam, then contact <I18nSupportLink></I18nSupportLink>. Questions? See <Link>help docs about taxes</Link>.",
   "ExpensePage.title": "{title} · Wydatek #{id}",
   "ExpensePolicies": "Polityka wydatków",
   "ExpenseReceiptImagePreview.Alt": "Podgląd rachunku wydatków",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1030,7 +1030,7 @@
   "ExpenseForm.Type.Request": "Solicitação de concessão",
   "ExpenseFormAttachments.TotalAmount": "Valor total:",
   "expenseNeedsTaxForm.hover": "Não podemos realizar o pagamento até recebermos suas informações fiscais. Verifique se na sua caixa de entrada consta um e-mail da HelloWorks. Precisa de ajuda? Entre em contato com support@opencollective.com",
-  "expenseNeedsTaxFormMessage.msg": "Precisamos das suas informações fiscais para que possamos lhe pagar. Você receberá um e-mail da HelloWorks dizendo que a Open Collective está solicitando que você preencha um formulário. Isto é exigido pelo IRS (agência fiscal dos EUA) para todos os que facturam 600 dólares ou mais por ano. Exigimos também que seja concedido aos beneficiários para os nossos discursos. Se você não recebeu o e-mail dentro de 24 horas, ou se tiver alguma dúvida, entre em contato com <I18nSupportLink></I18nSupportLink>. Para obter mais informações, consulte a nossa <Link>documentação sobre impostos</Link>.",
+  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email with a link to fill out a form. If you have not received the email within 24 hours, check your spam, then contact <I18nSupportLink></I18nSupportLink>. Questions? See <Link>help docs about taxes</Link>.",
   "ExpensePage.title": "{title} · Despesa #{id}",
   "ExpensePolicies": "Políticas de despesas",
   "ExpenseReceiptImagePreview.Alt": "Visualização do recibo de despesa",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1030,7 +1030,7 @@
   "ExpenseForm.Type.Request": "Request Grant",
   "ExpenseFormAttachments.TotalAmount": "Valor total:",
   "expenseNeedsTaxForm.hover": "We can't pay until we receive your tax info. Check your inbox for an email from HelloWorks. Need help? Contact support@opencollective.com",
-  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email from HelloWorks saying Open Collective is requesting you fill out a form. This is required by the IRS (US tax agency) for everyone who invoices $600 or more per year. We also require one for grant recipients for our records. If you have not received the email within 24 hours, or you have any questions, please contact <I18nSupportLink></I18nSupportLink>. For more info, see our <Link>help docs about taxes</Link>.",
+  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email with a link to fill out a form. If you have not received the email within 24 hours, check your spam, then contact <I18nSupportLink></I18nSupportLink>. Questions? See <Link>help docs about taxes</Link>.",
   "ExpensePage.title": "{title} · Despesa #{id}",
   "ExpensePolicies": "Políticas de despesas",
   "ExpenseReceiptImagePreview.Alt": "Visualização do recibo de despesa",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1030,7 +1030,7 @@
   "ExpenseForm.Type.Request": "Запросить грант",
   "ExpenseFormAttachments.TotalAmount": "Всего:",
   "expenseNeedsTaxForm.hover": "We can't pay until we receive your tax info. Check your inbox for an email from HelloWorks. Need help? Contact support@opencollective.com",
-  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email from HelloWorks saying Open Collective is requesting you fill out a form. This is required by the IRS (US tax agency) for everyone who invoices $600 or more per year. We also require one for grant recipients for our records. If you have not received the email within 24 hours, or you have any questions, please contact <I18nSupportLink></I18nSupportLink>. For more info, see our <Link>help docs about taxes</Link>.",
+  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email with a link to fill out a form. If you have not received the email within 24 hours, check your spam, then contact <I18nSupportLink></I18nSupportLink>. Questions? See <Link>help docs about taxes</Link>.",
   "ExpensePage.title": "{title} · Расход #{id}",
   "ExpensePolicies": "Политика расходов",
   "ExpenseReceiptImagePreview.Alt": "Expense receipt preview",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -1030,7 +1030,7 @@
   "ExpenseForm.Type.Request": "Request Grant",
   "ExpenseFormAttachments.TotalAmount": "Загальна сума:",
   "expenseNeedsTaxForm.hover": "We can't pay until we receive your tax info. Check your inbox for an email from HelloWorks. Need help? Contact support@opencollective.com",
-  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email from HelloWorks saying Open Collective is requesting you fill out a form. This is required by the IRS (US tax agency) for everyone who invoices $600 or more per year. We also require one for grant recipients for our records. If you have not received the email within 24 hours, or you have any questions, please contact <I18nSupportLink></I18nSupportLink>. For more info, see our <Link>help docs about taxes</Link>.",
+  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email with a link to fill out a form. If you have not received the email within 24 hours, check your spam, then contact <I18nSupportLink></I18nSupportLink>. Questions? See <Link>help docs about taxes</Link>.",
   "ExpensePage.title": "{title} · Витрата #{id}",
   "ExpensePolicies": "Правила витрат",
   "ExpenseReceiptImagePreview.Alt": "Попередній перегляд квитанції витрат",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1030,7 +1030,7 @@
   "ExpenseForm.Type.Request": "请求授权",
   "ExpenseFormAttachments.TotalAmount": "总金额：",
   "expenseNeedsTaxForm.hover": "We can't pay until we receive your tax info. Check your inbox for an email from HelloWorks. Need help? Contact support@opencollective.com",
-  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email from HelloWorks saying Open Collective is requesting you fill out a form. This is required by the IRS (US tax agency) for everyone who invoices $600 or more per year. We also require one for grant recipients for our records. If you have not received the email within 24 hours, or you have any questions, please contact <I18nSupportLink></I18nSupportLink>. For more info, see our <Link>help docs about taxes</Link>.",
+  "expenseNeedsTaxFormMessage.msg": "We need your tax information before we can pay you. You will receive an email with a link to fill out a form. If you have not received the email within 24 hours, check your spam, then contact <I18nSupportLink></I18nSupportLink>. Questions? See <Link>help docs about taxes</Link>.",
   "ExpensePage.title": "{title} · Expense #{id}",
   "ExpensePolicies": "支出政策",
   "ExpenseReceiptImagePreview.Alt": "支出收据预览",

--- a/pages/expense.js
+++ b/pages/expense.js
@@ -534,7 +534,7 @@ class ExpensePage extends React.Component {
               <MessageBox type="warning" withIcon={true} mb={4}>
                 <FormattedMessage
                   id="expenseNeedsTaxFormMessage.msg"
-                  defaultMessage="We need your tax information before we can pay you. You will receive an email from HelloWorks saying Open Collective is requesting you fill out a form. This is required by the IRS (US tax agency) for everyone who invoices $600 or more per year. We also require one for grant recipients for our records. If you have not received the email within 24 hours, or you have any questions, please contact <I18nSupportLink></I18nSupportLink>. For more info, see our <Link>help docs about taxes</Link>."
+                  defaultMessage="We need your tax information before we can pay you. You will receive an email with a link to fill out a form. If you have not received the email within 24 hours, check your spam, then contact <I18nSupportLink></I18nSupportLink>. Questions? See <Link>help docs about taxes</Link>."
                   values={{
                     I18nSupportLink,
                     Link: getI18nLink({


### PR DESCRIPTION
Updated text to remove reference to HelloWorks email now that we send the emails ourselves, and made it more concise.