### PR TITLE
Add parent url Part for Standalone Tier Pages

### DIFF
--- a/pages/tier.js
+++ b/pages/tier.js
@@ -2,6 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from '@apollo/client/react/hoc';
 import { get } from 'lodash';
+import { withRouter } from 'next/router';
+
+import { addParentToURLIfMissing } from '../lib/url-helpers';
 
 import CollectiveThemeProvider from '../components/CollectiveThemeProvider';
 import ErrorPage from '../components/ErrorPage';
@@ -27,7 +30,14 @@ class TierPage extends React.Component {
     LoggedInUser: PropTypes.object, // from withUser
     tierSlug: PropTypes.string,
     redirect: PropTypes.string,
+    router: PropTypes.object,
   };
+
+  componentDidMount() {
+    const { router, tierId, tierSlug, data } = this.props;
+    const collective = data?.Tier?.collective;
+    addParentToURLIfMissing(router, collective, `/contribute/${tierSlug}-${tierId}`);
+  }
 
   // See https://github.com/opencollective/opencollective/issues/1872
   shouldComponentUpdate(newProps) {
@@ -85,4 +95,4 @@ class TierPage extends React.Component {
 
 const addTierPageData = graphql(tierPageQuery);
 
-export default withUser(addTierPageData(TierPage));
+export default withRouter(withUser(addTierPageData(TierPage)));

--- a/rewrites.js
+++ b/rewrites.js
@@ -177,7 +177,8 @@ exports.REWRITES = [
   },
   // Tier page
   {
-    source: '/:collectiveSlug/:verb(tiers|contribute)/:tierSlug?-:tierId([0-9]+)',
+    source:
+      '/:parentCollectiveSlug?/:collectiveType(events|projects)?/:collectiveSlug/:verb(tiers|contribute)/:tierSlug?-:tierId([0-9]+)',
     destination: '/tier',
   },
   // Conversations


### PR DESCRIPTION
Originally posted on slack at, https://opencollective.slack.com/archives/C6JTTA4SK/p1644611739484079. 

Seems that we've missed adding the parent url parts for standalone tier pages. I've fixed that in this PR. 

Related to https://github.com/opencollective/opencollective/issues/5157

![tier-page-project-rul](https://user-images.githubusercontent.com/12435965/153847147-af04f5ee-a2f5-4d02-b561-ab8c3f87fb5f.gif)


