### PR TITLE
fixed phrasing of empty profile message

### DIFF
--- a/components/collective-page/sections/Empty.js
+++ b/components/collective-page/sections/Empty.js
@@ -53,7 +53,7 @@ const SectionEmpty = props => {
             <P fontSize="20px" color="black.600" lineHeight="28px">
               <FormattedMessage
                 id="EmptyCollectivePage"
-                defaultMessage="{collective} is still working on its public profile. In the mean time you can check out some other Collectives!"
+                defaultMessage="{collective} is still working on their public profile. In the meantime, check out some other Collectives!"
                 values={{
                   collective: collective.name,
                 }}


### PR DESCRIPTION
You can't call a person "it" in English