### PR TITLE
Fix embed contribution flow redirect when parent slug is missing

### DIFF
--- a/lib/url-helpers.js
+++ b/lib/url-helpers.js
@@ -176,7 +176,7 @@ export const isTrustedRedirectHost = host => {
   });
 };
 
-export const addParentToURLIfMissing = (router, account, url = '', queryParams) => {
+export const addParentToURLIfMissing = (router, account, url = '', queryParams = undefined, options = {}) => {
   const query = router.query;
   if (
     [CollectiveType.EVENT, CollectiveType.PROJECT].includes(account?.type) &&
@@ -184,6 +184,7 @@ export const addParentToURLIfMissing = (router, account, url = '', queryParams) 
     !(router.query.eventSlug && router.query.collectiveSlug)
   ) {
     const urlWithParent = getCollectivePageRoute(account) + url;
-    router.push({ pathname: urlWithParent, query: queryParams }, null, { shallow: true });
+    const prefix = options?.prefix || '';
+    router.push({ pathname: `${prefix}${urlWithParent}`, query: queryParams }, null, { shallow: true });
   }
 };

--- a/pages/embed/contribution-flow.js
+++ b/pages/embed/contribution-flow.js
@@ -129,7 +129,8 @@ class NewContributionFlowPage extends React.Component {
     const { router, data } = this.props;
     const account = data?.account;
     const path = router.asPath;
-    addParentToURLIfMissing(router, account, path.replace(new RegExp(`^/${account?.slug}/`), '/'));
+    const rawPath = path.replace(new RegExp(`^/embed/${account?.slug}/`), '/');
+    addParentToURLIfMissing(router, account, rawPath, null, { prefix: '/embed' });
   }
 
   componentDidUpdate(prevProps) {

--- a/rewrites.js
+++ b/rewrites.js
@@ -168,6 +168,15 @@ exports.REWRITES = [
     source: '/:collectiveSlug/:verb(tiers|contribute|events|projects|connected-collectives)',
     destination: '/contribute',
   },
+  // Embed
+  {
+    source: `/embed/:parentCollectiveSlug?/:collectiveType(events|projects)?/:collectiveSlug/:verb(donate)/:paymentFlow(crypto)?/:step(${contributionFlowSteps})?`,
+    destination: '/embed/contribution-flow',
+  },
+  {
+    source: `/embed/:parentCollectiveSlug?/:collectiveType(events|projects)?/:collectiveSlug/contribute/:tierSlug?-:tierId([0-9]+)/:step(${contributionFlowSteps})?`,
+    destination: '/embed/contribution-flow',
+  },
   // Tier page
   {
     source:
@@ -186,15 +195,6 @@ exports.REWRITES = [
   {
     source: '/:collectiveSlug/conversations/:slug?-:id([a-z0-9]+)',
     destination: '/conversation',
-  },
-  // Embed
-  {
-    source: `/embed/:parentCollectiveSlug?/:collectiveType(events|projects)?/:collectiveSlug/:verb(donate)/:paymentFlow(crypto)?/:step(${contributionFlowSteps})?`,
-    destination: '/embed/contribution-flow',
-  },
-  {
-    source: `/embed/:parentCollectiveSlug?/:collectiveType(events|projects)?/:collectiveSlug/contribute/:tierSlug?-:tierId([0-9]+)/:step(${contributionFlowSteps})?`,
-    destination: '/embed/contribution-flow',
   },
   // Contribute Flow
   // ---------------


### PR DESCRIPTION
Probably the root cause for https://opencollective.freshdesk.com/a/tickets/69673

This PR fixes 2 issues introduced in https://github.com/opencollective/opencollective-frontend/pull/7395:
1. The embed contribution flow routes were placed after the `/tier` route, so the last would take precedence. As a result, https://opencollective.com/embed/mautic-conference-europe-4da0de72/contribute/general-access-ticket-32898 was serving the tier page rather than the embed contribution flow. This is similar to what was fixed in https://github.com/opencollective/opencollective-frontend/pull/7476.
2. The redirect implemented in `pages/embed/contribution-flow.js` was not handling the `/embed` part of the URL, redirecting `/embed/mautic-conference-europe-4da0de72/contribute/general-access-ticket-32898` to `/mautic/events/mautic-conference-europe-4da0de72/embed/mautic-conference-europe-4da0de72/contribute/general-access-ticket-32898` resulting in a 404 error