### PR TITLE
Fix spacing issues for new member invite cards

### DIFF
--- a/components/Text.js
+++ b/components/Text.js
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components';
-import { color, display, space, typography } from 'styled-system';
+import { color, display, layout, space, typography } from 'styled-system';
 
 import { cursor, overflowWrap, textTransform, whiteSpace, wordBreak } from '../lib/styled-system-custom-properties';
 
@@ -10,6 +10,7 @@ export const P = styled.p.attrs(props => ({
 }))`
   ${color}
   ${display}
+  ${layout}
   ${space}
   ${typography}
   ${textTransform}

--- a/components/Text.js
+++ b/components/Text.js
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components';
-import { color, display, layout, space, typography } from 'styled-system';
+import { color, display, space, typography } from 'styled-system';
 
 import { cursor, overflowWrap, textTransform, whiteSpace, wordBreak } from '../lib/styled-system-custom-properties';
 
@@ -10,7 +10,6 @@ export const P = styled.p.attrs(props => ({
 }))`
   ${color}
   ${display}
-  ${layout}
   ${space}
   ${typography}
   ${textTransform}

--- a/components/edit-collective/sections/Members.js
+++ b/components/edit-collective/sections/Members.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from '@apollo/client/react/hoc';
 import { Edit } from '@styled-icons/material/Edit';
-import { compose, get, omit } from 'lodash';
+import { compose, get, omit, truncate } from 'lodash';
 import memoizeOne from 'memoize-one';
 import { defineMessages, FormattedDate, FormattedMessage, injectIntl } from 'react-intl';
 import styled from 'styled-components';
@@ -209,9 +209,13 @@ class Members extends React.Component {
             <FormattedMessage id="user.since.label" defaultMessage="Since" />:{' '}
             <FormattedDate value={get(member, 'since')} />
           </P>
-          <P fontSize="11px" lineHeight="16px" mx={2} minHeight={16} fontWeight={400} mb={5}>
-            {get(member, 'description')}
-          </P>
+          <Box mb={5} overflow="hidden" height={32}>
+            <P fontSize="11px" lineHeight="16px" mx={2} minHeight={16} fontWeight={400}>
+              {truncate(get(member, 'description'), {
+                length: 30,
+              })}
+            </P>
+          </Box>
           {isInvitation && (
             <React.Fragment>
               <TagContainer>

--- a/components/edit-collective/sections/Members.js
+++ b/components/edit-collective/sections/Members.js
@@ -209,7 +209,7 @@ class Members extends React.Component {
             <FormattedMessage id="user.since.label" defaultMessage="Since" />:{' '}
             <FormattedDate value={get(member, 'since')} />
           </P>
-          <P fontSize="11px" lineHeight="16px" mx={2} fontWeight={400} mb={5}>
+          <P fontSize="11px" lineHeight="16px" mx={2} minHeight={16} fontWeight={400} mb={5}>
             {get(member, 'description')}
           </P>
           {isInvitation && (

--- a/components/edit-collective/sections/Members.js
+++ b/components/edit-collective/sections/Members.js
@@ -210,7 +210,7 @@ class Members extends React.Component {
             <FormattedDate value={get(member, 'since')} />
           </P>
           <Box mb={5} overflow="hidden" height={32}>
-            <P fontSize="11px" lineHeight="16px" mx={2} minHeight={16} fontWeight={400}>
+            <P fontSize="11px" lineHeight="16px" mx={2} fontWeight={400}>
               {truncate(get(member, 'description'), {
                 length: 30,
               })}


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/5585

# Description

This PR adds a minimum height to description paragraph (matching the line-height) in new member invite cards. This takes care of spacing issues when there are member cards with empty description. 

To add `minHeight`, default `layout` from `styled-system` was imported (https://styled-system.com/table#layout), since `minHeight` is part of  `layout`. I'm not well versed with `styled-system`, but I guess this should be fine.

Fixes - https://github.com/opencollective/opencollective/issues/5585

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots

![Screenshot 2022-06-01 at 12 47 36 PM](https://user-images.githubusercontent.com/4299398/171349261-1e02b1f8-4485-4b8c-b5e8-8670f22c9944.png)

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
