### PR TITLE
Fetch admin fields in the expense's list

### DIFF
--- a/components/expenses/PayoutBankInformationForm.js
+++ b/components/expenses/PayoutBankInformationForm.js
@@ -34,7 +34,9 @@ export const msg = defineMessages({
 const requiredFieldsQuery = gqlV2/* GraphQL */ `
   query PayoutBankInformationRequiredFields($slug: String, $currency: String!, $accountDetails: JSON) {
     host(slug: $slug) {
+      id
       transferwise {
+        id
         requiredFields(currency: $currency, accountDetails: $accountDetails) {
           type
           title
@@ -381,9 +383,11 @@ DetailsForm.propTypes = {
 const availableCurrenciesQuery = gqlV2/* GraphQL */ `
   query PayoutBankInformationAvailableCurrencies($slug: String, $ignoreBlockedCurrencies: Boolean) {
     host(slug: $slug) {
+      id
       slug
       currency
       transferwise {
+        id
         availableCurrencies(ignoreBlockedCurrencies: $ignoreBlockedCurrencies)
       }
     }

--- a/components/expenses/graphql/fragments.js
+++ b/components/expenses/graphql/fragments.js
@@ -109,6 +109,10 @@ export const expenseHostFields = gqlV2/* GraphQL */ `
       address
       country
     }
+    transferwise {
+      id
+      availableCurrencies
+    }
     supportedPayoutMethods
     isTrustedHost
     plan {

--- a/pages/create-expense.js
+++ b/pages/create-expense.js
@@ -458,6 +458,7 @@ const hostFieldsFragment = gqlV2/* GraphQL */ `
       country
     }
     transferwise {
+      id
       availableCurrencies
     }
     supportedPayoutMethods


### PR DESCRIPTION
It was not possible to pay with Wise/Automatic from the expenses list because of that. Added some `id`s to query to be more defensive with Apollo caching issues.