### PR TITLE
Fix: wrongly escaped messages in Thread Activity

### DIFF
--- a/components/conversations/ThreadActivity.js
+++ b/components/conversations/ThreadActivity.js
@@ -10,7 +10,6 @@ import { Plus as PlusIcon } from '@styled-icons/feather/Plus';
 import { UserCheck as ApprovedIcon } from '@styled-icons/feather/UserCheck';
 import { UserMinus as UnapprovedIcon } from '@styled-icons/feather/UserMinus';
 import { Update as UpdateIcon } from '@styled-icons/material/Update';
-import { escape } from 'lodash';
 import { defineMessage, FormattedMessage, useIntl } from 'react-intl';
 import styled, { useTheme } from 'styled-components';
 
@@ -203,7 +202,7 @@ const ThreadActivity = ({ activity }) => {
           {details && (
             <Fragment>
               <br />
-              {escape(details)}
+              {details}
             </Fragment>
           )}
         </ActivityParagraph>


### PR DESCRIPTION
Bug reported trough Slack:

![Screen Shot 2022-05-18 at 13 41 22](https://user-images.githubusercontent.com/2119706/169096622-2901ab45-8a57-43fd-aee1-b0fcc267e525.png)
