### PR TITLE
Remove specific behavior for CI

### DIFF
--- a/components/CreateEvent.js
+++ b/components/CreateEvent.js
@@ -65,7 +65,6 @@ class CreateEvent extends React.Component {
     this.setState({ status: 'loading' });
     EventInputType.type = 'EVENT';
     EventInputType.ParentCollectiveId = parentCollective.id;
-    EventInputType.tiers = EventInputType.tiers.filter(tier => tier.name);
     EventInputType.settings = { disableCustomContributions: true };
     try {
       const res = await this.props.createCollective(EventInputType);
@@ -95,7 +94,7 @@ class CreateEvent extends React.Component {
   async handleTemplateChange(event) {
     delete event.id;
     delete event.slug;
-    this.setState({ event, tiers: event.tiers });
+    this.setState({ event });
   }
 
   render() {

--- a/components/CreateEventForm.js
+++ b/components/CreateEventForm.js
@@ -6,7 +6,6 @@ import { defineMessages, injectIntl } from 'react-intl';
 
 import { convertDateFromApiUtc, convertDateToApiUtc } from '../lib/date-utils';
 
-import Tickets from './edit-collective/sections/Tickets';
 import Container from './Container';
 import InputField from './InputField';
 import StyledButton from './StyledButton';
@@ -30,7 +29,6 @@ class CreateEventForm extends React.Component {
     event.slug = event.slug ? event.slug.replace(/.*\//, '') : '';
     this.state = {
       event,
-      tiers: event.tiers || [{}],
       disabled: false,
       showDeleteModal: false,
       validStartDate: true,
@@ -78,7 +76,7 @@ class CreateEventForm extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (this.props.event && (!prevProps.event || this.props.event.name !== prevProps.event.name)) {
-      this.setState({ event: this.props.event, tiers: this.props.event.tiers });
+      this.setState({ event: this.props.event });
     }
   }
 
@@ -132,7 +130,7 @@ class CreateEventForm extends React.Component {
   }
 
   async handleSubmit() {
-    this.props.onSubmit({ ...this.state.event, tiers: this.state.tiers });
+    this.props.onSubmit({ ...this.state.event });
   }
 
   getFieldDefaultValue(field) {
@@ -250,15 +248,6 @@ class CreateEventForm extends React.Component {
               ),
             )}
           </div>
-          {['e2e', 'ci'].includes(process.env.OC_ENV) && (
-            <Tickets
-              title="Tickets"
-              tiers={this.state.tiers}
-              collective={{ ...event, type: 'EVENT' }}
-              currency={event.parentCollective.currency}
-              onChange={tiers => this.setState({ tiers })}
-            />
-          )}
         </Container>
         <Container margin="5rem auto 1rem" textAlign="center">
           <StyledButton

--- a/components/NotificationBar.js
+++ b/components/NotificationBar.js
@@ -154,7 +154,7 @@ class NotificationBar extends React.Component {
     const isHostAdmin = LoggedInUser && LoggedInUser.isHostAdmin(collective);
 
     return (
-      <NotificationBarContainer className={classNames(status, 'NotificationBar')}>
+      <NotificationBarContainer className={classNames(status, 'NotificationBar')} data-cy="notification-bar">
         {status === 'error' && (
           <ErrorMessageContainer>
             <CollectiveLogo src={logo} alt="Open Collective logo" />

--- a/components/edit-collective/Form.js
+++ b/components/edit-collective/Form.js
@@ -895,6 +895,7 @@ class EditCollectiveForm extends React.Component {
 
                 <Container className="backToProfile" fontSize="1.3rem" margin="1rem">
                   <Link
+                    data-cy="edit-collective-back-to-profile"
                     href={
                       isEvent ? `/${collective.parentCollective.slug}/events/${collective.slug}` : `/${collective.slug}`
                     }

--- a/test/cypress/integration/23-event.create.test.js
+++ b/test/cypress/integration/23-event.create.test.js
@@ -22,15 +22,26 @@ describe('event.create.test.js', () => {
     cy.get('.geosuggest__suggests > :nth-child(1)').click();
     cy.get('#location .address').contains('Lesbroussart');
     cy.get('#location .address').contains('1050');
+    cy.contains('button', 'Create Event').click();
+    cy.getByDataCy('notification-bar').contains('Your Event has been created');
+    cy.get('#location .address').contains('Lesbroussart');
+    cy.get('#location .address').contains('1050');
+
+    // Go to "Edit tiers"
+    cy.get('[data-cy=edit-collective-btn]:first').click();
+    cy.getByDataCy('menu-item-tickets').click();
+    cy.getByDataCy('add-tier-button').click();
     cy.get('.EditTiers .tier .inputField.name input').type('Free ticket');
     cy.get('.EditTiers .tier .inputField.description textarea').type('Free ticket for students');
     cy.get('.EditTiers .tier .inputField.maxQuantity input').type('10');
     cy.get('.addTier').click();
     cy.get('.EditTiers .tier').last().find('.inputField.name input').type('Paid ticket');
     cy.get('.EditTiers .tier').last().find('.inputField.amount input').type(15).blur();
-    cy.contains('button', 'Create Event').click();
-    cy.get('#location .address').contains('Lesbroussart');
-    cy.get('#location .address').contains('1050');
+    cy.contains('button', 'Save').click();
+    cy.get('.actions > [data-cy="collective-save"]').contains('Saved');
+    cy.getByDataCy('edit-collective-back-to-profile').click();
+
+    // Check collective page
     cy.get('[data-cy=Tickets] [data-cy=contribute-card-tier]').should('have.length', 2);
     cy.get('[data-cy=Tickets] [data-cy=contribute-card-tier] [data-cy=amount]').contains(15);
     cy.get('#top').scrollIntoView();


### PR DESCRIPTION
The E2e test for `createEvent` relied on a specific condition that made its behavior different from what we have in other environments: the tiers creation was embedded directly on the create event form. This PR changes this to match the normal flow: first, create the event then the tickets.

This should help with the unreliability issues that we've been facing on this one lately.