### PR TITLE
Fix error message on sign in when token has already been used

### DIFF
--- a/lib/withLoggedInUser.js
+++ b/lib/withLoggedInUser.js
@@ -110,9 +110,11 @@ const withLoggedInUser = WrappedComponent => {
         } else {
           // Used for the first exchange of the login token
           newToken = await maybeRefreshAccessToken(token);
-          const decodedNewToken = jwt.decode(newToken);
-          if (decodedNewToken.scope === 'twofactorauth') {
-            throw new Error('Two-factor authentication is enabled on this account. Please enter the code');
+          if (newToken) {
+            const decodedNewToken = jwt.decode(newToken);
+            if (decodedNewToken.scope === 'twofactorauth') {
+              throw new Error('Two-factor authentication is enabled on this account. Please enter the code');
+            }
           }
         }
 


### PR DESCRIPTION
The error message when re-using a sign-in link was a bit cryptic:
![image](https://user-images.githubusercontent.com/1556356/168533661-ad9263f3-3225-42c9-831f-29fd52750ea9.png)

_Note: this issue was not visible in dev because we're more permissive with invalid tokens in there. [This line](https://github.com/opencollective/opencollective-api/blob/09b6c83e51f279e4eeac67ab563624894238a23b/server/middleware/authentication.js#L132) needs to be commented out to try this fix._