### PR TITLE
Document that dev install requires npm version 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you see a step below that could be improved (or is outdated), please update t
 
 ### Prerequisite
 
-1. Make sure you have Node.js version >= 14.
+1. Make sure you have Node.js version 14.x and NPM version 6.x. Verison 7 of NPM is currently not supported, because it changes the contents of the lockfile, see [issue #4177](https://github.com/opencollective/opencollective/issues/4177) for details.
 
 - We recommend using [nvm](https://github.com/creationix/nvm): `nvm use`.
 


### PR DESCRIPTION
# Description

This PR updates the developer documentation to state that version 14 of Node and version 6 of NPM is required and that newer versions are not, as of https://github.com/opencollective/opencollective/issues/4177.


I was trying to get started locally with a newer version of Node and NPM and it refused to install, as documented in the above issue:

```
$ npm install
npm WARN old lockfile
npm WARN old lockfile The package-lock.json file was created with an old version of npm,
npm WARN old lockfile so supplemental metadata must be fetched from the registry.
npm WARN old lockfile
npm WARN old lockfile This is a one-time fix-up, please be patient...
npm WARN old lockfile
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: opencollective-frontend@2.2.0
npm ERR! notsup Not compatible with your version of node/npm: opencollective-frontend@2.2.0
npm ERR! notsup Required: {"node":"14.x","npm":"6.x"}
npm ERR! notsup Actual:   {"npm":"8.4.1","node":"v17.5.0"}
```
