### PR TITLE
Fix Overlapping `span` on Search Bar Issue

### DIFF
--- a/pages/search.js
+++ b/pages/search.js
@@ -237,12 +237,12 @@ class SearchPage extends React.Component {
                         <FormattedMessage defaultMessage="Make sure your spelling is correct" />
                       </li>
                       <li>
-                        <Span pt={8}>
+                        <Span pt="8px">
                           <FormattedMessage defaultMessage="Broaden your search (e.g. search 'garden' instead of 'community garden')" />
                         </Span>
                       </li>
                       <li>
-                        <Span pt={8}>
+                        <Span pt="8px">
                           <FormattedMessage
                             defaultMessage="Search our <Link>Docs</Link> for more info about using the Open Collective platform"
                             values={{


### PR DESCRIPTION
It  seems that https://github.com/opencollective/opencollective-frontend/pull/7580 has a small bug where we introduce a span that overlaps with the search bar, making it difficult to type on the search bar. This PR corrects it. 

![Screenshot from 2022-04-05 11-11-39](https://user-images.githubusercontent.com/12435965/161822136-392c2687-9f4e-4db3-b5db-2035fa1cf32a.png)

