### PR TITLE
Return `null` for emoji when country code is not found

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15579,9 +15579,9 @@
       "integrity": "sha512-MqmIWr3aucoU/3XZU44e0sz6izAlErqaUYp9/NFzdnzb9TrwwornyW3ws2da5TSnpTUr2qP2840oJW9oNKXCoQ=="
     },
     "country-currency-emoji-flags": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/country-currency-emoji-flags/-/country-currency-emoji-flags-1.0.5.tgz",
-      "integrity": "sha512-XYjwqNF4OHlBkMjZDLxrUL904X0YkaPz16C3ELP7/M0/L3mwl4shL3PAXLuIwMztqlJfJmB+aNXLfTHs19TzKQ=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/country-currency-emoji-flags/-/country-currency-emoji-flags-1.0.6.tgz",
+      "integrity": "sha512-GgQy2pYo8q89Z309+FsI02AR/EuDHvgZrO+W8t9VrLbxnNm3w+bEBhVRAC60Coktsd+O5dKWrZu8C7av4XU42g=="
     },
     "cp-file": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "cloudflare-ip": "0.0.7",
     "cookie-parser": "1.4.6",
     "copy-to-clipboard": "3.3.1",
-    "country-currency-emoji-flags": "1.0.5",
+    "country-currency-emoji-flags": "1.0.6",
     "cross-fetch": "3.1.5",
     "currency-symbol-map": "5.0.1",
     "dayjs": "1.10.8",


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/5236

I thought the safer bet is to return `null` when the country code is not found rather than returning an error since this could potentially crash the expense form if by chance somehow a wrong country code or a null/undefined value is passed. 

https://github.com/opencollective/country-currency-emoji-flags/commit/bffc18cf4aca8875569ac2d240979d3fbabf4101