### PR TITLE
Correct Rounding of Thousands in Money Managed Section - Host Dashboards

### DIFF
--- a/components/host-dashboard/reports-section/HostFeesSectionHistorical.js
+++ b/components/host-dashboard/reports-section/HostFeesSectionHistorical.js
@@ -109,11 +109,6 @@ const getChartOptions = (intl, hostCurrency) => ({
       formatter: value => formatAmountForLegend(value, hostCurrency, intl.locale),
     },
   },
-  tooltip: {
-    y: {
-      formatter: value => formatAmountForLegend(value, hostCurrency, intl.locale),
-    },
-  },
 });
 
 const SERIES_NAMES = defineMessages({

--- a/components/host-dashboard/reports-section/helpers.js
+++ b/components/host-dashboard/reports-section/helpers.js
@@ -1,3 +1,5 @@
+import { max, min } from 'lodash';
+
 export const getActiveYearsOptions = host => {
   const currentYear = new Date().getFullYear();
   const firstYear = host ? parseInt(host.createdAt.split('-')[0]) : currentYear;
@@ -5,11 +7,16 @@ export const getActiveYearsOptions = host => {
   return activeYears.map(year => ({ value: year, label: year })).reverse();
 };
 
-export const formatAmountForLegend = (value, currency, locale) => {
+export const formatAmountForLegend = (value, currency, locale, isCompactNotation = true) => {
   return new Intl.NumberFormat(locale, {
     currency,
     style: 'currency',
-    notation: 'compact',
-    compactDisplay: 'short',
+    notation: isCompactNotation ? 'compact' : 'standard',
   }).format(value);
+};
+
+export const getMinMaxDifference = numberArray => {
+  const minVal = min(numberArray);
+  const maxVal = max(numberArray);
+  return maxVal - minVal;
 };


### PR DESCRIPTION
This is initially reported at, https://opencollective.slack.com/archives/C02C146LFCP/p1645405685633519. In the money manged historical view currently we are formatting the y-axis values regardless of the upper and lower bounds resulting in duplicate labels for cases where there's only few values to show. 

This PR corrects this problem by making sure we only round when the diff between the max and min values is >= 10k.

![money-manged-formattting](https://user-images.githubusercontent.com/12435965/155411376-b77c2377-8d2b-45bb-8d89-be6ed05a8ca3.gif)


