### PR TITLE
Remove unused fields/code from search page

### DIFF
--- a/pages/search.js
+++ b/pages/search.js
@@ -13,7 +13,6 @@ import i18nSearchSortingOptions from '../lib/i18n/search-sorting-options';
 import { parseToBoolean } from '../lib/utils';
 
 import Container from '../components/Container';
-import PledgedCollectiveCard from '../components/discover/PledgedCollectiveCard';
 import ErrorPage from '../components/ErrorPage';
 import { Box, Flex } from '../components/Grid';
 import Hide from '../components/Hide';
@@ -420,15 +419,9 @@ class SearchPage extends React.Component {
                 ))
               : accounts?.nodes?.map(collective => (
                   <Flex key={collective.slug} my={3} mx={2}>
-                    {collective.isPledged ? (
-                      <CollectiveCardContainer key={collective.id}>
-                        <PledgedCollectiveCard collective={collective} />
-                      </CollectiveCardContainer>
-                    ) : (
-                      <CollectiveCardContainer key={collective.id}>
-                        <SearchCollectiveCard collective={collective} />
-                      </CollectiveCardContainer>
-                    )}
+                    <CollectiveCardContainer key={collective.id}>
+                      <SearchCollectiveCard collective={collective} />
+                    </CollectiveCardContainer>
                   </Flex>
                 ))}
 

--- a/pages/search.js
+++ b/pages/search.js
@@ -562,19 +562,10 @@ export const searchPageQuery = gqlV2/* GraphQL */ `
         imageUrl
         backgroundImageUrl
         description
-        longDescription
         website
         currency
         stats {
           id
-          totalAmountSpent {
-            currency
-            valueInCents
-          }
-          yearlyBudget {
-            currency
-            valueInCents
-          }
           totalAmountReceived {
             currency
             valueInCents
@@ -595,9 +586,6 @@ export const searchPageQuery = gqlV2/* GraphQL */ `
           }
         }
         backers: members(role: BACKER) {
-          totalCount
-        }
-        memberOf(role: BACKER) {
           totalCount
         }
       }


### PR DESCRIPTION
- Remove unused fields (`memberOf(role: BACKER)`, `stats.totalAmountSpent`, `stats.yearlyBudget`). Some of these were heavy fields that certainly impacted the performance while not being used
- Remove `PledgedCollectiveCard`, we're not fetching `collective.isPledged` so this was dead code