### PR TITLE
Fix ExpenseFilters wrap on mobile

### DIFF
--- a/components/Grid.js
+++ b/components/Grid.js
@@ -26,9 +26,10 @@ Box.propTypes = {
 };
 
 export const Flex = styled(Box)(
-  {
+  props => ({
     display: 'flex',
-  },
+    gap: props.gap,
+  }),
   compose(space, layout, flexbox),
 );
 

--- a/components/expenses/ExpensesFilters.js
+++ b/components/expenses/ExpensesFilters.js
@@ -17,9 +17,6 @@ import ExpensesTypeFilter from './filters/ExpensesTypeFilter';
 const FilterContainer = styled.div`
   margin-bottom: 8px;
   flex: 1 1 120px;
-  &:not(:last-child) {
-    margin-right: 18px;
-  }
 `;
 
 const FilterLabel = styled.label`
@@ -42,7 +39,7 @@ const ExpensesFilters = ({ collective, filters, onChange, wrap = true }) => {
   });
 
   return (
-    <Flex flexWrap={wrap ? 'wrap' : 'nowrap'}>
+    <Flex flexWrap={['wrap', null, wrap ? 'wrap' : 'nowrap']} gap="18px">
       <FilterContainer>
         <FilterLabel htmlFor="expenses-filter-type">
           <FormattedMessage id="expense.type" defaultMessage="Type" />


### PR DESCRIPTION
Also adjusts how we set the gap between filters.

Related to https://github.com/opencollective/opencollective-frontend/pull/7743#discussion_r865853569