### PR TITLE
fix(Updates): reposition button 'Load more' and capitalize its text (#5451)

### DIFF
--- a/components/Updates.js
+++ b/components/Updates.js
@@ -83,15 +83,15 @@ class Updates extends React.Component {
               <FormattedMessage id="updates.empty" defaultMessage="No Updates" />
             </Container>
           )}
-          {showLoadMore && (
-            <Container margin="1rem" textAlign="center">
-              <StyledButton onClick={this.fetchMore}>
-                {this.state.loading && <FormattedMessage id="loading" defaultMessage="loading" />}
-                {!this.state.loading && <FormattedMessage id="loadMore" defaultMessage="load more" />}
-              </StyledButton>
-            </Container>
-          )}
         </Container>
+        {showLoadMore && (
+          <Container margin="1rem" textAlign="center">
+            <StyledButton onClick={this.fetchMore} textTransform="capitalize">
+              {this.state.loading && <FormattedMessage id="loading" defaultMessage="loading" />}
+              {!this.state.loading && <FormattedMessage id="loadMore" defaultMessage="load more" />}
+            </StyledButton>
+          </Container>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
This PR resolves issue https://github.com/opencollective/opencollective/issues/5451

![](https://i.postimg.cc/43HzCQNG/image.png)

On `Updates` page button 'Load more' is repositioned and its text is capitalized