### PR TITLE
Correct Scrolling Offset on Mobile

### DIFF
--- a/components/collective-navbar/NavBarCategoryDropdown.js
+++ b/components/collective-navbar/NavBarCategoryDropdown.js
@@ -178,16 +178,8 @@ NavBarCategory.propTypes = {
   category: PropTypes.oneOf(Object.values(NAVBAR_CATEGORIES)).isRequired,
 };
 
-const NavBarScrollContainer = ({ useAnchor, category, children }) => {
-  const isMobile = typeof window !== 'undefined' && window.matchMedia('only screen and (max-width: 640px)').matches;
-  return useAnchor ? (
-    <Scrollchor to={`#category-${category}`} animate={{ offset: isMobile ? -window.innerHeight : 0 }}>
-      {children}
-    </Scrollchor>
-  ) : (
-    children
-  );
-};
+const NavBarScrollContainer = ({ useAnchor, category, children }) =>
+  useAnchor ? <Scrollchor to={`#category-${category}`}>{children}</Scrollchor> : children;
 
 NavBarScrollContainer.propTypes = {
   category: PropTypes.oneOf(Object.values(NAVBAR_CATEGORIES)).isRequired,

--- a/components/collective-navbar/NavBarCategoryDropdown.js
+++ b/components/collective-navbar/NavBarCategoryDropdown.js
@@ -178,8 +178,16 @@ NavBarCategory.propTypes = {
   category: PropTypes.oneOf(Object.values(NAVBAR_CATEGORIES)).isRequired,
 };
 
-const NavBarScrollContainer = ({ useAnchor, category, children }) =>
-  useAnchor ? <Scrollchor to={`#category-${category}`}>{children}</Scrollchor> : children;
+const NavBarScrollContainer = ({ useAnchor, category, children }) => {
+  const isMobile = typeof window !== 'undefined' && window.matchMedia('only screen and (max-width: 640px)').matches;
+  return useAnchor ? (
+    <Scrollchor to={`#category-${category}`} animate={{ offset: isMobile ? -window.innerHeight : 0 }}>
+      {children}
+    </Scrollchor>
+  ) : (
+    children
+  );
+};
 
 NavBarScrollContainer.propTypes = {
   category: PropTypes.oneOf(Object.values(NAVBAR_CATEGORIES)).isRequired,

--- a/components/collective-navbar/index.js
+++ b/components/collective-navbar/index.js
@@ -452,7 +452,7 @@ const CollectiveNavbar = ({
     if (!outside && isExpanded) {
       setTimeout(() => {
         setExpanded(false);
-      }, 200);
+      }, 500);
     }
   });
 


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/5152

It seems that the root cause is that the scrolling happens before the navbar dropdown is collapsed thus we need to add an offset. However maybe there's a better fix, if we can make the scroll happen after the fact; but I couldn't come up with anything better for the moment. Let me know if you have any thoughts. 🤔 

![scroll-offset](https://user-images.githubusercontent.com/12435965/153586713-12385ba9-7829-4adb-beac-cca5c0f130e2.gif)

