### PR TITLE
Resize accounts images on search page

### DIFF
--- a/pages/search.js
+++ b/pages/search.js
@@ -552,8 +552,8 @@ export const searchPageQuery = gqlV2/* GraphQL */ `
         }
         tags
         isHost
-        imageUrl
-        backgroundImageUrl
+        imageUrl(height: 96)
+        backgroundImageUrl(height: 208)
         description
         website
         currency


### PR DESCRIPTION
Raw images are not resized, resulting in super heavy loads when loaded directly

![image](https://user-images.githubusercontent.com/1556356/167662974-2e4e55ff-7be9-4411-8198-74a9c0499212.png)
