### PR TITLE
Fix updating recurring contributions for PayPal contributions with a tip

### DIFF
--- a/components/recurring-contributions/AddPaymentMethod.js
+++ b/components/recurring-contributions/AddPaymentMethod.js
@@ -52,8 +52,8 @@ const AddPaymentMethod = ({ onStripeReady, onPaypalSuccess, setNewPaymentMethodI
         )}
         {host.paypalClientId && (
           <PayWithPaypalButton
-            totalAmount={order.amount.valueInCents}
-            currency={order.amount.currency}
+            totalAmount={order.totalAmount.valueInCents}
+            currency={order.totalAmount.currency}
             interval={getIntervalFromContributionFrequency(order.frequency)}
             host={host}
             collective={order.toAccount}
@@ -93,7 +93,7 @@ AddPaymentMethod.propTypes = {
   onPaypalSuccess: PropTypes.func,
   isSubmitting: PropTypes.bool,
   order: PropTypes.shape({
-    amount: PropTypes.object,
+    totalAmount: PropTypes.object,
     frequency: PropTypes.string,
     toAccount: PropTypes.object,
     tier: PropTypes.object,

--- a/components/recurring-contributions/RecurringContributionsCard.js
+++ b/components/recurring-contributions/RecurringContributionsCard.js
@@ -113,13 +113,9 @@ const RecurringContributionsCard = ({
             </P>
             <P fontSize="14px" lineHeight="20px" fontWeight="bold" data-cy="recurring-contribution-amount-contributed">
               <FormattedMoneyAmount
-                amount={
-                  !isNil(contribution.platformTipAmount?.valueInCents)
-                    ? contribution.amount.valueInCents + contribution.platformTipAmount.valueInCents
-                    : contribution.amount.valueInCents
-                }
+                amount={contribution.totalAmount.valueInCents}
                 interval={contribution.frequency.toLowerCase().slice(0, -2)}
-                currency={contribution.amount.currency}
+                currency={contribution.totalAmount.currency}
               />
             </P>
             {!isNil(contribution.platformTipAmount?.valueInCents) && (
@@ -198,6 +194,7 @@ RecurringContributionsCard.propTypes = {
   onEdit: PropTypes.func,
   contribution: PropTypes.shape({
     amount: PropTypes.object.isRequired,
+    totalAmount: PropTypes.object.isRequired,
     platformTipAmount: PropTypes.object,
     frequency: PropTypes.string.isRequired,
     totalDonations: PropTypes.object.isRequired,

--- a/components/recurring-contributions/graphql/queries.js
+++ b/components/recurring-contributions/graphql/queries.js
@@ -43,6 +43,11 @@ export const recurringContributionsQuery = gqlV2/* GraphQL */ `
             valueInCents
             currency
           }
+          totalAmount {
+            value
+            valueInCents
+            currency
+          }
           status
           frequency
           tier {

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -1836,7 +1836,16 @@ type Order {
   id: String!
   legacyId: Int!
   description: String
+
+  """
+  Base order amount (without platform tip)
+  """
   amount: Amount!
+
+  """
+  Total order amount, including all taxes and platform tip
+  """
+  totalAmount: Amount!
   quantity: Int
   status: OrderStatus
   frequency: ContributionFrequency


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-api/pull/7177

We broke the update of recurring contributions with a tip when trying to use a PayPal account in https://github.com/opencollective/opencollective-api/pull/6121, because [this line](https://github.com/opencollective/opencollective-frontend/blob/c81b297e68c04ba54f1e265b85c227874f7af178/components/recurring-contributions/AddPaymentMethod.js#L55) in the frontend used the total amount to get the right PayPal plan. As a consequence, we were getting the plan for a lower amount (e.g. $20 instead of $23 for contributions that included a $3 tip) and therefore the API was rejecting it (because API checks that [the plan amount matches the order amount](https://github.com/opencollective/opencollective-api/blob/b8857e41392bbbddfd54d251201ab9b0f43e54a4/server/paymentProviders/paypal/subscription.ts#L306)).

There should be no other consequences and nothing to migrate, users that have been impacted by this just got an error message and probably tried another way.