### PR TITLE
Correct Justification of the Profile Dropdown Menu Items

### DIFF
--- a/components/TopBarProfileMenu.js
+++ b/components/TopBarProfileMenu.js
@@ -383,7 +383,7 @@ class TopBarProfileMenu extends React.Component {
     const { LoggedInUser } = this.props;
 
     return (
-      <StyledProfileButton isBorderless onClick={this.toggleProfileMenu}>
+      <StyledProfileButton isBorderless textAlign="left" onClick={this.toggleProfileMenu}>
         <Flex alignItems="center" data-cy="user-menu-trigger">
           <Flex>
             <Avatar collective={get(LoggedInUser, 'collective')} radius="40px" mr={2} />


### PR DESCRIPTION
Small regression caused by a the recent PR; https://github.com/opencollective/opencollective-frontend/pull/7854

The profile menu items seems to have incorrect justifications; 

![image](https://user-images.githubusercontent.com/12435965/172772696-eeac30bb-8a44-4396-a198-257a9d07e475.png)

This PR corrects it,

![image](https://user-images.githubusercontent.com/12435965/172772731-8d8cf8c4-da37-45ef-a1d6-3d4f634da1da.png)
 