### PR TITLE
Change some instances of `getErrorFromGraphqlException` to `i18nGraphqlException`

### DIFF
--- a/components/ReplyToMemberInvitationCard.js
+++ b/components/ReplyToMemberInvitationCard.js
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
 import roles from '../lib/constants/roles';
-import { getErrorFromGraphqlException } from '../lib/errors';
+import { i18nGraphqlException } from '../lib/errors';
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
 import formatMemberRole from '../lib/i18n/member-role';
 
@@ -133,7 +133,7 @@ const ReplyToMemberInvitationCard = ({ invitation, isSelected, refetchLoggedInUs
           )}
           {error && (
             <MessageBox type="error" withIcon my={3}>
-              {getErrorFromGraphqlException(error).message}
+              {i18nGraphqlException(intl, error)}
             </MessageBox>
           )}
           <Flex mt={4} justifyContent="space-evenly">

--- a/components/conversations/CommentActions.js
+++ b/components/conversations/CommentActions.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 import { useMutation } from '@apollo/client';
 import { X } from '@styled-icons/feather/X';
 import { Edit } from '@styled-icons/material/Edit';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { usePopper } from 'react-popper';
 import styled from 'styled-components';
 
-import { getErrorFromGraphqlException } from '../../lib/errors';
+import { i18nGraphqlException } from '../../lib/errors';
 import { API_V2_CONTEXT, gqlV2 } from '../../lib/graphql/helpers';
 import useGlobalBlur from '../../lib/hooks/useGlobalBlur';
 
@@ -116,6 +116,7 @@ const REACT_POPPER_MODIFIERS = [
 const mutationOptions = { context: API_V2_CONTEXT };
 
 const CommentActions = ({ comment, isConversationRoot, canEdit, canDelete, onDelete, onEditClick }) => {
+  const intl = useIntl();
   const [isDeleting, setDeleting] = React.useState(null);
   const [showAdminActions, setShowAdminActions] = React.useState(false);
   const [refElement, setRefElement] = React.useState(null);
@@ -208,7 +209,7 @@ const CommentActions = ({ comment, isConversationRoot, canEdit, canDelete, onDel
           </Container>
           {deleteError && (
             <MessageBox type="error" withIcon mt={3}>
-              {getErrorFromGraphqlException(deleteError).message}
+              {i18nGraphqlException(intl, deleteError)}
             </MessageBox>
           )}
         </ConfirmationModal>

--- a/components/conversations/CreateConversationForm.js
+++ b/components/conversations/CreateConversationForm.js
@@ -4,7 +4,7 @@ import { useMutation } from '@apollo/client';
 import { useFormik } from 'formik';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
-import { createError, ERROR, getErrorFromGraphqlException } from '../../lib/errors';
+import { createError, ERROR, i18nGraphqlException } from '../../lib/errors';
 import FormPersister from '../../lib/form-persister';
 import { formatFormErrorMessage } from '../../lib/form-utils';
 import { API_V2_CONTEXT, gqlV2 } from '../../lib/graphql/helpers';
@@ -196,7 +196,7 @@ const CreateConversationForm = ({ collective, LoggedInUser, suggestedTags, onSuc
       </Flex>
       {submitError && (
         <MessageBox type="error" mt={3}>
-          {getErrorFromGraphqlException(submitError).message}
+          {i18nGraphqlException(intl, submitError)}
         </MessageBox>
       )}
       <StyledButton

--- a/components/edit-collective/sections/HostTwoFactorAuth.js
+++ b/components/edit-collective/sections/HostTwoFactorAuth.js
@@ -6,7 +6,7 @@ import { cloneDeep, get, pick, set } from 'lodash';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import styled from 'styled-components';
 
-import { getErrorFromGraphqlException } from '../../../lib/errors';
+import { i18nGraphqlException } from '../../../lib/errors';
 
 import Container from '../../Container';
 import HostPayouts2FARollingLimitFAQ from '../../faqs/HostPayouts2FARollingLimitFAQ';
@@ -52,7 +52,7 @@ const ScreenshotPreview = styled.div`
 `;
 
 const HostTwoFactorAuth = ({ collective }) => {
-  const { formatMessage } = useIntl();
+  const intl = useIntl();
   const { addToast } = useToasts();
   const [setSettings, { loading, error }] = useMutation(editCollectiveSettingsMutation);
   const doesHostAlreadyHaveTwoFactorAuthEnabled = get(collective, 'settings.payoutsTwoFactorAuth.enabled', false);
@@ -108,7 +108,7 @@ const HostTwoFactorAuth = ({ collective }) => {
                         name="rollingLimit"
                         htmlFor="rollingLimit"
                         disabled={loading}
-                        label={formatMessage(messages['rollingLimit.label'])}
+                        label={intl.formatMessage(messages['rollingLimit.label'])}
                         labelProps={{ mb: 2, pt: 2, lineHeight: '18px', fontWeight: 'bold' }}
                       >
                         {inputProps => (
@@ -118,7 +118,7 @@ const HostTwoFactorAuth = ({ collective }) => {
                             type="number"
                             fontSize="14px"
                             value={formik.values.rollingLimit}
-                            placeholder={formatMessage(messages['rollingLimit.placeholder'])}
+                            placeholder={intl.formatMessage(messages['rollingLimit.placeholder'])}
                             onChange={value => formik.setFieldValue('rollingLimit', value)}
                             min={100}
                             precision={2}
@@ -146,7 +146,7 @@ const HostTwoFactorAuth = ({ collective }) => {
               ) : (
                 <StyledCheckbox
                   name="enable-rolling-limit"
-                  label={formatMessage(messages['rollingLimit.enable'])}
+                  label={intl.formatMessage(messages['rollingLimit.enable'])}
                   defaultChecked={defaultIsChecked}
                   width="auto"
                   isLoading={loading}
@@ -161,7 +161,7 @@ const HostTwoFactorAuth = ({ collective }) => {
           </Flex>
           {error && (
             <MessageBox type="error" fontSize="14px" withIcon mb={3}>
-              {getErrorFromGraphqlException(error).message}
+              {i18nGraphqlException(intl, error)}
             </MessageBox>
           )}
           <Flex flexWrap="wrap" justifyContent="space-between" width="100%">

--- a/components/edit-collective/sections/InvoicesReceipts.js
+++ b/components/edit-collective/sections/InvoicesReceipts.js
@@ -58,7 +58,7 @@ const InvoicesReceipts = ({ collective }) => {
       </P>
       {error && (
         <MessageBox type="error" fontSize="14px" withIcon mb={3}>
-          {i18nGraphqlException(intl, setValue)}
+          {i18nGraphqlException(intl, error)}
         </MessageBox>
       )}
       <Flex flexWrap="wrap" justifyContent="space-between" maxWidth={800}>

--- a/components/edit-collective/sections/InvoicesReceipts.js
+++ b/components/edit-collective/sections/InvoicesReceipts.js
@@ -4,7 +4,7 @@ import { useMutation } from '@apollo/client';
 import { get } from 'lodash';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
-import { getErrorFromGraphqlException } from '../../../lib/errors';
+import { i18nGraphqlException } from '../../../lib/errors';
 
 import Container from '../../Container';
 import { Box, Flex } from '../../Grid';
@@ -28,7 +28,7 @@ const messages = defineMessages({
 });
 
 const InvoicesReceipts = ({ collective }) => {
-  const { formatMessage } = useIntl();
+  const intl = useIntl();
 
   // For invoice Title
   const defaultValue = get(collective.settings, 'invoiceTitle');
@@ -58,7 +58,7 @@ const InvoicesReceipts = ({ collective }) => {
       </P>
       {error && (
         <MessageBox type="error" fontSize="14px" withIcon mb={3}>
-          {getErrorFromGraphqlException(setValue).message}
+          {i18nGraphqlException(intl, setValue)}
         </MessageBox>
       )}
       <Flex flexWrap="wrap" justifyContent="space-between" maxWidth={800}>
@@ -73,7 +73,7 @@ const InvoicesReceipts = ({ collective }) => {
           />
 
           <StyledTextarea
-            placeholder={formatMessage(messages.extraInfoPlaceholder)}
+            placeholder={intl.formatMessage(messages.extraInfoPlaceholder)}
             defaultValue={info}
             onChange={e => setInfo(e.target.value)}
             width="100%"

--- a/components/edit-collective/sections/Members.js
+++ b/components/edit-collective/sections/Members.js
@@ -8,7 +8,7 @@ import { defineMessages, FormattedDate, FormattedMessage, injectIntl } from 'rea
 import styled from 'styled-components';
 
 import roles from '../../../lib/constants/roles';
-import { getErrorFromGraphqlException } from '../../../lib/errors';
+import { i18nGraphqlException } from '../../../lib/errors';
 import { API_V2_CONTEXT, gqlV2 } from '../../../lib/graphql/helpers';
 import formatMemberRole from '../../../lib/i18n/member-role';
 
@@ -315,14 +315,14 @@ class Members extends React.Component {
   }
 
   render() {
-    const { data } = this.props;
+    const { data, intl } = this.props;
 
     if (data.loading) {
       return <Loading />;
     } else if (data.error) {
       return (
         <MessageBox type="error" withIcon>
-          {getErrorFromGraphqlException(data.error).message}
+          {i18nGraphqlException(intl, data.error)}
         </MessageBox>
       );
     } else if (data.account?.parentAccount) {


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/5216

Here I've replaced all the `getErrorFromGraphqlException(err).message` with `i18nGraphqlException(intl, err)` just so that the error messages are internationalized properly. 
