### PR TITLE
Fix(support links) changed links from mailto:support to /help

### DIFF
--- a/components/ErrorPage.js
+++ b/components/ErrorPage.js
@@ -130,7 +130,7 @@ class ErrorPage extends React.Component {
           &nbsp; 🤕
         </H1>
         <Flex mt={5} flexWrap="wrap" alignItems="center" justifyContent="center">
-          <StyledLink my={2} href="mailto:support@opencollective.com" mx={2} buttonStyle="standard" buttonSize="large">
+          <StyledLink my={2} href="https://opencollective.com/help" mx={2} buttonStyle="standard" buttonSize="large">
             <Support size="1em" /> <FormattedMessage id="error.contactSupport" defaultMessage="Contact support" />
           </StyledLink>
           <StyledButton my={2} mx={2} buttonSize="large" onClick={() => location.reload()}>

--- a/components/I18nFormatters.js
+++ b/components/I18nFormatters.js
@@ -9,9 +9,7 @@ export const getI18nLink = linkProps => chunks =>
 export const I18nBold = chunks => <strong>{chunks}</strong>;
 export const I18nItalic = chunks => <i>{chunks}</i>;
 export const I18nSupportLink = chunks => (
-  <StyledLink href="mailto:support@opencollective.com">
-    {chunks.length ? chunks : 'support@opencollective.com'}
-  </StyledLink>
+  <StyledLink href="https://opencollective.com/help">{chunks.length ? chunks : 'opencollective.com/help'}</StyledLink>
 );
 export const I18nSignInLink = chunks => (
   <Link href={{ pathname: '/signin', query: { next: typeof window !== undefined ? window.location.pathname : '' } }}>


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve [opencollective/opencollective/5401
](https://github.com/opencollective/opencollective/issues/5401)

# Description

Made changes to the two places referencing mailto:support@opencollective.com, left the TOS and policies unchanged, since those probably require approval before any change to them. 

Wasn't also sure about links that explicitly mentioned emailing, and not support, but should be an easy add if we want to include those. 

# Screenshots

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
