### PR TITLE
PayExpenseModal: convert processor fees amount when paying manually

### DIFF
--- a/components/expenses/PayExpenseModal.js
+++ b/components/expenses/PayExpenseModal.js
@@ -180,8 +180,9 @@ const getInitialValues = (expense, host, payoutMethodType) => {
 
 const getPaymentProcessorFee = (formik, expense, quoteQuery) => {
   if (formik.values.forceManual) {
+    const fxRate = expense.amountInAccountCurrency?.exchangeRate?.value || 1;
     return {
-      valueInCents: formik.values.paymentProcessorFee,
+      valueInCents: Math.round(formik.values.paymentProcessorFee * fxRate),
       currency: expense.currency,
     };
   } else if (quoteQuery?.data?.expense?.quote) {


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/5146

![image](https://user-images.githubusercontent.com/1556356/160096911-ac461943-9bc5-4410-a3a2-3b74d7745131.png)
