### PR TITLE
Ignore some commits in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# refactor: reorganize project structure 
+b9beb049d1cd1e6a891abc24ebefdaadb37bd5f1


### PR DESCRIPTION
`.git-blame-ignore-revs` is now [officially supported](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view) on Github, this will make our lives easier when trying to find the origin of a change.

Ignored:
- https://github.com/opencollective/opencollective-frontend/commit/b9beb049d1cd1e6a891abc24ebefdaadb37bd5f1