### PR TITLE
feat: fix updates should be listed by publication date

### DIFF
--- a/components/NewsAndUpdatesModal.js
+++ b/components/NewsAndUpdatesModal.js
@@ -34,15 +34,15 @@ const ModalFooterWrapper = styled(ModalFooter)`
 `;
 
 const newsAndUpdatesQuery = gqlV2/* GraphQL */ `
-  query ChangelogUpdates(
-    $collectiveSlug: String
-    $onlyChangelogUpdates: Boolean
-    $onlyPublishedUpdates: Boolean
-    $limit: Int
-  ) {
-    account(slug: $collectiveSlug) {
+  query ChangelogUpdates($limit: Int) {
+    account(slug: "opencollective") {
       id
-      updates(onlyChangelogUpdates: $onlyChangelogUpdates, onlyPublishedUpdates: $onlyPublishedUpdates, limit: $limit) {
+      updates(
+        orderBy: { field: PUBLISHED_AT, direction: DESC }
+        onlyChangelogUpdates: true
+        onlyPublishedUpdates: true
+        limit: $limit
+      ) {
         nodes {
           id
           slug
@@ -154,16 +154,7 @@ const NewsAndUpdatesModal = ({ onClose, ...modalProps }) => {
       </ModalHeaderWrapper>
       <hr />
       <ModalBody>
-        <Query
-          query={newsAndUpdatesQuery}
-          variables={{
-            collectiveSlug: 'opencollective',
-            onlyChangelogUpdates: true,
-            onlyPublishedUpdates: true,
-            limit: 5,
-          }}
-          context={API_V2_CONTEXT}
-        >
+        <Query query={newsAndUpdatesQuery} variables={{ limit: 5 }} context={API_V2_CONTEXT}>
           {({ data, loading, error }) => renderStyledCarousel(data, loading, error, onClose)}
         </Query>
       </ModalBody>

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -569,7 +569,7 @@ interface Account {
     """
     onlyPublishedUpdates: Boolean = false
     onlyChangelogUpdates: Boolean
-    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
+    orderBy: UpdateChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
     searchTerm: String
   ): UpdateCollection!
 
@@ -2915,7 +2915,7 @@ type Host implements Account & AccountWithContributions {
     """
     onlyPublishedUpdates: Boolean = false
     onlyChangelogUpdates: Boolean
-    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
+    orderBy: UpdateChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
     searchTerm: String
   ): UpdateCollection!
 
@@ -3803,6 +3803,36 @@ type UpdateAudienceStats {
   The total number of emails to send
   """
   total: Int!
+}
+
+"""
+Input to order updates chronologically
+"""
+input UpdateChronologicalOrderInput {
+  """
+  Field to chronologically order by.
+  """
+  field: UpdateDateTimeField! = CREATED_AT
+
+  """
+  Ordering direction.
+  """
+  direction: OrderDirection! = DESC
+}
+
+"""
+All possible DateTime fields for an update
+"""
+enum UpdateDateTimeField {
+  """
+  The creation time
+  """
+  CREATED_AT
+
+  """
+  The creation time
+  """
+  PUBLISHED_AT
 }
 
 """
@@ -4951,7 +4981,7 @@ type Bot implements Account {
     """
     onlyPublishedUpdates: Boolean = false
     onlyChangelogUpdates: Boolean
-    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
+    orderBy: UpdateChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
     searchTerm: String
   ): UpdateCollection!
 
@@ -5447,7 +5477,7 @@ type Collective implements Account & AccountWithHost & AccountWithContributions 
     """
     onlyPublishedUpdates: Boolean = false
     onlyChangelogUpdates: Boolean
-    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
+    orderBy: UpdateChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
     searchTerm: String
   ): UpdateCollection!
 
@@ -6271,7 +6301,7 @@ type Event implements Account & AccountWithHost & AccountWithContributions & Acc
     """
     onlyPublishedUpdates: Boolean = false
     onlyChangelogUpdates: Boolean
-    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
+    orderBy: UpdateChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
     searchTerm: String
   ): UpdateCollection!
 
@@ -6878,7 +6908,7 @@ type Individual implements Account {
     """
     onlyPublishedUpdates: Boolean = false
     onlyChangelogUpdates: Boolean
-    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
+    orderBy: UpdateChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
     searchTerm: String
   ): UpdateCollection!
 
@@ -7464,7 +7494,7 @@ type Organization implements Account & AccountWithContributions {
     """
     onlyPublishedUpdates: Boolean = false
     onlyChangelogUpdates: Boolean
-    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
+    orderBy: UpdateChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
     searchTerm: String
   ): UpdateCollection!
 
@@ -8082,7 +8112,7 @@ type Vendor implements Account & AccountWithHost & AccountWithContributions {
     """
     onlyPublishedUpdates: Boolean = false
     onlyChangelogUpdates: Boolean
-    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
+    orderBy: UpdateChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
     searchTerm: String
   ): UpdateCollection!
 
@@ -10158,7 +10188,7 @@ type ActivityCollection implements Collection {
   offset: Int
   limit: Int
   totalCount: Int
-  nodes: [Activity]
+  nodes: [Activity!]
 }
 
 input ExpenseReferenceInput {
@@ -10638,7 +10668,7 @@ type Fund implements Account & AccountWithHost & AccountWithContributions {
     """
     onlyPublishedUpdates: Boolean = false
     onlyChangelogUpdates: Boolean
-    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
+    orderBy: UpdateChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
     searchTerm: String
   ): UpdateCollection!
 
@@ -11234,7 +11264,7 @@ type Project implements Account & AccountWithHost & AccountWithContributions & A
     """
     onlyPublishedUpdates: Boolean = false
     onlyChangelogUpdates: Boolean
-    orderBy: ChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
+    orderBy: UpdateChronologicalOrderInput! = { field: CREATED_AT, direction: DESC }
     searchTerm: String
   ): UpdateCollection!
 

--- a/pages/updates.js
+++ b/pages/updates.js
@@ -205,7 +205,7 @@ export const getUpdatesVariables = (slug, orderBy = null, searchTerm = null) => 
     collectiveSlug: slug,
     offset: 0,
     limit: UPDATES_PER_PAGE * 2,
-    orderBy: { field: 'CREATED_AT', direction: orderBy === 'oldest' ? 'ASC' : 'DESC' },
+    orderBy: { field: 'PUBLISHED_AT', direction: orderBy === 'oldest' ? 'ASC' : 'DESC' },
     searchTerm: searchTerm,
   };
 };

--- a/pages/updates.js
+++ b/pages/updates.js
@@ -148,7 +148,7 @@ export const updatesQuery = gqlV2/* GraphQL */ `
     $limit: Int
     $offset: Int
     $searchTerm: String
-    $orderBy: ChronologicalOrderInput
+    $orderBy: UpdateChronologicalOrderInput
   ) {
     account(slug: $collectiveSlug, throwIfMissing: false) {
       id


### PR DESCRIPTION
Resolve [#5690](https://github.com/opencollective/opencollective/issues/5690) 
Require https://github.com/opencollective/opencollective-api/pull/7818

# Description

This is a small fix to order updates by publishedAt instead of createdAt. 
