### PR TITLE
Correct types in query string on `/search` page

### DIFF
--- a/pages/search.js
+++ b/pages/search.js
@@ -92,7 +92,7 @@ class SearchPage extends React.Component {
   static getInitialProps({ query }) {
     return {
       term: query.q || '',
-      types: query.types ? decodeURIComponent(query.types).split(',') : DEFAULT_SEARCH_TYPES,
+      type: query.type ? decodeURIComponent(query.type).split(',') : DEFAULT_SEARCH_TYPES,
       isHost: isNil(query.isHost) ? undefined : parseToBoolean(query.isHost),
       limit: Number(query.limit) || 20,
       offset: Number(query.offset) || 0,
@@ -121,7 +121,7 @@ class SearchPage extends React.Component {
     const { router } = this.props;
     const { q } = form;
 
-    router.push({ pathname: router.pathname, query: { q: q.value, types: router.query.types } });
+    router.push({ pathname: router.pathname, query: { q: q.value, type: router.query.type } });
   };
 
   onClick = filter => {
@@ -130,7 +130,7 @@ class SearchPage extends React.Component {
     if (filter === 'HOST') {
       this.props.router.push({ pathname: '/search', query: { q: term, isHost: true } });
     } else if (filter !== 'ALL') {
-      this.props.router.push({ pathname: '/search', query: { q: term, types: filter } });
+      this.props.router.push({ pathname: '/search', query: { q: term, type: filter } });
     } else {
       this.props.router.push({ pathname: '/search', query: { q: term } });
     }


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/5364

Something I've missed in https://github.com/opencollective/opencollective-frontend/pull/7633 is to update the `type` part of the query in the `/search` page. We need this as otherwise the search page starts showing users as well. 🤯 