### PR TITLE
Display host currency on create virtual card form

### DIFF
--- a/components/edit-collective/CreateVirtualCardModal.js
+++ b/components/edit-collective/CreateVirtualCardModal.js
@@ -92,7 +92,7 @@ const CreateVirtualCardModal = ({ host, collective, onSuccess, onClose, ...modal
             assignee: { id: assignee.id },
             account: typeof collective.id === 'string' ? { id: collective.id } : { legacyId: collective.id },
             name: cardName,
-            monthlyLimit: { currency: collective.currency, valueInCents: monthlyLimit, value: monthlyLimit / 100 },
+            monthlyLimit: { currency: host.currency, valueInCents: monthlyLimit },
           },
         });
       } catch (e) {
@@ -246,8 +246,8 @@ const CreateVirtualCardModal = ({ host, collective, onSuccess, onClose, ...modal
                 <StyledInputAmount
                   {...inputProps}
                   id="monthlyLimit"
-                  currency={formik.values.collective?.currency || 'USD'}
-                  prepend={formik.values.collective?.currency || 'USD'}
+                  currency={host.currency || 'USD'}
+                  prepend={host.currency || 'USD'}
                   onChange={value => formik.setFieldValue('monthlyLimit', value)}
                   value={formik.values.monthlyLimit}
                   disabled={isBusy}


### PR DESCRIPTION
@kewitz The error is not coming from your work, but I'm assigning you for the review since you have a good context grasp on VCs. The currency used by Stripe for this parameter seems to be the host currency, not the collective currency: https://github.com/opencollective/opencollective-api/blob/0c0531bd364e4a1eb6eebf6864a5d20560e5b3d1/server/paymentProviders/stripe/virtual-cards.js#L75