### PR TITLE
chore: update `cypress` to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15692,9 +15692,9 @@
       }
     },
     "@types/sinonjs__fake-timers": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.4.tgz",
-      "integrity": "sha512-IFQTJARgMUBF+xVd2b+hIgXWrZEjND3vJtRCvIelcFB5SIXfjV4bOHbHJ0eXKh+0COrBRc8MqteKAz/j88rE0A==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
+      "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
       "dev": true
     },
     "@types/sizzle": {
@@ -20368,24 +20368,25 @@
       "dev": true
     },
     "cypress": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-8.7.0.tgz",
-      "integrity": "sha512-b1bMC3VQydC6sXzBMFnSqcvwc9dTZMgcaOzT0vpSD+Gq1yFc+72JDWi55sfUK5eIeNLAtWOGy1NNb6UlhMvB+Q==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.4.1.tgz",
+      "integrity": "sha512-+JgMG9uT+QFx97JU9kOHE3jO3+0UdkQ9H1oCBiC7A74qme7Jkdy2sYDBCPjjGczutnWnGUTMRlwiNMP/Uq6LrQ==",
       "dev": true,
       "requires": {
-        "@cypress/request": "^2.88.6",
+        "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^14.14.31",
-        "@types/sinonjs__fake-timers": "^6.0.2",
+        "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
+        "buffer": "^5.6.0",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
         "cli-cursor": "^3.1.0",
-        "cli-table3": "~0.6.0",
+        "cli-table3": "~0.6.1",
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
@@ -20408,12 +20409,11 @@
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
-        "ramda": "~0.27.1",
         "request-progress": "^3.0.0",
+        "semver": "^7.3.2",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
-        "url": "^0.11.0",
         "yauzl": "^2.10.0"
       },
       "dependencies": {
@@ -20430,6 +20430,16 @@
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
+          }
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
           }
         },
         "cachedir": {
@@ -20625,6 +20635,15 @@
           "dev": true,
           "requires": {
             "tslib": "^2.1.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
           }
         },
         "shebang-command": {
@@ -34244,12 +34263,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
       "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
-      "dev": true
-    },
-    "ramda": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
-      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==",
       "dev": true
     },
     "randexp": {

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "commitizen": "^4.2.4",
     "cross-env": "^7.0.3",
     "css-loader": "^6.6.0",
-    "cypress": "^8.7.0",
+    "cypress": "^9.4.1",
     "cypress-file-upload": "^3.5.3",
     "cz-conventional-changelog": "^3.3.0",
     "enzyme": "^3.11.0",

--- a/pages/confirmEmail.js
+++ b/pages/confirmEmail.js
@@ -96,7 +96,7 @@ class ConfirmEmailPage extends React.Component {
           )}
           {status === 'error' && (
             <MessageBox type="error" withIcon>
-              {error.name === 'InvalidToken' ? (
+              {error.extensions?.code === 'INVALID_TOKEN' ? (
                 <FormattedMessage
                   id="confirmEmail.error.InvalidToken"
                   defaultMessage="The confirmation link is invalid or has expired"

--- a/test/cypress/integration/08-user.change-email.test.js
+++ b/test/cypress/integration/08-user.change-email.test.js
@@ -48,7 +48,7 @@ describe('Users can change their email address', () => {
 
   it('shows an error if validation link is invalid/expired', () => {
     cy.visit('/confirm/email/ThisIsDefinitelyNotAValidToken');
-    cy.contains('Invalid email confirmation token');
+    cy.contains('The confirmation link is invalid or has expired');
   });
 
   it('can re-send the confirmation email', () => {

--- a/test/cypress/integration/08-user.change-email.test.js
+++ b/test/cypress/integration/08-user.change-email.test.js
@@ -48,7 +48,7 @@ describe('Users can change their email address', () => {
 
   it('shows an error if validation link is invalid/expired', () => {
     cy.visit('/confirm/email/ThisIsDefinitelyNotAValidToken');
-    cy.contains('The confirmation link is invalid or has expired');
+    cy.contains('Invalid email confirmation token');
   });
 
   it('can re-send the confirmation email', () => {


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/5204

Requires https://github.com/opencollective/opencollective-api/pull/7136

# Description

Fix https://github.com/opencollective/opencollective-frontend/pull/7446
Upgrade `cypress` to the latest version.

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

## Regression Explanation

The Regression was due to an existing bug that was not caught by the older cypress version.

The front end was not showing the correct error message for the [`/confirm/email/ThisIsDefinitelyNotAValidToken`](https://opencollective.com/confirm/email/ThisIsDefinitelyNotAValidToken) route.

But this was not caught in the older version of cypress, upgrading cypress caught this bug hence E2E tests failed in https://github.com/opencollective/opencollective-frontend/pull/7446

https://github.com/opencollective/opencollective-frontend/blob/668728d1dc1b78a1769c57c5c4476c7f67b69d65/test/cypress/integration/08-user.change-email.test.js#L49-L52

I created a PR in the API to fix the regression and updated the related code for the frontend too.


