### PR TITLE
OAuth: Add redirect UI state to ApplicationApproveScreen

### DIFF
--- a/lang/ca.json
+++ b/lang/ca.json
@@ -904,6 +904,7 @@
   "errorMsg": "Error: {error}",
   "errors.PM.Remove.HasActiveSubscriptions": "Aquest mètode de pagament no es pot suprimir perquè té contribucions financeres periòdiques actives.",
   "ERs/eC": "{count, plural, one {# Grant} other {# Grants}}",
+  "ET/GW3": "Redirecting…",
   "event.create.btn": "Crea un esdeveniment",
   "event.created": "Your Event has been created.",
   "Event.CreatedBy": "Creat per: {CollectiveLink}",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -904,6 +904,7 @@
   "errorMsg": "Chyba: {error}",
   "errors.PM.Remove.HasActiveSubscriptions": "This payment method cannot be removed because it has active recurring financial contributions.",
   "ERs/eC": "{count, plural, one {# Grant} other {# Grants}}",
+  "ET/GW3": "Redirecting…",
   "event.create.btn": "Create Event",
   "event.created": "Your Event has been created.",
   "Event.CreatedBy": "Created by: {CollectiveLink}",

--- a/lang/de.json
+++ b/lang/de.json
@@ -904,6 +904,7 @@
   "errorMsg": "Fehler: {error}",
   "errors.PM.Remove.HasActiveSubscriptions": "This payment method cannot be removed because it has active recurring financial contributions.",
   "ERs/eC": "{count, plural, one {# Grant} other {# Grants}}",
+  "ET/GW3": "Redirecting…",
   "event.create.btn": "Event erstellen",
   "event.created": "Your Event has been created.",
   "Event.CreatedBy": "Erstellt von: {CollectiveLink}",

--- a/lang/en.json
+++ b/lang/en.json
@@ -904,6 +904,7 @@
   "errorMsg": "Error: {error}",
   "errors.PM.Remove.HasActiveSubscriptions": "This payment method cannot be removed because it has active recurring financial contributions.",
   "ERs/eC": "{count, plural, one {# Grant} other {# Grants}}",
+  "ET/GW3": "Redirecting…",
   "event.create.btn": "Create Event",
   "event.created": "Your Event has been created.",
   "Event.CreatedBy": "Created by: {CollectiveLink}",

--- a/lang/es.json
+++ b/lang/es.json
@@ -904,6 +904,7 @@
   "errorMsg": "Error: {error}",
   "errors.PM.Remove.HasActiveSubscriptions": "No se puede eliminar este método de pago porque tiene contribuciones económicas activas.",
   "ERs/eC": "{count, plural, one {# Subvención} other {# Subvenciones}}",
+  "ET/GW3": "Redirecting…",
   "event.create.btn": "Crear un Evento",
   "event.created": "Tu evento ha sido creado.",
   "Event.CreatedBy": "Creado por: {CollectiveLink}",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -904,6 +904,7 @@
   "errorMsg": "Erreur : {error}",
   "errors.PM.Remove.HasActiveSubscriptions": "Ce moyen de paiement ne peut pas être supprimé car des contribution financières récurrentes lui sont liées.",
   "ERs/eC": "{count, plural, one {# Grant} other {# Grants}}",
+  "ET/GW3": "Redirecting…",
   "event.create.btn": "Créer un événement",
   "event.created": "Votre événement a été créé.",
   "Event.CreatedBy": "Créé par : {CollectiveLink}",

--- a/lang/it.json
+++ b/lang/it.json
@@ -904,6 +904,7 @@
   "errorMsg": "Error: {error}",
   "errors.PM.Remove.HasActiveSubscriptions": "This payment method cannot be removed because it has active recurring financial contributions.",
   "ERs/eC": "{count, plural, one {# Grant} other {# Grants}}",
+  "ET/GW3": "Redirecting…",
   "event.create.btn": "Crea Evento",
   "event.created": "Your Event has been created.",
   "Event.CreatedBy": "Created by: {CollectiveLink}",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -904,6 +904,7 @@
   "errorMsg": "エラー: {error}",
   "errors.PM.Remove.HasActiveSubscriptions": "This payment method cannot be removed because it has active recurring financial contributions.",
   "ERs/eC": "{count, plural, one {# Grant} other {# Grants}}",
+  "ET/GW3": "Redirecting…",
   "event.create.btn": "イベントを作成",
   "event.created": "Your Event has been created.",
   "Event.CreatedBy": "作成者： {CollectiveLink}",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -904,6 +904,7 @@
   "errorMsg": "오류: {error}",
   "errors.PM.Remove.HasActiveSubscriptions": "This payment method cannot be removed because it has active recurring financial contributions.",
   "ERs/eC": "{count, plural, one {# Grant} other {# Grants}}",
+  "ET/GW3": "Redirecting…",
   "event.create.btn": "이벤트 생성",
   "event.created": "Your Event has been created.",
   "Event.CreatedBy": "{CollectiveLink}이/가 생성",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -904,6 +904,7 @@
   "errorMsg": "Error: {error}",
   "errors.PM.Remove.HasActiveSubscriptions": "This payment method cannot be removed because it has active recurring financial contributions.",
   "ERs/eC": "{count, plural, one {# Grant} other {# Grants}}",
+  "ET/GW3": "Redirecting…",
   "event.create.btn": "Create Event",
   "event.created": "Your Event has been created.",
   "Event.CreatedBy": "Created by: {CollectiveLink}",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -904,6 +904,7 @@
   "errorMsg": "Błąd: {error}",
   "errors.PM.Remove.HasActiveSubscriptions": "Ta metoda płatności nie może zostać usunięta, ponieważ ma aktywne powtarzające się wkłady finansowe.",
   "ERs/eC": "{count, plural, one {# Dotacja} few {# Dotacje} many {# Dotacji} other {# Dotacji}}",
+  "ET/GW3": "Redirecting…",
   "event.create.btn": "Utwórz wydarzenie",
   "event.created": "Twoje wydarzenie zostało utworzone.",
   "Event.CreatedBy": "Stworzone przez: {CollectiveLink}",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -904,6 +904,7 @@
   "errorMsg": "Erro: {error}",
   "errors.PM.Remove.HasActiveSubscriptions": "Este método de pagamento não pode ser removido porque tem contribuições financeiras recorrentes ativas.",
   "ERs/eC": "{count, plural, one {# Grant} other {# Grants}}",
+  "ET/GW3": "Redirecting…",
   "event.create.btn": "Criar Evento",
   "event.created": "Seu evento foi criado.",
   "Event.CreatedBy": "Criado por: {CollectiveLink}",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -904,6 +904,7 @@
   "errorMsg": "Erro: {error}",
   "errors.PM.Remove.HasActiveSubscriptions": "Este método de pagamento não pode ser removido porque tem contribuições financeiras recorrentes atreladas.",
   "ERs/eC": "{count, plural, one {# Grant} other {# Grants}}",
+  "ET/GW3": "Redirecting…",
   "event.create.btn": "Criar evento",
   "event.created": "Your Event has been created.",
   "Event.CreatedBy": "Criado por: {CollectiveLink}",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -904,6 +904,7 @@
   "errorMsg": "Ошибка: {error}",
   "errors.PM.Remove.HasActiveSubscriptions": "Этот способ оплаты не может быть удален, так как он имеет активные периодические финансовые вклады.",
   "ERs/eC": "{count, plural, one {# Grant} other {# Grants}}",
+  "ET/GW3": "Redirecting…",
   "event.create.btn": "Создать Мероприятие",
   "event.created": "Your Event has been created.",
   "Event.CreatedBy": "Создано: {CollectiveLink}",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -904,6 +904,7 @@
   "errorMsg": "Помилка: {error}",
   "errors.PM.Remove.HasActiveSubscriptions": "This payment method cannot be removed because it has active recurring financial contributions.",
   "ERs/eC": "{count, plural, one {# Grant} other {# Grants}}",
+  "ET/GW3": "Redirecting…",
   "event.create.btn": "Створити подію",
   "event.created": "Вашу подію було створено.",
   "Event.CreatedBy": "Створено: {CollectiveLink}",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -904,6 +904,7 @@
   "errorMsg": "错误：{error}",
   "errors.PM.Remove.HasActiveSubscriptions": "This payment method cannot be removed because it has active recurring financial contributions.",
   "ERs/eC": "{count, plural, one {# Grant} other {# Grants}}",
+  "ET/GW3": "Redirecting…",
   "event.create.btn": "创建事件",
   "event.created": "Your Event has been created.",
   "Event.CreatedBy": "由 {社群Link} 创建",

--- a/stories/oauth/ApplicationApproveScreen.stories.mdx
+++ b/stories/oauth/ApplicationApproveScreen.stories.mdx
@@ -1,0 +1,42 @@
+import { ArgsTable, Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { ApplicationApproveScreen } from '../../components/oauth/ApplicationApproveScreen';
+import { UserContext } from '../../components/UserProvider';
+import { loggedInUser } from '../mocks/loggedInUser';
+
+export const testApp = {
+  name: 'Test Application',
+  clientId: 'test-client-id',
+  redirectUri: 'http://localhost:3000/oauth/callback',
+  account: {
+    id: 'test-account-id',
+    name: 'Test Account',
+    slug: 'test-account',
+    imageUrl: 'https://images.opencollective.com/github/fc5f232/logo/256.png',
+  },
+};
+
+<Meta title="OAuth/ApplicationApproveScreen" component={ApplicationApproveScreen} />
+
+<Canvas>
+  <Story name="Default">
+    {() => {
+      return (
+        <UserContext.Provider value={{ LoggedInUser: loggedInUser, loadingLoggedInUser: false }}>
+          <ApplicationApproveScreen application={testApp} />
+        </UserContext.Provider>
+      );
+    }}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="Auto-approve (redirecting)">
+    {() => {
+      return (
+        <UserContext.Provider value={{ LoggedInUser: loggedInUser, loadingLoggedInUser: false }}>
+          <ApplicationApproveScreen autoApprove application={testApp} />
+        </UserContext.Provider>
+      );
+    }}
+  </Story>
+</Canvas>


### PR DESCRIPTION
Try it on: https://opencollective-styleguide-git-enhancement-8e4535-opencollective.vercel.app/?path=/story/oauth-applicationapprovescreen--auto-approve-redirecting

Adds a "Redirect" UI state displayed:
- After clicking on "Approve" (if the approval succeeds)
- Or when auto-approve is true (existing authorization)

This will prevent the flashing approve form.

![Peek 2022-05-24 13-02](https://user-images.githubusercontent.com/1556356/170020612-7b0254bc-f93b-4f98-bc22-72740902fd56.gif)
