### PR TITLE
Do Not Change Step to Payee When Expense Type is Changed

### DIFF
--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -208,7 +208,7 @@ const HiddenFragment = styled.div`
   display: ${({ show }) => (show ? 'block' : 'none')};
 `;
 
-const STEPS = {
+export const STEPS = {
   PAYEE: 'PAYEE',
   EXPENSE: 'EXPENSE',
 };
@@ -233,6 +233,7 @@ const ExpenseFormBody = ({
   expensesTags,
   shouldLoadValuesFromPersister,
   isDraft,
+  initialStep,
 }) => {
   const intl = useIntl();
   const { formatMessage } = intl;
@@ -253,7 +254,16 @@ const ExpenseFormBody = ({
     ? true
     : (stepOneCompleted || isCreditCardCharge) && hasBaseFormFieldsCompleted && values.items.length > 0;
 
-  const [step, setStep] = React.useState(stepOneCompleted || isCreditCardCharge ? STEPS.EXPENSE : STEPS.PAYEE);
+  if (!initialStep) {
+    if (isInvite) {
+      initialStep = STEPS.PAYEE;
+    } else if (stepOneCompleted || isCreditCardCharge) {
+      initialStep = STEPS.EXPENSE;
+    } else {
+      initialStep = STEPS.PAYEE;
+    }
+  }
+  const [step, setStep] = React.useState(initialStep);
   // Only true when logged in and drafting the expense
   const [isOnBehalf, setOnBehalf] = React.useState(false);
   const [showResetModal, setShowResetModal] = React.useState(false);
@@ -303,7 +313,6 @@ const ExpenseFormBody = ({
   // Return to Payee step if type is changed and reset some values
   React.useEffect(() => {
     if (!isCreditCardCharge) {
-      setStep(STEPS.PAYEE);
       setOnBehalf(false);
 
       if (!isDraft && values.payee?.isInvite) {
@@ -718,6 +727,7 @@ ExpenseFormBody.propTypes = {
       }),
     ),
   }),
+  initialStep: PropTypes.oneOf([STEPS.EXPENSE, STEPS.PAYEE]),
 };
 
 /**
@@ -737,6 +747,7 @@ const ExpenseForm = ({
   loading,
   expensesTags,
   shouldLoadValuesFromPersister,
+  initialStep,
 }) => {
   const isDraft = expense?.status === expenseStatus.DRAFT;
   const [hasValidate, setValidate] = React.useState(validateOnChange && !isDraft);
@@ -782,6 +793,7 @@ const ExpenseForm = ({
           loading={loading}
           shouldLoadValuesFromPersister={shouldLoadValuesFromPersister}
           isDraft={isDraft}
+          initialStep={initialStep}
         />
       )}
     </Formik>
@@ -858,6 +870,7 @@ ExpenseForm.propTypes = {
       ),
     }),
   ),
+  initialStep: PropTypes.oneOf([STEPS.EXPENSE, STEPS.PAYEE]),
 };
 
 ExpenseForm.defaultProps = {

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -208,7 +208,7 @@ const HiddenFragment = styled.div`
   display: ${({ show }) => (show ? 'block' : 'none')};
 `;
 
-export const STEPS = {
+const STEPS = {
   PAYEE: 'PAYEE',
   EXPENSE: 'EXPENSE',
 };
@@ -233,7 +233,6 @@ const ExpenseFormBody = ({
   expensesTags,
   shouldLoadValuesFromPersister,
   isDraft,
-  initialStep,
 }) => {
   const intl = useIntl();
   const { formatMessage } = intl;
@@ -254,16 +253,7 @@ const ExpenseFormBody = ({
     ? true
     : (stepOneCompleted || isCreditCardCharge) && hasBaseFormFieldsCompleted && values.items.length > 0;
 
-  if (!initialStep) {
-    if (isInvite) {
-      initialStep = STEPS.PAYEE;
-    } else if (stepOneCompleted || isCreditCardCharge) {
-      initialStep = STEPS.EXPENSE;
-    } else {
-      initialStep = STEPS.PAYEE;
-    }
-  }
-  const [step, setStep] = React.useState(initialStep);
+  const [step, setStep] = React.useState(stepOneCompleted || isCreditCardCharge ? STEPS.EXPENSE : STEPS.PAYEE);
   // Only true when logged in and drafting the expense
   const [isOnBehalf, setOnBehalf] = React.useState(false);
   const [showResetModal, setShowResetModal] = React.useState(false);
@@ -313,6 +303,7 @@ const ExpenseFormBody = ({
   // Return to Payee step if type is changed and reset some values
   React.useEffect(() => {
     if (!isCreditCardCharge) {
+      setStep(STEPS.PAYEE);
       setOnBehalf(false);
 
       if (!isDraft && values.payee?.isInvite) {
@@ -727,7 +718,6 @@ ExpenseFormBody.propTypes = {
       }),
     ),
   }),
-  initialStep: PropTypes.oneOf([STEPS.EXPENSE, STEPS.PAYEE]),
 };
 
 /**
@@ -747,7 +737,6 @@ const ExpenseForm = ({
   loading,
   expensesTags,
   shouldLoadValuesFromPersister,
-  initialStep,
 }) => {
   const isDraft = expense?.status === expenseStatus.DRAFT;
   const [hasValidate, setValidate] = React.useState(validateOnChange && !isDraft);
@@ -793,7 +782,6 @@ const ExpenseForm = ({
           loading={loading}
           shouldLoadValuesFromPersister={shouldLoadValuesFromPersister}
           isDraft={isDraft}
-          initialStep={initialStep}
         />
       )}
     </Formik>
@@ -870,7 +858,6 @@ ExpenseForm.propTypes = {
       ),
     }),
   ),
-  initialStep: PropTypes.oneOf([STEPS.EXPENSE, STEPS.PAYEE]),
 };
 
 ExpenseForm.defaultProps = {

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -312,7 +312,7 @@ const ExpenseFormBody = ({
 
   // Return to Payee step if type is changed and reset some values
   React.useEffect(() => {
-    if (previousValue && !isCreditCardCharge) {
+    if ((previousValue || values.payee?.isInvite) && !isCreditCardCharge) {
       setStep(STEPS.PAYEE);
       setOnBehalf(false);
 

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -300,9 +300,19 @@ const ExpenseFormBody = ({
     }
   }, [values.payee]);
 
+  const usePreviousValue = value => {
+    const ref = React.useRef();
+    React.useEffect(() => {
+      ref.current = value;
+    });
+    return ref.current;
+  };
+
+  const previousValue = usePreviousValue(values.type);
+
   // Return to Payee step if type is changed and reset some values
   React.useEffect(() => {
-    if (!isCreditCardCharge) {
+    if (previousValue && !isCreditCardCharge) {
       setStep(STEPS.PAYEE);
       setOnBehalf(false);
 

--- a/pages/expense.js
+++ b/pages/expense.js
@@ -26,7 +26,7 @@ import Thread from '../components/conversations/Thread';
 import ErrorPage from '../components/ErrorPage';
 import ExpenseAdminActions from '../components/expenses/ExpenseAdminActions';
 import ExpenseAttachedFiles from '../components/expenses/ExpenseAttachedFiles';
-import ExpenseForm, { prepareExpenseForSubmit } from '../components/expenses/ExpenseForm';
+import ExpenseForm, { prepareExpenseForSubmit, STEPS } from '../components/expenses/ExpenseForm';
 import ExpenseInfoSidebar from '../components/expenses/ExpenseInfoSidebar';
 import ExpenseInviteNotificationBanner from '../components/expenses/ExpenseInviteNotificationBanner';
 import ExpenseMissingReceiptNotificationBanner from '../components/expenses/ExpenseMissingReceiptNotificationBanner';
@@ -253,7 +253,7 @@ class ExpensePage extends React.Component {
       expense?.permissions?.canEdit &&
       expense?.items?.every(item => !item.url);
     if (this.props.edit && isMissingReceipt && this.state.status !== PAGE_STATUS.EDIT) {
-      this.onEditBtnClick();
+      this.onEditBtnClick('EXPENSE');
       this.props.router.replace(document.location.pathname);
     }
 
@@ -437,8 +437,12 @@ class ExpensePage extends React.Component {
     return sortBy([...(comments || []), ...activities], 'createdAt');
   });
 
-  onEditBtnClick = async () => {
-    return this.setState(() => ({ status: PAGE_STATUS.EDIT, editedExpense: this.props.data.expense }));
+  onEditBtnClick = async initialStep => {
+    return this.setState(() => ({
+      status: PAGE_STATUS.EDIT,
+      editedExpense: this.props.data.expense,
+      initialStep: initialStep,
+    }));
   };
 
   onDelete = async expense => {
@@ -520,7 +524,7 @@ class ExpensePage extends React.Component {
                   collective={collective}
                   permissions={expense?.permissions}
                   onError={error => this.setState({ error })}
-                  onEdit={this.onEditBtnClick}
+                  onEdit={() => this.onEditBtnClick(STEPS.PAYEE)}
                 />
               )}
             </Flex>
@@ -574,7 +578,7 @@ class ExpensePage extends React.Component {
                   isLoadingLoggedInUser={loadingLoggedInUser || isRefetchingDataForUser}
                   collective={collective}
                   onError={error => this.setState({ error })}
-                  onEdit={this.onEditBtnClick}
+                  onEdit={() => this.onEditBtnClick(STEPS.PAYEE)}
                   onDelete={this.onDelete}
                   suggestedTags={this.getSuggestedTags(collective)}
                   canEditTags={get(expense, 'permissions.canEditTags', false)}
@@ -677,7 +681,7 @@ class ExpensePage extends React.Component {
                         mr={[null, 3]}
                         whiteSpace="nowrap"
                         data-cy="edit-expense-btn"
-                        onClick={() => this.setState({ status: PAGE_STATUS.EDIT })}
+                        onClick={() => this.setState({ status: PAGE_STATUS.EDIT, initialStep: STEPS.EXPENSE })}
                         disabled={this.state.isSubmitting}
                       >
                         ← <FormattedMessage id="Expense.edit" defaultMessage="Edit expense" />
@@ -733,6 +737,7 @@ class ExpensePage extends React.Component {
                         });
                       }
                     }}
+                    initialStep={this.state.initialStep}
                     validateOnChange
                     disableSubmitIfUntouched
                   />

--- a/pages/expense.js
+++ b/pages/expense.js
@@ -26,7 +26,7 @@ import Thread from '../components/conversations/Thread';
 import ErrorPage from '../components/ErrorPage';
 import ExpenseAdminActions from '../components/expenses/ExpenseAdminActions';
 import ExpenseAttachedFiles from '../components/expenses/ExpenseAttachedFiles';
-import ExpenseForm, { prepareExpenseForSubmit, STEPS } from '../components/expenses/ExpenseForm';
+import ExpenseForm, { prepareExpenseForSubmit } from '../components/expenses/ExpenseForm';
 import ExpenseInfoSidebar from '../components/expenses/ExpenseInfoSidebar';
 import ExpenseInviteNotificationBanner from '../components/expenses/ExpenseInviteNotificationBanner';
 import ExpenseMissingReceiptNotificationBanner from '../components/expenses/ExpenseMissingReceiptNotificationBanner';
@@ -253,7 +253,7 @@ class ExpensePage extends React.Component {
       expense?.permissions?.canEdit &&
       expense?.items?.every(item => !item.url);
     if (this.props.edit && isMissingReceipt && this.state.status !== PAGE_STATUS.EDIT) {
-      this.onEditBtnClick('EXPENSE');
+      this.onEditBtnClick();
       this.props.router.replace(document.location.pathname);
     }
 
@@ -437,12 +437,8 @@ class ExpensePage extends React.Component {
     return sortBy([...(comments || []), ...activities], 'createdAt');
   });
 
-  onEditBtnClick = async initialStep => {
-    return this.setState(() => ({
-      status: PAGE_STATUS.EDIT,
-      editedExpense: this.props.data.expense,
-      initialStep: initialStep,
-    }));
+  onEditBtnClick = async () => {
+    return this.setState(() => ({ status: PAGE_STATUS.EDIT, editedExpense: this.props.data.expense }));
   };
 
   onDelete = async expense => {
@@ -524,7 +520,7 @@ class ExpensePage extends React.Component {
                   collective={collective}
                   permissions={expense?.permissions}
                   onError={error => this.setState({ error })}
-                  onEdit={() => this.onEditBtnClick(STEPS.PAYEE)}
+                  onEdit={this.onEditBtnClick}
                 />
               )}
             </Flex>
@@ -578,7 +574,7 @@ class ExpensePage extends React.Component {
                   isLoadingLoggedInUser={loadingLoggedInUser || isRefetchingDataForUser}
                   collective={collective}
                   onError={error => this.setState({ error })}
-                  onEdit={() => this.onEditBtnClick(STEPS.PAYEE)}
+                  onEdit={this.onEditBtnClick}
                   onDelete={this.onDelete}
                   suggestedTags={this.getSuggestedTags(collective)}
                   canEditTags={get(expense, 'permissions.canEditTags', false)}
@@ -681,7 +677,7 @@ class ExpensePage extends React.Component {
                         mr={[null, 3]}
                         whiteSpace="nowrap"
                         data-cy="edit-expense-btn"
-                        onClick={() => this.setState({ status: PAGE_STATUS.EDIT, initialStep: STEPS.EXPENSE })}
+                        onClick={() => this.setState({ status: PAGE_STATUS.EDIT })}
                         disabled={this.state.isSubmitting}
                       >
                         ← <FormattedMessage id="Expense.edit" defaultMessage="Edit expense" />
@@ -737,7 +733,6 @@ class ExpensePage extends React.Component {
                         });
                       }
                     }}
-                    initialStep={this.state.initialStep}
                     validateOnChange
                     disableSubmitIfUntouched
                   />

--- a/test/cypress/integration/27-expenses.test.js
+++ b/test/cypress/integration/27-expenses.test.js
@@ -94,7 +94,6 @@ describe('New expense flow', () => {
 
       // Start editing
       cy.getByDataCy('edit-expense-btn').click();
-      cy.getByDataCy('expense-next').click();
       cy.get('input[name="description"]').type(' edited');
       cy.get('input[name="items[0].description"]').type(' but not too expensive');
       cy.get('input[name="items[0].amount"]').type('{selectall}111');
@@ -432,7 +431,6 @@ describe('New expense flow', () => {
 
       // Start editing
       cy.get('[data-cy="edit-expense-btn"]:visible').click();
-      cy.getByDataCy('expense-next').click();
 
       // Add new item
       cy.getByDataCy('expense-add-item-btn').click();
@@ -456,7 +454,6 @@ describe('New expense flow', () => {
       // ---- 3. Remove VAT ----
       // Start editing
       cy.get('[data-cy="edit-expense-btn"]:visible').click();
-      cy.getByDataCy('expense-next').click();
 
       // Disable VAT
       cy.getByDataCy('checkbox-tax-VAT').click();


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/5235

I don't see any reason we need to change the step to `PAYEE` when the expense type is changed. What we should do I think is just reset the `payee` information and everything seems to work fine, both for an invited expense a regular expense. Let me know if I am missing anything. 

![expense-back-forth](https://user-images.githubusercontent.com/12435965/157538965-4264d0c0-9009-4fa1-9849-89260fd9dd10.gif)



