### PR TITLE
Cleanup conditions for contributing to past events

### DIFF
--- a/lib/collective-sections.js
+++ b/lib/collective-sections.js
@@ -161,11 +161,6 @@ const filterSectionsByData = (sections, collective, isAdmin, isHostAdmin) => {
   return sections.filter(e => e.type !== 'CATEGORY' || e.sections.length > 0);
 };
 
-const showContributeSection = (collective, isAdmin) => {
-  const status = collective?.features?.[FEATURES.RECEIVE_FINANCIAL_CONTRIBUTIONS];
-  return ['ACTIVE', 'AVAILABLE'].includes(status) || isAdmin; // Allow admins to see/edit tiers, even if not active/past event
-};
-
 const getSectionsToRemoveForUser = (collective, isAdmin) => {
   const toRemove = new Set();
   collective = collective || {};
@@ -176,7 +171,7 @@ const getSectionsToRemoveForUser = (collective, isAdmin) => {
     return status === 'ACTIVE' || (status === 'AVAILABLE' && isAdmin);
   };
 
-  if (!showContributeSection(collective, isAdmin)) {
+  if (!hasAccessToFeature(FEATURES.RECEIVE_FINANCIAL_CONTRIBUTIONS)) {
     toRemove.add(Sections.CONTRIBUTE);
     toRemove.add(Sections.TOP_FINANCIAL_CONTRIBUTORS);
   }


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/5660
Require https://github.com/opencollective/opencollective-api/pull/7662

This is a cleanup to rely on API for the logic and prevent showing the contribute section if we're later going to face a "This account cannot receive financial contributions at this time" message.