### PR TITLE
Preserve the `/create-account` form state when moving back and forth

### DIFF
--- a/components/CreateProfile.js
+++ b/components/CreateProfile.js
@@ -123,8 +123,8 @@ TOSCheckBox.propTypes = {
   checked: PropTypes.bool,
 };
 
-const useForm = ({ onEmailChange, errors }) => {
-  const [state, setState] = useState({ errors, newsletterOptIn: false, tosOptIn: false });
+const useForm = ({ onEmailChange, onFieldChange, name, newsletterOptIn, tosOptIn, errors }) => {
+  const [state, setState] = useState({ errors, name, newsletterOptIn, tosOptIn });
 
   return {
     getFieldProps: name => ({
@@ -139,6 +139,8 @@ const useForm = ({ onEmailChange, errors }) => {
         if (target.name === 'email') {
           value = undefined;
           onEmailChange(target.value);
+        } else {
+          onFieldChange(target.name, value);
         }
         setState({
           ...state,
@@ -166,16 +168,28 @@ const useForm = ({ onEmailChange, errors }) => {
 
 const CreateProfile = ({
   email,
+  name,
+  newsletterOptIn,
+  tosOptIn,
   submitting,
   errors,
   onEmailChange,
+  onFieldChange,
   onSubmit,
   onSecondaryAction,
   emailAlreadyExists,
   ...props
 }) => {
   const { formatMessage } = useIntl();
-  const { getFieldError, getFieldProps, state } = useForm({ onEmailChange, errors, formatMessage });
+  const { getFieldError, getFieldProps, state } = useForm({
+    onEmailChange,
+    onFieldChange,
+    name,
+    newsletterOptIn,
+    tosOptIn,
+    errors,
+    formatMessage,
+  });
   const isValid = isEmpty(compact(values(state.errors)));
 
   return (
@@ -226,7 +240,12 @@ const CreateProfile = ({
                 required
               >
                 {inputProps => (
-                  <StyledInput {...inputProps} {...getFieldProps(inputProps.name)} placeholder="e.g., John Doe" />
+                  <StyledInput
+                    {...inputProps}
+                    {...getFieldProps(inputProps.name)}
+                    value={name}
+                    placeholder="e.g., John Doe"
+                  />
                 )}
               </StyledInputField>
             </Box>
@@ -335,8 +354,16 @@ CreateProfile.propTypes = {
   submitting: PropTypes.bool,
   /** Set the value of email input */
   email: PropTypes.string.isRequired,
+  /** Set the value of name input */
+  name: PropTypes.string.isRequired,
+  /** Set the value of newsLetterOptIn input */
+  newsletterOptIn: PropTypes.bool.isRequired,
+  /** Set the value of tosOptIn input */
+  tosOptIn: PropTypes.bool.isRequired,
   /** handles changes in the email input */
   onEmailChange: PropTypes.func.isRequired,
+  /** handles changes in input fields */
+  onFieldChange: PropTypes.func.isRequired,
   /** specifies whether the email is already registered **/
   emailAlreadyExists: PropTypes.bool,
   /** All props from `StyledCard` */

--- a/components/SignInOrJoinFree.js
+++ b/components/SignInOrJoinFree.js
@@ -373,9 +373,13 @@ class SignInOrJoinFree extends React.Component {
                   <Box maxWidth={535} mx={[2, 4]} width="100%">
                     <CreateProfile
                       email={email}
+                      name={this.state.name}
+                      newsletterOptIn={this.state.newsletterOptIn}
+                      tosOptIn={this.state.tosOptIn}
                       onEmailChange={email =>
                         this.setState({ email, unknownEmailError: false, emailAlreadyExists: false })
                       }
+                      onFieldChange={(name, value) => this.setState({ [name]: value })}
                       onSubmit={this.createProfile}
                       onSecondaryAction={routes.signin || (() => this.switchForm('signin'))}
                       submitting={submitting}


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/5663

https://user-images.githubusercontent.com/12435965/174148836-f587bdce-74eb-4d5f-8a98-ef005a2d04a6.mp4


