### PR TITLE
Make the nav bar logo more responsive on different screen sizes

### DIFF
--- a/components/TopBarV2.js
+++ b/components/TopBarV2.js
@@ -56,12 +56,6 @@ const NavItem = styled(StyledLink)`
   }
 `;
 
-const LogoContainer = styled(Container)`
-  @media (min-width: 641px) and (max-width: 710px) {
-    display: none;
-  }
-`;
-
 const TopBarV2 = ({ showSearch, menuItems }) => {
   const [showMobileMenu, setShowMobileMenu] = useState(false);
   const ref = useRef();
@@ -82,9 +76,7 @@ const TopBarV2 = ({ showSearch, menuItems }) => {
     >
       <Link href="/">
         <Flex alignItems="center">
-          <LogoContainer>
-            <Image width="36" height="36" src="/static/images/opencollective-icon.png" alt="Open Collective logo" />
-          </LogoContainer>
+          <Image width="36" height="36" src="/static/images/opencollective-icon.png" alt="Open Collective logo" />
           <Hide xs sm md>
             <Box mx={2}>
               <Image height={21} width={141} src="/static/images/logotype.svg" alt="Open Collective" />
@@ -94,7 +86,7 @@ const TopBarV2 = ({ showSearch, menuItems }) => {
       </Link>
 
       <Flex alignItems="center" justifyContent={['flex-end', 'flex-end', 'center']} flex="1 1 auto">
-        <Hide xs>
+        <Hide xs sm>
           <NavList as="ul" p={0} m={0} justifyContent="space-around" css="margin: 0;">
             {menuItems.solutions && (
               <PopupMenu
@@ -217,7 +209,7 @@ const TopBarV2 = ({ showSearch, menuItems }) => {
         </Hide>
       </Container>
       <TopBarProfileMenu />
-      <Hide sm md lg>
+      <Hide md lg>
         <TopBarMobileMenuV2 showMobileMenu={showMobileMenu} closeMenu={toggleMobileMenu} />
         <Box mx={3} onClick={toggleMobileMenu}>
           <Flex as="a">

--- a/components/TopBarV2.js
+++ b/components/TopBarV2.js
@@ -56,6 +56,12 @@ const NavItem = styled(StyledLink)`
   }
 `;
 
+const LogoContainer = styled(Container)`
+  @media (min-width: 641px) and (max-width: 710px) {
+    display: none;
+  }
+`;
+
 const TopBarV2 = ({ showSearch, menuItems }) => {
   const [showMobileMenu, setShowMobileMenu] = useState(false);
   const ref = useRef();
@@ -76,8 +82,10 @@ const TopBarV2 = ({ showSearch, menuItems }) => {
     >
       <Link href="/">
         <Flex alignItems="center">
-          <Image width="36" height="36" src="/static/images/opencollective-icon.png" alt="Open Collective logo" />
-          <Hide xs sm>
+          <LogoContainer>
+            <Image width="36" height="36" src="/static/images/opencollective-icon.png" alt="Open Collective logo" />
+          </LogoContainer>
+          <Hide xs sm md>
             <Box mx={2}>
               <Image height={21} width={141} src="/static/images/logotype.svg" alt="Open Collective" />
             </Box>


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/5612

It was brought to attention that the TopBarV2 logo when making the screen smaller behaves a bit weird. Currently the the logo is resized and subsequently hidden as shown in the below screen-cast. 

https://user-images.githubusercontent.com/12435965/171747197-0cd10152-d489-415c-b792-3791c4ffb4c9.mp4

Ideally we should not make the logo smaller like this but rather hide the logo depending on the screen size. This PR corrects this behavior. The screen-cast below shows the newly update logo;

https://user-images.githubusercontent.com/12435965/171747404-13333c41-33b8-4e7a-85b2-ae7e44010c4b.mp4

cc: @Memo-Es 