### PR TITLE
Fetch collective settings in transactions page

### DIFF
--- a/pages/transactions.js
+++ b/pages/transactions.js
@@ -67,6 +67,7 @@ const transactionsPageQuery = gqlV2/* GraphQL */ `
       createdAt
       imageUrl(height: 256)
       currency
+      settings
       features {
         ...NavbarFields
       }


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/5137

This is important because `isSectionForAdminsOnly` looks at `settings.collectivePage.sections` to decide whether or not we can display the page.