### PR TITLE
Avatar anti-aliasing for OAuth approve screen

### DIFF
--- a/components/oauth/ApplicationApproveScreen.js
+++ b/components/oauth/ApplicationApproveScreen.js
@@ -108,9 +108,11 @@ export const ApplicationApproveScreen = ({ application, redirectUri, autoApprove
           <RadialIconContainer size="32px" bg="#29cc75">
             <Check size={12} />
           </RadialIconContainer>
-          <RadialIconContainer bg="blue.700" size={96} border="1px solid #DCDEE0">
-            <Image src="/static/images/oc-logo-inverted.svg" height={56} width={56} />
-          </RadialIconContainer>
+          <Container borderRadius="50%" border="1px solid #DCDEE0">
+            <RadialIconContainer size={96} bg="blue.700">
+              <Image src="/static/images/oc-logo-inverted.svg" height={56} width={56} />
+            </RadialIconContainer>
+          </Container>
         </TopAvatarsContainer>
         <Box pt={56}>
           {isRedirecting ? (


### PR DESCRIPTION
A very subtle change, but this looked bad on Firefox (see blue OC avatar on the right).

| Before | After |
| ---- | ---- |
| ![2022-05-30_18-17-50](https://user-images.githubusercontent.com/1556356/171030688-d2c41fd8-8236-4451-ada4-5bf95a9de7b9.jpg) | ![2022-05-30_18-14-59](https://user-images.githubusercontent.com/1556356/171030684-157af78d-ab45-4d5a-baf5-ff69fcd68a0d.jpg) |


