### PR TITLE
ContributionFlow: Consider currency for presets and min amounts

### DIFF
--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -35,16 +35,17 @@ const getCustomFields = (collective, tier) => {
 const StepDetails = ({ onChange, data, collective, tier, showFeesOnTop, router, isEmbed }) => {
   const intl = useIntl();
   const amount = data?.amount;
+  const currency = tier?.amount.currency || collective.currency;
+  const presets = getTierPresets(tier, collective.type, currency);
   const getDefaultOtherAmountSelected = () => isNil(amount) || !presets?.includes(amount);
-  const presets = React.useMemo(() => getTierPresets(tier, collective.type), [tier, collective.type]);
   const [isOtherAmountSelected, setOtherAmountSelected] = React.useState(getDefaultOtherAmountSelected);
   const [temporaryInterval, setTemporaryInterval] = React.useState(undefined);
-  const minAmount = getTierMinAmount(tier);
+  const { LoggedInUser } = useUser();
+
+  const minAmount = getTierMinAmount(tier, currency);
   const hasQuantity = tier?.type === TierTypes.TICKET || tier?.type === TierTypes.PRODUCT;
   const isFixedContribution = tier?.amountType === AmountTypes.FIXED;
-  const { LoggedInUser } = useUser();
   const customFields = getCustomFields(collective, tier);
-  const currency = tier?.amount.currency || collective.currency;
   const selectedInterval = data?.interval !== INTERVALS.flexible ? data?.interval : null;
   const supportsRecurring = canContributeRecurring(collective, LoggedInUser) && (!tier || tier?.interval);
   const isFixedInterval = tier?.interval && tier.interval !== INTERVALS.flexible;

--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -142,6 +142,7 @@ class ContributionFlow extends React.Component {
     this.captchaRef = React.createRef();
 
     const isCryptoFlow = props.paymentFlow === PAYMENT_FLOW.CRYPTO;
+    const currency = isCryptoFlow ? CRYPTO_CURRENCIES[0] : props.tier?.amount?.currency || props.collective.currency;
     this.state = {
       error: null,
       stripe: null,
@@ -156,9 +157,9 @@ class ContributionFlow extends React.Component {
       stepDetails: {
         quantity: 1,
         interval: props.fixedInterval || getDefaultInterval(props.tier),
-        amount: isCryptoFlow ? '' : props.fixedAmount || getDefaultTierAmount(props.tier),
+        amount: isCryptoFlow ? '' : props.fixedAmount || getDefaultTierAmount(props.tier, props.collective, currency),
         platformContribution: props.platformContribution,
-        currency: isCryptoFlow ? CRYPTO_CURRENCIES[0] : props.tier?.amount?.currency || props.collective.currency,
+        currency,
       },
     };
   }
@@ -571,7 +572,8 @@ class ContributionFlow extends React.Component {
     const { intl, fixedInterval, fixedAmount, collective, host, tier, LoggedInUser, paymentFlow } = this.props;
     const { stepDetails, stepProfile, stepPayment, stepSummary } = this.state;
     const isFixedContribution = this.isFixedContribution(tier, fixedAmount, fixedInterval);
-    const minAmount = this.getTierMinAmount(tier);
+    const currency = tier?.amount.currency || collective.currency;
+    const minAmount = this.getTierMinAmount(tier, currency);
     const noPaymentRequired = minAmount === 0 && (isFixedContribution || stepDetails?.amount === 0);
     const isStepProfileCompleted = Boolean((stepProfile && LoggedInUser) || stepProfile?.isGuest);
     const isCrypto = paymentFlow === PAYMENT_FLOW.CRYPTO;
@@ -598,7 +600,6 @@ class ContributionFlow extends React.Component {
             stepDetails.platformContribution &&
             stepDetails.platformContribution / stepDetails.amount >= 0.5
           ) {
-            const currency = tier?.amount.currency || collective.currency;
             return confirm(
               intl.formatMessage(OTHER_MESSAGES.tipAmountContributionWarning, {
                 contributionAmount: formatCurrency(stepDetails.amount, currency, { locale: intl.locale }),
@@ -801,7 +802,7 @@ class ContributionFlow extends React.Component {
                 isSubmitted={this.state.isSubmitted}
                 loading={isValidating || isLoading}
                 currency={currency}
-                isFreeTier={this.getTierMinAmount(tier) === 0}
+                isFreeTier={this.getTierMinAmount(tier, currency) === 0}
               />
             </StepsProgressBox>
             {/* main container */}

--- a/lib/__tests__/tier-utils.test.js
+++ b/lib/__tests__/tier-utils.test.js
@@ -31,4 +31,9 @@ describe('getTierPresets', () => {
     expect(getTierPresets(getTierWithMin(7555))).toEqual([7555, 20000, 40000]);
     expect(getTierPresets(getTierWithMin(80000))).toEqual([80000, 200000, 400000]);
   });
+
+  it('returns different values based on currency', () => {
+    expect(getTierPresets(null, 'COLLECTIVE', 'JPY')).toEqual([50000, 100000, 200000, 500000]);
+    expect(getTierPresets(null, 'COLLECTIVE', 'STD')).toEqual([10000000, 20000000, 40000000, 100000000]);
+  });
 });

--- a/lib/tier-utils.js
+++ b/lib/tier-utils.js
@@ -12,13 +12,149 @@ export const DEFAULT_FUNDS_PRESETS = [100000, 200000, 500000, 1000000];
 export const DEFAULT_MINIMUM_AMOUNT = 100;
 
 /**
+ * Generated from the following query, using rounded number to make sure we don't suggest odd amounts.
+ *
+ * ```sql
+ * WITH uniq_currencies AS (
+ *     SELECT DISTINCT "to"
+ *     FROM "CurrencyExchangeRates"
+ *     WHERE "from" = 'USD'
+ * ) SELECT uc."to", (
+ *     -- Keep only first digit from number (e.g. 4 -> 4, 89 -> 80, 1337 -> 1000)
+ *     SELECT LEFT(rate::TEXT, 1)::integer * POW(10, LENGTH(CAST(ROUND(rate) AS TEXT)) - 1)
+ *     FROM "CurrencyExchangeRates" e WHERE e.from = 'USD' AND e.to = uc.to ORDER BY e."createdAt" DESC LIMIT 1
+ *   ) AS rate
+ * FROM uniq_currencies uc
+ * ORDER BY rate DESC
+ * ```
+ */
+const CURRENCY_ADJUSTMENT_RATES = {
+  STD: 20000,
+  VND: 20000,
+  LAK: 10000,
+  IDR: 10000,
+  SLL: 10000,
+  UZS: 10000,
+  GNF: 8000,
+  PYG: 6000,
+  KHR: 4000,
+  MGA: 4000,
+  UGX: 3000,
+  COP: 3000,
+  MNT: 3000,
+  TZS: 2000,
+  CDF: 2000,
+  BIF: 2000,
+  MWK: 1000,
+  KRW: 1000,
+  LBP: 1000,
+  MMK: 1000,
+  RWF: 1000,
+  CLP: 800,
+  XAF: 600,
+  XOF: 600,
+  CRC: 600,
+  SOS: 500,
+  KZT: 400,
+  KMF: 400,
+  AMD: 400,
+  NGN: 400,
+  AOA: 400,
+  HUF: 300,
+  LKR: 300,
+  MRO: 300,
+  GYD: 200,
+  PKR: 200,
+  YER: 200,
+  DJF: 100,
+  JPY: 100,
+  RSD: 100,
+  KES: 100,
+  XPF: 100,
+  NPR: 100,
+  ALL: 100,
+  HTG: 100,
+  VUV: 100,
+  ISK: 100,
+  JMD: 100,
+  LRD: 100,
+  CVE: 100,
+  DZD: 100,
+  ARS: 100,
+  BDT: 90,
+  SEK: 90,
+  MAD: 90,
+  AFN: 80,
+  KGS: 70,
+  INR: 70,
+  RUB: 60,
+  MZN: 60,
+  PHP: 50,
+  GMD: 50,
+  DOP: 50,
+  MKD: 50,
+  ETB: 50,
+  UYU: 40,
+  MUR: 40,
+  NIO: 30,
+  THB: 30,
+  HNL: 20,
+  TWD: 20,
+  CZK: 20,
+  UAH: 20,
+  SRD: 20,
+  LSL: 10,
+  ZAR: 10,
+  SZL: 10,
+  MVR: 10,
+  ZMW: 10,
+  NAD: 10,
+  EGP: 10,
+  MDL: 10,
+  TJS: 10,
+  MXN: 10,
+  SCR: 10,
+  TRY: 10,
+  BWP: 10,
+  NOK: 9,
+  MOP: 8,
+  SBD: 8,
+  HKD: 7,
+  HRK: 7,
+  GTQ: 7,
+  TTD: 6,
+  CNY: 6,
+  BOB: 6,
+  DKK: 6,
+  RON: 4,
+  BRL: 4,
+  MYR: 4,
+  PLN: 4,
+  PEN: 3,
+  PGK: 3,
+  SAR: 3,
+  BYN: 3,
+  AED: 3,
+  ILS: 3,
+  QAR: 3,
+  BBD: 2,
+  TOP: 2,
+  FJD: 2,
+  GEL: 2,
+  BZD: 2,
+  XCD: 2,
+  WST: 2,
+};
+
+/**
  * Get the min authorized amount for order, in cents.
  * ⚠️ Only work with data from GQLV2.
  */
-export const getTierMinAmount = tier => {
+export const getTierMinAmount = (tier, currency) => {
+  const rate = CURRENCY_ADJUSTMENT_RATES[currency] || 1;
   if (!tier) {
     // When making a donation, min amount is $1
-    return DEFAULT_MINIMUM_AMOUNT;
+    return DEFAULT_MINIMUM_AMOUNT * rate;
   } else if (tier.amountType === AmountTypes.FIXED) {
     return tier.amount?.valueInCents || 0;
   } else if (tier.minimumAmount.valueInCents !== null) {
@@ -26,7 +162,16 @@ export const getTierMinAmount = tier => {
   } else if (tier.presets?.length && min(tier.presets) === 0) {
     return 0;
   } else {
-    return DEFAULT_MINIMUM_AMOUNT;
+    return DEFAULT_MINIMUM_AMOUNT * rate;
+  }
+};
+
+const adaptPresetsForCurrency = (presets, currency) => {
+  const rate = CURRENCY_ADJUSTMENT_RATES[currency];
+  if (!rate) {
+    return presets;
+  } else {
+    return presets.map(amount => Math.round(amount * rate));
   }
 };
 
@@ -34,16 +179,16 @@ export const getTierMinAmount = tier => {
  * Get the presets for a given tier, or the default presets
  * ⚠️ Only work with data from GQLV2.
  */
-export const getTierPresets = (tier, collectiveType) => {
+export const getTierPresets = (tier, collectiveType, currency) => {
   if (tier?.presets?.length > 0) {
     return tier.presets;
   } else if (collectiveType === CollectiveType.FUND) {
-    return DEFAULT_FUNDS_PRESETS;
+    return adaptPresetsForCurrency(DEFAULT_FUNDS_PRESETS, currency);
   } else if (!tier) {
-    return DEFAULT_PRESETS;
+    return adaptPresetsForCurrency(DEFAULT_PRESETS, currency);
   }
 
-  const minAmount = getTierMinAmount(tier);
+  const minAmount = getTierMinAmount(tier, currency);
   if (minAmount === 0) {
     return [0, 500, 1500, 5000];
   } else if (minAmount < 1000) {
@@ -62,14 +207,14 @@ export const getTierPresets = (tier, collectiveType) => {
  * Returns the default selected amount from a tier.
  * ⚠️ Only work with data from GQLV2.
  */
-export const getDefaultTierAmount = tier => {
+export const getDefaultTierAmount = (tier, collective, currency) => {
   if (tier && !isNil(tier.amount?.valueInCents)) {
     return tier.amount.valueInCents;
-  } else if (getTierMinAmount(tier) === 0) {
+  } else if (getTierMinAmount(tier, currency) === 0) {
     // Free tiers are free per default, even when user can make a donation
     return 0;
   } else {
-    const presets = getTierPresets(tier);
+    const presets = getTierPresets(tier, collective.type, currency);
     return presets[Math.floor(presets.length / 2)];
   }
 };

--- a/lib/tier-utils.js
+++ b/lib/tier-utils.js
@@ -168,11 +168,7 @@ export const getTierMinAmount = (tier, currency) => {
 
 const adaptPresetsForCurrency = (presets, currency) => {
   const rate = CURRENCY_ADJUSTMENT_RATES[currency];
-  if (!rate) {
-    return presets;
-  } else {
-    return presets.map(amount => Math.round(amount * rate));
-  }
+  return !rate ? presets : presets.map(amount => Math.round(amount * rate));
 };
 
 /**


### PR DESCRIPTION
Reported in https://opencollective.slack.com/archives/C6JTTA4SK/p1654599518219889

Multiply default amounts with heavily rounded multipliers, to prevent suggesting odd amounts. We do something like:
- FX rate 5.2 => multiply by 5
- FX rate 74.5 => multiply by 70
- FX rate 3188.5 => multiplay by 3000