### PR TITLE
Revert "Redirect `/hosts` page to new search page with host filter selected"

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -169,7 +169,7 @@ const navigation = {
     createACollective: '/create',
     aboutFiscalHosting: '/fiscal-hosting',
     discover: '/discover',
-    findAFiscalHost: '/search?isHost=true',
+    findAFiscalHost: '/hosts',
     becomeASponsor: '/become-a-sponsor',
     becomeAHost: '/become-a-host',
   },

--- a/components/Hosts.js
+++ b/components/Hosts.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
+import styled from 'styled-components';
+
+import Body from './Body';
+import Container from './Container';
+import Footer from './Footer';
+import Header from './Header';
+import HostsWithData from './HostsWithData';
+import Link from './Link';
+import { H1, P } from './Text';
+
+const CoverSmallCTA = styled.span`
+  a:hover {
+    text-decoration: underline !important;
+  }
+`;
+
+class Hosts extends React.Component {
+  static propTypes = {
+    collective: PropTypes.object,
+    LoggedInUser: PropTypes.object,
+    intl: PropTypes.object.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = { status: 'idle', result: {} };
+    this.messages = defineMessages({
+      'hosts.title': {
+        id: 'hosts.title',
+        defaultMessage: 'Open Collective Hosts',
+      },
+    });
+  }
+
+  render() {
+    const { LoggedInUser, intl } = this.props;
+
+    const title = intl.formatMessage(this.messages['hosts.title']);
+
+    return (
+      <Container>
+        <Header title={title} twitterHandle="opencollect" className={this.state.status} LoggedInUser={LoggedInUser} />
+
+        <Body>
+          <Container mt={2} mb={2}>
+            <H1 fontSize={['24px', '40px']} lineHeight={3} fontWeight="bold" textAlign="center" color="black.900">
+              {title}
+            </H1>
+            <P textAlign="center">
+              <FormattedMessage
+                id="hosts.description"
+                defaultMessage="<FiscalHostingLink>Fiscal Hosts</FiscalHostingLink> hold money on behalf of Collectives, taking care of accounting, taxes, invoices, etc. Some also provide extra services. <FindOutMoreLink>Find out more</FindOutMoreLink> about <BecomingAHostLink>becoming a Fiscal Host</BecomingAHostLink>."
+                values={{
+                  FiscalHostingLink: msg => (
+                    <CoverSmallCTA>
+                      <Link href="/fiscal-hosting">{msg}</Link>
+                    </CoverSmallCTA>
+                  ),
+                  FindOutMoreLink: msg => (
+                    <CoverSmallCTA>
+                      <a
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        href="https://docs.opencollective.com/help/fiscal-hosts/become-a-fiscal-host"
+                      >
+                        {msg}
+                      </a>
+                    </CoverSmallCTA>
+                  ),
+                  BecomingAHostLink: msg => (
+                    <CoverSmallCTA>
+                      <Link href="/become-a-host">{msg}</Link>
+                    </CoverSmallCTA>
+                  ),
+                }}
+              />
+            </P>
+          </Container>
+
+          <div className="content">
+            <HostsWithData LoggedInUser={LoggedInUser} />
+          </div>
+        </Body>
+        <Footer />
+      </Container>
+    );
+  }
+}
+
+export default injectIntl(Hosts);

--- a/components/accept-financial-contributions/HostsContainer.js
+++ b/components/accept-financial-contributions/HostsContainer.js
@@ -102,7 +102,7 @@ class HostsContainer extends React.Component {
           </AllCardsContainer>
         </Hide>
         <Flex justifyContent="center" mt={[2, 0]} width={['100%', null, '90%']}>
-          <Link href="/search?isHost=true">
+          <Link href="/hosts">
             <StyledButton fontSize="13px" buttonStyle="dark" minHeight="36px" mt={[2, 3]} mb={3} px={4}>
               {intl.formatMessage(this.messages.seeMoreHosts)}
             </StyledButton>

--- a/components/become-a-host/CaseStudiesSection.js
+++ b/components/become-a-host/CaseStudiesSection.js
@@ -186,7 +186,7 @@ const CaseStudies = () => {
         ))}
       </Container>
       <Box mt={4}>
-        <StyledLink buttonStyle="standard" buttonSize="medium" href="/search?isHost=true" fontWeight="500">
+        <StyledLink buttonStyle="standard" buttonSize="medium" href="/hosts" fontWeight="500">
           <FormattedMessage id="becomeAHost.discoverMore" defaultMessage="Discover more hosts" />
         </StyledLink>
       </Box>

--- a/components/collective-page/README.md
+++ b/components/collective-page/README.md
@@ -13,10 +13,10 @@ The binding of the data to the section happens in `components/collective-page/in
 
 The following rule should ideally be applied when fetching data for a section:
 
-If the section is going to be displayed for the majority of the collectives (contribute, updates...etc.)
+If the section is going to be displayed for the majority of the collectives (contribute, updates...etc)
 then we should fetch the data in the page container, `pages/collective-page.js`.
 
-However, if the section will only be displayed for certain collectives, under certain conditions or
+However if the section will only be displayed for certain collectives, under certain conditions or
 if it will only be displayed for users/organizations/hosts then the data should be fetched at the component
 level.
 

--- a/components/edit-collective/sections/Host.js
+++ b/components/edit-collective/sections/Host.js
@@ -499,11 +499,7 @@ class Host extends React.Component {
                         defaultMessage="Suggested Hosts"
                       />
                     </H4>
-                    <StyledLink
-                      as={Link}
-                      fontSize="13px"
-                      href={`${collective.slug}/accept-financial-contributions/host`}
-                    >
+                    <StyledLink as={Link} fontSize="13px" href="/hosts">
                       <FormattedMessage id="collective.edit.host.viewAllHosts" defaultMessage="View all Fiscal Hosts" />
                     </StyledLink>
                   </Container>

--- a/components/fiscal-hosting/ApplyToFiscalHostSection.js
+++ b/components/fiscal-hosting/ApplyToFiscalHostSection.js
@@ -194,7 +194,7 @@ const ApplyToFiscalHosts = () => (
           values={{
             orgsAroundTheWorldLink: getI18nLink({
               as: Link,
-              href: '/search?isHost=true',
+              href: '/hosts',
             }),
             createYourOwnFiscalHostLink: getI18nLink({
               as: Link,

--- a/components/home/sections/FiscalHost.js
+++ b/components/home/sections/FiscalHost.js
@@ -285,7 +285,7 @@ const FiscalHost = () => {
             <Box my={2} alignSelf={[null, 'center', null, 'flex-start']}>
               <DiscoverLink
                 as={Link}
-                href="/search?isHost=true"
+                href="/hosts"
                 fontSize="15px"
                 lineHeight="23px"
                 letterSpacing="-0.12px"

--- a/components/pricing/ForCollectiveCard.js
+++ b/components/pricing/ForCollectiveCard.js
@@ -245,7 +245,7 @@ const ForCollectiveCard = () => {
                 <FormattedMessage id="home.create" defaultMessage="Create a Collective" />
               </StyledButton>
             </Link>
-            <Link href="/search?isHost=true">
+            <Link href="/hosts">
               <StyledButton
                 buttonStyle="secondary"
                 py="8px"

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1475,6 +1475,8 @@
   "HostFee.MonthlyRetainer": "Monthly retainer",
   "HostFeesSection.Title": "Host Fees per year",
   "HostingSince": "Hosting since",
+  "hosts.description": "<FiscalHostingLink>Fiscal Hosts</FiscalHostingLink> hold money on behalf of Collectives, taking care of accounting, taxes, invoices, etc. Some also provide extra services. <FindOutMoreLink>Find out more</FindOutMoreLink> about <BecomingAHostLink>becoming a Fiscal Host</BecomingAHostLink>.",
+  "hosts.title": "Amfitrions d'Open Collective",
   "HostSince": "Host since",
   "howItWorks": "How it works",
   "howItWorks.becomeHost": "About becoming a fiscal host",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1475,6 +1475,8 @@
   "HostFee.MonthlyRetainer": "Měsíční uchovávání",
   "HostFeesSection.Title": "Host Fees per year",
   "HostingSince": "Hostování od",
+  "hosts.description": "<FiscalHostingLink>Fiscal Hosts</FiscalHostingLink> hold money on behalf of Collectives, taking care of accounting, taxes, invoices, etc. Some also provide extra services. <FindOutMoreLink>Find out more</FindOutMoreLink> about <BecomingAHostLink>becoming a Fiscal Host</BecomingAHostLink>.",
+  "hosts.title": "Open Collective Hosts",
   "HostSince": "Hostitel od",
   "howItWorks": "How it works",
   "howItWorks.becomeHost": "About becoming a fiscal host",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1475,6 +1475,8 @@
   "HostFee.MonthlyRetainer": "Monthly retainer",
   "HostFeesSection.Title": "Host Fees per year",
   "HostingSince": "Hosting since",
+  "hosts.description": "<FiscalHostingLink>Fiscal Hosts</FiscalHostingLink> hold money on behalf of Collectives, taking care of accounting, taxes, invoices, etc. Some also provide extra services. <FindOutMoreLink>Find out more</FindOutMoreLink> about <BecomingAHostLink>becoming a Fiscal Host</BecomingAHostLink>.",
+  "hosts.title": "Open Collective Hosts",
   "HostSince": "Host since",
   "howItWorks": "So funktioniert es",
   "howItWorks.becomeHost": "About becoming a fiscal host",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1475,6 +1475,8 @@
   "HostFee.MonthlyRetainer": "Monthly retainer",
   "HostFeesSection.Title": "Host Fees per year",
   "HostingSince": "Hosting since",
+  "hosts.description": "<FiscalHostingLink>Fiscal Hosts</FiscalHostingLink> hold money on behalf of Collectives, taking care of accounting, taxes, invoices, etc. Some also provide extra services. <FindOutMoreLink>Find out more</FindOutMoreLink> about <BecomingAHostLink>becoming a Fiscal Host</BecomingAHostLink>.",
+  "hosts.title": "Open Collective Hosts",
   "HostSince": "Host since",
   "howItWorks": "How it works",
   "howItWorks.becomeHost": "About becoming a fiscal host",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1475,6 +1475,8 @@
   "HostFee.MonthlyRetainer": "Retención mensual",
   "HostFeesSection.Title": "Tarifas de Anfitrión por año",
   "HostingSince": "Anfitrión desde",
+  "hosts.description": "<FiscalHostingLink>Anfitriones Fiscales</FiscalHostingLink> guardan el dinero en nombre de los Colectivos, encargándose de la contabilidad, los impuestos, las facturas, etc. Algunos también ofrecen servicios adicionales. <FindOutMoreLink>Más información</FindOutMoreLink> sobre <BecomingAHostLink>cómo convertirte en Anfitrión Fiscal</BecomingAHostLink>.",
+  "hosts.title": "Host Colectivo Abierto",
   "HostSince": "Anfitrión desde",
   "howItWorks": "Cómo funciona",
   "howItWorks.becomeHost": "Sobre cómo convertirte en Anfitrión Fiscal",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1475,6 +1475,8 @@
   "HostFee.MonthlyRetainer": "Abonnement mensuel",
   "HostFeesSection.Title": "Host Fees per year",
   "HostingSince": "Hôte depuis",
+  "hosts.description": "<FiscalHostingLink>Fiscal Hosts</FiscalHostingLink> hold money on behalf of Collectives, taking care of accounting, taxes, invoices, etc. Some also provide extra services. <FindOutMoreLink>Find out more</FindOutMoreLink> about <BecomingAHostLink>becoming a Fiscal Host</BecomingAHostLink>.",
+  "hosts.title": "Hôtes d'Open Collective",
   "HostSince": "Hôte depuis",
   "howItWorks": "How it works",
   "howItWorks.becomeHost": "About becoming a fiscal host",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1475,6 +1475,8 @@
   "HostFee.MonthlyRetainer": "Monthly retainer",
   "HostFeesSection.Title": "Host Fees per year",
   "HostingSince": "Hosting since",
+  "hosts.description": "<FiscalHostingLink>Fiscal Hosts</FiscalHostingLink> hold money on behalf of Collectives, taking care of accounting, taxes, invoices, etc. Some also provide extra services. <FindOutMoreLink>Find out more</FindOutMoreLink> about <BecomingAHostLink>becoming a Fiscal Host</BecomingAHostLink>.",
+  "hosts.title": "Open Collective Hosts",
   "HostSince": "Host since",
   "howItWorks": "How it works",
   "howItWorks.becomeHost": "About becoming a fiscal host",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1475,6 +1475,8 @@
   "HostFee.MonthlyRetainer": "Monthly retainer",
   "HostFeesSection.Title": "Host Fees per year",
   "HostingSince": "Hosting since",
+  "hosts.description": "<FiscalHostingLink>Fiscal Hosts</FiscalHostingLink> hold money on behalf of Collectives, taking care of accounting, taxes, invoices, etc. Some also provide extra services. <FindOutMoreLink>Find out more</FindOutMoreLink> about <BecomingAHostLink>becoming a Fiscal Host</BecomingAHostLink>.",
+  "hosts.title": "Open Collective ホスト",
   "HostSince": "Host since",
   "howItWorks": "How it works",
   "howItWorks.becomeHost": "About becoming a fiscal host",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1475,6 +1475,8 @@
   "HostFee.MonthlyRetainer": "Monthly retainer",
   "HostFeesSection.Title": "Host Fees per year",
   "HostingSince": "Hosting since",
+  "hosts.description": "<FiscalHostingLink>Fiscal Hosts</FiscalHostingLink> hold money on behalf of Collectives, taking care of accounting, taxes, invoices, etc. Some also provide extra services. <FindOutMoreLink>Find out more</FindOutMoreLink> about <BecomingAHostLink>becoming a Fiscal Host</BecomingAHostLink>.",
+  "hosts.title": "Open Collective Hosts",
   "HostSince": "Host since",
   "howItWorks": "How it works",
   "howItWorks.becomeHost": "About becoming a fiscal host",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1475,6 +1475,8 @@
   "HostFee.MonthlyRetainer": "Monthly retainer",
   "HostFeesSection.Title": "Host Fees per year",
   "HostingSince": "Hosting since",
+  "hosts.description": "<FiscalHostingLink>Fiscal Hosts</FiscalHostingLink> hold money on behalf of Collectives, taking care of accounting, taxes, invoices, etc. Some also provide extra services. <FindOutMoreLink>Find out more</FindOutMoreLink> about <BecomingAHostLink>becoming a Fiscal Host</BecomingAHostLink>.",
+  "hosts.title": "Open Collective Hosts",
   "HostSince": "Host since",
   "howItWorks": "How it works",
   "howItWorks.becomeHost": "About becoming a fiscal host",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -1475,6 +1475,8 @@
   "HostFee.MonthlyRetainer": "Opłata miesięczna",
   "HostFeesSection.Title": "Host Fees per year",
   "HostingSince": "Hosting since",
+  "hosts.description": "<FiscalHostingLink>Fiscal Hosts</FiscalHostingLink> hold money on behalf of Collectives, taking care of accounting, taxes, invoices, etc. Some also provide extra services. <FindOutMoreLink>Find out more</FindOutMoreLink> about <BecomingAHostLink>becoming a Fiscal Host</BecomingAHostLink>.",
+  "hosts.title": "Open Collective Hosts",
   "HostSince": "Host since",
   "howItWorks": "How it works",
   "howItWorks.becomeHost": "O zostaniu gospodarzem podatkowym",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1475,6 +1475,8 @@
   "HostFee.MonthlyRetainer": "Recipiente mensal",
   "HostFeesSection.Title": "Host Fees per year",
   "HostingSince": "Administrado desde",
+  "hosts.description": "<FiscalHostingLink>Fiscal Hosts</FiscalHostingLink> hold money on behalf of Collectives, taking care of accounting, taxes, invoices, etc. Some also provide extra services. <FindOutMoreLink>Find out more</FindOutMoreLink> about <BecomingAHostLink>becoming a Fiscal Host</BecomingAHostLink>.",
+  "hosts.title": "Administradores da Open Collective",
   "HostSince": "Administrador desde",
   "howItWorks": "How it works",
   "howItWorks.becomeHost": "About becoming a fiscal host",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1475,6 +1475,8 @@
   "HostFee.MonthlyRetainer": "Monthly retainer",
   "HostFeesSection.Title": "Host Fees per year",
   "HostingSince": "Hosting since",
+  "hosts.description": "<FiscalHostingLink>Fiscal Hosts</FiscalHostingLink> hold money on behalf of Collectives, taking care of accounting, taxes, invoices, etc. Some also provide extra services. <FindOutMoreLink>Find out more</FindOutMoreLink> about <BecomingAHostLink>becoming a Fiscal Host</BecomingAHostLink>.",
+  "hosts.title": "Organizadores do Open Collective",
   "HostSince": "Host since",
   "howItWorks": "How it works",
   "howItWorks.becomeHost": "About becoming a fiscal host",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1475,6 +1475,8 @@
   "HostFee.MonthlyRetainer": "Monthly retainer",
   "HostFeesSection.Title": "Host Fees per year",
   "HostingSince": "Представитель с",
+  "hosts.description": "<FiscalHostingLink>Fiscal Hosts</FiscalHostingLink> hold money on behalf of Collectives, taking care of accounting, taxes, invoices, etc. Some also provide extra services. <FindOutMoreLink>Find out more</FindOutMoreLink> about <BecomingAHostLink>becoming a Fiscal Host</BecomingAHostLink>.",
+  "hosts.title": "Представители Open Collective",
   "HostSince": "Представитель с",
   "howItWorks": "Как это работает",
   "howItWorks.becomeHost": "О том, как стать фискальным представителем",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -1475,6 +1475,8 @@
   "HostFee.MonthlyRetainer": "Щомісячна виплата",
   "HostFeesSection.Title": "Host Fees per year",
   "HostingSince": "Фіскальний вузол з",
+  "hosts.description": "<FiscalHostingLink>Fiscal Hosts</FiscalHostingLink> hold money on behalf of Collectives, taking care of accounting, taxes, invoices, etc. Some also provide extra services. <FindOutMoreLink>Find out more</FindOutMoreLink> about <BecomingAHostLink>becoming a Fiscal Host</BecomingAHostLink>.",
+  "hosts.title": "Фіскальні вузли Open Collective",
   "HostSince": "Фіскальний вузол з",
   "howItWorks": "Як це працює",
   "howItWorks.becomeHost": "Як стати фіскальним вузлом",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1475,6 +1475,8 @@
   "HostFee.MonthlyRetainer": "每月定金",
   "HostFeesSection.Title": "Host Fees per year",
   "HostingSince": "Hosting since",
+  "hosts.description": "<FiscalHostingLink>Fiscal Hosts</FiscalHostingLink> hold money on behalf of Collectives, taking care of accounting, taxes, invoices, etc. Some also provide extra services. <FindOutMoreLink>Find out more</FindOutMoreLink> about <BecomingAHostLink>becoming a Fiscal Host</BecomingAHostLink>.",
+  "hosts.title": "Open Collective Hosts",
   "HostSince": "Host since",
   "howItWorks": "How it works",
   "howItWorks.becomeHost": "About becoming a fiscal host",

--- a/next.config.js
+++ b/next.config.js
@@ -187,12 +187,6 @@ const nextConfig = {
         destination: '/help',
         permanent: true,
       },
-      // Redirect /hosts to /search page with hosts filter applied
-      {
-        source: '/hosts',
-        destination: '/search?isHost=true',
-        permanent: true,
-      },
     ];
   },
 };

--- a/pages/hosts.js
+++ b/pages/hosts.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Hosts from '../components/Hosts';
+import { withUser } from '../components/UserProvider';
+
+class HostsPage extends React.Component {
+  static propTypes = {
+    LoggedInUser: PropTypes.object,
+  };
+
+  render() {
+    const { LoggedInUser } = this.props;
+
+    return (
+      <div>
+        <Hosts LoggedInUser={LoggedInUser} />
+      </div>
+    );
+  }
+}
+
+export default withUser(HostsPage);

--- a/rewrites.js
+++ b/rewrites.js
@@ -276,6 +276,10 @@ exports.REWRITES = [
     destination: '/search',
   },
   {
+    source: '/hosts',
+    destination: '/hosts',
+  },
+  {
     source: '/pricing',
     destination: '/pricing',
   },


### PR DESCRIPTION
Reverts opencollective/opencollective-frontend#7725

Reverting this as per the following discussion; https://opencollective.slack.com/archives/C035S573ZD2/p1651000865937619.