### PR TITLE
Expense page: do not mark host as pending for host organizations

### DIFF
--- a/components/expenses/ExpenseInfoSidebar.js
+++ b/components/expenses/ExpenseInfoSidebar.js
@@ -20,7 +20,6 @@ import ExpandableExpensePolicies from './ExpandableExpensePolicies';
  */
 const ExpenseInfoSidebar = ({ isLoading, host, collective, children }) => {
   const balanceWithBlockedFunds = collective?.stats.balanceWithBlockedFunds;
-
   return (
     <Box width="100%">
       <Box display={['none', 'block']}>
@@ -64,7 +63,7 @@ const ExpenseInfoSidebar = ({ isLoading, host, collective, children }) => {
                   </Span>
                   <br />
                   <LinkCollective collective={host}>
-                    {collective && collective.isApproved ? (
+                    {collective?.isActive ? (
                       host.name
                     ) : (
                       <FormattedMessage
@@ -103,7 +102,7 @@ ExpenseInfoSidebar.propTypes = {
     currency: PropTypes.string.isRequired,
     type: PropTypes.string,
     parent: PropTypes.object,
-    isApproved: PropTypes.bool,
+    isActive: PropTypes.bool,
     stats: PropTypes.shape({
       balanceWithBlockedFunds: PropTypes.shape({
         valueInCents: PropTypes.number.isRequired,

--- a/components/expenses/ExpensePayeeDetails.js
+++ b/components/expenses/ExpensePayeeDetails.js
@@ -215,7 +215,7 @@ const ExpensePayeeDetails = ({ expense, host, isLoading, borderless, isLoadingLo
             <Flex alignItems="center">
               <Avatar collective={displayedHost} radius={24} />
               <Span ml={2} color="black.900" fontSize="12px" fontWeight="bold" truncateOverflow>
-                {collective && collective.isApproved ? (
+                {collective?.isActive ? (
                   formatAccountName(displayedHost.name, displayedHost.legalName)
                 ) : (
                   <FormattedMessage
@@ -360,7 +360,7 @@ ExpensePayeeDetails.propTypes = {
   borderless: PropTypes.bool,
   collective: PropTypes.shape({
     id: PropTypes.string.isRequired,
-    isApproved: PropTypes.bool,
+    isActive: PropTypes.bool,
   }),
 };
 

--- a/components/expenses/MobileCollectiveInfoStickyBar.js
+++ b/components/expenses/MobileCollectiveInfoStickyBar.js
@@ -66,7 +66,7 @@ const MobileCollectiveInfoStickyBar = ({ isLoading, collective, host }) => {
             </P>
             <LinkCollective collective={host}>
               <P color="black.600" fontSize="11px" fontWeight="bold" truncateOverflow maxWidth={135}>
-                {collective && collective.isApproved ? (
+                {collective?.isActive ? (
                   host.name
                 ) : (
                   <FormattedMessage
@@ -92,7 +92,7 @@ MobileCollectiveInfoStickyBar.propTypes = {
   collective: PropTypes.shape({
     currency: PropTypes.string.isRequired,
     type: PropTypes.string,
-    isApproved: PropTypes.bool,
+    isActive: PropTypes.bool,
     stats: PropTypes.shape({
       balanceWithBlockedFunds: PropTypes.shape({
         valueInCents: PropTypes.number.isRequired,


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/5636
Followup on https://github.com/opencollective/opencollective-api/pull/7566, which fixed the issue for independent collectives but not organizations

`isApproved` is not available for host organizations, leading to profiles like `/opensource/expenses/42` marked as pending host. This PR changes the definition to use `host IS NOT NULL` + `isActive`, which should cover all profile types.

Alternative to this PR is to introduce the `isApproved` flag for organizations in the API, but it feels like a strange workaround to me to have a flag that will tell you whether you approved yourself.