### PR TITLE
Prevent user form searching for empty search term

### DIFF
--- a/components/SearchForm.js
+++ b/components/SearchForm.js
@@ -40,9 +40,17 @@ const SearchButton = styled(Flex)`
 
 class SearchForm extends React.Component {
   handleSubmit = event => {
-    const searchInput = event.target.elements.q;
-    this.props.router.push({ pathname: '/search', query: { q: searchInput.value } });
     event.preventDefault();
+    const searchInput = event.target.elements.q;
+    /*
+     * Make sure we don't perform the re-fetch if search term is empty
+     *
+     * TODO: Remove this once, https://github.com/opencollective/opencollective/issues/5454 is done
+     */
+    if (searchInput.value.trim()?.length === 0) {
+      return;
+    }
+    this.props.router.push({ pathname: '/search', query: { q: searchInput.value } });
   };
 
   render() {

--- a/pages/search.js
+++ b/pages/search.js
@@ -220,6 +220,15 @@ class SearchPage extends React.Component {
     const { router } = this.props;
     const { q } = form;
 
+    /*
+     * Make sure we don't perform the re-fetch if search term is empty
+     *
+     * TODO: Remove this once, https://github.com/opencollective/opencollective/issues/5454 is done
+     */
+    if (q.value?.trim()?.length === 0) {
+      return;
+    }
+
     const query = { q: q.value, type: router.query.type };
     router.push({ pathname: router.pathname, query: pickBy(query, value => !isNil(value)) });
   };


### PR DESCRIPTION
Related to the discussion at, https://opencollective.slack.com/archives/C035S573ZD2/p1650509963021629

This prevents the user from typing an empty search term or just some space characters until we have the default "activity" search ready; https://github.com/opencollective/opencollective/issues/5454