### PR TITLE
Add configurable margin to Popup in `PopupMenu.js`

### DIFF
--- a/components/PopupMenu.js
+++ b/components/PopupMenu.js
@@ -17,7 +17,7 @@ const Popup = styled(Box)`
   z-index: ${props => props.zIndex ?? 1000};
 `;
 
-const PopupMenu = ({ Button, children, placement, onClose, closingEvents, zIndex }) => {
+const PopupMenu = ({ Button, children, placement, onClose, closingEvents, zIndex, popupMarginTop }) => {
   const [isOpen, setOpen] = React.useState(false);
   const ref = React.useRef();
   useGlobalBlur(
@@ -53,7 +53,7 @@ const PopupMenu = ({ Button, children, placement, onClose, closingEvents, zIndex
           ]}
         >
           {({ style, ref }) => (
-            <Popup mt="-10px" zIndex={zIndex} {...{ style, ref }}>
+            <Popup mt={popupMarginTop} zIndex={zIndex} {...{ style, ref }}>
               {typeof children === 'function' ? children({ setOpen }) : children}
             </Popup>
           )}
@@ -74,6 +74,7 @@ PopupMenu.propTypes = {
    * For example, mouseover, mousedown, mouseup, blur, focusin, focusout etc.
    */
   closingEvents: PropTypes.array,
+  popupMarginTop: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 };
 
 export default PopupMenu;

--- a/components/TopBarV2.js
+++ b/components/TopBarV2.js
@@ -115,6 +115,7 @@ const TopBarV2 = ({ showSearch, menuItems }) => {
                   </NavButton>
                 )}
                 placement="bottom"
+                popupMarginTop="-10px"
               >
                 <NavLinkContainer>
                   {/* TODO: Add this part back when the /collectives page is designed */}
@@ -154,6 +155,7 @@ const TopBarV2 = ({ showSearch, menuItems }) => {
                   </NavButton>
                 )}
                 placement="bottom"
+                popupMarginTop="-10px"
               >
                 <NavLinkContainer>
                   <Link href="/pricing">
@@ -192,6 +194,7 @@ const TopBarV2 = ({ showSearch, menuItems }) => {
                   </NavButton>
                 )}
                 placement="bottom"
+                popupMarginTop="-10px"
               >
                 <NavLinkContainer>
                   <a href="https://blog.opencollective.com/">


### PR DESCRIPTION
Seems there's a small regression created by the new nav-bar where we needed add a margin that is different from the default in Popper. However this effects all popups such as the one below in expenses page. 

![image](https://user-images.githubusercontent.com/12435965/173140147-e5113952-9a1c-4bf0-b9b3-aaee2daab0ef.png)

This PR corrects it by making the margin configurable. 

![image](https://user-images.githubusercontent.com/12435965/173140567-8ed432fa-d36f-412d-90e6-e4ee33b525b6.png)

