### PR TITLE
Fix payment method label for Project balance

### DIFF
--- a/components/contribution-flow/utils.js
+++ b/components/contribution-flow/utils.js
@@ -83,7 +83,7 @@ export const generatePaymentMethodOptions = (
   const paymentMethodsOptions = paymentMethods.map(pm => ({
     id: pm.id,
     key: `pm-${pm.id}`,
-    title: getPaymentMethodName(pm),
+    title: getPaymentMethodName(pm, stepProfile),
     subtitle: getPaymentMethodMetadata(pm, totalAmount),
     icon: getPaymentMethodIcon(pm),
     disabled: isPaymentMethodDisabled(pm, totalAmount),

--- a/lib/payment_method_label.js
+++ b/lib/payment_method_label.js
@@ -13,7 +13,7 @@
  */
 
 import dayjs from 'dayjs';
-import { get, padStart } from 'lodash';
+import { capitalize, get, padStart } from 'lodash';
 import { defineMessages } from 'react-intl';
 
 import { PAYMENT_METHOD_SERVICE, PAYMENT_METHOD_TYPE } from './constants/payment-methods';
@@ -79,7 +79,7 @@ function formatCreditCardBrand(brand) {
 /**
  * Format payment method name
  */
-export const getPaymentMethodName = ({ name, data, service, type }) => {
+export const getPaymentMethodName = ({ name, data, service, type }, collective) => {
   if (type === PAYMENT_METHOD_TYPE.GIFTCARD) {
     return name?.replace('card from', 'Gift Card from') || 'Gift card';
   } else if (type === PAYMENT_METHOD_TYPE.PREPAID) {
@@ -93,6 +93,8 @@ export const getPaymentMethodName = ({ name, data, service, type }) => {
     return 'Bank transfer';
   } else if (type === PAYMENT_METHOD_TYPE.ALIPAY) {
     return 'Alipay';
+  } else if (type === PAYMENT_METHOD_TYPE.COLLECTIVE && collective) {
+    return name || `${collective.name} (${capitalize(collective.type)})`;
   } else {
     return name || `${service} - ${type}`;
   }


### PR DESCRIPTION
This was something that François caught on the demo but after I reviewed how the Collective payment method was created, I thought it was already solved in the backend.

Apparently, this still doesn't cover older payment methods and I decided to implement the same naming mechanism on the frontend.

Preview:
![image](https://user-images.githubusercontent.com/2119706/156373850-3bc10741-1a5f-4545-891a-5a70f4a996f2.png)
