### PR TITLE
Enable `TopBarV2` for all users

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -8,7 +8,6 @@ import { getCollectiveImage } from '../lib/image-utils';
 import { truncate } from '../lib/utils';
 
 import GlobalWarnings from './GlobalWarnings';
-import TopBar from './TopBar';
 import TopBarV2 from './TopBarV2';
 
 const messages = defineMessages({
@@ -99,7 +98,7 @@ class Header extends React.Component {
   }
 
   render() {
-    const { css, className, canonicalURL, withTopBar, LoggedInUser } = this.props;
+    const { css, canonicalURL, withTopBar } = this.props;
     return (
       <header>
         <Head>
@@ -120,21 +119,13 @@ class Header extends React.Component {
           {canonicalURL && <link rel="canonical" href={canonicalURL} />}
         </Head>
         <div id="top" />
-        {withTopBar &&
-          (LoggedInUser?.collective?.settings?.useNewTopBar ? (
-            <TopBarV2
-              showSearch={this.props.showSearch}
-              menuItems={this.props.menuItemsV2}
-              showProfileAndChangelogMenu={this.props.showProfileAndChangelogMenu}
-            />
-          ) : (
-            <TopBar
-              className={className}
-              showSearch={this.props.showSearch}
-              menuItems={this.props.menuItems}
-              showProfileAndChangelogMenu={this.props.showProfileAndChangelogMenu}
-            />
-          ))}
+        {withTopBar && (
+          <TopBarV2
+            showSearch={this.props.showSearch}
+            menuItems={this.props.menuItemsV2}
+            showProfileAndChangelogMenu={this.props.showProfileAndChangelogMenu}
+          />
+        )}
         <GlobalWarnings collective={this.props.collective} />
       </header>
     );


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective-frontend/pull/7850

Enables new navigation bar for all users. 

![image](https://user-images.githubusercontent.com/12435965/174825424-94a9c802-5e94-4a54-a3e1-e1487072de6c.png)

