### PR TITLE
refactor: remove `show` prop from modals

### DIFF
--- a/components/AddFundsBtn.js
+++ b/components/AddFundsBtn.js
@@ -10,9 +10,7 @@ const AddFundsBtn = ({ children, collective, host }) => {
   return (
     <Fragment>
       {children({ onClick: () => setShowModal(true) })}
-      {showModal && (
-        <AddFundsModal collective={collective} host={host} setShow={setShowModal} onClose={() => setShowModal(null)} />
-      )}
+      {showModal && <AddFundsModal collective={collective} host={host} onClose={() => setShowModal(null)} />}
     </Fragment>
   );
 };

--- a/components/AddFundsBtn.js
+++ b/components/AddFundsBtn.js
@@ -11,13 +11,7 @@ const AddFundsBtn = ({ children, collective, host }) => {
     <Fragment>
       {children({ onClick: () => setShowModal(true) })}
       {showModal && (
-        <AddFundsModal
-          show
-          collective={collective}
-          host={host}
-          setShow={setShowModal}
-          onClose={() => setShowModal(null)}
-        />
+        <AddFundsModal collective={collective} host={host} setShow={setShowModal} onClose={() => setShowModal(null)} />
       )}
     </Fragment>
   );

--- a/components/ApplyToHostModal.js
+++ b/components/ApplyToHostModal.js
@@ -26,7 +26,7 @@ import StyledButton from './StyledButton';
 import StyledCheckbox from './StyledCheckbox';
 import StyledHr from './StyledHr';
 import StyledInputFormikField from './StyledInputFormikField';
-import Modal, { ModalBody, ModalFooter, ModalHeader } from './StyledModal';
+import StyledModal, { ModalBody, ModalFooter, ModalHeader } from './StyledModal';
 import StyledTextarea from './StyledTextarea';
 import { H1, P } from './Text';
 import { TOAST_TYPE, useToasts } from './ToastProvider';
@@ -202,7 +202,7 @@ const ApplyToHostModal = ({ hostSlug, collective, onClose, onSuccess, router, ..
   const isOCFHost = host?.legacyId === OPENCOLLECTIVE_FOUNDATION_ID;
 
   return (
-    <Modal onClose={onClose} width="570px" {...props}>
+    <StyledModal onClose={onClose} width="570px" {...props}>
       {loading ? (
         <React.Fragment>
           <ModalHeader hideCloseIcon>
@@ -439,7 +439,7 @@ const ApplyToHostModal = ({ hostSlug, collective, onClose, onSuccess, router, ..
           )}
         </Formik>
       )}
-    </Modal>
+    </StyledModal>
   );
 };
 
@@ -451,10 +451,6 @@ ApplyToHostModal.propTypes = {
   /** Use this to force the value for `collective`. If not specified, user's administrated collectives will be displayed instead */
   collective: PropTypes.object,
   router: PropTypes.object,
-};
-
-ApplyToHostModal.defaultProps = {
-  show: true,
 };
 
 export default withRouter(ApplyToHostModal);

--- a/components/AssignVirtualCardBtn.js
+++ b/components/AssignVirtualCardBtn.js
@@ -23,14 +23,14 @@ const AssignVirtualCardBtn = ({ children, collective, host }) => {
   return (
     <Fragment>
       {children({ onClick: () => setShowModal(true) })}
-      <AssignVirtualCardModal
-        host={host}
-        collective={collective}
-        onClose={() => setShowModal(false)}
-        setShow={setShowModal}
-        onSuccess={handleAssignCardSuccess}
-        show={showModal}
-      />
+      {showModal && (
+        <AssignVirtualCardModal
+          host={host}
+          collective={collective}
+          onClose={() => setShowModal(false)}
+          onSuccess={handleAssignCardSuccess}
+        />
+      )}
     </Fragment>
   );
 };

--- a/components/ConfirmationModal.js
+++ b/components/ConfirmationModal.js
@@ -4,7 +4,7 @@ import { defineMessages, useIntl } from 'react-intl';
 
 import Container from './Container';
 import StyledButton from './StyledButton';
-import Modal, { ModalBody, ModalFooter, ModalHeader } from './StyledModal';
+import StyledModal, { ModalBody, ModalFooter, ModalHeader } from './StyledModal';
 import { P } from './Text';
 
 const messages = defineMessages({
@@ -34,7 +34,6 @@ const confirmBtnMsgs = defineMessages({
  * confirmation purpose.
  */
 const ConfirmationModal = ({
-  show,
   header,
   body,
   children,
@@ -53,7 +52,7 @@ const ConfirmationModal = ({
   const { formatMessage } = useIntl();
 
   return (
-    <Modal role="alertdialog" width="570px" show={show} onClose={onClose} trapFocus {...props}>
+    <StyledModal role="alertdialog" width="570px" onClose={onClose} trapFocus {...props}>
       <ModalHeader onClose={onClose}>{header}</ModalHeader>
       <ModalBody pt={2}>{children || <P>{body}</P>}</ModalBody>
       <ModalFooter>
@@ -89,13 +88,11 @@ const ConfirmationModal = ({
           </StyledButton>
         </Container>
       </ModalFooter>
-    </Modal>
+    </StyledModal>
   );
 };
 
 ConfirmationModal.propTypes = {
-  /** a boolean to determin when to show modal */
-  show: PropTypes.bool.isRequired,
   /** header of the confirmation modal */
   header: PropTypes.node.isRequired,
   /** body of the confirmation modal */

--- a/components/ContactCollectiveModal.js
+++ b/components/ContactCollectiveModal.js
@@ -2,22 +2,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import CollectiveContactForm from './CollectiveContactForm';
-import Modal, { ModalHeader } from './StyledModal';
+import StyledModal, { ModalHeader } from './StyledModal';
 
-const ContactCollectiveModal = ({ collective, onClose, show }) => {
+const ContactCollectiveModal = ({ collective, onClose }) => {
   return (
-    <Modal role="alertdialog" width="578px" show={show} onClose={onClose} trapFocus>
+    <StyledModal role="alertdialog" width="578px" onClose={onClose} trapFocus>
       <ModalHeader />
       <CollectiveContactForm collective={collective} isModal onClose={onClose} />
-    </Modal>
+    </StyledModal>
   );
 };
 
 ContactCollectiveModal.propTypes = {
   /** the collective that is contacted */
   collective: PropTypes.object,
-  /** a boolean to determine when to show modal */
-  show: PropTypes.bool.isRequired,
   /** handles how the modal is closed */
   onClose: PropTypes.func.isRequired,
 };

--- a/components/ContributionConfirmationModal.js
+++ b/components/ContributionConfirmationModal.js
@@ -12,7 +12,7 @@ import { Box, Flex } from './Grid';
 import StyledButton from './StyledButton';
 import StyledHr from './StyledHr';
 import StyledInputAmount from './StyledInputAmount';
-import Modal, { ModalBody, ModalFooter, ModalHeader } from './StyledModal';
+import StyledModal, { ModalBody, ModalFooter, ModalHeader } from './StyledModal';
 import { P, Span } from './Text';
 import { TOAST_TYPE, useToasts } from './ToastProvider';
 
@@ -38,7 +38,7 @@ const confirmContributionMutation = gqlV2/* GraphQL */ `
   }
 `;
 
-const ContributionConfirmationModal = ({ order, onClose, show }) => {
+const ContributionConfirmationModal = ({ order, onClose }) => {
   const platformTipAmount = order.platformTipAmount?.valueInCents || 0;
   const amountInitiated = order.amount.valueInCents + platformTipAmount;
   const currency = order.amount.currency;
@@ -85,7 +85,7 @@ const ContributionConfirmationModal = ({ order, onClose, show }) => {
   };
 
   return (
-    <Modal width="578px" show={show} onClose={onClose} trapFocus>
+    <StyledModal width="578px" onClose={onClose} trapFocus>
       <ModalHeader>
         <FormattedMessage defaultMessage="Confirm Contribution" />
       </ModalHeader>
@@ -203,15 +203,13 @@ const ContributionConfirmationModal = ({ order, onClose, show }) => {
           </StyledButton>
         </Container>
       </ModalFooter>
-    </Modal>
+    </StyledModal>
   );
 };
 
 ContributionConfirmationModal.propTypes = {
   /** the order that is being confirmed */
   order: PropTypes.object,
-  /** a boolean to determine when to show modal */
-  show: PropTypes.bool.isRequired,
   /** handles how the modal is closed */
   onClose: PropTypes.func.isRequired,
 };

--- a/components/CreateVirtualCardBtn.js
+++ b/components/CreateVirtualCardBtn.js
@@ -26,7 +26,6 @@ const CreateVirtualCardBtn = ({ children, host, collective }) => {
           host={host}
           collective={collective}
           onClose={() => setShowModal(false)}
-          setShow={setShowModal}
           onSuccess={handleCreateCardSuccess}
         />
       )}

--- a/components/CreateVirtualCardBtn.js
+++ b/components/CreateVirtualCardBtn.js
@@ -21,14 +21,15 @@ const CreateVirtualCardBtn = ({ children, host, collective }) => {
   return (
     <Fragment>
       {children({ onClick: () => setShowModal(true) })}
-      <CreateVirtualCardModal
-        host={host}
-        collective={collective}
-        onClose={() => setShowModal(false)}
-        setShow={setShowModal}
-        onSuccess={handleCreateCardSuccess}
-        show={showModal}
-      />
+      {showModal && (
+        <CreateVirtualCardModal
+          host={host}
+          collective={collective}
+          onClose={() => setShowModal(false)}
+          setShow={setShowModal}
+          onSuccess={handleCreateCardSuccess}
+        />
+      )}
     </Fragment>
   );
 };

--- a/components/GlobalNewsAndUpdates.js
+++ b/components/GlobalNewsAndUpdates.js
@@ -6,7 +6,7 @@ import { useNewsAndUpdates } from './NewsAndUpdatesProvider';
 
 const GlobalNewsAndUpdates = () => {
   const { showNewsAndUpdates, setShowNewsAndUpdates } = useNewsAndUpdates();
-  return <NewsAndUpdatesModal show={showNewsAndUpdates} onClose={() => setShowNewsAndUpdates(false)} />;
+  return showNewsAndUpdates ? <NewsAndUpdatesModal onClose={() => setShowNewsAndUpdates(false)} /> : null;
 };
 
 GlobalNewsAndUpdates.propTypes = {

--- a/components/NewsAndUpdatesModal.js
+++ b/components/NewsAndUpdatesModal.js
@@ -17,14 +17,14 @@ import MessageBox from './MessageBox';
 import StyledButton from './StyledButton';
 import StyledCarousel from './StyledCarousel';
 import StyledLink from './StyledLink';
-import Modal, { ModalBody, ModalFooter, ModalHeader } from './StyledModal';
+import StyledModal, { ModalBody, ModalFooter, ModalHeader } from './StyledModal';
 import { P, Span } from './Text';
 
 const ModalHeaderWrapper = styled(ModalHeader)`
   height: 58px;
 `;
 
-const ModalWrapper = styled(Modal)`
+const ModalWrapper = styled(StyledModal)`
   padding-top: 8px;
   padding-bottom: 0px;
 `;

--- a/components/PublishUpdateBtnWithData.js
+++ b/components/PublishUpdateBtnWithData.js
@@ -120,7 +120,6 @@ const PublishUpdateBtn = ({ id, isHost, isChangelog }) => {
         )}
         {showModal ? (
           <ConfirmationModal
-            show
             onClose={() => setShowModal(false)}
             continueLabel={<FormattedMessage id="update.publish.btn" defaultMessage="Publish" />}
             header={<FormattedMessage id="update.publish.modal.header" defaultMessage="Publish update" />}

--- a/components/RequestVirtualCardBtn.js
+++ b/components/RequestVirtualCardBtn.js
@@ -8,14 +8,7 @@ const RequestVirtualCardBtn = ({ children, collective, host }) => {
   return (
     <Fragment>
       {children({ onClick: () => setShowModal(true) })}
-      {showModal && (
-        <RequestVirtualCardModal
-          host={host}
-          collective={collective}
-          onClose={() => setShowModal(false)}
-          setShow={setShowModal}
-        />
-      )}
+      {showModal && <RequestVirtualCardModal host={host} collective={collective} onClose={() => setShowModal(false)} />}
     </Fragment>
   );
 };

--- a/components/RequestVirtualCardBtn.js
+++ b/components/RequestVirtualCardBtn.js
@@ -14,7 +14,6 @@ const RequestVirtualCardBtn = ({ children, collective, host }) => {
           collective={collective}
           onClose={() => setShowModal(false)}
           setShow={setShowModal}
-          show
         />
       )}
     </Fragment>

--- a/components/StyledModal.js
+++ b/components/StyledModal.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Times } from '@styled-icons/fa-solid/Times';
-import themeGet from '@styled-system/theme-get';
+import { themeGet } from '@styled-system/theme-get';
 import FocusTrap from 'focus-trap-react';
 import { createPortal } from 'react-dom';
 import styled, { createGlobalStyle, css } from 'styled-components';
@@ -179,18 +179,18 @@ ModalFooter.defaultProps = {
  * Modal component. Will pass down additional props to `ModalWrapper`, which is
  * a styled `Container`.
  */
-const StyledModal = ({ children, show, onClose, usePortal, trapFocus, ignoreEscapeKey, ...props }) => {
+const StyledModal = ({ children, onClose, usePortal, trapFocus, ignoreEscapeKey, ...props }) => {
   const TrapContainer = trapFocus ? FocusTrap : React.Fragment;
   const onEscape = React.useCallback(() => {
-    if (show && !ignoreEscapeKey) {
+    if (!ignoreEscapeKey) {
       onClose();
     }
-  }, [show]);
+  }, []);
 
   // Closes the modal upon the `ESC` key press.
   useKeyBoardShortcut({ callback: onEscape, keyMatch: ESCAPE_KEY });
 
-  if (show && usePortal === false) {
+  if (usePortal === false) {
     return (
       <React.Fragment>
         <GlobalModalStyle />
@@ -209,7 +209,7 @@ const StyledModal = ({ children, show, onClose, usePortal, trapFocus, ignoreEsca
       </React.Fragment>
     );
   }
-  if (show && typeof document !== 'undefined') {
+  if (typeof document !== 'undefined') {
     return createPortal(
       <React.Fragment>
         <GlobalModalStyle />
@@ -245,8 +245,6 @@ const StyledModal = ({ children, show, onClose, usePortal, trapFocus, ignoreEsca
 };
 
 StyledModal.propTypes = {
-  /** a boolean to determine when to show modal */
-  show: PropTypes.bool.isRequired,
   /** width of the modal component */
   width: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array]),
   /** height of the modal component */

--- a/components/accept-financial-contributions/HostCollectiveCard.js
+++ b/components/accept-financial-contributions/HostCollectiveCard.js
@@ -29,7 +29,7 @@ const messages = defineMessages({
 });
 
 const HostCollectiveCard = ({ host, collective, onChange, ...props }) => {
-  const [show, setShow] = useState(false);
+  const [showModal, setShowModal] = useState(false);
   const { formatMessage, locale } = useIntl();
 
   return (
@@ -58,7 +58,7 @@ const HostCollectiveCard = ({ host, collective, onChange, ...props }) => {
             mb={2}
             px={3}
             onClick={() => {
-              setShow(true);
+              setShowModal(true);
               onChange('chosenHost', host);
             }}
             data-cy="afc-host-apply-button"
@@ -67,12 +67,11 @@ const HostCollectiveCard = ({ host, collective, onChange, ...props }) => {
           </StyledButton>
         </Container>
       </StyledCollectiveCard>
-      {show && (
+      {showModal && (
         <ApplyToHostModal
           hostSlug={host.slug}
           collective={collective}
-          show={show}
-          onClose={() => setShow(false)}
+          onClose={() => setShowModal(false)}
           onSuccess={() => {
             return props.router
               .push(`${collective.slug}/accept-financial-contributions/host/success`)

--- a/components/budget/ExpenseBudgetItem.js
+++ b/components/budget/ExpenseBudgetItem.js
@@ -336,7 +336,6 @@ const ExpenseBudgetItem = ({
       </Flex>
       {hasFilesPreview && (
         <ExpenseFilesPreviewModal
-          show
           collective={expense.account}
           expense={expense}
           onClose={() => showFilesPreview(false)}

--- a/components/collective-navbar/ActionsMenu.js
+++ b/components/collective-navbar/ActionsMenu.js
@@ -388,11 +388,9 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction, hiddenActionFo
           )}
         </ActionsDropdown>
       </Box>
-      <ContactCollectiveModal
-        show={showContactModal}
-        collective={collective}
-        onClose={() => setShowContactModal(false)}
-      />
+      {showContactModal && (
+        <ContactCollectiveModal collective={collective} onClose={() => setShowContactModal(false)} />
+      )}
     </Container>
   );
 };

--- a/components/collective-page/hero/Hero.js
+++ b/components/collective-page/hero/Hero.js
@@ -45,7 +45,7 @@ const HeroEventDetails = dynamic(() => import('./HeroEventDetails'));
 const HeroBackgroundCropperModal = dynamic(() => import('./HeroBackgroundCropperModal'), {
   loading() {
     return (
-      <StyledModal show>
+      <StyledModal>
         <LoadingPlaceholder height={300} minWidth={280} />
       </StyledModal>
     );
@@ -337,11 +337,9 @@ const Hero = ({ collective, host, isAdmin, onPrimaryColorChange }) => {
           )}
         </ContainerSectionContent>
       </Container>
-      <ContactCollectiveModal
-        show={showContactModal}
-        collective={collective}
-        onClose={() => setShowContactModal(false)}
-      />
+      {showContactModal && (
+        <ContactCollectiveModal collective={collective} onClose={() => setShowContactModal(false)} />
+      )}
     </Fragment>
   );
 };

--- a/components/collective-page/hero/HeroAvatar.js
+++ b/components/collective-page/hero/HeroAvatar.js
@@ -196,7 +196,6 @@ const HeroAvatar = ({ collective, isAdmin, intl }) => {
         </Dropzone>
         {showModal && (
           <ConfirmationModal
-            show={showModal}
             width="100%"
             maxWidth="570px"
             onClose={() => {

--- a/components/collective-page/hero/HeroBackgroundCropperModal.js
+++ b/components/collective-page/hero/HeroBackgroundCropperModal.js
@@ -83,7 +83,7 @@ const HeroBackgroundCropperModal = ({ onClose, collective }) => {
   };
 
   return (
-    <StyledModal show onClose={onClose} ignoreEscapeKey>
+    <StyledModal onClose={onClose} ignoreEscapeKey>
       <ModalHeader mb={3}>
         <Span fontSize="20px" fontWeight="500">
           <FormattedMessage defaultMessage="Add cover image" />

--- a/components/collective-page/sections/OurTeam.js
+++ b/components/collective-page/sections/OurTeam.js
@@ -58,11 +58,9 @@ const SectionOurTeam = ({ collective, coreContributors, LoggedInUser }) => {
           </Container>
         )}
       </Container>
-      <ContactCollectiveModal
-        show={showContactModal}
-        collective={collective}
-        onClose={() => setShowContactModal(false)}
-      />
+      {showContactModal && (
+        <ContactCollectiveModal collective={collective} onClose={() => setShowContactModal(false)} />
+      )}
     </ContainerSectionContent>
   );
 };

--- a/components/contribution-flow/ChangeTierWarningModal.js
+++ b/components/contribution-flow/ChangeTierWarningModal.js
@@ -5,10 +5,9 @@ import { FormattedMessage } from 'react-intl';
 import ConfirmationModal from '../ConfirmationModal';
 import { P } from '../Text';
 
-const ChangeTierWarningModal = ({ show, onClose, tierName, onConfirm }) => {
+const ChangeTierWarningModal = ({ onClose, tierName, onConfirm }) => {
   return (
     <ConfirmationModal
-      show={show}
       width="100%"
       maxWidth="570px"
       onClose={onClose}
@@ -27,8 +26,6 @@ const ChangeTierWarningModal = ({ show, onClose, tierName, onConfirm }) => {
 };
 
 ChangeTierWarningModal.propTypes = {
-  /** a boolean to know when to show modal */
-  show: PropTypes.bool.isRequired,
   /** handles how the modal is closed */
   onClose: PropTypes.func.isRequired,
   onConfirm: PropTypes.func.isRequired,

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -237,7 +237,6 @@ const StepDetails = ({ onChange, data, collective, tier, showFeesOnTop, router, 
       )}
       {temporaryInterval !== undefined && (
         <ChangeTierWarningModal
-          show
           tierName={tier.name}
           onClose={() => setTemporaryInterval(undefined)}
           onConfirm={() => {

--- a/components/conversations/CommentActions.js
+++ b/components/conversations/CommentActions.js
@@ -177,7 +177,6 @@ const CommentActions = ({ comment, isConversationRoot, canEdit, canDelete, onDel
       {/** Confirm Modals */}
       {isDeleting && (
         <ConfirmationModal
-          show
           isDanger
           type="delete"
           onClose={() => setDeleting(false)}

--- a/components/edit-collective/AssignVirtualCardModal.js
+++ b/components/edit-collective/AssignVirtualCardModal.js
@@ -18,7 +18,7 @@ import StyledInput from '../StyledInput';
 import StyledInputField from '../StyledInputField';
 import StyledInputGroup from '../StyledInputGroup';
 import StyledInputMask from '../StyledInputMask';
-import Modal, { ModalBody, ModalFooter, ModalHeader } from '../StyledModal';
+import StyledModal, { ModalBody, ModalFooter, ModalHeader } from '../StyledModal';
 import StyledSelect from '../StyledSelect';
 import { P } from '../Text';
 import { TOAST_TYPE, useToasts } from '../ToastProvider';
@@ -170,7 +170,7 @@ const AssignVirtualCardModal = ({ collective, host, onSuccess, onClose, ...modal
   const collectiveUsers = users?.account?.members.nodes.map(node => node.account);
 
   return (
-    <Modal width="382px" onClose={handleClose} trapFocus {...modalProps}>
+    <StyledModal width="382px" onClose={handleClose} trapFocus {...modalProps}>
       <form onSubmit={formik.handleSubmit}>
         <ModalHeader onClose={handleClose}>
           <FormattedMessage id="Host.VirtualCards.AssignCard" defaultMessage="Assign Card" />
@@ -385,7 +385,7 @@ const AssignVirtualCardModal = ({ collective, host, onSuccess, onClose, ...modal
           </Container>
         </ModalFooter>
       </form>
-    </Modal>
+    </StyledModal>
   );
 };
 

--- a/components/edit-collective/CreateVirtualCardModal.js
+++ b/components/edit-collective/CreateVirtualCardModal.js
@@ -16,7 +16,7 @@ import StyledHr from '../StyledHr';
 import StyledInput from '../StyledInput';
 import StyledInputAmount from '../StyledInputAmount';
 import StyledInputField from '../StyledInputField';
-import Modal, { ModalBody, ModalFooter, ModalHeader } from '../StyledModal';
+import StyledModal, { ModalBody, ModalFooter, ModalHeader } from '../StyledModal';
 import { P } from '../Text';
 import { TOAST_TYPE, useToasts } from '../ToastProvider';
 
@@ -155,7 +155,7 @@ const CreateVirtualCardModal = ({ host, collective, onSuccess, onClose, ...modal
   const collectiveUsers = users?.account?.members.nodes.map(node => node.account);
 
   return (
-    <Modal width="382px" onClose={handleClose} trapFocus {...modalProps}>
+    <StyledModal width="382px" onClose={handleClose} trapFocus {...modalProps}>
       <form onSubmit={formik.handleSubmit}>
         <ModalHeader onClose={handleClose}>
           <FormattedMessage defaultMessage="Create virtual card" />
@@ -272,7 +272,7 @@ const CreateVirtualCardModal = ({ host, collective, onSuccess, onClose, ...modal
           </Container>
         </ModalFooter>
       </form>
-    </Modal>
+    </StyledModal>
   );
 };
 

--- a/components/edit-collective/DeleteVirtualCardModal.js
+++ b/components/edit-collective/DeleteVirtualCardModal.js
@@ -8,7 +8,7 @@ import { API_V2_CONTEXT, gqlV2 } from '../../lib/graphql/helpers';
 
 import Container from '../Container';
 import StyledButton from '../StyledButton';
-import Modal, { ModalBody, ModalFooter, ModalHeader } from '../StyledModal';
+import StyledModal, { ModalBody, ModalFooter, ModalHeader } from '../StyledModal';
 import { P } from '../Text';
 import { TOAST_TYPE, useToasts } from '../ToastProvider';
 
@@ -58,7 +58,7 @@ const DeleteVirtualCardModal = ({ virtualCard, onSuccess, onClose, ...modalProps
   };
 
   return (
-    <Modal width="382px" onClose={handleClose} trapFocus {...modalProps}>
+    <StyledModal width="382px" onClose={handleClose} trapFocus {...modalProps}>
       <form onSubmit={formik.handleSubmit}>
         <ModalHeader onClose={handleClose}>
           <FormattedMessage defaultMessage="Delete virtual card" />
@@ -84,7 +84,7 @@ const DeleteVirtualCardModal = ({ virtualCard, onSuccess, onClose, ...modalProps
           </Container>
         </ModalFooter>
       </form>
-    </Modal>
+    </StyledModal>
   );
 };
 

--- a/components/edit-collective/EditVirtualCardModal.js
+++ b/components/edit-collective/EditVirtualCardModal.js
@@ -15,7 +15,7 @@ import StyledHr from '../StyledHr';
 import StyledInput from '../StyledInput';
 import StyledInputAmount from '../StyledInputAmount';
 import StyledInputField from '../StyledInputField';
-import Modal, { ModalBody, ModalFooter, ModalHeader } from '../StyledModal';
+import StyledModal, { ModalBody, ModalFooter, ModalHeader } from '../StyledModal';
 import { P } from '../Text';
 import { TOAST_TYPE, useToasts } from '../ToastProvider';
 
@@ -150,7 +150,7 @@ const EditVirtualCardModal = ({ virtualCard, onSuccess, onClose, ...modalProps }
   const collectiveUsers = users?.account?.members.nodes.map(node => node.account);
 
   return (
-    <Modal width="382px" onClose={handleClose} trapFocus {...modalProps}>
+    <StyledModal width="382px" onClose={handleClose} trapFocus {...modalProps}>
       <form onSubmit={formik.handleSubmit}>
         <ModalHeader onClose={handleClose}>
           <FormattedMessage defaultMessage="Edit virtual card" />
@@ -241,7 +241,7 @@ const EditVirtualCardModal = ({ virtualCard, onSuccess, onClose, ...modalProps }
           </Container>
         </ModalFooter>
       </form>
-    </Modal>
+    </StyledModal>
   );
 };
 

--- a/components/edit-collective/RequestVirtualCardModal.js
+++ b/components/edit-collective/RequestVirtualCardModal.js
@@ -16,7 +16,7 @@ import StyledHr from '../StyledHr';
 import StyledInput from '../StyledInput';
 import StyledInputAmount from '../StyledInputAmount';
 import StyledInputField from '../StyledInputField';
-import Modal, { ModalBody, ModalFooter, ModalHeader } from '../StyledModal';
+import StyledModal, { ModalBody, ModalFooter, ModalHeader } from '../StyledModal';
 import StyledTextarea from '../StyledTextarea';
 import { P, Span } from '../Text';
 import { TOAST_TYPE, useToasts } from '../ToastProvider';
@@ -81,7 +81,7 @@ const RequestVirtualCardModal = props => {
   };
 
   return (
-    <Modal width="382px" onClose={handleClose} trapFocus {...props}>
+    <StyledModal width="382px" onClose={handleClose} trapFocus {...props}>
       <form onSubmit={formik.handleSubmit}>
         <ModalHeader onClose={props.onClose}>
           <FormattedMessage id="Collective.VirtualCards.RequestCard" defaultMessage="Request a Card" />
@@ -219,7 +219,7 @@ const RequestVirtualCardModal = props => {
           </Container>
         </ModalFooter>
       </form>
-    </Modal>
+    </StyledModal>
   );
 };
 

--- a/components/edit-collective/SendFundsToCollectiveSection.js
+++ b/components/edit-collective/SendFundsToCollectiveSection.js
@@ -7,7 +7,7 @@ import { formatCurrency } from '../../lib/currency-utils';
 import Container from '../Container';
 import SendMoneyToCollectiveBtn from '../SendMoneyToCollectiveBtn';
 import StyledButton from '../StyledButton';
-import Modal, { ModalBody, ModalFooter, ModalHeader } from '../StyledModal';
+import StyledModal, { ModalBody, ModalFooter, ModalHeader } from '../StyledModal';
 import { P } from '../Text';
 
 const SendFundsToCollectiveSection = ({ collective, toCollective, LoggedInUser }) => {
@@ -45,38 +45,40 @@ const SendFundsToCollectiveSection = ({ collective, toCollective, LoggedInUser }
           />
         </StyledButton>
       )}
-      <Modal show={modal.show} width="570px" onClose={closeModal}>
-        <ModalHeader onClose={closeModal}>
-          <FormattedMessage
-            id="collective.emptyBalance.header"
-            values={{ action: modal.type }}
-            defaultMessage={'{action} Balance'}
-          />
-        </ModalHeader>
-        <ModalBody>
-          <P>
+      {modal.show && (
+        <StyledModal width="570px" onClose={closeModal}>
+          <ModalHeader onClose={closeModal}>
             <FormattedMessage
-              id="collective.emptyBalance.body"
-              values={{ collective: toCollective.name, action: modal.type.toLowerCase() }}
-              defaultMessage={'Are you sure you want to {action} to {collective}?'}
+              id="collective.emptyBalance.header"
+              values={{ action: modal.type }}
+              defaultMessage={'{action} Balance'}
             />
-          </P>
-        </ModalBody>
-        <ModalFooter>
-          <Container display="flex" justifyContent="flex-end">
-            <StyledButton mx={20} onClick={() => setModal({ ...modal, show: false, isApproved: false })}>
-              <FormattedMessage id="actions.cancel" defaultMessage={'Cancel'} />
-            </StyledButton>
-            <StyledButton
-              buttonStyle="primary"
-              data-cy="action"
-              onClick={() => setModal({ ...modal, show: false, isApproved: true })}
-            >
-              <FormattedMessage id="confirm" defaultMessage={'Confirm'} />
-            </StyledButton>
-          </Container>
-        </ModalFooter>
-      </Modal>
+          </ModalHeader>
+          <ModalBody>
+            <P>
+              <FormattedMessage
+                id="collective.emptyBalance.body"
+                values={{ collective: toCollective.name, action: modal.type.toLowerCase() }}
+                defaultMessage={'Are you sure you want to {action} to {collective}?'}
+              />
+            </P>
+          </ModalBody>
+          <ModalFooter>
+            <Container display="flex" justifyContent="flex-end">
+              <StyledButton mx={20} onClick={() => setModal({ ...modal, show: false, isApproved: false })}>
+                <FormattedMessage id="actions.cancel" defaultMessage={'Cancel'} />
+              </StyledButton>
+              <StyledButton
+                buttonStyle="primary"
+                data-cy="action"
+                onClick={() => setModal({ ...modal, show: false, isApproved: true })}
+              >
+                <FormattedMessage id="confirm" defaultMessage={'Confirm'} />
+              </StyledButton>
+            </Container>
+          </ModalFooter>
+        </StyledModal>
+      )}
     </Fragment>
   );
 };

--- a/components/edit-collective/actions/Archive.js
+++ b/components/edit-collective/actions/Archive.js
@@ -11,7 +11,7 @@ import Container from '../../Container';
 import { getI18nLink } from '../../I18nFormatters';
 import MessageBox from '../../MessageBox';
 import StyledButton from '../../StyledButton';
-import Modal, { ModalBody, ModalFooter, ModalHeader } from '../../StyledModal';
+import StyledModal, { ModalBody, ModalFooter, ModalHeader } from '../../StyledModal';
 import { P } from '../../Text';
 import SettingsSectionTitle from '../sections/SettingsSectionTitle';
 
@@ -185,69 +185,71 @@ const ArchiveCollective = ({ collective }) => {
         </StyledButton>
       )}
 
-      <Modal show={modal.show} width="570px" onClose={closeModal}>
-        <ModalHeader onClose={closeModal}>
-          {modal.type === 'Unarchive' ? (
-            <FormattedMessage
-              id="unarchive.modal.header"
-              defaultMessage="Unarchive {name}"
-              values={{ name: collective.name }}
-            />
-          ) : (
-            <FormattedMessage
-              id="archive.modal.header"
-              defaultMessage="Archive {name}"
-              values={{ name: collective.name }}
-            />
-          )}
-        </ModalHeader>
-        <ModalBody>
-          <P>
-            {modal.type !== 'Unarchive' && (
+      {modal.show && (
+        <StyledModal width="570px" onClose={closeModal}>
+          <ModalHeader onClose={closeModal}>
+            {modal.type === 'Unarchive' ? (
               <FormattedMessage
-                id="archive.account.confirmation"
-                defaultMessage={
-                  'Are you sure you want to archive {type, select, EVENT {this Event} PROJECT {this Project} FUND {this Fund} COLLECTIVE {this Collective} ORGANIZATION {this Organization} other {this account}}?'
-                }
-                values={{ type: collective.type }}
+                id="unarchive.modal.header"
+                defaultMessage="Unarchive {name}"
+                values={{ name: collective.name }}
+              />
+            ) : (
+              <FormattedMessage
+                id="archive.modal.header"
+                defaultMessage="Archive {name}"
+                values={{ name: collective.name }}
               />
             )}
-            {modal.type === 'Unarchive' && (
-              <FormattedMessage
-                id="unarchive.account.confirmation"
-                defaultMessage={
-                  'Are you sure you want to unarchive {type, select, EVENT {this Event} PROJECT {this Project} FUND {this Fund} COLLECTIVE {this Collective} ORGANIZATION {this Organization} other {this account}}?'
-                }
-                values={{ type: collective.type }}
-              />
-            )}
-          </P>
-        </ModalBody>
-        <ModalFooter>
-          <Container display="flex" justifyContent="flex-end">
-            <StyledButton mx={20} onClick={() => setModal({ ...modal, show: false })}>
-              <FormattedMessage id="actions.cancel" defaultMessage={'Cancel'} />
-            </StyledButton>
-            <StyledButton
-              buttonStyle="primary"
-              data-cy="action"
-              onClick={() => {
-                if (modal.type === 'Unarchive') {
-                  handleUnarchiveCollective({ id: collective.id });
-                } else {
-                  handleArchiveCollective({ id: collective.id });
-                }
-              }}
-            >
-              {modal.type === 'Unarchive' ? (
-                <FormattedMessage id="collective.unarchive.confirm.btn" defaultMessage={'Unarchive'} />
-              ) : (
-                <FormattedMessage id="collective.archive.confirm.btn" defaultMessage={'Archive'} />
+          </ModalHeader>
+          <ModalBody>
+            <P>
+              {modal.type !== 'Unarchive' && (
+                <FormattedMessage
+                  id="archive.account.confirmation"
+                  defaultMessage={
+                    'Are you sure you want to archive {type, select, EVENT {this Event} PROJECT {this Project} FUND {this Fund} COLLECTIVE {this Collective} ORGANIZATION {this Organization} other {this account}}?'
+                  }
+                  values={{ type: collective.type }}
+                />
               )}
-            </StyledButton>
-          </Container>
-        </ModalFooter>
-      </Modal>
+              {modal.type === 'Unarchive' && (
+                <FormattedMessage
+                  id="unarchive.account.confirmation"
+                  defaultMessage={
+                    'Are you sure you want to unarchive {type, select, EVENT {this Event} PROJECT {this Project} FUND {this Fund} COLLECTIVE {this Collective} ORGANIZATION {this Organization} other {this account}}?'
+                  }
+                  values={{ type: collective.type }}
+                />
+              )}
+            </P>
+          </ModalBody>
+          <ModalFooter>
+            <Container display="flex" justifyContent="flex-end">
+              <StyledButton mx={20} onClick={() => setModal({ ...modal, show: false })}>
+                <FormattedMessage id="actions.cancel" defaultMessage={'Cancel'} />
+              </StyledButton>
+              <StyledButton
+                buttonStyle="primary"
+                data-cy="action"
+                onClick={() => {
+                  if (modal.type === 'Unarchive') {
+                    handleUnarchiveCollective({ id: collective.id });
+                  } else {
+                    handleArchiveCollective({ id: collective.id });
+                  }
+                }}
+              >
+                {modal.type === 'Unarchive' ? (
+                  <FormattedMessage id="collective.unarchive.confirm.btn" defaultMessage={'Unarchive'} />
+                ) : (
+                  <FormattedMessage id="collective.archive.confirm.btn" defaultMessage={'Archive'} />
+                )}
+              </StyledButton>
+            </Container>
+          </ModalFooter>
+        </StyledModal>
+      )}
     </Container>
   );
 };

--- a/components/edit-collective/actions/Delete.js
+++ b/components/edit-collective/actions/Delete.js
@@ -10,7 +10,7 @@ import { getErrorFromGraphqlException } from '../../../lib/errors';
 import Container from '../../Container';
 import { getI18nLink } from '../../I18nFormatters';
 import StyledButton from '../../StyledButton';
-import Modal, { ModalBody, ModalFooter, ModalHeader } from '../../StyledModal';
+import StyledModal, { ModalBody, ModalFooter, ModalHeader } from '../../StyledModal';
 import { P } from '../../Text';
 import { withUser } from '../../UserProvider';
 import SettingsSectionTitle from '../sections/SettingsSectionTitle';
@@ -141,43 +141,45 @@ const DeleteCollective = ({ collective, ...props }) => {
             />
           </P>
         )}
-      <Modal show={showModal} width="570px" onClose={closeModal}>
-        <ModalHeader onClose={closeModal}>
-          <FormattedMessage
-            id="collective.delete.modal.header"
-            defaultMessage={'Delete {name}'}
-            values={{ name: collective.name }}
-          />
-        </ModalHeader>
-        <ModalBody>
-          <P>
+      {showModal && (
+        <StyledModal width="570px" onClose={closeModal}>
+          <ModalHeader onClose={closeModal}>
             <FormattedMessage
-              id="collective.delete.modal.body"
-              defaultMessage={
-                'Are you sure you want to delete {type, select, EVENT {this Event} PROJECT {this Project} FUND {this Fund} COLLECTIVE {this Collective} ORGANIZATION {this Organization} other {this account}}?'
-              }
-              values={{ type: collective.type }}
+              id="collective.delete.modal.header"
+              defaultMessage={'Delete {name}'}
+              values={{ name: collective.name }}
             />
-          </P>
-        </ModalBody>
-        <ModalFooter>
-          <Container display="flex" justifyContent="flex-end">
-            <StyledButton mx={20} onClick={() => setShowModal(false)}>
-              <FormattedMessage id="actions.cancel" defaultMessage={'Cancel'} />
-            </StyledButton>
-            <StyledButton
-              buttonStyle="primary"
-              data-cy="delete"
-              onClick={() => {
-                setShowModal(false);
-                handleDelete();
-              }}
-            >
-              <FormattedMessage id="actions.delete" defaultMessage="Delete" />
-            </StyledButton>
-          </Container>
-        </ModalFooter>
-      </Modal>
+          </ModalHeader>
+          <ModalBody>
+            <P>
+              <FormattedMessage
+                id="collective.delete.modal.body"
+                defaultMessage={
+                  'Are you sure you want to delete {type, select, EVENT {this Event} PROJECT {this Project} FUND {this Fund} COLLECTIVE {this Collective} ORGANIZATION {this Organization} other {this account}}?'
+                }
+                values={{ type: collective.type }}
+              />
+            </P>
+          </ModalBody>
+          <ModalFooter>
+            <Container display="flex" justifyContent="flex-end">
+              <StyledButton mx={20} onClick={() => setShowModal(false)}>
+                <FormattedMessage id="actions.cancel" defaultMessage={'Cancel'} />
+              </StyledButton>
+              <StyledButton
+                buttonStyle="primary"
+                data-cy="delete"
+                onClick={() => {
+                  setShowModal(false);
+                  handleDelete();
+                }}
+              >
+                <FormattedMessage id="actions.delete" defaultMessage="Delete" />
+              </StyledButton>
+            </Container>
+          </ModalFooter>
+        </StyledModal>
+      )}
     </Container>
   );
 };

--- a/components/edit-collective/sections/BankTransfer.js
+++ b/components/edit-collective/sections/BankTransfer.js
@@ -267,7 +267,6 @@ const BankTransfer = props => {
       )}
       {showRemoveBankConfirmationModal && (
         <ConfirmationModal
-          show={showRemoveBankConfirmationModal}
           width="100%"
           maxWidth="570px"
           onClose={() => {

--- a/components/edit-collective/sections/EditMemberModal.js
+++ b/components/edit-collective/sections/EditMemberModal.js
@@ -13,7 +13,7 @@ import { API_V2_CONTEXT, gqlV2 } from '../../../lib/graphql/helpers';
 import Container from '../../Container';
 import { Flex } from '../../Grid';
 import StyledButton from '../../StyledButton';
-import Modal, { ModalBody, ModalFooter, ModalHeader } from '../../StyledModal';
+import StyledModal, { ModalBody, ModalFooter, ModalHeader } from '../../StyledModal';
 import StyledTooltip from '../../StyledTooltip';
 import { TOAST_TYPE, useToasts } from '../../ToastProvider';
 
@@ -78,7 +78,7 @@ const removeMemberMutation = gqlV2/* GraphQL */ `
 `;
 
 const EditMemberModal = props => {
-  const { intl, member, show, collective, isLastAdmin, cancelHandler, LoggedInUser, refetchLoggedInUser } = props;
+  const { intl, member, collective, isLastAdmin, cancelHandler, LoggedInUser, refetchLoggedInUser } = props;
 
   const { addToast } = useToasts();
 
@@ -259,7 +259,7 @@ const EditMemberModal = props => {
 
   return (
     <Container>
-      <Modal width={688} show={show} onClose={cancelHandler}>
+      <StyledModal width={688} onClose={cancelHandler}>
         <ModalHeader>
           <FormattedMessage id="editTeam.member.edit" defaultMessage="Edit Team Member" />
         </ModalHeader>
@@ -330,7 +330,7 @@ const EditMemberModal = props => {
             </StyledButton>
           </Container>
         </ModalFooter>
-      </Modal>
+      </StyledModal>
     </Container>
   );
 };
@@ -343,7 +343,6 @@ EditMemberModal.propTypes = {
   member: PropTypes.object,
   LoggedInUser: PropTypes.object.isRequired,
   refetchLoggedInUser: PropTypes.func.isRequired,
-  show: PropTypes.bool,
   router: PropTypes.object,
 };
 

--- a/components/edit-collective/sections/FiscalHosting.js
+++ b/components/edit-collective/sections/FiscalHosting.js
@@ -10,7 +10,7 @@ import useKeyboardShortcut, { ENTER_KEY } from '../../../lib/hooks/useKeyboardKe
 import { adminPanelQuery } from '../../../pages/admin-panel';
 import Container from '../../Container';
 import StyledButton from '../../StyledButton';
-import Modal, { ModalBody, ModalFooter, ModalHeader } from '../../StyledModal';
+import StyledModal, { ModalBody, ModalFooter, ModalHeader } from '../../StyledModal';
 import { P } from '../../Text';
 
 import SettingsSectionTitle from './SettingsSectionTitle';
@@ -245,68 +245,70 @@ const FiscalHosting = ({ collective }) => {
         </P>
       )}
 
-      <Modal show={activateAsHostModal.show} width="570px" onClose={closeActivateAsHost}>
-        <ModalHeader onClose={closeActivateAsHost}>
-          {activateAsHostModal.type === 'Activate' && (
-            <FormattedMessage id="collective.activateAsHost" defaultMessage={'Activate as Host'} />
-          )}
-          {activateAsHostModal.type === 'Deactivate' && (
-            <FormattedMessage id="host.deactivate" defaultMessage={'Deactivate as Host'} />
-          )}
-        </ModalHeader>
-        <ModalBody>
-          <P mb="1rem">
-            <FormattedMessage
-              id="collective.hostAccount.modal.description"
-              defaultMessage={
-                'A Fiscal Host is a legal entity (company or individual) who holds Collective funds in their bank account, and can generate invoices and receipts for Financial Contributors.{br}Think of a Fiscal Host as an umbrella organization for its Collectives.'
-              }
-              values={{
-                br: <br />,
-              }}
-            />
-          </P>
-          <P>
+      {activateAsHostModal.show && (
+        <StyledModal width="570px" onClose={closeActivateAsHost}>
+          <ModalHeader onClose={closeActivateAsHost}>
             {activateAsHostModal.type === 'Activate' && (
-              <FormattedMessage
-                id="collective.hostAccount.modal.activate.body"
-                defaultMessage={'Are you sure you want to activate this Fiscal Host?'}
-              />
+              <FormattedMessage id="collective.activateAsHost" defaultMessage={'Activate as Host'} />
             )}
             {activateAsHostModal.type === 'Deactivate' && (
-              <FormattedMessage
-                id="collective.hostAccount.modal.deactivate.body"
-                defaultMessage={'Are you sure you want to deactivate this Fiscal Host?'}
-              />
+              <FormattedMessage id="host.deactivate" defaultMessage={'Deactivate as Host'} />
             )}
-          </P>
-        </ModalBody>
-        <ModalFooter>
-          <Container display="flex" justifyContent="flex-end">
-            <StyledButton mx={20} onClick={() => setActivateAsHostModal({ ...activateAsHostModal, show: false })}>
-              <FormattedMessage id="actions.cancel" defaultMessage={'Cancel'} />
-            </StyledButton>
-            <StyledButton
-              buttonStyle="primary"
-              data-cy="action"
-              onClick={() => {
-                if (activateAsHostModal.type === 'Deactivate') {
-                  handleDeactivateAsHost({ id: collective.id });
-                } else {
-                  handleActivateAsHost({ id: collective.id });
+          </ModalHeader>
+          <ModalBody>
+            <P mb="1rem">
+              <FormattedMessage
+                id="collective.hostAccount.modal.description"
+                defaultMessage={
+                  'A Fiscal Host is a legal entity (company or individual) who holds Collective funds in their bank account, and can generate invoices and receipts for Financial Contributors.{br}Think of a Fiscal Host as an umbrella organization for its Collectives.'
                 }
-              }}
-            >
+                values={{
+                  br: <br />,
+                }}
+              />
+            </P>
+            <P>
               {activateAsHostModal.type === 'Activate' && (
-                <FormattedMessage id="collective.activateAsHost" defaultMessage={'Activate as Host'} />
+                <FormattedMessage
+                  id="collective.hostAccount.modal.activate.body"
+                  defaultMessage={'Are you sure you want to activate this Fiscal Host?'}
+                />
               )}
               {activateAsHostModal.type === 'Deactivate' && (
-                <FormattedMessage id="host.deactivate" defaultMessage={'Deactivate as Host'} />
+                <FormattedMessage
+                  id="collective.hostAccount.modal.deactivate.body"
+                  defaultMessage={'Are you sure you want to deactivate this Fiscal Host?'}
+                />
               )}
-            </StyledButton>
-          </Container>
-        </ModalFooter>
-      </Modal>
+            </P>
+          </ModalBody>
+          <ModalFooter>
+            <Container display="flex" justifyContent="flex-end">
+              <StyledButton mx={20} onClick={() => setActivateAsHostModal({ ...activateAsHostModal, show: false })}>
+                <FormattedMessage id="actions.cancel" defaultMessage={'Cancel'} />
+              </StyledButton>
+              <StyledButton
+                buttonStyle="primary"
+                data-cy="action"
+                onClick={() => {
+                  if (activateAsHostModal.type === 'Deactivate') {
+                    handleDeactivateAsHost({ id: collective.id });
+                  } else {
+                    handleActivateAsHost({ id: collective.id });
+                  }
+                }}
+              >
+                {activateAsHostModal.type === 'Activate' && (
+                  <FormattedMessage id="collective.activateAsHost" defaultMessage={'Activate as Host'} />
+                )}
+                {activateAsHostModal.type === 'Deactivate' && (
+                  <FormattedMessage id="host.deactivate" defaultMessage={'Deactivate as Host'} />
+                )}
+              </StyledButton>
+            </Container>
+          </ModalFooter>
+        </StyledModal>
+      )}
 
       {isHostAccount && (
         <Fragment>
@@ -352,47 +354,49 @@ const FiscalHosting = ({ collective }) => {
         </Fragment>
       )}
 
-      <Modal show={activateBudgetModal.show} width="570px" onClose={closeActivateBudget}>
-        <ModalHeader onClose={closeActivateBudget}>
-          {activateBudgetModal.type === 'Activate' && (
-            <FormattedMessage id="FiscalHosting.budget.activate" defaultMessage={'Activate Host Budget'} />
-          )}
-          {activateBudgetModal.type === 'Deactivate' && (
-            <FormattedMessage id="FiscalHosting.budget.deactivate" defaultMessage={'Deactivate Host Budget'} />
-          )}
-        </ModalHeader>
-        <ModalBody>
-          <P>
+      {activateBudgetModal.show && (
+        <StyledModal width="570px" onClose={closeActivateBudget}>
+          <ModalHeader onClose={closeActivateBudget}>
             {activateBudgetModal.type === 'Activate' && (
-              <FormattedMessage
-                id="FiscalHosting.budget.modal.activate.body"
-                defaultMessage={'Are you sure you want to activate the Host budget?'}
-              />
+              <FormattedMessage id="FiscalHosting.budget.activate" defaultMessage={'Activate Host Budget'} />
             )}
             {activateBudgetModal.type === 'Deactivate' && (
-              <FormattedMessage
-                id="FiscalHosting.budget.modal.deactivate.body"
-                defaultMessage={'Are you sure you want to deactivate the Host budget?'}
-              />
+              <FormattedMessage id="FiscalHosting.budget.deactivate" defaultMessage={'Deactivate Host Budget'} />
             )}
-          </P>
-        </ModalBody>
-        <ModalFooter>
-          <Container display="flex" justifyContent="flex-end">
-            <StyledButton mx={20} onClick={() => setActivateBudgetModal({ ...activateBudgetModal, show: false })}>
-              <FormattedMessage id="actions.cancel" defaultMessage={'Cancel'} />
-            </StyledButton>
-            <StyledButton buttonStyle="primary" data-cy="action" onClick={() => handlePrimaryBtnClick()}>
+          </ModalHeader>
+          <ModalBody>
+            <P>
               {activateBudgetModal.type === 'Activate' && (
-                <FormattedMessage id="FiscalHosting.budget.activate" defaultMessage={'Activate Host Budget'} />
+                <FormattedMessage
+                  id="FiscalHosting.budget.modal.activate.body"
+                  defaultMessage={'Are you sure you want to activate the Host budget?'}
+                />
               )}
               {activateBudgetModal.type === 'Deactivate' && (
-                <FormattedMessage id="FiscalHosting.budget.deactivate" defaultMessage={'Deactivate Host Budget'} />
+                <FormattedMessage
+                  id="FiscalHosting.budget.modal.deactivate.body"
+                  defaultMessage={'Are you sure you want to deactivate the Host budget?'}
+                />
               )}
-            </StyledButton>
-          </Container>
-        </ModalFooter>
-      </Modal>
+            </P>
+          </ModalBody>
+          <ModalFooter>
+            <Container display="flex" justifyContent="flex-end">
+              <StyledButton mx={20} onClick={() => setActivateBudgetModal({ ...activateBudgetModal, show: false })}>
+                <FormattedMessage id="actions.cancel" defaultMessage={'Cancel'} />
+              </StyledButton>
+              <StyledButton buttonStyle="primary" data-cy="action" onClick={() => handlePrimaryBtnClick()}>
+                {activateBudgetModal.type === 'Activate' && (
+                  <FormattedMessage id="FiscalHosting.budget.activate" defaultMessage={'Activate Host Budget'} />
+                )}
+                {activateBudgetModal.type === 'Deactivate' && (
+                  <FormattedMessage id="FiscalHosting.budget.deactivate" defaultMessage={'Deactivate Host Budget'} />
+                )}
+              </StyledButton>
+            </Container>
+          </ModalFooter>
+        </StyledModal>
+      )}
     </Container>
   );
 };

--- a/components/edit-collective/sections/Host.js
+++ b/components/edit-collective/sections/Host.js
@@ -18,7 +18,7 @@ import MessageBox from '../../MessageBox';
 import StyledButton from '../../StyledButton';
 import StyledInput from '../../StyledInput';
 import StyledLink from '../../StyledLink';
-import Modal, { ModalBody, ModalFooter, ModalHeader } from '../../StyledModal';
+import StyledModal, { ModalBody, ModalFooter, ModalHeader } from '../../StyledModal';
 import { H4, P } from '../../Text';
 import CreateHostFormWithData from '../CreateHostFormWithData';
 import EditConnectedAccount from '../EditConnectedAccount';
@@ -279,55 +279,61 @@ class Host extends React.Component {
               )}
             </Box>
           </Flex>
-          <Modal show={showModal} width="570px" onClose={closeModal}>
-            <ModalHeader onClose={closeModal}>
-              {action === 'Remove' ? (
-                <FormattedMessage id="collective.editHost.remove" values={{ name }} defaultMessage={'Remove {name}'} />
-              ) : (
-                <FormattedMessage
-                  id="collective.editHost.header"
-                  values={{ name }}
-                  defaultMessage={'Withdraw application to {name}'}
-                />
-              )}
-            </ModalHeader>
-            <ModalBody>
-              <P>
-                {action === 'Withdraw' && (
+          {showModal && (
+            <StyledModal width="570px" onClose={closeModal}>
+              <ModalHeader onClose={closeModal}>
+                {action === 'Remove' ? (
                   <FormattedMessage
-                    id="collective.editHost.withdrawApp"
+                    id="collective.editHost.remove"
                     values={{ name }}
-                    defaultMessage={'Are you sure you want to withdraw your application to {name}?'}
+                    defaultMessage={'Remove {name}'}
+                  />
+                ) : (
+                  <FormattedMessage
+                    id="collective.editHost.header"
+                    values={{ name }}
+                    defaultMessage={'Withdraw application to {name}'}
                   />
                 )}
-                {action === 'Remove' && (
-                  <FormattedMessage
-                    id="collective.editHost.removeHost"
-                    values={{ name }}
-                    defaultMessage={'Are you sure you want to remove {name}?'}
-                  />
-                )}
-              </P>
-            </ModalBody>
-            <ModalFooter>
-              <Container display="flex" justifyContent="flex-end">
-                <StyledButton
-                  mx={20}
-                  onClick={() =>
-                    this.setState({
-                      showModal: false,
-                    })
-                  }
-                >
-                  <FormattedMessage id="actions.cancel" defaultMessage={'Cancel'} />
-                </StyledButton>
-                <StyledButton buttonStyle="primary" onClick={() => this.changeHost()} data-cy="continue">
-                  {/** TODO(i18n): This should be internationalized */}
-                  {action}
-                </StyledButton>
-              </Container>
-            </ModalFooter>
-          </Modal>
+              </ModalHeader>
+              <ModalBody>
+                <P>
+                  {action === 'Withdraw' && (
+                    <FormattedMessage
+                      id="collective.editHost.withdrawApp"
+                      values={{ name }}
+                      defaultMessage={'Are you sure you want to withdraw your application to {name}?'}
+                    />
+                  )}
+                  {action === 'Remove' && (
+                    <FormattedMessage
+                      id="collective.editHost.removeHost"
+                      values={{ name }}
+                      defaultMessage={'Are you sure you want to remove {name}?'}
+                    />
+                  )}
+                </P>
+              </ModalBody>
+              <ModalFooter>
+                <Container display="flex" justifyContent="flex-end">
+                  <StyledButton
+                    mx={20}
+                    onClick={() =>
+                      this.setState({
+                        showModal: false,
+                      })
+                    }
+                  >
+                    <FormattedMessage id="actions.cancel" defaultMessage={'Cancel'} />
+                  </StyledButton>
+                  <StyledButton buttonStyle="primary" onClick={() => this.changeHost()} data-cy="continue">
+                    {/** TODO(i18n): This should be internationalized */}
+                    {action}
+                  </StyledButton>
+                </Container>
+              </ModalFooter>
+            </StyledModal>
+          )}
         </Fragment>
       );
     }

--- a/components/edit-collective/sections/HostVirtualCards.js
+++ b/components/edit-collective/sections/HostVirtualCards.js
@@ -279,7 +279,6 @@ const HostVirtualCards = props => {
           onClose={() => {
             setAssignCardModalDisplay(false);
           }}
-          show
         />
       )}
       {editingVirtualCard && (
@@ -290,7 +289,6 @@ const HostVirtualCards = props => {
             setEditingVirtualCard(undefined);
           }}
           virtualCard={editingVirtualCard}
-          show
         />
       )}
       {deletingVirtualCard && (
@@ -301,7 +299,6 @@ const HostVirtualCards = props => {
             setDeletingVirtualCard(undefined);
           }}
           virtualCard={deletingVirtualCard}
-          show
         />
       )}
       {displayCreateVirtualCardModal && (
@@ -311,7 +308,6 @@ const HostVirtualCards = props => {
           onClose={() => {
             setCreateVirtualCardModalDisplay(false);
           }}
-          show
         />
       )}
     </Fragment>

--- a/components/edit-collective/sections/InviteMemberModal.js
+++ b/components/edit-collective/sections/InviteMemberModal.js
@@ -12,7 +12,7 @@ import Container from '../../Container';
 import { Flex } from '../../Grid';
 import MessageBox from '../../MessageBox';
 import StyledButton from '../../StyledButton';
-import Modal, { ModalBody, ModalFooter, ModalHeader } from '../../StyledModal';
+import StyledModal, { ModalBody, ModalFooter, ModalHeader } from '../../StyledModal';
 import { P } from '../../Text';
 import { TOAST_TYPE, useToasts } from '../../ToastProvider';
 
@@ -43,7 +43,7 @@ const inviteMemberMutation = gqlV2/* GraphQL */ `
 `;
 
 const InviteMemberModal = props => {
-  const { intl, show, collective, membersIds, cancelHandler } = props;
+  const { intl, collective, membersIds, cancelHandler } = props;
 
   const { addToast } = useToasts();
 
@@ -113,7 +113,7 @@ const InviteMemberModal = props => {
 
   return (
     <Container>
-      <Modal width={688} show={show} onClose={cancelHandler}>
+      <StyledModal width={688} onClose={cancelHandler}>
         <ModalHeader mb={4}>
           <FormattedMessage id="editTeam.member.invite" defaultMessage="Invite Team Member" />
         </ModalHeader>
@@ -173,7 +173,7 @@ const InviteMemberModal = props => {
             </StyledButton>
           </Container>
         </ModalFooter>
-      </Modal>
+      </StyledModal>
     </Container>
   );
 };
@@ -183,7 +183,6 @@ InviteMemberModal.propTypes = {
   cancelHandler: PropTypes.func,
   intl: PropTypes.object.isRequired,
   membersIds: PropTypes.array,
-  show: PropTypes.bool,
 };
 
 export default InviteMemberModal;

--- a/components/edit-collective/sections/Members.js
+++ b/components/edit-collective/sections/Members.js
@@ -170,7 +170,6 @@ class Members extends React.Component {
           memberModalKey === this.state.currentModalKey ? (
             <EditMemberModal
               key={`member-edit-modal-${index}-${memberKey}`}
-              show={this.state.showEditModal}
               intl={intl}
               member={this.state.currentMember}
               collective={collective}
@@ -270,7 +269,6 @@ class Members extends React.Component {
             <Grid gridGap={20} gridTemplateColumns="repeat(auto-fill, 164px)">
               {this.state.showInviteModal ? (
                 <InviteMemberModal
-                  show={this.state.showInviteModal}
                   intl={intl}
                   collective={collective}
                   membersIds={membersCollectiveIds}

--- a/components/edit-collective/sections/UserTwoFactorAuth.js
+++ b/components/edit-collective/sections/UserTwoFactorAuth.js
@@ -22,7 +22,7 @@ import MessageBox from '../../MessageBox';
 import StyledButton from '../../StyledButton';
 import StyledInput from '../../StyledInput';
 import StyledInputField from '../../StyledInputField';
-import Modal, { ModalBody, ModalFooter, ModalHeader } from '../../StyledModal';
+import StyledModal, { ModalBody, ModalFooter, ModalHeader } from '../../StyledModal';
 import StyledTooltip from '../../StyledTooltip';
 import { H3, P } from '../../Text';
 import { withUser } from '../../UserProvider';
@@ -253,11 +253,7 @@ class UserTwoFactorAuth extends React.Component {
                       const { values, errors, touched, handleSubmit, isSubmitting } = formik;
 
                       return (
-                        <Modal
-                          show={this.state.disablingTwoFactorAuth}
-                          width="570px"
-                          onClose={() => this.setState({ disablingTwoFactorAuth: false })}
-                        >
+                        <StyledModal width="570px" onClose={() => this.setState({ disablingTwoFactorAuth: false })}>
                           <ModalHeader>
                             <FormattedMessage
                               id="TwoFactorAuth.Disable.Header"
@@ -320,7 +316,7 @@ class UserTwoFactorAuth extends React.Component {
                               </StyledButton>
                             </Container>
                           </ModalFooter>
-                        </Modal>
+                        </StyledModal>
                       );
                     }}
                   </Formik>
@@ -386,30 +382,31 @@ class UserTwoFactorAuth extends React.Component {
                       </Container>
                     </Box>
                   </Container>
-                  <ConfirmationModal
-                    show={showRecoveryCodesModal}
-                    isDanger
-                    type="confirm"
-                    onClose={() => this.setState({ showRecoveryCodesModal: false })}
-                    continueHandler={() =>
-                      this.setState({
-                        recoveryCodes: null,
-                        enablingTwoFactorAuth: false,
-                        showRecoveryCodesModal: false,
-                      })
-                    }
-                    header={
+                  {showRecoveryCodesModal && (
+                    <ConfirmationModal
+                      isDanger
+                      type="confirm"
+                      onClose={() => this.setState({ showRecoveryCodesModal: false })}
+                      continueHandler={() =>
+                        this.setState({
+                          recoveryCodes: null,
+                          enablingTwoFactorAuth: false,
+                          showRecoveryCodesModal: false,
+                        })
+                      }
+                      header={
+                        <FormattedMessage
+                          id="TwoFactorAuth.Setup.RecoveryCodes.ConfirmationModal.Header"
+                          defaultMessage="Are you sure?"
+                        />
+                      }
+                    >
                       <FormattedMessage
-                        id="TwoFactorAuth.Setup.RecoveryCodes.ConfirmationModal.Header"
-                        defaultMessage="Are you sure?"
+                        id="TwoFactorAuth.Setup.RecoveryCodes.ConfirmationModal.Body"
+                        defaultMessage="Once you click 'Confirm', you will no longer have access to your recovery codes."
                       />
-                    }
-                  >
-                    <FormattedMessage
-                      id="TwoFactorAuth.Setup.RecoveryCodes.ConfirmationModal.Body"
-                      defaultMessage="Once you click 'Confirm', you will no longer have access to your recovery codes."
-                    />
-                  </ConfirmationModal>
+                    </ConfirmationModal>
+                  )}
                 </Fragment>
               ) : (
                 <Fragment>

--- a/components/expenses/DeleteExpenseButton.js
+++ b/components/expenses/DeleteExpenseButton.js
@@ -66,7 +66,6 @@ const DeleteExpenseButton = ({ expense, onDelete, buttonProps, isDisabled, onMod
           {deleteExpense => (
             <ConfirmationModal
               isDanger
-              show
               type="delete"
               onClose={() => showDeleteConfirm(false)}
               header={<FormattedMessage id="actions.delete" defaultMessage="Delete" />}

--- a/components/expenses/ExpenseFilesPreviewModal.js
+++ b/components/expenses/ExpenseFilesPreviewModal.js
@@ -91,7 +91,7 @@ ExpenseInvoicePreview.propTypes = {
   fileURL: PropTypes.string,
 };
 
-const ExpenseFilesPreviewModal = ({ collective, expense, show, onClose }) => {
+const ExpenseFilesPreviewModal = ({ collective, expense, onClose }) => {
   const [invoiceFile, setInvoiceFile] = React.useState(false);
   const [invoiceBlob, setInvoiceBlob] = React.useState(null);
   const [invoiceError, setInvoiceError] = React.useState(false);
@@ -116,7 +116,6 @@ const ExpenseFilesPreviewModal = ({ collective, expense, show, onClose }) => {
 
   return (
     <FilesPreviewModal
-      show={show}
       files={files}
       onClose={onClose}
       renderInfo={({ item }) => (
@@ -155,7 +154,6 @@ ExpenseFilesPreviewModal.propTypes = {
   collective: PropTypes.object,
   expense: PropTypes.object,
   onClose: PropTypes.func.isRequired,
-  show: PropTypes.bool,
 };
 
 export default ExpenseFilesPreviewModal;

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -603,7 +603,6 @@ const ExpenseFormBody = ({
                 <StyledHr flex="1" borderColor="white.full" mx={2} />
                 {showResetModal ? (
                   <ConfirmationModal
-                    show
                     onClose={() => setShowResetModal(false)}
                     header={editingExpense ? formatMessage(msg.cancelEditExpense) : formatMessage(msg.clearExpenseForm)}
                     body={

--- a/components/expenses/MarkExpenseAsUnpaidButton.js
+++ b/components/expenses/MarkExpenseAsUnpaidButton.js
@@ -25,7 +25,6 @@ const MarkExpenseAsUnpaidButton = ({ onConfirm, ...props }) => {
     <React.Fragment>
       {button}
       <ConfirmationModal
-        show
         id="mark-expense-as-unpaid-modal"
         header={<FormattedMessage id="Expense.markAsUnpaid" defaultMessage="Mark expense as unpaid" />}
         width="100%"

--- a/components/expenses/PayExpenseModal.js
+++ b/components/expenses/PayExpenseModal.js
@@ -207,15 +207,7 @@ const PayExpenseModal = ({ onClose, onSubmit, expense, collective, host, error }
   const totalAmount = getTotalPayoutAmount(expense, { paymentProcessorFee, feesPayer: formik.values.feesPayer });
 
   return (
-    <StyledModal
-      show
-      onClose={onClose}
-      width="100%"
-      minWidth={280}
-      maxWidth={334}
-      data-cy="pay-expense-modal"
-      trapFocus
-    >
+    <StyledModal onClose={onClose} width="100%" minWidth={280} maxWidth={334} data-cy="pay-expense-modal" trapFocus>
       <ModalHeader>
         <H4 fontSize="20px" fontWeight="700">
           <FormattedMessage id="PayExpenseTitle" defaultMessage="Pay expense" />

--- a/components/expenses/PayoutMethodSelect.js
+++ b/components/expenses/PayoutMethodSelect.js
@@ -318,7 +318,6 @@ class PayoutMethodSelect extends React.Component {
         />
         {removingPayoutMethod && (
           <ConfirmationModal
-            show
             isDanger
             type="remove"
             onClose={() => this.setState({ removingPayoutMethod: null })}

--- a/components/home/sections/MakeCommunity.js
+++ b/components/home/sections/MakeCommunity.js
@@ -7,7 +7,7 @@ import Container from '../../Container';
 import { Box, Flex } from '../../Grid';
 import Link from '../../Link';
 import StyledButton from '../../StyledButton';
-import Modal from '../../StyledModal';
+import StyledModal from '../../StyledModal';
 import { H1, H2, P, Span } from '../../Text';
 import NextIllustration from '../HomeNextIllustration';
 
@@ -172,25 +172,26 @@ const MakeCommunity = () => {
           </P>
         </Box>
       </Container>
-      <Modal
-        padding="0"
-        background="transparent"
-        show={showModal}
-        width={[1, null, '670px', null, '770px']}
-        onClose={() => setShowModal(false)}
-      >
-        <Container display="flex" width={1} height={400} maxWidth={712} background="black">
-          <iframe
-            title="YouTube video"
-            width="100%"
-            height="400px"
-            src="https://www.youtube.com/embed/IBU5fSILAe8"
-            frameBorder="0"
-            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-            allowFullScreen
-          />
-        </Container>
-      </Modal>
+      {showModal && (
+        <StyledModal
+          padding="0"
+          background="transparent"
+          width={[1, null, '670px', null, '770px']}
+          onClose={() => setShowModal(false)}
+        >
+          <Container display="flex" width={1} height={400} maxWidth={712} background="black">
+            <iframe
+              title="YouTube video"
+              width="100%"
+              height="400px"
+              src="https://www.youtube.com/embed/IBU5fSILAe8"
+              frameBorder="0"
+              allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          </Container>
+        </StyledModal>
+      )}
     </Fragment>
   );
 };

--- a/components/host-dashboard/AcceptRejectButtons.js
+++ b/components/host-dashboard/AcceptRejectButtons.js
@@ -44,16 +44,17 @@ const AcceptRejectButtons = ({ collective, isLoading, onApprove, onReject }) => 
         <Ban size={12} />
         &nbsp; <FormattedMessage id="actions.reject" defaultMessage="Reject" />
       </StyledButton>
-      <ApplicationRejectionReasonModal
-        show={showRejectModal}
-        collective={collective}
-        onClose={() => setShowRejectModal(false)}
-        onConfirm={message => {
-          setAction('REJECT');
-          setShowRejectModal(false);
-          onReject(message);
-        }}
-      />
+      {showRejectModal && (
+        <ApplicationRejectionReasonModal
+          collective={collective}
+          onClose={() => setShowRejectModal(false)}
+          onConfirm={message => {
+            setAction('REJECT');
+            setShowRejectModal(false);
+            onReject(message);
+          }}
+        />
+      )}
     </Flex>
   );
 };

--- a/components/host-dashboard/ApplicationMessageModal.js
+++ b/components/host-dashboard/ApplicationMessageModal.js
@@ -10,7 +10,7 @@ import LinkCollective from '../LinkCollective';
 import StyledButton from '../StyledButton';
 import StyledCheckbox from '../StyledCheckbox';
 import StyledLink from '../StyledLink';
-import Modal, { ModalBody, ModalFooter, ModalHeader } from '../StyledModal';
+import StyledModal, { ModalBody, ModalFooter, ModalHeader } from '../StyledModal';
 import StyledTextarea from '../StyledTextarea';
 import { P, Span } from '../Text';
 
@@ -19,7 +19,7 @@ const ApplicationMessageModal = ({ collective, onClose, onConfirm, ...modalProps
   const [isPrivate, setIsPrivate] = useState(false);
 
   return (
-    <Modal onClose={onClose} width="576px" {...modalProps}>
+    <StyledModal onClose={onClose} width="576px" {...modalProps}>
       <ModalHeader hideCloseIcon>
         <Flex justifyContent="space-between" flexDirection={['column', 'row']} width="100%">
           <Flex>
@@ -125,7 +125,7 @@ const ApplicationMessageModal = ({ collective, onClose, onConfirm, ...modalProps
           </StyledButton>
         </Container>
       </ModalFooter>
-    </Modal>
+    </StyledModal>
   );
 };
 

--- a/components/host-dashboard/ApplicationRejectionReasonModal.js
+++ b/components/host-dashboard/ApplicationRejectionReasonModal.js
@@ -10,7 +10,7 @@ import LinkCollective from '../LinkCollective';
 import LinkContributor from '../LinkContributor';
 import StyledButton from '../StyledButton';
 import StyledLink from '../StyledLink';
-import Modal, { ModalBody, ModalFooter, ModalHeader } from '../StyledModal';
+import StyledModal, { ModalBody, ModalFooter, ModalHeader } from '../StyledModal';
 import StyledTextarea from '../StyledTextarea';
 import { P, Span } from '../Text';
 
@@ -29,7 +29,7 @@ const ApplicationRejectionReasonModal = ({ collective, onClose, onConfirm, ...mo
   const totalAdminCount = collective.admins?.totalCount || admins.length;
 
   return (
-    <Modal onClose={onClose} width="576px" {...modalProps}>
+    <StyledModal onClose={onClose} width="576px" {...modalProps}>
       <ModalHeader hideCloseIcon>
         <Flex justifyContent="space-between" flexDirection={['column', 'row']} width="100%">
           <Flex>
@@ -127,7 +127,7 @@ const ApplicationRejectionReasonModal = ({ collective, onClose, onConfirm, ...mo
           </StyledButton>
         </Container>
       </ModalFooter>
-    </Modal>
+    </StyledModal>
   );
 };
 

--- a/components/host-dashboard/CollectiveSettingsModal.js
+++ b/components/host-dashboard/CollectiveSettingsModal.js
@@ -85,7 +85,7 @@ const CollectiveSettingsModal = ({ host, collective, ...props }) => {
   const hasParent = Boolean(collective.parent);
 
   return (
-    <StyledModal show maxWidth={432} trapFocus {...props}>
+    <StyledModal maxWidth={432} trapFocus {...props}>
       <CollectiveModalHeader collective={collective} mb={3} />
       <ModalBody>
         <P fontSize="16px" lineHeight="24px" fontWeight="500" mb={2}>

--- a/components/host-dashboard/HostAdminCollectiveCard.js
+++ b/components/host-dashboard/HostAdminCollectiveCard.js
@@ -123,7 +123,7 @@ const HostAdminCollectiveCard = ({ since, collective, host, ...props }) => {
         </Container>
       </Box>
       {currentModal === 'addFunds' && (
-        <AddFundsModal show collective={collective} host={host} onClose={() => setCurrentModal(null)} />
+        <AddFundsModal collective={collective} host={host} onClose={() => setCurrentModal(null)} />
       )}
       {currentModal === 'accountSettings' && (
         <CollectiveSettingsModal collective={collective} host={host} onClose={() => setCurrentModal(null)} />

--- a/components/host-dashboard/PendingApplication.js
+++ b/components/host-dashboard/PendingApplication.js
@@ -390,16 +390,17 @@ const PendingApplication = ({ host, application, ...props }) => {
           </Container>
         )}
       </Container>
-      <ApplicationMessageModal
-        show={showContactModal}
-        collective={collective}
-        onClose={() => setShowContactModal(false)}
-        onConfirm={(message, isPrivate, resetMessage) => {
-          setShowContactModal(false);
-          const action = isPrivate ? ACTIONS.SEND_PRIVATE_MESSAGE : ACTIONS.SEND_PUBLIC_MESSAGE;
-          processApplication(action, message, resetMessage);
-        }}
-      />
+      {showContactModal && (
+        <ApplicationMessageModal
+          collective={collective}
+          onClose={() => setShowContactModal(false)}
+          onConfirm={(message, isPrivate, resetMessage) => {
+            setShowContactModal(false);
+            const action = isPrivate ? ACTIONS.SEND_PRIVATE_MESSAGE : ACTIONS.SEND_PUBLIC_MESSAGE;
+            processApplication(action, message, resetMessage);
+          }}
+        />
+      )}
     </Container>
   );
 };

--- a/components/host-dashboard/ScheduledExpensesBanner.js
+++ b/components/host-dashboard/ScheduledExpensesBanner.js
@@ -124,7 +124,6 @@ const ScheduledExpensesBanner = ({ host, onSubmit, secondButton, expenses }) => 
             />
           }
           continueHandler={handlePayBatch}
-          show
         />
       )}
     </React.Fragment>

--- a/components/onboarding-modal/OnboardingModal.js
+++ b/components/onboarding-modal/OnboardingModal.js
@@ -15,7 +15,13 @@ import { compose } from '../../lib/utils';
 import Container from '../../components/Container';
 import MessageBox from '../../components/MessageBox';
 import StyledButton from '../../components/StyledButton';
-import Modal, { CloseIcon, ModalBody, ModalFooter, ModalHeader, ModalOverlay } from '../../components/StyledModal';
+import StyledModal, {
+  CloseIcon,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+} from '../../components/StyledModal';
 import { H1, P } from '../../components/Text';
 
 import { Box, Flex } from '../Grid';
@@ -35,7 +41,7 @@ const StepsProgressBox = styled(Box)`
   }
 `;
 
-const ResponsiveModal = styled(Modal)`
+const ResponsiveModal = styled(StyledModal)`
   @media screen and (max-width: 40em) {
     transform: translate(0%, 0%);
     position: fixed;
@@ -266,125 +272,117 @@ class OnboardingModal extends React.Component {
       <React.Fragment>
         {step === 3 ? (
           <React.Fragment>
-            <ModalWithImage
-              usePortal={false}
-              width="576px"
-              minHeight="456px"
-              onClose={this.onClose}
-              show={showOnboardingModal}
-            >
-              <ModalBody>
-                <Flex flexDirection="column" alignItems="center">
-                  <Container display="flex" flexDirection="column" alignItems="center">
-                    <Box maxWidth="336px">
-                      <H1
-                        fontSize="40px"
-                        lineHeight="44px"
-                        fontWeight="bold"
-                        color="black.900"
-                        textAlign="center"
-                        mt={6}
-                        mb={4}
-                        mx={2}
-                        data-cy="welcome-collective"
-                      >
-                        <FormattedMessage
-                          id="onboarding.success.header"
-                          defaultMessage="Welcome to your new Collective!"
-                        />
-                      </H1>
-                    </Box>
-                    <Box maxWidth="450px">
-                      <P fontSize="16px" lineHeight="24px" color="black.900" textAlign="center" mb={4} mx={2}>
-                        <FormattedMessage
-                          id="onboarding.success.text"
-                          defaultMessage="You're all set! Customize the look, start accepting contributions, and interact with your community."
-                        />
-                      </P>
-                    </Box>
-                  </Container>
-                </Flex>
-              </ModalBody>
-              <ResponsiveModalFooter>
-                <Flex flexDirection="column" alignItems="center">
-                  <StyledButton buttonStyle="primary" onClick={this.onClose} data-cy="close-button">
-                    <FormattedMessage id="Close" defaultMessage="Close" />
-                  </StyledButton>
-                </Flex>
-              </ResponsiveModalFooter>
-            </ModalWithImage>
+            {showOnboardingModal && (
+              <ModalWithImage usePortal={false} width="576px" minHeight="456px" onClose={this.onClose}>
+                <ModalBody>
+                  <Flex flexDirection="column" alignItems="center">
+                    <Container display="flex" flexDirection="column" alignItems="center">
+                      <Box maxWidth="336px">
+                        <H1
+                          fontSize="40px"
+                          lineHeight="44px"
+                          fontWeight="bold"
+                          color="black.900"
+                          textAlign="center"
+                          mt={6}
+                          mb={4}
+                          mx={2}
+                          data-cy="welcome-collective"
+                        >
+                          <FormattedMessage
+                            id="onboarding.success.header"
+                            defaultMessage="Welcome to your new Collective!"
+                          />
+                        </H1>
+                      </Box>
+                      <Box maxWidth="450px">
+                        <P fontSize="16px" lineHeight="24px" color="black.900" textAlign="center" mb={4} mx={2}>
+                          <FormattedMessage
+                            id="onboarding.success.text"
+                            defaultMessage="You're all set! Customize the look, start accepting contributions, and interact with your community."
+                          />
+                        </P>
+                      </Box>
+                    </Container>
+                  </Flex>
+                </ModalBody>
+                <ResponsiveModalFooter>
+                  <Flex flexDirection="column" alignItems="center">
+                    <StyledButton buttonStyle="primary" onClick={this.onClose} data-cy="close-button">
+                      <FormattedMessage id="Close" defaultMessage="Close" />
+                    </StyledButton>
+                  </Flex>
+                </ResponsiveModalFooter>
+              </ModalWithImage>
+            )}
           </React.Fragment>
         ) : (
           <React.Fragment>
-            <ResponsiveModal
-              usePortal={false}
-              width="576px"
-              minHeight="456px"
-              onClose={this.onClose}
-              show={showOnboardingModal}
-            >
-              <ResponsiveModalHeader onClose={this.onClose}>
-                <Flex flexDirection="column" alignItems="center" width="100%">
-                  <StepsProgressBox ml={[0, '15px']} mb={[3, null, 4]} width={[1.0, 0.8]}>
-                    <OnboardingStepsProgress
-                      step={step}
-                      mode={mode}
-                      handleStep={step => this.setState({ step })}
-                      slug={collective.slug}
-                    />
-                  </StepsProgressBox>
-                </Flex>
-              </ResponsiveModalHeader>
-              <Formik
-                initialValues={{ website: '', twitterHandle: '', githubHandle: '' }}
-                onSubmit={values => {
-                  this.submitCollectiveInfo(values);
-                }}
-                validate={this.validateFormik}
-                validateOnBlur={true}
-              >
-                {({ values, handleSubmit, errors, touched }) => (
-                  <FormWithStyles>
-                    <ResponsiveModalBody>
-                      <Flex flexDirection="column" alignItems="center">
-                        <Image
-                          alt="OnBoarding"
-                          width={160}
-                          height={this.getStepParams(step, 'height')}
-                          src={this.getStepParams(step, 'src')}
-                        />
-                        <OnboardingContentBox
-                          slug={collective.slug}
-                          step={step}
-                          collective={collective}
-                          LoggedInUser={LoggedInUser}
-                          updateAdmins={this.updateAdmins}
-                          values={values}
-                          errors={errors}
-                          touched={touched}
-                        />
-                        {error && (
-                          <MessageBox type="error" withIcon mt={2}>
-                            {error.message}
-                          </MessageBox>
-                        )}
-                      </Flex>
-                    </ResponsiveModalBody>
-                    <ResponsiveModalFooter>
-                      <Flex flexDirection="column" alignItems="center">
-                        <OnboardingNavButtons
-                          step={step}
-                          mode={mode}
-                          slug={collective.slug}
-                          loading={isSubmitting}
-                          handleSubmit={handleSubmit}
-                        />
-                      </Flex>
-                    </ResponsiveModalFooter>
-                  </FormWithStyles>
-                )}
-              </Formik>
-            </ResponsiveModal>
+            {showOnboardingModal && (
+              <ResponsiveModal usePortal={false} width="576px" minHeight="456px" onClose={this.onClose}>
+                <ResponsiveModalHeader onClose={this.onClose}>
+                  <Flex flexDirection="column" alignItems="center" width="100%">
+                    <StepsProgressBox ml={[0, '15px']} mb={[3, null, 4]} width={[1.0, 0.8]}>
+                      <OnboardingStepsProgress
+                        step={step}
+                        mode={mode}
+                        handleStep={step => this.setState({ step })}
+                        slug={collective.slug}
+                      />
+                    </StepsProgressBox>
+                  </Flex>
+                </ResponsiveModalHeader>
+                <Formik
+                  initialValues={{ website: '', twitterHandle: '', githubHandle: '' }}
+                  onSubmit={values => {
+                    this.submitCollectiveInfo(values);
+                  }}
+                  validate={this.validateFormik}
+                  validateOnBlur={true}
+                >
+                  {({ values, handleSubmit, errors, touched }) => (
+                    <FormWithStyles>
+                      <ResponsiveModalBody>
+                        <Flex flexDirection="column" alignItems="center">
+                          <Image
+                            alt="OnBoarding"
+                            width={160}
+                            height={this.getStepParams(step, 'height')}
+                            src={this.getStepParams(step, 'src')}
+                          />
+                          <OnboardingContentBox
+                            slug={collective.slug}
+                            step={step}
+                            collective={collective}
+                            LoggedInUser={LoggedInUser}
+                            updateAdmins={this.updateAdmins}
+                            values={values}
+                            errors={errors}
+                            touched={touched}
+                          />
+                          {error && (
+                            <MessageBox type="error" withIcon mt={2}>
+                              {error.message}
+                            </MessageBox>
+                          )}
+                        </Flex>
+                      </ResponsiveModalBody>
+                      <ResponsiveModalFooter>
+                        <Flex flexDirection="column" alignItems="center">
+                          <OnboardingNavButtons
+                            step={step}
+                            mode={mode}
+                            slug={collective.slug}
+                            loading={isSubmitting}
+                            handleSubmit={handleSubmit}
+                          />
+                        </Flex>
+                      </ResponsiveModalFooter>
+                    </FormWithStyles>
+                  )}
+                </Formik>
+              </ResponsiveModal>
+            )}
           </React.Fragment>
         )}
         <ResponsiveModalOverlay onClick={this.onClose} noOverlay={noOverlay} />

--- a/components/orders/ProcessOrderButtons.js
+++ b/components/orders/ProcessOrderButtons.js
@@ -107,7 +107,6 @@ const ProcessOrderButtons = ({ order, permissions }) => {
       )}
       {hasConfirm && (
         <ConfirmationModal
-          show
           onClose={() => setConfirm(false)}
           continueHandler={() => triggerAction(selectedAction)}
           isDanger={selectedAction === 'MARK_AS_EXPIRED'}
@@ -129,11 +128,7 @@ const ProcessOrderButtons = ({ order, permissions }) => {
         </ConfirmationModal>
       )}
       {showContributionConfirmationModal && (
-        <ContributionConfirmationModal
-          show={showContributionConfirmationModal}
-          order={order}
-          onClose={() => setShowContributionConfirmationModal(false)}
-        />
+        <ContributionConfirmationModal order={order} onClose={() => setShowContributionConfirmationModal(false)} />
       )}
     </React.Fragment>
   );

--- a/components/root-actions/MergeAccountsForm.js
+++ b/components/root-actions/MergeAccountsForm.js
@@ -112,7 +112,6 @@ const MergeAccountsForm = () => {
       </StyledButton>
       {mergeSummary && (
         <ConfirmationModal
-          show
           isDanger
           continueLabel="Merge profiles"
           header={mergeCTA}

--- a/components/root-actions/MoveAuthoredContributions.js
+++ b/components/root-actions/MoveAuthoredContributions.js
@@ -263,7 +263,6 @@ const MoveAuthoredContributions = () => {
 
       {hasConfirmationModal && (
         <ConfirmationModal
-          show
           header={callToAction}
           continueHandler={moveContributions}
           disableSubmit={hasConfirmCheckbox && !hasConfirmed}

--- a/components/root-actions/MoveReceivedContributions.js
+++ b/components/root-actions/MoveReceivedContributions.js
@@ -200,7 +200,6 @@ const MoveReceivedContributions = () => {
 
       {hasConfirmationModal && (
         <ConfirmationModal
-          show
           header={callToAction}
           continueHandler={moveContributions}
           onClose={() => setHasConfirmationModal(false)}

--- a/components/transactions/TransactionRefundButton.js
+++ b/components/transactions/TransactionRefundButton.js
@@ -58,29 +58,30 @@ const TransactionRefundButton = props => {
             <FormattedMessage id="transaction.refund.btn" defaultMessage="refund" />
           </Flex>
         </StyledButton>
-        <ConfirmationModal
-          show={isEnabled}
-          onClose={closeModal}
-          header={<FormattedMessage id="Refund" defaultMessage="Refund" />}
-          body={
-            <div>
+        {isEnabled && (
+          <ConfirmationModal
+            onClose={closeModal}
+            header={<FormattedMessage id="Refund" defaultMessage="Refund" />}
+            body={
               <div>
-                <FormattedMessage
-                  id="transaction.refund.info"
-                  defaultMessage="The contributor will be refunded the full amount."
-                />
+                <div>
+                  <FormattedMessage
+                    id="transaction.refund.info"
+                    defaultMessage="The contributor will be refunded the full amount."
+                  />
+                </div>
+                {error && <MessageBoxGraphqlError mt="12px" error={error} />}
               </div>
-              {error && <MessageBoxGraphqlError mt="12px" error={error} />}
-            </div>
-          }
-          continueLabel={
-            <Flex alignItems="center" justifyContent="space-evenly">
-              <Undo size={16} />
-              <FormattedMessage id="Refund" defaultMessage="Refund" />
-            </Flex>
-          }
-          continueHandler={handleRefundTransaction}
-        />
+            }
+            continueLabel={
+              <Flex alignItems="center" justifyContent="space-evenly">
+                <Undo size={16} />
+                <FormattedMessage id="Refund" defaultMessage="Refund" />
+              </Flex>
+            }
+            continueHandler={handleRefundTransaction}
+          />
+        )}
       </Box>
     </Flex>
   );

--- a/components/transactions/TransactionRejectButton.js
+++ b/components/transactions/TransactionRejectButton.js
@@ -82,46 +82,47 @@ const TransactionRejectButton = props => {
             </Flex>
           </StyledButton>
         </StyledTooltip>
-        <ConfirmationModal
-          show={isEnabled}
-          onClose={closeModal}
-          header={<FormattedMessage id="RejectContribution" defaultMessage="Reject and refund" />}
-          body={
-            <React.Fragment>
-              <Flex flexDirection="column" alignItems="center" justifyContent="center">
-                <MessageBox type="warning" mx={2}>
-                  <FormattedMessage
-                    id="transaction.reject.info"
-                    defaultMessage="Only reject if you want to remove the contributor from your Collective. This will refund their transaction, remove them from your Collective, and display the contribution as 'rejected'."
-                  />
-                  <br />
-                  <br />
-                  {props.canRefund ? (
+        {isEnabled && (
+          <ConfirmationModal
+            onClose={closeModal}
+            header={<FormattedMessage id="RejectContribution" defaultMessage="Reject and refund" />}
+            body={
+              <React.Fragment>
+                <Flex flexDirection="column" alignItems="center" justifyContent="center">
+                  <MessageBox type="warning" mx={2}>
                     <FormattedMessage
-                      id="transaction.reject.info.canRefund"
-                      defaultMessage="If you are only trying to refund a mistaken transaction, please use the 'Refund' button instead."
+                      id="transaction.reject.info"
+                      defaultMessage="Only reject if you want to remove the contributor from your Collective. This will refund their transaction, remove them from your Collective, and display the contribution as 'rejected'."
                     />
-                  ) : (
-                    <FormattedMessage
-                      id="transaction.reject.info.cannotRefund"
-                      defaultMessage="Please only use this option if you do not wish for this contributor to be a part of your Collective. This will remove them from your Collective."
-                    />
-                  )}
-                </MessageBox>
-                {error && <MessageBoxGraphqlError mt="12px" error={error} />}
-                <TransactionRejectMessageForm message={message} onChange={message => setMessage(message)} />
+                    <br />
+                    <br />
+                    {props.canRefund ? (
+                      <FormattedMessage
+                        id="transaction.reject.info.canRefund"
+                        defaultMessage="If you are only trying to refund a mistaken transaction, please use the 'Refund' button instead."
+                      />
+                    ) : (
+                      <FormattedMessage
+                        id="transaction.reject.info.cannotRefund"
+                        defaultMessage="Please only use this option if you do not wish for this contributor to be a part of your Collective. This will remove them from your Collective."
+                      />
+                    )}
+                  </MessageBox>
+                  {error && <MessageBoxGraphqlError mt="12px" error={error} />}
+                  <TransactionRejectMessageForm message={message} onChange={message => setMessage(message)} />
+                </Flex>
+              </React.Fragment>
+            }
+            continueLabel={
+              <Flex alignItems="center" justifyContent="space-evenly">
+                <MinusCircle size={16} />
+                <FormattedMessage id="transaction.reject.yes.btn" defaultMessage="Yes, reject" />
               </Flex>
-            </React.Fragment>
-          }
-          continueLabel={
-            <Flex alignItems="center" justifyContent="space-evenly">
-              <MinusCircle size={16} />
-              <FormattedMessage id="transaction.reject.yes.btn" defaultMessage="Yes, reject" />
-            </Flex>
-          }
-          continueHandler={handleRejectTransaction}
-          isDanger
-        />
+            }
+            continueHandler={handleRejectTransaction}
+            isDanger
+          />
+        )}
       </Box>
     </Flex>
   );

--- a/stories/design-system/ConfirmationModal.stories.mdx
+++ b/stories/design-system/ConfirmationModal.stories.mdx
@@ -12,7 +12,6 @@ import StyledButton from '../../components/StyledButton';
         <div>
           {show ? (
             <ConfirmationModal
-              show
               header={'Use modal'}
               body={'Are you sure you want to use this modal?'}
               onClose={() => setShow(false)}

--- a/stories/design-system/FilesPreviewModal.stories.mdx
+++ b/stories/design-system/FilesPreviewModal.stories.mdx
@@ -10,22 +10,23 @@ import FilesPreviewModal from '../../components/FilesPreviewModal';
       return (
         <div>
           <button onClick={() => setOpen(true)}>Show modal</button>
-          <FilesPreviewModal
-            show={isOpen}
-            onClose={() => setOpen(false)}
-            files={[
-              { url: 'https://loremflickr.com/600/600/invoice?lock=1' },
-              { url: 'https://loremflickr.com/400/1200/invoice?lock=2' },
-              { url: 'https://loremflickr.com/210/290/invoice?lock=3' },
-              { url: 'https://loremflickr.com/700/600/invoice?lock=4' },
-              { url: 'https://loremflickr.com/600/600/invoice?lock=5' },
-              { url: 'https://loremflickr.com/600/600/invoice?lock=6' },
-              { url: 'https://loremflickr.com/600/600/invoice?lock=7' },
-              { url: 'https://loremflickr.com/600/600/invoice?lock=8' },
-              { url: 'https://loremflickr.com/600/600/invoice?lock=9' },
-              { url: 'https://loremflickr.com/600/600/invoice?lock=10' },
-            ]}
-          />
+          {isOpen && (
+            <FilesPreviewModal
+              onClose={() => setOpen(false)}
+              files={[
+                { url: 'https://loremflickr.com/600/600/invoice?lock=1' },
+                { url: 'https://loremflickr.com/400/1200/invoice?lock=2' },
+                { url: 'https://loremflickr.com/210/290/invoice?lock=3' },
+                { url: 'https://loremflickr.com/700/600/invoice?lock=4' },
+                { url: 'https://loremflickr.com/600/600/invoice?lock=5' },
+                { url: 'https://loremflickr.com/600/600/invoice?lock=6' },
+                { url: 'https://loremflickr.com/600/600/invoice?lock=7' },
+                { url: 'https://loremflickr.com/600/600/invoice?lock=8' },
+                { url: 'https://loremflickr.com/600/600/invoice?lock=9' },
+                { url: 'https://loremflickr.com/600/600/invoice?lock=10' },
+              ]}
+            />
+          )}
         </div>
       );
     }}

--- a/stories/design-system/StyledModal.stories.mdx
+++ b/stories/design-system/StyledModal.stories.mdx
@@ -1,8 +1,8 @@
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
-import Modal, { ModalBody, ModalHeader, ModalFooter } from '../../components/StyledModal';
+import StyledModal, { ModalBody, ModalHeader, ModalFooter } from '../../components/StyledModal';
 import StyledButton from '../../components/StyledButton';
 
-<Meta title="Design system/StyledModal" component={Modal} />
+<Meta title="Design system/StyledModal" component={StyledModal} />
 
 ### Default
 
@@ -13,7 +13,7 @@ import StyledButton from '../../components/StyledButton';
       return (
         <div>
           {show ? (
-            <Modal show onClose={() => setShow(false)}>
+            <StyledModal onClose={() => setShow(false)}>
               <ModalHeader>Modal title goes here</ModalHeader>
               <ModalBody>
                 Contents of the modal goes here. There will be different content types but for noew lerts use this
@@ -33,7 +33,7 @@ import StyledButton from '../../components/StyledButton';
                   Go with this version
                 </StyledButton>
               </ModalFooter>
-            </Modal>
+            </StyledModal>
           ) : (
             <StyledButton buttonSize="large" buttonStyle="primary" onClick={() => setShow(true)}>
               Show modal


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/5160

# Description

Removed the `show` property from StyledModals and all Modal components that wrap it. Updated calling code accordingly, pulling conditions out where necessary as described in the issue. (In some cases it wasn't necessary, as the rendering was already conditional and the prop was redundant — even more reason why the refactoring was a good idea.)

If successful, no functionality should change anywhere at all (as expected for a proper refactoring). As far as I was able to test, I didn't see any, but the refactoring is pretty broad, so a quick lookaround by someone more familiar with the software would be appreciated.
