### PR TITLE
Improve reliabitily for 23-create-event

### DIFF
--- a/test/cypress/integration/23-event.create.test.js
+++ b/test/cypress/integration/23-event.create.test.js
@@ -37,6 +37,7 @@ describe('event.create.test.js', () => {
     cy.get('.addTier').click();
     cy.get('.EditTiers .tier').last().find('.inputField.name input').type('Paid ticket');
     cy.get('.EditTiers .tier').last().find('.inputField.amount input').type(15).blur();
+    cy.wait(100);
     cy.contains('button', 'Save').click();
     cy.get('.actions > [data-cy="collective-save"]').contains('Saved');
     cy.getByDataCy('edit-collective-back-to-profile').click();
@@ -49,14 +50,14 @@ describe('event.create.test.js', () => {
     cy.wait(400);
     // edit event info
     cy.get('.inputs .inputField.name input').type(`{selectall}${updatedTitle}`);
-    cy.get('.actions > [data-cy="collective-save"]').click();
     cy.wait(400);
+    cy.get('.actions > [data-cy="collective-save"]').click();
     cy.get('.actions > [data-cy="collective-save"]').contains('Saved');
     // edit event tickets
     cy.getByDataCy('menu-item-tickets').click();
     cy.get('.EditTiers .tier:nth-child(2) .removeTier').click();
-    cy.get('.actions > [data-cy="collective-save"]').click();
     cy.wait(400);
+    cy.get('.actions > [data-cy="collective-save"]').click();
     cy.get('.actions > [data-cy="collective-save"]').contains('Saved');
     // edit event tiers
     cy.getByDataCy('menu-item-tiers').click();
@@ -64,8 +65,8 @@ describe('event.create.test.js', () => {
     cy.get('.EditTiers .tier .inputField.name input').type('Sponsor');
     cy.get('.EditTiers .tier .inputField.description textarea').type('Become a sponsor');
     cy.get('.EditTiers .tier .inputField.amount input').type(200);
-    cy.get('.actions > [data-cy="collective-save"]').click();
     cy.wait(400);
+    cy.get('.actions > [data-cy="collective-save"]').click();
     cy.get('.actions > [data-cy="collective-save"]').contains('Saved');
     // verify update
     cy.contains('a', 'view event page').click();


### PR DESCRIPTION
Followup on https://github.com/opencollective/opencollective-frontend/pull/7883

Input events can be delayed, by waiting before we click on save we'll make sure we don't save partial data.