### PR TITLE
Prevent hidding budget if not already set

### DIFF
--- a/components/edit-collective/sections/EditCollectivePage.js
+++ b/components/edit-collective/sections/EditCollectivePage.js
@@ -142,8 +142,9 @@ const CollectiveSectionEntry = ({
   if (collectiveType !== CollectiveType.FUND && collectiveType !== CollectiveType.PROJECT) {
     options = options.filter(({ value }) => value !== 'ADMIN');
   }
-  if (section === 'budget' && ![CollectiveType.FUND, CollectiveType.PROJECT].includes(collectiveType)) {
-    options = options.filter(({ value }) => value !== 'DISABLED');
+  // Can't hide the budget, expect if already hidden
+  if (section === 'budget' && isEnabled && !isEqual(restrictedTo, ['ADMIN'])) {
+    options = options.filter(({ value }) => value !== 'ADMIN' && value !== 'DISABLED');
   }
 
   let defaultValue;


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/5270
Resolve https://github.com/opencollective/opencollective/issues/5270

Removes the ability to hide the budget for accounts where it's not hidden already. 

![image](https://user-images.githubusercontent.com/1556356/156131910-70310ea3-d5a1-4b1b-94a2-215c50412315.png)
