### PR TITLE
Remove unnecessary field in VirtualCards query

### DIFF
--- a/components/edit-collective/sections/HostVirtualCards.js
+++ b/components/edit-collective/sections/HostVirtualCards.js
@@ -36,7 +36,6 @@ const hostVirtualCardsQuery = gqlV2/* GraphQL */ `
       id
       legacyId
       slug
-      supportedPayoutMethods
       name
       imageUrl
       currency


### PR DESCRIPTION
`supportedPayoutMethods` did not seem to be used by virtual cards