### PR TITLE
Fixed ContributeCard.latestActivity localization in Italian

### DIFF
--- a/lang/it.json
+++ b/lang/it.json
@@ -574,7 +574,7 @@
   "ContributeCard.BtnViewEvent": "Visualizza evento",
   "ContributeCard.footer.pastEvent": "Eseguito da",
   "ContributeCard.footer.ticket": "Attending",
-  "ContributeCard.latestActivity": "Ultima attività alle",
+  "ContributeCard.latestActivity": "Ultima attività da",
   "ContributeCard.ReadMore": "Leggi di più",
   "ContributeCard.SeeCollective": "Vedi collettivo",
   "ContributeCard.SeeMore": "Vedi altro",


### PR DESCRIPTION
# Description

Previous translation was _Latest activity at_ expecting a time right after - the context is a list of users instead so the string to translate is _Latest activity by_ that is switching _alle_ with _da_ in italian.
