### PR TITLE
Better handle API errors during SSR

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -57,19 +57,20 @@ class OpenCollectiveFrontendApp extends App {
   }
 
   static async getInitialProps({ Component, ctx, client }) {
-    try {
-      let pageProps = {};
+    // Get the `locale` and `messages` from the request object on the server.
+    // In the browser, use the same values that the server serialized.
+    const { locale, messages } = ctx?.req || window.__NEXT_DATA__.props;
+    const props = { pageProps: {}, scripts: {}, locale, messages };
 
+    try {
       if (Component.getInitialProps) {
-        pageProps = await Component.getInitialProps({ ...ctx, client });
+        props.pageProps = await Component.getInitialProps({ ...ctx, client });
       }
 
-      const scripts = {};
-
-      if (pageProps.scripts) {
-        if (pageProps.scripts.googleMaps) {
+      if (props.pageProps.scripts) {
+        if (props.pageProps.scripts.googleMaps) {
           if (ctx.req) {
-            scripts['google-maps'] = getGoogleMapsScriptUrl();
+            props.scripts['google-maps'] = getGoogleMapsScriptUrl();
           } else {
             try {
               await loadGoogleMaps();
@@ -80,16 +81,11 @@ class OpenCollectiveFrontendApp extends App {
           }
         }
       }
-
-      // Get the `locale` and `messages` from the request object on the server.
-      // In the browser, use the same values that the server serialized.
-      const { req } = ctx;
-      const { locale, messages } = req || window.__NEXT_DATA__.props;
-
-      return { pageProps, scripts, locale, messages };
     } catch (error) {
-      return { hasError: true, errorEventId: sentryLib.captureException(error, ctx) };
+      return { ...props, hasError: true, errorEventId: sentryLib.captureException(error, ctx) };
     }
+
+    return props;
   }
 
   static getDerivedStateFromProps(props, state) {


### PR DESCRIPTION
API errors happening during SSR are currently resulting in unhandled errors that don't look good in dev:

![crash](https://user-images.githubusercontent.com/1556356/164027827-420a527b-96f3-494a-b637-b4296e37732d.png)

Render the "Unexpected" error in prod, and pollute the logs with unrelated messages:

```
[Network error]: ServerParseError: Unexpected token < in JSON at position 0
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at OpenCollectiveFrontendApp.render (/app/dist/.next/server/pages/_app.js:1500:18)
    at d (/app/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:35:231)
    at bb (/app/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:36:16)
    at a.b.render (/app/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:42:43)
    at a.b.read (/app/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:41:83)
    at Object.exports.renderToString (/app/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:52:138)
    at renderPage (/app/node_modules/next/dist/server/render.js:768:45)
    at Object.ctx.renderPage (/app/dist/.next/server/pages/_document.js:156:30)
    at Object.defaultGetInitialProps (/app/node_modules/next/dist/server/render.js:375:51)
    at Function.getInitialProps (/app/dist/.next/server/chunks/6859.js:671:16)
    at Function.getInitialProps (/app/dist/.next/server/pages/_document.js:160:88)
    at Object.loadGetInitialProps (/app/node_modules/next/dist/shared/lib/utils.js:65:29)
    at documentInitialProps (/app/node_modules/next/dist/server/render.js:781:48)
    at renderDocument (/app/node_modules/next/dist/server/render.js:806:55)
    at Object.renderToHTML (/app/node_modules/next/dist/server/render.js:906:34)	
```

This is all because we're trying to call `Object.keys` on `scripts`, but `scripts` is undefined if there's an API error during SSR.

With this PR, we're making sure that empty values are always returned for objects marked as required by prop types - even if there's an error. The page now rendered looks like this:

![image](https://user-images.githubusercontent.com/1556356/164029001-caca002a-ce26-46bb-b46a-b2bd5e234590.png)
