### PR TITLE
Simply display collective `type` in the collective card

### DIFF
--- a/components/search-page/StyledCollectiveCard.js
+++ b/components/search-page/StyledCollectiveCard.js
@@ -200,9 +200,7 @@ const StyledCollectiveCard = ({
             <Container>
               {tag === undefined ? (
                 <StyledTag display="inline-block" variant="rounded-right" my={2} backgroundColor="blue.50">
-                  <I18nCollectiveTags
-                    tags={getCollectiveMainTag(get(collective, 'host.id'), collective.tags, collective.type)}
-                  />
+                  <I18nCollectiveTags tags={getCollectiveMainTag(null, null, collective.type)} />
                 </StyledTag>
               ) : (
                 tag


### PR DESCRIPTION
Related to the discussion at, https://opencollective.slack.com/archives/C035S573ZD2/p1650360760337069

We have decided to simply use the collective `type` in the collective card in `/search` page instead of complicating the logic by trying to display the tags etc. 

![image](https://user-images.githubusercontent.com/12435965/164318509-c04e72b8-46cc-4a95-b04a-d3aec03f24a1.png)
