### PR TITLE
Rename EditEventForm -> CreateEventForm

### DIFF
--- a/components/CreateEvent.js
+++ b/components/CreateEvent.js
@@ -10,7 +10,7 @@ import { addCreateCollectiveMutation } from '../lib/graphql/mutations';
 import Body from './Body';
 import CollectiveNavbar from './collective-navbar';
 import Container from './Container';
-import EditEventForm from './EditEventForm';
+import CreateEventForm from './CreateEventForm';
 import Footer from './Footer';
 import Header from './Header';
 import Link from './Link';
@@ -127,7 +127,7 @@ class CreateEvent extends React.Component {
             )}
             {canCreateEvent && (
               <div>
-                <EditEventForm
+                <CreateEventForm
                   event={this.state.event}
                   onSubmit={this.createEvent}
                   onChange={this.resetError}

--- a/components/CreateEventForm.js
+++ b/components/CreateEventForm.js
@@ -12,7 +12,7 @@ import InputField from './InputField';
 import StyledButton from './StyledButton';
 import TimezonePicker from './TimezonePicker';
 
-class EditEventForm extends React.Component {
+class CreateEventForm extends React.Component {
   static propTypes = {
     event: PropTypes.object,
     loading: PropTypes.bool,
@@ -265,4 +265,4 @@ class EditEventForm extends React.Component {
   }
 }
 
-export default injectIntl(EditEventForm);
+export default injectIntl(CreateEventForm);


### PR DESCRIPTION
Follow up from a review at https://github.com/opencollective/opencollective-frontend/pull/7323

I was wondering why the change was not impacting edition. Answer: because it's not used in edition.