### PR TITLE
Refactor query and fix preloading for BudgetSection

### DIFF
--- a/components/collective-page/graphql/preload.js
+++ b/components/collective-page/graphql/preload.js
@@ -7,13 +7,13 @@ import {
   getTotalCollectiveContributionsQueryVariables,
   totalCollectiveContributionsQuery,
 } from '../hero/HeroTotalCollectiveContributionsWithData';
-import { getBudgetSectionQueryVariables } from '../sections/Budget';
+import { getBudgetSectionQuery, getBudgetSectionQueryVariables } from '../sections/Budget';
 import { conversationsSectionQuery, getConversationsSectionQueryVariables } from '../sections/Conversations';
 import { getRecurringContributionsSectionQueryVariables } from '../sections/RecurringContributions';
 import { getTransactionsSectionQueryVariables, transactionsSectionQuery } from '../sections/Transactions';
 import { getUpdatesSectionQueryVariables, updatesSectionQuery } from '../sections/Updates';
 
-import { budgetSectionQuery, collectivePageQuery, getCollectivePageQueryVariables } from './queries';
+import { collectivePageQuery, getCollectivePageQueryVariables } from './queries';
 
 export const preloadCollectivePageGraphqlQueries = async (slug, client) => {
   const result = await client.query({
@@ -28,8 +28,8 @@ export const preloadCollectivePageGraphqlQueries = async (slug, client) => {
     if (sectionsNames.includes('budget')) {
       queries.push(
         client.query({
-          query: budgetSectionQuery,
-          variables: getBudgetSectionQueryVariables(slug),
+          query: getBudgetSectionQuery(Boolean(collective.host)),
+          variables: getBudgetSectionQueryVariables(slug, collective.host?.slug),
           context: API_V2_CONTEXT,
         }),
       );

--- a/components/collective-page/graphql/queries.js
+++ b/components/collective-page/graphql/queries.js
@@ -1,10 +1,6 @@
 import { gql } from '@apollo/client';
 
-import { gqlV2 } from '../../../lib/graphql/helpers';
-
 import { MAX_CONTRIBUTORS_PER_CONTRIBUTE_CARD } from '../../contribute-cards/Contribute';
-import { expensesListFieldsFragment } from '../../expenses/graphql/fragments';
-import { transactionsQueryCollectionFragment } from '../../transactions/graphql/fragments';
 
 import * as fragments from './fragments';
 
@@ -203,49 +199,6 @@ export const collectivePageQuery = gql`
   ${fragments.contributeCardProjectFieldsFragment}
 `;
 /* eslint-enable graphql/template-strings */
-
-export const budgetSectionQuery = gqlV2/* GraphQL */ `
-  query BudgetSection($slug: String!, $limit: Int!, $kind: [TransactionKind]) {
-    transactions(account: { slug: $slug }, limit: $limit, hasExpense: false, kind: $kind) {
-      ...TransactionsQueryCollectionFragment
-    }
-    expenses(account: { slug: $slug }, limit: $limit) {
-      totalCount
-      nodes {
-        ...ExpensesListFieldsFragment
-      }
-    }
-    account(slug: $slug) {
-      id
-      stats {
-        id
-        balance {
-          valueInCents
-          currency
-        }
-        yearlyBudget {
-          valueInCents
-          currency
-        }
-        activeRecurringContributions
-        totalAmountReceived(periodInMonths: 12) {
-          valueInCents
-          currency
-        }
-        totalAmountRaised: totalAmountReceived {
-          valueInCents
-          currency
-        }
-        totalNetAmountRaised: totalNetAmountReceived {
-          valueInCents
-          currency
-        }
-      }
-    }
-  }
-  ${transactionsQueryCollectionFragment}
-  ${expensesListFieldsFragment}
-`;
 
 export const getCollectivePageQueryVariables = slug => {
   return {

--- a/components/host-dashboard/AddFundsModal.js
+++ b/components/host-dashboard/AddFundsModal.js
@@ -11,12 +11,8 @@ import { formatCurrency } from '../../lib/currency-utils';
 import { requireFields } from '../../lib/form-utils';
 import { API_V2_CONTEXT, gqlV2 } from '../../lib/graphql/helpers';
 
-import {
-  budgetSectionQuery,
-  collectivePageQuery,
-  getCollectivePageQueryVariables,
-} from '../collective-page/graphql/queries';
-import { getBudgetSectionQueryVariables } from '../collective-page/sections/Budget';
+import { collectivePageQuery, getCollectivePageQueryVariables } from '../collective-page/graphql/queries';
+import { getBudgetSectionQuery, getBudgetSectionQueryVariables } from '../collective-page/sections/Budget';
 import { DefaultCollectiveLabel } from '../CollectivePicker';
 import CollectivePickerAsync from '../CollectivePickerAsync';
 import Container from '../Container';
@@ -271,9 +267,9 @@ const AddFundsModal = ({ host, collective, ...props }) => {
     context: API_V2_CONTEXT,
     refetchQueries: [
       {
-        query: budgetSectionQuery,
         context: API_V2_CONTEXT,
-        variables: getBudgetSectionQueryVariables(collective.slug),
+        query: getBudgetSectionQuery(true),
+        variables: getBudgetSectionQueryVariables(collective.slug, host.slug),
       },
       { query: collectivePageQuery, variables: getCollectivePageQueryVariables(collective.slug) },
     ],
@@ -680,6 +676,7 @@ const AddFundsModal = ({ host, collective, ...props }) => {
 AddFundsModal.propTypes = {
   host: PropTypes.shape({
     id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    slug: PropTypes.string.isRequired,
     name: PropTypes.string,
     plan: PropTypes.shape({
       hostFees: PropTypes.bool,


### PR DESCRIPTION
Followup on https://github.com/opencollective/opencollective-api/pull/7077
Should resolve (hopefully, needs to be confirmed by Sentry) https://github.com/opencollective/opencollective/issues/5202

Add common fragments and helpers between the two versions of the budget query.