### PR TITLE
Make Status Tag Styles Consistent

### DIFF
--- a/components/transactions/TransactionItem.js
+++ b/components/transactions/TransactionItem.js
@@ -265,7 +265,10 @@ const TransactionItem = ({ displayActions, collective, transaction, onMutationSu
                 isRefund={isRefund}
                 isRefunded={isRefunded}
                 isOrderRejected={isOrderRejected}
-                fontSize="9px"
+                fontSize="12px"
+                fontWeight="bold"
+                lineHeight="16px"
+                letterSpacing="0.06em"
                 px="6px"
                 py="2px"
               />


### PR DESCRIPTION
Related https://github.com/opencollective/opencollective-frontend/pull/7470 and https://github.com/opencollective/opencollective/issues/5209

This is something I've missed in the above pull request where we've updated the status tags. I realized that the same styles should be applied to the transactions status tags to make things consistent. 

![image](https://user-images.githubusercontent.com/12435965/153393799-bafbec72-89bf-4f56-bdab-45c55280f7b4.png)
