### PR TITLE
ESLint: prevent using next/link directly

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,10 @@
             "name": "react-intl",
             "importNames": ["FormattedHTMLMessage"],
             "message": "FormattedHTMLMessage is not allowed, please rely on the standard FormattedMessage."
+          },
+          {
+            "name": "next/link",
+            "message": "Next Link is not supposed to be used direclty. Please use components/Link instead."
           }
         ]
       }

--- a/components/Link.js
+++ b/components/Link.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { pick } from 'lodash';
-import NextLink from 'next/link';
+import NextLink from 'next/link'; // eslint-disable-line no-restricted-imports
 import { Scrollchor } from 'react-scrollchor';
 
 class Link extends React.Component {


### PR DESCRIPTION
We want developers to use our custom `component/Link`, because it plugs our custom logic and having two components with the same name/purpose but different behaviors create confusion and is misleading for reviewers, as recently in https://github.com/opencollective/opencollective-frontend/pull/7808#discussion_r879171872.