### PR TITLE
Enforce fetching GraphQL id when available (ESLint)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,6 +42,11 @@
       { "env": "apollo", "projectName": "opencollective" },
       { "env": "apollo", "tagName": "gqlV2", "projectName": "opencollective_v2" }
     ],
+    "graphql/required-fields": [
+      "error",
+      { "env": "apollo", "projectName": "opencollective", "requiredFields": ["id"] },
+      { "env": "apollo", "tagName": "gqlV2", "projectName": "opencollective_v2", "requiredFields": ["id"] }
+    ],
     "graphql/named-operations": ["error"],
     "graphql/capitalized-type-name": ["error"],
     "graphql/no-deprecated-fields": ["warn"],

--- a/components/ApplyToHostModal.js
+++ b/components/ApplyToHostModal.js
@@ -59,6 +59,7 @@ const hostFields = gqlV2/* GraphQL */ `
 const applyToHostQuery = gqlV2/* GraphQL */ `
   query ApplyToHost($hostSlug: String!) {
     host(slug: $hostSlug) {
+      id
       ...ApplyToHostFields
     }
   }
@@ -71,6 +72,7 @@ const applyToHostQuery = gqlV2/* GraphQL */ `
 const applyToHostWithAccountsQuery = gqlV2/* GraphQL */ `
   query ApplyToHostWithAccounts($hostSlug: String!) {
     host(slug: $hostSlug) {
+      id
       ...ApplyToHostFields
     }
     loggedInAccount {
@@ -107,6 +109,7 @@ const applyToHostMutation = gqlV2/* GraphQL */ `
         isActive
         isApproved
         host {
+          id
           ...ApplyToHostFields
         }
       }

--- a/components/CollectivesWithData.js
+++ b/components/CollectivesWithData.js
@@ -129,6 +129,7 @@ const collectivesQuery = gql`
       orderDirection: $orderDirection
       slugs: $slugs
     ) {
+      id
       total
       collectives {
         id
@@ -145,6 +146,7 @@ const collectivesQuery = gql`
           id
           yearlyBudget
           backers {
+            id
             all
           }
         }

--- a/components/CreateGiftCardsForm.js
+++ b/components/CreateGiftCardsForm.js
@@ -675,6 +675,7 @@ export const collectiveSourcePaymentMethodsQuery = gql`
       }
     }
     allHosts(limit: 100, onlyOpenHosts: false, minNbCollectivesHosted: 1) {
+      id
       collectives {
         id
         type

--- a/components/HostsWithData.js
+++ b/components/HostsWithData.js
@@ -115,6 +115,7 @@ const hostsQuery = gql`
       orderBy: $orderBy
       orderDirection: $orderDirection
     ) {
+      id
       total
       collectives {
         id
@@ -130,6 +131,7 @@ const hostsQuery = gql`
         stats {
           id
           collectives {
+            id
             hosted
           }
         }

--- a/components/MembersWithData.js
+++ b/components/MembersWithData.js
@@ -159,9 +159,11 @@ const membersQuery = gql`
       role
       createdAt
       collective {
+        id
         name
       }
       stats {
+        id
         totalDonations
       }
       tier {

--- a/components/MembershipsWithData.js
+++ b/components/MembershipsWithData.js
@@ -123,6 +123,7 @@ const membershipsQuery = gql`
       role
       createdAt
       stats {
+        id
         totalDonations
       }
       tier {
@@ -141,6 +142,7 @@ const membershipsQuery = gql`
         stats {
           id
           backers {
+            id
             all
           }
           yearlyBudget

--- a/components/SendMoneyToCollectiveBtn.js
+++ b/components/SendMoneyToCollectiveBtn.js
@@ -134,6 +134,7 @@ const addPaymentMethodsData = graphql(paymentMethodsQuery, {
 
 const collectiveBalanceFragment = gql`
   fragment StatFieldsFragment on CollectiveStatsType {
+    id
     balance
   }
 `;
@@ -144,7 +145,9 @@ const sendMoneyToCollectiveMutation = gqlV2/* GraphQL */ `
       order {
         id
         fromAccount {
+          id
           stats {
+            id
             balance {
               valueInCents
             }

--- a/components/accept-financial-contributions/HostsContainer.js
+++ b/components/accept-financial-contributions/HostsContainer.js
@@ -131,6 +131,7 @@ const hostsQuery = gqlV2/* GraphQL */ `
         totalHostedCollectives
         hostFeePercent
         stats {
+          id
           yearlyBudgetManaged {
             value
           }

--- a/components/collective-page/graphql/fragments.js
+++ b/components/collective-page/graphql/fragments.js
@@ -117,6 +117,7 @@ export const contributeCardTierFieldsFragment = gql`
       }
     }
     contributors(limit: $nbContributorsPerContributeCard) {
+      id
       ...ContributeCardContributorFields
     }
   }
@@ -139,6 +140,7 @@ export const contributeCardEventFieldsFragment = gql`
       type
     }
     contributors(limit: $nbContributorsPerContributeCard, roles: [BACKER, ATTENDEE]) {
+      id
       ...ContributeCardContributorFields
     }
     stats {
@@ -165,6 +167,7 @@ export const contributeCardProjectFieldsFragment = gql`
     isArchived
     backgroundImageUrl(height: 208)
     contributors(limit: $nbContributorsPerContributeCard, roles: [BACKER]) {
+      id
       ...ContributeCardContributorFields
     }
     stats {

--- a/components/collective-page/graphql/queries.js
+++ b/components/collective-page/graphql/queries.js
@@ -40,9 +40,11 @@ export const collectivePageQuery = gql`
       canApply
       canContact
       features {
+        id
         ...NavbarFields
       }
       ordersFromCollective(subscriptionsOnly: true) {
+        id
         isSubscriptionActive
       }
       memberOf(onlyActiveCollectives: true, limit: 1) {
@@ -65,6 +67,7 @@ export const collectivePageQuery = gql`
           organizations
         }
         transactions {
+          id
           all
         }
       }
@@ -86,6 +89,7 @@ export const collectivePageQuery = gql`
         twitterHandle
         type
         coreContributors: contributors(roles: [ADMIN, MEMBER]) {
+          id
           ...ContributorsFields
         }
       }
@@ -106,18 +110,23 @@ export const collectivePageQuery = gql`
         }
       }
       coreContributors: contributors(roles: [ADMIN, MEMBER]) {
+        id
         ...ContributorsFields
       }
       financialContributors: contributors(roles: [BACKER], limit: 150) {
+        id
         ...ContributorsFields
       }
       tiers {
+        id
         ...ContributeCardTierFields
       }
       events(includePastEvents: true, includeInactive: true) {
+        id
         ...ContributeCardEventFields
       }
       projects {
+        id
         ...ContributeCardProjectFields
       }
       connectedCollectives: members(role: "CONNECTED_COLLECTIVE") {
@@ -139,11 +148,13 @@ export const collectivePageQuery = gql`
             }
           }
           contributors(limit: $nbContributorsPerContributeCard) {
+            id
             ...ContributeCardContributorFields
           }
         }
       }
       updates(limit: 3, onlyPublishedUpdates: true) {
+        id
         ...UpdatesFields
       }
       plan {

--- a/components/collective-page/sections/Budget.js
+++ b/components/collective-page/sections/Budget.js
@@ -72,10 +72,12 @@ export const budgetSectionQuery = gqlV2/* GraphQL */ `
     expenses(account: { slug: $slug }, limit: $limit, includeChildrenExpenses: true) {
       totalCount
       nodes {
+        id
         ...ExpensesListFieldsFragment
       }
     }
     account(slug: $slug) {
+      id
       ...BudgetSectionAccountFields
     }
   }
@@ -87,6 +89,7 @@ export const budgetSectionQuery = gqlV2/* GraphQL */ `
 export const budgetSectionWithHostQuery = gqlV2/* GraphQL */ `
   query BudgetSectionWithHost($slug: String!, $hostSlug: String!, $limit: Int!, $kind: [TransactionKind]) {
     host(slug: $hostSlug) {
+      id
       ...ExpenseHostFields
     }
     transactions(
@@ -102,10 +105,12 @@ export const budgetSectionWithHostQuery = gqlV2/* GraphQL */ `
     expenses(account: { slug: $slug }, limit: $limit, includeChildrenExpenses: true) {
       totalCount
       nodes {
+        id
         ...ExpensesListFieldsFragment
       }
     }
     account(slug: $slug) {
+      id
       ...BudgetSectionAccountFields
     }
   }

--- a/components/collective-page/sections/Contributions.js
+++ b/components/collective-page/sections/Contributions.js
@@ -172,6 +172,7 @@ const contributionsSectionStaticQuery = gqlV2/* GraphQL */ `
           id
           role
           tier {
+            id
             name
             description
           }
@@ -228,6 +229,7 @@ const contributionsSectionQuery = gqlV2/* GraphQL */ `
           id
           role
           tier {
+            id
             name
             description
           }

--- a/components/collective-page/sections/Updates.js
+++ b/components/collective-page/sections/Updates.js
@@ -32,6 +32,7 @@ export const updatesSectionQuery = gql`
     Collective(slug: $slug) {
       id
       updates(limit: 3, onlyPublishedUpdates: $onlyPublishedUpdates) {
+        id
         ...UpdatesFields
       }
     }

--- a/components/contribution-flow/ContributionFlowSuccess.js
+++ b/components/contribution-flow/ContributionFlowSuccess.js
@@ -335,6 +335,7 @@ class ContributionFlowSuccess extends React.Component {
 const orderSuccessQuery = gqlV2/* GraphQL */ `
   query NewContributionFlowOrderSuccess($order: OrderReferenceInput!) {
     order(order: $order) {
+      id
       ...OrderSuccessFragment
     }
   }

--- a/components/contribution-flow/graphql/fragments.js
+++ b/components/contribution-flow/graphql/fragments.js
@@ -50,6 +50,7 @@ export const contributionFlowAccountFieldsFragment = gqlV2/* GraphQL */ `
       platformFeePercent
       platformContributionAvailable
       host {
+        id
         ...ContributionFlowHostFields
       }
     }
@@ -70,6 +71,7 @@ export const contributionFlowAccountFieldsFragment = gqlV2/* GraphQL */ `
     ... on AccountWithHost {
       hostFeePercent
       host {
+        id
         ...ContributionFlowHostFields
       }
     }
@@ -168,11 +170,13 @@ export const orderSuccessFragment = gqlV2/* GraphQL */ `
       }
       ... on AccountWithHost {
         host {
+          id
           ...OrderSuccessHostFragment
         }
       }
       ... on Organization {
         host {
+          id
           ...OrderSuccessHostFragment
           ... on AccountWithContributions {
             # limit: 1 as current best practice to avoid the API fetching entries it doesn't need
@@ -191,6 +195,7 @@ export const orderResponseFragment = gqlV2/* GraphQL */ `
   fragment OrderResponseFragment on OrderWithPayment {
     guestToken
     order {
+      id
       ...OrderSuccessFragment
     }
     stripeError {

--- a/components/contribution-flow/graphql/queries.js
+++ b/components/contribution-flow/graphql/queries.js
@@ -5,6 +5,7 @@ import { contributionFlowAccountFieldsFragment } from './fragments';
 export const contributionFlowAccountQuery = gqlV2/* GraphQL */ `
   query ContributionFlowAccountQuery($collectiveSlug: String!) {
     account(slug: $collectiveSlug, throwIfMissing: false) {
+      id
       ...ContributionFlowAccountFields
     }
   }
@@ -14,6 +15,7 @@ export const contributionFlowAccountQuery = gqlV2/* GraphQL */ `
 export const contributionFlowAccountWithTierQuery = gqlV2/* GraphQL */ `
   query ContributionFlowAccountWithTierQuery($collectiveSlug: String!, $tier: TierReferenceInput!) {
     account(slug: $collectiveSlug, throwIfMissing: false) {
+      id
       ...ContributionFlowAccountFields
     }
     tier(tier: $tier, throwIfMissing: false) {

--- a/components/conversations/Comment.js
+++ b/components/conversations/Comment.js
@@ -21,6 +21,7 @@ import { commentFieldsFragment } from './graphql';
 const editCommentMutation = gqlV2/* GraphQL */ `
   mutation EditComment($comment: CommentUpdateInput!) {
     editComment(comment: $comment) {
+      id
       ...CommentFields
     }
   }

--- a/components/conversations/CommentForm.js
+++ b/components/conversations/CommentForm.js
@@ -24,6 +24,7 @@ import { commentFieldsFragment } from './graphql';
 const createCommentMutation = gqlV2/* GraphQL */ `
   mutation CreateComment($comment: CommentCreateInput!) {
     createComment(comment: $comment) {
+      id
       ...CommentFields
     }
   }

--- a/components/create-collective/index.js
+++ b/components/create-collective/index.js
@@ -197,6 +197,7 @@ const tagStatsQuery = gqlV2/* GraphQL */ `
   query CreateCollectivePageQuery {
     tagStats {
       nodes {
+        id
         tag
       }
     }

--- a/components/edit-collective/AssignVirtualCardModal.js
+++ b/components/edit-collective/AssignVirtualCardModal.js
@@ -54,6 +54,7 @@ const collectiveMembersQuery = gqlV2/* GraphQL */ `
       id
       members(role: ADMIN) {
         nodes {
+          id
           account {
             id
             name

--- a/components/edit-collective/CreateVirtualCardModal.js
+++ b/components/edit-collective/CreateVirtualCardModal.js
@@ -45,6 +45,7 @@ const collectiveMembersQuery = gqlV2/* GraphQL */ `
       id
       members(role: ADMIN) {
         nodes {
+          id
           account {
             id
             name

--- a/components/edit-collective/EditVirtualCardModal.js
+++ b/components/edit-collective/EditVirtualCardModal.js
@@ -49,6 +49,7 @@ const collectiveMembersQuery = gqlV2/* GraphQL */ `
       id
       members(role: ADMIN) {
         nodes {
+          id
           account {
             id
             name

--- a/components/edit-collective/sections/Members.js
+++ b/components/edit-collective/sections/Members.js
@@ -407,6 +407,7 @@ export const coreContributorsQuery = gqlV2/* GraphQL */ `
       }
       members(role: [ADMIN, MEMBER, ACCOUNTANT], limit: 100) {
         nodes {
+          id
           ...MemberFields
         }
       }

--- a/components/expenses/MarkExpenseAsIncompleteModal.js
+++ b/components/expenses/MarkExpenseAsIncompleteModal.js
@@ -25,6 +25,7 @@ const messages = defineMessages({
 const processExpenseMutation = gqlV2/* GraphQL */ `
   mutation ProcessExpense($id: String, $legacyId: Int, $action: ExpenseProcessAction!, $message: String) {
     processExpense(expense: { id: $id, legacyId: $legacyId }, action: $action, message: $message) {
+      id
       ...ExpensePageExpenseFields
     }
   }

--- a/components/expenses/ProcessExpenseButtons.js
+++ b/components/expenses/ProcessExpenseButtons.js
@@ -33,6 +33,7 @@ const processExpenseMutation = gqlV2/* GraphQL */ `
     $paymentParams: ProcessExpensePaymentParams
   ) {
     processExpense(expense: { id: $id, legacyId: $legacyId }, action: $action, paymentParams: $paymentParams) {
+      id
       ...ExpensePageExpenseFields
     }
   }

--- a/components/expenses/graphql/fragments.js
+++ b/components/expenses/graphql/fragments.js
@@ -246,6 +246,7 @@ export const expensePageExpenseFieldsFragment = gqlV2/* GraphQL */ `
       currency
       expensePolicy
       features {
+        id
         ...NavbarFields
         MULTI_CURRENCY_EXPENSES
       }
@@ -270,6 +271,7 @@ export const expensePageExpenseFieldsFragment = gqlV2/* GraphQL */ `
       ... on AccountWithHost {
         isApproved
         host {
+          id
           ...ExpenseHostFields
           transferwise {
             id
@@ -284,6 +286,7 @@ export const expensePageExpenseFieldsFragment = gqlV2/* GraphQL */ `
         isHost
         isActive
         host {
+          id
           ...ExpenseHostFields
           transferwise {
             id
@@ -356,6 +359,7 @@ export const expensePageExpenseFieldsFragment = gqlV2/* GraphQL */ `
       }
     }
     recurringExpense {
+      id
       interval
       endsAt
     }

--- a/components/host-dashboard/AddFundsModal.js
+++ b/components/host-dashboard/AddFundsModal.js
@@ -104,6 +104,7 @@ const addFundsMutation = gqlV2/* GraphQL */ `
         slug
         name
         stats {
+          id
           balance {
             valueInCents
           }
@@ -137,6 +138,7 @@ const addFundsAccountQuery = gqlV2/* GraphQL */ `
       ... on Organization {
         tiers {
           nodes {
+            id
             ...AddFundsTierFields
           }
         }
@@ -151,6 +153,7 @@ const addFundsAccountQuery = gqlV2/* GraphQL */ `
       ... on AccountWithContributions {
         tiers {
           nodes {
+            id
             ...AddFundsTierFields
           }
         }

--- a/components/host-dashboard/HostDashboardExpenses.js
+++ b/components/host-dashboard/HostDashboardExpenses.js
@@ -51,6 +51,7 @@ const hostDashboardExpensesQuery = gqlV2/* GraphQL */ `
     $orderBy: ChronologicalOrderInput
   ) {
     host(slug: $hostSlug) {
+      id
       ...ExpenseHostFields
       ...HostInfoCardFields
       transferwise {
@@ -77,6 +78,7 @@ const hostDashboardExpensesQuery = gqlV2/* GraphQL */ `
       offset
       limit
       nodes {
+        id
         ...ExpensesListFieldsFragment
         ...ExpensesListAdminFieldsFragment
       }

--- a/components/host-dashboard/HostDashboardHostedCollectives.js
+++ b/components/host-dashboard/HostDashboardHostedCollectives.js
@@ -76,6 +76,7 @@ const hostedCollectivesQuery = gqlV2/* GraphQL */ `
             settings
             createdAt
             stats {
+              id
               balance {
                 valueInCents
               }

--- a/components/host-dashboard/HostInfoCard.js
+++ b/components/host-dashboard/HostInfoCard.js
@@ -49,6 +49,7 @@ export const hostInfoCardFields = gqlV2/* GraphQL */ `
       currency
     }
     stats {
+      id
       balance {
         valueInCents
       }

--- a/components/host-dashboard/PendingApplications.js
+++ b/components/host-dashboard/PendingApplications.js
@@ -40,6 +40,7 @@ const pendingApplicationsQuery = gqlV2/* GraphQL */ `
         limit
         totalCount
         nodes {
+          id
           message
           customData
           account {

--- a/components/recurring-contributions/UpdatePaymentMethodPopUp.js
+++ b/components/recurring-contributions/UpdatePaymentMethodPopUp.js
@@ -66,12 +66,14 @@ const paymentMethodsQuery = gqlV2/* GraphQL */ `
     account(id: $accountId) {
       id
       paymentMethods(enumType: [CREDITCARD, GIFTCARD, PREPAID]) {
+        id
         ...UpdatePaymentMethodFragment
       }
     }
     order(order: { id: $orderId }) {
       id
       paymentMethod {
+        id
         ...UpdatePaymentMethodFragment
       }
     }

--- a/components/recurring-contributions/graphql/queries.js
+++ b/components/recurring-contributions/graphql/queries.js
@@ -12,6 +12,7 @@ export const recurringContributionsQuery = gqlV2/* GraphQL */ `
       settings
       imageUrl
       features {
+        id
         ...NavbarFields
       }
       ... on AccountWithParent {

--- a/components/root-actions/MoveAuthoredContributions.js
+++ b/components/root-actions/MoveAuthoredContributions.js
@@ -54,6 +54,7 @@ const ordersQuery = gqlV2/* GraphQL */ `
   query AuthoredOrdersRoot($account: AccountReferenceInput!) {
     orders(account: $account, filter: OUTGOING, limit: 100, includeIncognito: true) {
       nodes {
+        id
         ...MoveOrdersFields
       }
     }
@@ -64,6 +65,7 @@ const ordersQuery = gqlV2/* GraphQL */ `
 const moveOrdersMutation = gqlV2/* GraphQL */ `
   mutation MoveOrders($orders: [OrderReferenceInput!]!, $fromAccount: AccountReferenceInput!, $makeIncognito: Boolean) {
     moveOrders(orders: $orders, fromAccount: $fromAccount, makeIncognito: $makeIncognito) {
+      id
       ...MoveOrdersFields
     }
   }

--- a/components/tier-page/graphql/queries.js
+++ b/components/tier-page/graphql/queries.js
@@ -53,6 +53,7 @@ export const tierPageQuery = gql`
           }
         }
         features {
+          id
           ...NavbarFields
         }
         admins: members(role: "ADMIN") {

--- a/components/transactions/graphql/fragments.js
+++ b/components/transactions/graphql/fragments.js
@@ -125,6 +125,7 @@ export const transactionsQueryCollectionFragment = gqlV2/* GraphQL */ `
         canReject
       }
       paymentMethod {
+        id
         type
       }
       order {

--- a/lib/graphql/mutations.js
+++ b/lib/graphql/mutations.js
@@ -21,6 +21,7 @@ const createCollectiveMutation = gql`
 export const editCollectiveMutation = gql`
   mutation EditCollective($collective: CollectiveInputType!) {
     editCollective(collective: $collective) {
+      id
       ...EditCollectivePageFields
     }
   }

--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -22,6 +22,7 @@ export const transactionFieldsFragment = gql`
     taxAmount
     paymentProcessorFeeInHostCurrency
     paymentMethod {
+      id
       service
       type
       name
@@ -67,6 +68,7 @@ export const transactionFieldsFragment = gql`
     ... on Order {
       createdAt
       subscription {
+        id
         interval
       }
     }
@@ -92,8 +94,10 @@ export const transactionsQuery = gql`
       dateTo: $dateTo
       kinds: $kinds
     ) {
+      id
       ...TransactionFields
       refundTransaction {
+        id
         ...TransactionFields
       }
     }
@@ -135,6 +139,7 @@ export const loggedInUserQuery = gql`
           isSaved
         }
         connectedAccounts {
+          id
           service
         }
       }
@@ -215,6 +220,7 @@ export const editCollectivePageFieldsFragment = gql`
       stats {
         id
         collectives {
+          id
           hosted
         }
       }
@@ -256,6 +262,7 @@ export const editCollectivePageFieldsFragment = gql`
       yearlyBudget
       balance
       backers {
+        id
         all
       }
       totalAmountSpent
@@ -289,6 +296,7 @@ export const editCollectivePageFieldsFragment = gql`
       role
       description
       stats {
+        id
         totalDonations
       }
       tier {
@@ -353,6 +361,7 @@ export const editCollectivePageFieldsFragment = gql`
       settings
     }
     features {
+      id
       ...NavbarFields
       VIRTUAL_CARDS
     }
@@ -363,6 +372,7 @@ export const editCollectivePageFieldsFragment = gql`
 export const editCollectivePageQuery = gql`
   query EditCollectivePage($slug: String) {
     Collective(slug: $slug) {
+      id
       ...EditCollectivePageFields
     }
   }
@@ -404,12 +414,14 @@ export const legacyCollectiveQuery = gql`
         balance
         yearlyBudget
         backers {
+          id
           all
           users
           organizations
           collectives
         }
         collectives {
+          id
           hosted
           memberOf
         }
@@ -448,6 +460,7 @@ export const legacyCollectiveQuery = gql`
           availableQuantity
         }
         orders(limit: 30, isActive: true) {
+          id
           fromCollective {
             id
             slug
@@ -501,6 +514,7 @@ export const legacyCollectiveQuery = gql`
           role
           createdAt
           stats {
+            id
             totalDonations
           }
           collective {
@@ -515,6 +529,7 @@ export const legacyCollectiveQuery = gql`
             description
             longDescription
             parentCollective {
+              id
               slug
             }
           }
@@ -526,6 +541,7 @@ export const legacyCollectiveQuery = gql`
           role
           createdAt
           stats {
+            id
             totalDonations
           }
           collective {
@@ -540,6 +556,7 @@ export const legacyCollectiveQuery = gql`
             description
             longDescription
             parentCollective {
+              id
               slug
             }
           }
@@ -571,6 +588,7 @@ export const collectiveNavbarQuery = gqlV2/* GraphQL */ `
         }
       }
       features {
+        id
         ...NavbarFields
       }
     }

--- a/pages/admin-panel.js
+++ b/pages/admin-panel.js
@@ -33,6 +33,7 @@ export const adminPanelQuery = gqlV2/* GraphQL */ `
       isIncognito
       imageUrl(height: 256)
       features {
+        id
         ...NavbarFields
         VIRTUAL_CARDS
         USE_PAYMENT_METHODS

--- a/pages/collective-contact.js
+++ b/pages/collective-contact.js
@@ -138,6 +138,7 @@ const collectiveContactPageQuery = gql`
       imageUrl
       twitterHandle
       features {
+        id
         ...NavbarFields
       }
     }

--- a/pages/contribute.js
+++ b/pages/contribute.js
@@ -360,6 +360,7 @@ const contributePageQuery = gql`
         slug
       }
       features {
+        id
         ...NavbarFields
       }
       host {
@@ -395,12 +396,15 @@ const contributePageQuery = gql`
         tiersIds
       }
       tiers {
+        id
         ...ContributeCardTierFields
       }
       events(includePastEvents: true, includeInactive: true) {
+        id
         ...ContributeCardEventFields
       }
       projects {
+        id
         ...ContributeCardProjectFields
       }
       connectedCollectives: members(role: "CONNECTED_COLLECTIVE") {
@@ -422,6 +426,7 @@ const contributePageQuery = gql`
             }
           }
           contributors(limit: $nbContributorsPerContributeCard) {
+            id
             ...ContributeCardContributorFields
           }
         }

--- a/pages/conversation.js
+++ b/pages/conversation.js
@@ -50,6 +50,7 @@ const conversationPageQuery = gqlV2/* GraphQL */ `
       imageUrl
       twitterHandle
       features {
+        id
         ...NavbarFields
       }
       conversationsTags {
@@ -69,11 +70,13 @@ const conversationPageQuery = gqlV2/* GraphQL */ `
       createdAt
       tags
       body {
+        id
         ...CommentFields
       }
       comments(limit: 100, offset: $offset) {
         totalCount
         nodes {
+          id
           ...CommentFields
         }
       }

--- a/pages/conversations.js
+++ b/pages/conversations.js
@@ -229,6 +229,7 @@ const conversationsPageQuery = gqlV2/* GraphQL */ `
         isApproved
       }
       features {
+        id
         ...NavbarFields
       }
     }

--- a/pages/create-conversation.js
+++ b/pages/create-conversation.js
@@ -152,6 +152,7 @@ const createConversationPageQuery = gqlV2/* GraphQL */ `
         tag
       }
       features {
+        id
         ...NavbarFields
       }
 

--- a/pages/create-expense.js
+++ b/pages/create-expense.js
@@ -496,6 +496,7 @@ const createExpensePageQuery = gqlV2/* GraphQL */ `
       isArchived
       expensePolicy
       features {
+        id
         ...NavbarFields
         MULTI_CURRENCY_EXPENSES
       }
@@ -505,6 +506,7 @@ const createExpensePageQuery = gqlV2/* GraphQL */ `
       }
 
       stats {
+        id
         balanceWithBlockedFunds {
           valueInCents
           currency
@@ -514,6 +516,7 @@ const createExpensePageQuery = gqlV2/* GraphQL */ `
       ... on AccountWithHost {
         isApproved
         host {
+          id
           ...CreateExpenseHostFields
         }
       }
@@ -525,6 +528,7 @@ const createExpensePageQuery = gqlV2/* GraphQL */ `
         isActive
         # NOTE: This will be the account itself in this case
         host {
+          id
           ...CreateExpenseHostFields
         }
       }
@@ -538,6 +542,7 @@ const createExpensePageQuery = gqlV2/* GraphQL */ `
       }
     }
     loggedInAccount {
+      id
       ...LoggedInAccountExpensePayoutFields
     }
   }
@@ -561,6 +566,7 @@ const createExpenseMutation = gqlV2/* GraphQL */ `
     $recurring: RecurringExpenseInput
   ) {
     createExpense(expense: $expense, account: $account, recurring: $recurring) {
+      id
       ...ExpensePageExpenseFields
     }
   }
@@ -575,6 +581,7 @@ const addCreateExpenseMutation = graphql(createExpenseMutation, {
 const draftExpenseAndInviteUserMutation = gqlV2/* GraphQL */ `
   mutation DraftExpenseAndInviteUser($expense: ExpenseInviteDraftInput!, $account: AccountReferenceInput!) {
     draftExpenseAndInviteUser(expense: $expense, account: $account) {
+      id
       ...ExpensePageExpenseFields
     }
   }

--- a/pages/expense.js
+++ b/pages/expense.js
@@ -72,10 +72,12 @@ const messages = defineMessages({
 const expensePageQuery = gqlV2/* GraphQL */ `
   query ExpensePage($legacyExpenseId: Int!, $draftKey: String, $offset: Int, $totalPaidExpensesDateFrom: DateTime) {
     expense(expense: { legacyId: $legacyExpenseId }, draftKey: $draftKey) {
+      id
       ...ExpensePageExpenseFields
       comments(limit: 100, offset: $offset) {
         totalCount
         nodes {
+          id
           ...CommentFields
         }
       }
@@ -105,6 +107,7 @@ const expensePageQuery = gqlV2/* GraphQL */ `
     }
 
     loggedInAccount {
+      id
       ...LoggedInAccountExpensePayoutFields
     }
   }
@@ -117,6 +120,7 @@ const expensePageQuery = gqlV2/* GraphQL */ `
 const editExpenseMutation = gqlV2/* GraphQL */ `
   mutation EditExpense($expense: ExpenseUpdateInput!, $draftKey: String) {
     editExpense(expense: $expense, draftKey: $draftKey) {
+      id
       ...ExpensePageExpenseFields
     }
   }
@@ -127,6 +131,7 @@ const editExpenseMutation = gqlV2/* GraphQL */ `
 const verifyExpenseMutation = gqlV2/* GraphQL */ `
   mutation VerifyExpense($expense: ExpenseReferenceInput!, $draftKey: String) {
     verifyExpense(expense: $expense, draftKey: $draftKey) {
+      id
       ...ExpensePageExpenseFields
     }
   }

--- a/pages/expenses.js
+++ b/pages/expenses.js
@@ -381,10 +381,12 @@ const expensesPageQuery = gqlV2/* GraphQL */ `
         tag
       }
       features {
+        id
         ...NavbarFields
       }
 
       stats {
+        id
         balanceWithBlockedFunds {
           valueInCents
           currency
@@ -394,6 +396,7 @@ const expensesPageQuery = gqlV2/* GraphQL */ `
       ... on AccountWithHost {
         isApproved
         host {
+          id
           ...ExpenseHostFields
         }
       }
@@ -441,6 +444,7 @@ const expensesPageQuery = gqlV2/* GraphQL */ `
       offset
       limit
       nodes {
+        id
         ...ExpensesListFieldsFragment
       }
     }

--- a/pages/member-invitations.js
+++ b/pages/member-invitations.js
@@ -12,7 +12,7 @@ import MemberInvitationsList from '../components/MemberInvitationsList';
 import MessageBox from '../components/MessageBox';
 import { H1 } from '../components/Text';
 
-const memberInvitationsPageQuery = gqlV2`
+const memberInvitationsPageQuery = gqlV2/* GraphQL */ `
   query MemberInvitationsPage($memberAccount: AccountReferenceInput!) {
     memberInvitations(memberAccount: $memberAccount) {
       id
@@ -28,6 +28,7 @@ const memberInvitationsPageQuery = gqlV2`
         isHost
         ... on AccountWithHost {
           host {
+            id
             name
             termsUrl
           }

--- a/pages/oauth/authorize.js
+++ b/pages/oauth/authorize.js
@@ -29,6 +29,7 @@ const applicationQuery = gqlV2`
         imageUrl(height: 192)
       }
       oAuthAuthorization {
+        id
         expiresAt
       }
     }

--- a/pages/search.js
+++ b/pages/search.js
@@ -603,6 +603,7 @@ export const searchPageQuery = gqlV2/* GraphQL */ `
 
     tagStats(searchTerm: $term) {
       nodes {
+        id
         tag
       }
     }

--- a/pages/transactions.js
+++ b/pages/transactions.js
@@ -70,6 +70,7 @@ const transactionsPageQuery = gqlV2/* GraphQL */ `
       currency
       settings
       features {
+        id
         ...NavbarFields
       }
       ... on AccountWithParent {

--- a/pages/update.js
+++ b/pages/update.js
@@ -206,6 +206,7 @@ const updateQuery = gqlV2/* GraphQL */ `
         }
       }
       features {
+        id
         ...NavbarFields
       }
       conversationsTags {
@@ -254,6 +255,7 @@ const updateQuery = gqlV2/* GraphQL */ `
       comments(limit: 100, offset: $offset) {
         totalCount
         nodes {
+          id
           ...CommentFields
         }
       }

--- a/pages/updates.js
+++ b/pages/updates.js
@@ -168,6 +168,7 @@ export const updatesQuery = gqlV2/* GraphQL */ `
         }
       }
       features {
+        id
         ...NavbarFields
       }
       updates(limit: $limit, offset: $offset, searchTerm: $searchTerm, orderBy: $orderBy) {


### PR DESCRIPTION
_Require https://github.com/opencollective/opencollective-api/pull/7627 as we were returning `null` for some GraphQL ids_

We had many issues caused by a missing `id` on GraphQL queries in the past (to link just a few: https://github.com/opencollective/opencollective-frontend/pull/6204, https://github.com/opencollective/opencollective-frontend/pull/7461, https://github.com/opencollective/opencollective-frontend/pull/6691, https://github.com/opencollective/opencollective-frontend/pull/6314). It never costs much to include them and it can prevent performance and caching issues that are difficult to debug and investigate.

I'm therefore proposing to enforce the `graphql/required-fields` rule to make sure `id` is always fetched if available. The main downside of this rule is that we need [to repeat the `id`](https://github.com/apollographql/eslint-plugin-graphql/issues/248) if it's defined in the fragment:

```graphql
myFragment {
  id
  data
}

myField {
  id
  ...myFragment
}
```

But according to https://github.com/apollographql/eslint-plugin-graphql/issues/248#issuecomment-547014188, this is the desired behavior and it will be easy to enforce for new developments. 