### PR TITLE
StyledSelect: default to disable search under 8 options

### DIFF
--- a/components/StyledSelect.js
+++ b/components/StyledSelect.js
@@ -182,102 +182,107 @@ export const makeStyledSelect = SelectComponent => styled(SelectComponent).attrs
     menuPortalTarget,
     selectTheme,
     noOptionsMessage = () => intl.formatMessage(Messages.noOptions),
-  }) => ({
-    menuPortalTarget: menuPortalTarget === null || typeof document === 'undefined' ? undefined : document.body,
-    isDisabled: disabled || isDisabled,
-    placeholder: placeholder || intl.formatMessage(Messages.placeholder),
-    loadingMessage: () => intl.formatMessage(Messages.loading),
-    noOptionsMessage,
-    components: getComponents(components, useSearchIcon),
-    instanceId: instanceId ? instanceId : inputId,
-    theme: selectTheme,
-    styles: {
-      control: (baseStyles, state) => {
-        const customStyles = { borderColor: theme.colors.black[300] };
+    options,
+  }) => {
+    isSearchable = isSearchable === undefined ? options?.length > 8 : isSearchable;
+    return {
+      isSearchable,
+      menuPortalTarget: menuPortalTarget === null || typeof document === 'undefined' ? undefined : document.body,
+      isDisabled: disabled || isDisabled,
+      placeholder: placeholder || intl.formatMessage(Messages.placeholder),
+      loadingMessage: () => intl.formatMessage(Messages.loading),
+      noOptionsMessage,
+      components: getComponents(components, useSearchIcon),
+      instanceId: instanceId ? instanceId : inputId,
+      theme: selectTheme,
+      styles: {
+        control: (baseStyles, state) => {
+          const customStyles = { borderColor: theme.colors.black[300] };
 
-        if (error) {
-          customStyles.borderColor = theme.colors.red[500];
-          customStyles['&:hover'] = { borderColor: theme.colors.red[300] };
-        } else if (!state.isFocused) {
-          customStyles['&:hover'] = { borderColor: theme.colors.primary[300] };
-        } else if (state.isDisabled) {
-          customStyles.boxShadow = 'none';
-        } else {
-          customStyles.borderColor = theme.colors.primary[500];
-          customStyles.boxShadow = `inset 0px 2px 2px ${theme.colors.primary[50]}`;
-        }
+          if (error) {
+            customStyles.borderColor = theme.colors.red[500];
+            customStyles['&:hover'] = { borderColor: theme.colors.red[300] };
+          } else if (!state.isFocused) {
+            customStyles['&:hover'] = { borderColor: theme.colors.primary[300] };
+          } else if (state.isDisabled) {
+            customStyles.boxShadow = 'none';
+          } else {
+            customStyles.borderColor = theme.colors.primary[500];
+            customStyles.boxShadow = `inset 0px 2px 2px ${theme.colors.primary[50]}`;
+          }
 
-        if (isSearchable !== false) {
-          customStyles.cursor = 'text';
-        } else {
-          customStyles.cursor = 'pointer';
-        }
+          if (isSearchable !== false) {
+            customStyles.cursor = 'text';
+          } else {
+            customStyles.cursor = 'pointer';
+          }
 
-        if (typeof styles?.control === 'function') {
-          return styles.control({ ...baseStyles, ...customStyles }, state);
-        } else {
-          return { ...baseStyles, ...customStyles, ...styles?.control };
-        }
+          if (typeof styles?.control === 'function') {
+            return styles.control({ ...baseStyles, ...customStyles }, state);
+          } else {
+            return { ...baseStyles, ...customStyles, ...styles?.control };
+          }
+        },
+        option: (baseStyles, state) => {
+          const customStyles = { cursor: 'pointer' };
+
+          if (state.data.__background__) {
+            // Ability to force background by setting a special option prop
+            customStyles.background = state.data.__background__;
+          } else if (state.isSelected) {
+            customStyles.backgroundColor = theme.colors.primary[200];
+            customStyles.color = undefined;
+          } else if (state.isFocused) {
+            customStyles.backgroundColor = theme.colors.primary[100];
+          } else {
+            customStyles['&:hover'] = { backgroundColor: theme.colors.primary[100] };
+          }
+
+          return { ...baseStyles, ...customStyles, ...styles?.option };
+        },
+        singleValue: baseStyles => ({
+          ...baseStyles,
+          width: '100%',
+        }),
+        menu: baseStyles => {
+          return hideMenu
+            ? STYLES_DISPLAY_NONE
+            : {
+                ...baseStyles,
+                ...styles?.menu,
+                overflow: 'hidden', // for children border-radius to apply
+                zIndex: 10,
+              };
+        },
+        menuList: baseStyles => ({
+          ...baseStyles,
+          ...styles?.menuList,
+          paddingTop: 0,
+          paddingBottom: 0,
+        }),
+        indicatorSeparator: () => ({
+          display: 'none',
+        }),
+        clearIndicator: baseStyles => ({
+          ...baseStyles,
+          cursor: 'pointer',
+        }),
+        dropdownIndicator: baseStyles => {
+          if (hideDropdownIndicator) {
+            return STYLES_DISPLAY_NONE;
+          } else if (styles?.dropdownIndicator) {
+            return { ...baseStyles, ...styles.dropdownIndicator };
+          } else {
+            return baseStyles;
+          }
+        },
+        menuPortal: baseStyles => ({
+          ...baseStyles,
+          zIndex: 99999,
+        }),
       },
-      option: (baseStyles, state) => {
-        const customStyles = { cursor: 'pointer' };
-
-        if (state.data.__background__) {
-          // Ability to force background by setting a special option prop
-          customStyles.background = state.data.__background__;
-        } else if (state.isSelected) {
-          customStyles.backgroundColor = theme.colors.primary[200];
-          customStyles.color = undefined;
-        } else if (state.isFocused) {
-          customStyles.backgroundColor = theme.colors.primary[100];
-        } else {
-          customStyles['&:hover'] = { backgroundColor: theme.colors.primary[100] };
-        }
-
-        return { ...baseStyles, ...customStyles, ...styles?.option };
-      },
-      singleValue: baseStyles => ({
-        ...baseStyles,
-        width: '100%',
-      }),
-      menu: baseStyles => {
-        return hideMenu
-          ? STYLES_DISPLAY_NONE
-          : {
-              ...baseStyles,
-              ...styles?.menu,
-              overflow: 'hidden', // for children border-radius to apply
-              zIndex: 10,
-            };
-      },
-      menuList: baseStyles => ({
-        ...baseStyles,
-        ...styles?.menuList,
-        paddingTop: 0,
-        paddingBottom: 0,
-      }),
-      indicatorSeparator: () => ({
-        display: 'none',
-      }),
-      clearIndicator: baseStyles => ({
-        ...baseStyles,
-        cursor: 'pointer',
-      }),
-      dropdownIndicator: baseStyles => {
-        if (hideDropdownIndicator) {
-          return STYLES_DISPLAY_NONE;
-        } else if (styles?.dropdownIndicator) {
-          return { ...baseStyles, ...styles.dropdownIndicator };
-        } else {
-          return baseStyles;
-        }
-      },
-      menuPortal: baseStyles => ({
-        ...baseStyles,
-        zIndex: 99999,
-      }),
-    },
-  }),
+    };
+  },
 )`
   ${typography}
   ${layout}

--- a/components/__tests__/__snapshots__/AddFundsSourcePicker.test.js.snap
+++ b/components/__tests__/__snapshots__/AddFundsSourcePicker.test.js.snap
@@ -30,7 +30,7 @@ exports[`AddFundsSourcePicker component renders default options 1`] = `
       className="css-1f43avz-a11yText-A11yText"
     />
     <div
-      className=" css-p2fiel-control"
+      className=" css-13ncb8r-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -43,49 +43,25 @@ exports[`AddFundsSourcePicker component renders default options 1`] = `
         >
           Search for Users or Organizations
         </div>
-        <div
-          className=" css-6j8wv5-Input"
-          data-value=""
-        >
-          <input
-            aria-autocomplete="list"
-            aria-controls="react-select-sourcePicker-listbox"
-            aria-describedby="react-select-sourcePicker-placeholder"
-            aria-expanded={false}
-            aria-haspopup={true}
-            aria-owns="react-select-sourcePicker-listbox"
-            autoCapitalize="none"
-            autoComplete="off"
-            autoCorrect="off"
-            className=""
-            disabled={false}
-            id="sourcePicker"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            role="combobox"
-            spellCheck="false"
-            style={
-              Object {
-                "background": 0,
-                "border": 0,
-                "color": "inherit",
-                "font": "inherit",
-                "gridArea": "1 / 2",
-                "label": "input",
-                "margin": 0,
-                "minWidth": "2px",
-                "opacity": 1,
-                "outline": 0,
-                "padding": 0,
-                "width": "100%",
-              }
-            }
-            tabIndex={0}
-            type="text"
-            value=""
-          />
-        </div>
+        <input
+          aria-autocomplete="list"
+          aria-controls="react-select-sourcePicker-listbox"
+          aria-describedby="react-select-sourcePicker-placeholder"
+          aria-expanded={false}
+          aria-haspopup={true}
+          aria-owns="react-select-sourcePicker-listbox"
+          aria-readonly={true}
+          className="css-mohuvp-dummyInput-DummyInput"
+          disabled={false}
+          id="sourcePicker"
+          inputMode="none"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          role="combobox"
+          tabIndex={0}
+          value=""
+        />
       </div>
       <div
         className=" css-1hb7zxy-IndicatorsContainer"
@@ -152,7 +128,7 @@ exports[`AddFundsSourcePicker component renders fromCollectives by type in optgr
       className="css-1f43avz-a11yText-A11yText"
     />
     <div
-      className=" css-p2fiel-control"
+      className=" css-13ncb8r-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -165,49 +141,25 @@ exports[`AddFundsSourcePicker component renders fromCollectives by type in optgr
         >
           Search for Users or Organizations
         </div>
-        <div
-          className=" css-6j8wv5-Input"
-          data-value=""
-        >
-          <input
-            aria-autocomplete="list"
-            aria-controls="react-select-sourcePicker-listbox"
-            aria-describedby="react-select-sourcePicker-placeholder"
-            aria-expanded={false}
-            aria-haspopup={true}
-            aria-owns="react-select-sourcePicker-listbox"
-            autoCapitalize="none"
-            autoComplete="off"
-            autoCorrect="off"
-            className=""
-            disabled={false}
-            id="sourcePicker"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            role="combobox"
-            spellCheck="false"
-            style={
-              Object {
-                "background": 0,
-                "border": 0,
-                "color": "inherit",
-                "font": "inherit",
-                "gridArea": "1 / 2",
-                "label": "input",
-                "margin": 0,
-                "minWidth": "2px",
-                "opacity": 1,
-                "outline": 0,
-                "padding": 0,
-                "width": "100%",
-              }
-            }
-            tabIndex={0}
-            type="text"
-            value=""
-          />
-        </div>
+        <input
+          aria-autocomplete="list"
+          aria-controls="react-select-sourcePicker-listbox"
+          aria-describedby="react-select-sourcePicker-placeholder"
+          aria-expanded={false}
+          aria-haspopup={true}
+          aria-owns="react-select-sourcePicker-listbox"
+          aria-readonly={true}
+          className="css-mohuvp-dummyInput-DummyInput"
+          disabled={false}
+          id="sourcePicker"
+          inputMode="none"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          role="combobox"
+          tabIndex={0}
+          value=""
+        />
       </div>
       <div
         className=" css-1hb7zxy-IndicatorsContainer"
@@ -274,7 +226,7 @@ exports[`AddFundsSourcePicker component renders host name as first option 1`] = 
       className="css-1f43avz-a11yText-A11yText"
     />
     <div
-      className=" css-p2fiel-control"
+      className=" css-13ncb8r-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -287,49 +239,25 @@ exports[`AddFundsSourcePicker component renders host name as first option 1`] = 
         >
           Search for Users or Organizations
         </div>
-        <div
-          className=" css-6j8wv5-Input"
-          data-value=""
-        >
-          <input
-            aria-autocomplete="list"
-            aria-controls="react-select-sourcePicker-listbox"
-            aria-describedby="react-select-sourcePicker-placeholder"
-            aria-expanded={false}
-            aria-haspopup={true}
-            aria-owns="react-select-sourcePicker-listbox"
-            autoCapitalize="none"
-            autoComplete="off"
-            autoCorrect="off"
-            className=""
-            disabled={false}
-            id="sourcePicker"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            role="combobox"
-            spellCheck="false"
-            style={
-              Object {
-                "background": 0,
-                "border": 0,
-                "color": "inherit",
-                "font": "inherit",
-                "gridArea": "1 / 2",
-                "label": "input",
-                "margin": 0,
-                "minWidth": "2px",
-                "opacity": 1,
-                "outline": 0,
-                "padding": 0,
-                "width": "100%",
-              }
-            }
-            tabIndex={0}
-            type="text"
-            value=""
-          />
-        </div>
+        <input
+          aria-autocomplete="list"
+          aria-controls="react-select-sourcePicker-listbox"
+          aria-describedby="react-select-sourcePicker-placeholder"
+          aria-expanded={false}
+          aria-haspopup={true}
+          aria-owns="react-select-sourcePicker-listbox"
+          aria-readonly={true}
+          className="css-mohuvp-dummyInput-DummyInput"
+          disabled={false}
+          id="sourcePicker"
+          inputMode="none"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          role="combobox"
+          tabIndex={0}
+          value=""
+        />
       </div>
       <div
         className=" css-1hb7zxy-IndicatorsContainer"
@@ -396,7 +324,7 @@ exports[`AddFundsSourcePicker component renders loading state 1`] = `
       className="css-1f43avz-a11yText-A11yText"
     />
     <div
-      className=" css-p2fiel-control"
+      className=" css-13ncb8r-control"
       onMouseDown={[Function]}
       onTouchEnd={[Function]}
     >
@@ -409,49 +337,25 @@ exports[`AddFundsSourcePicker component renders loading state 1`] = `
         >
           Search for Users or Organizations
         </div>
-        <div
-          className=" css-6j8wv5-Input"
-          data-value=""
-        >
-          <input
-            aria-autocomplete="list"
-            aria-controls="react-select-sourcePicker-listbox"
-            aria-describedby="react-select-sourcePicker-placeholder"
-            aria-expanded={false}
-            aria-haspopup={true}
-            aria-owns="react-select-sourcePicker-listbox"
-            autoCapitalize="none"
-            autoComplete="off"
-            autoCorrect="off"
-            className=""
-            disabled={false}
-            id="sourcePicker"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            role="combobox"
-            spellCheck="false"
-            style={
-              Object {
-                "background": 0,
-                "border": 0,
-                "color": "inherit",
-                "font": "inherit",
-                "gridArea": "1 / 2",
-                "label": "input",
-                "margin": 0,
-                "minWidth": "2px",
-                "opacity": 1,
-                "outline": 0,
-                "padding": 0,
-                "width": "100%",
-              }
-            }
-            tabIndex={0}
-            type="text"
-            value=""
-          />
-        </div>
+        <input
+          aria-autocomplete="list"
+          aria-controls="react-select-sourcePicker-listbox"
+          aria-describedby="react-select-sourcePicker-placeholder"
+          aria-expanded={false}
+          aria-haspopup={true}
+          aria-owns="react-select-sourcePicker-listbox"
+          aria-readonly={true}
+          className="css-mohuvp-dummyInput-DummyInput"
+          disabled={false}
+          id="sourcePicker"
+          inputMode="none"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          role="combobox"
+          tabIndex={0}
+          value=""
+        />
       </div>
       <div
         className=" css-1hb7zxy-IndicatorsContainer"

--- a/components/expenses/ExpenseFormPayeeStep.js
+++ b/components/expenses/ExpenseFormPayeeStep.js
@@ -210,6 +210,7 @@ const ExpenseFormPayeeStep = ({
         <CollectivePickerAsync
           inputId={id}
           data-cy="select-expense-payee"
+          isSearchable
           collective={values.payee}
           onChange={({ value }) => {
             if (value) {
@@ -257,6 +258,7 @@ const ExpenseFormPayeeStep = ({
           customOptions={payeeOptions}
           getDefaultOptions={build => values.payee && build(values.payee)}
           data-cy="select-expense-payee"
+          isSearchable
           collective={values.payee}
           onChange={({ value }) => {
             formik.setFieldValue('payee', value);


### PR DESCRIPTION
This PR changes the default behavior of `StyledSelect` to make it searchable by default (aka. you get a text cursor and can type in the field to filter the options) only when there are more than 8 elements.

We often end up adding `isSearchable={false}` (24 occurrences in our code) because being able to search when there are very few options doesn't make sense.

This change won't impact selects that have this prop already set.