### PR TITLE
Correct top bar profile menu dropdown sizing for medium screens

### DIFF
--- a/components/TopBarMobileMenuV2.js
+++ b/components/TopBarMobileMenuV2.js
@@ -52,8 +52,8 @@ class TopBarMobileMenu extends React.Component {
         bg="white.full"
         width="100%"
         position="absolute"
-        right={[0, 16]}
-        top={[69, 75]}
+        right={[0, 0, 16]}
+        top={[69, 69, 75]}
         p={3}
         zIndex={3000}
         borderRadius="0px 0px 16px 16px"


### PR DESCRIPTION
It was noticed that on medium screen sizes there's a slight offset of the top bar dropdown menu; 

![image](https://user-images.githubusercontent.com/12435965/172774314-09c409e6-b811-4826-983b-3ebeb29cdef8.png)

This PR fixes that,

https://user-images.githubusercontent.com/12435965/172774102-c90a82ce-dd16-45ea-8747-aae886d75072.mp4

Related discussion; https://opencollective.slack.com/archives/D014W1CE5P0/p1654594176940629 (private chat)