### PR TITLE
refactor(hook): rename useUser to useLoggedInUser

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -11,7 +11,7 @@ import styled from 'styled-components';
 
 import languages from '../lib/constants/locales';
 
-import { useUser } from '../components/UserProvider';
+import { useLoggedInUser } from '../components/UserProvider';
 
 import TranslateIcon from './icons/TranslateIcon';
 import Container from './Container';
@@ -221,7 +221,7 @@ const Footer = () => {
   const intl = useIntl();
   const languageOptions = React.useMemo(generateLanguageOptions);
   const defaultLanguage = languageOptions.find(language => language.value === intl.locale);
-  const { LoggedInUser } = useUser();
+  const { LoggedInUser } = useLoggedInUser();
   const formatLanguageOptionLabel = ({ value, label }, { context }) => (
     <Span fontSize="12px" fontWeight={context === 'menu' && value === intl.locale ? 'bold' : 'normal'}>
       {label}

--- a/components/GlobalWarnings.js
+++ b/components/GlobalWarnings.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import I18nFormatters from './I18nFormatters';
 import { P } from './Text';
-import { useUser } from './UserProvider';
+import { useLoggedInUser } from './UserProvider';
 
 const GlobalWarningContainer = styled.div`
   width: 100;
@@ -23,7 +23,7 @@ const GlobalWarningContainer = styled.div`
  * Displays warnings related to the user account.
  */
 const GlobalWarnings = ({ collective }) => {
-  const { LoggedInUser } = useUser();
+  const { LoggedInUser } = useLoggedInUser();
 
   if (collective?.isFrozen) {
     // Frozen collectives

--- a/components/UserProvider.js
+++ b/components/UserProvider.js
@@ -4,9 +4,9 @@ import { withApollo } from '@apollo/client/react/hoc';
 import { isEqual } from 'lodash';
 import Router from 'next/router';
 
+import withLoggedInUser from '../lib/hooks/withLoggedInUser';
 import { LOCAL_STORAGE_KEYS, removeFromLocalStorage } from '../lib/local-storage';
 import UserClass from '../lib/LoggedInUser';
-import withLoggedInUser from '../lib/withLoggedInUser';
 
 export const UserContext = React.createContext({
   loadingLoggedInUser: true,
@@ -158,8 +158,8 @@ const withUser = WrappedComponent => {
   return WithUser;
 };
 
-const useUser = () => React.useContext(UserContext);
+const useLoggedInUser = () => React.useContext(UserContext);
 
 export default withApollo(withLoggedInUser(UserProvider));
 
-export { UserConsumer, withUser, useUser };
+export { UserConsumer, withUser, useLoggedInUser };

--- a/components/admin-panel/sections/AccountSettings.js
+++ b/components/admin-panel/sections/AccountSettings.js
@@ -15,10 +15,10 @@ import { adminPanelQuery } from '../../../pages/admin-panel';
 import SettingsForm from '../../edit-collective/Form';
 import Loading from '../../Loading';
 import { TOAST_TYPE, useToasts } from '../../ToastProvider';
-import { useUser } from '../../UserProvider';
+import { useLoggedInUser } from '../../UserProvider';
 
 const AccountSettings = ({ account, section }) => {
-  const { LoggedInUser, refetchLoggedInUser } = useUser();
+  const { LoggedInUser, refetchLoggedInUser } = useLoggedInUser();
   const router = useRouter();
   const [state, setState] = React.useState({ status: undefined, result: undefined });
   const { addToast } = useToasts();

--- a/components/admin-panel/sections/AuthorizedApps.js
+++ b/components/admin-panel/sections/AuthorizedApps.js
@@ -15,14 +15,14 @@ import { authorizedAppsQuery } from '../../oauth/queries';
 import Pagination from '../../Pagination';
 import StyledHr from '../../StyledHr';
 import { P } from '../../Text';
-import { useUser } from '../../UserProvider';
+import { useLoggedInUser } from '../../UserProvider';
 
 const AuthorizedAppsSection = () => {
   const router = useRouter() || {};
   const query = router.query;
   const variables = { limit: 10, offset: query.offset ? parseInt(query.offset) : 0 };
   const { data, loading, error, refetch } = useQuery(authorizedAppsQuery, { variables, context: API_V2_CONTEXT });
-  const { LoggedInUser } = useUser();
+  const { LoggedInUser } = useLoggedInUser();
   const authorizations = data?.loggedInAccount?.oAuthAuthorizations;
 
   // Redirect to previous page when removing the last item of a page

--- a/components/collective-navbar/index.js
+++ b/components/collective-navbar/index.js
@@ -39,7 +39,7 @@ import LoadingPlaceholder from '../LoadingPlaceholder';
 import StyledButton from '../StyledButton';
 import { fadeIn } from '../StyledKeyframes';
 import { Span } from '../Text';
-import { useUser } from '../UserProvider';
+import { useLoggedInUser } from '../UserProvider';
 
 import CollectiveNavbarActionsMenu from './ActionsMenu';
 import { NAVBAR_CATEGORIES } from './constants';
@@ -433,7 +433,7 @@ const CollectiveNavbar = ({
 }) => {
   const intl = useIntl();
   const [isExpanded, setExpanded] = React.useState(false);
-  const { LoggedInUser } = useUser();
+  const { LoggedInUser } = useLoggedInUser();
   const isAccountant = LoggedInUser?.hasRole(roles.ACCOUNTANT, collective);
   isAdmin = isAdmin || LoggedInUser?.canEditCollective(collective);
   const isHostAdmin = LoggedInUser?.isHostAdmin(collective);

--- a/components/collective-page/hero/Hero.js
+++ b/components/collective-page/hero/Hero.js
@@ -31,7 +31,7 @@ import StyledTag from '../../StyledTag';
 import { H1, Span } from '../../Text';
 import TruncatedTextWithTooltip from '../../TruncatedTextWithTooltip';
 import UserCompany from '../../UserCompany';
-import { useUser } from '../../UserProvider';
+import { useLoggedInUser } from '../../UserProvider';
 import ContainerSectionContent from '../ContainerSectionContent';
 
 import CollectiveColorPicker from './CollectiveColorPicker';
@@ -100,7 +100,7 @@ const HiddenTagItem = styled(StyledLink)`
  */
 const Hero = ({ collective, host, isAdmin, onPrimaryColorChange }) => {
   const intl = useIntl();
-  const { LoggedInUser } = useUser();
+  const { LoggedInUser } = useLoggedInUser();
   const [hasColorPicker, showColorPicker] = React.useState(false);
   const [isEditingCover, editCover] = React.useState(false);
   const isEditing = hasColorPicker || isEditingCover;

--- a/components/collective-page/sections/Location.js
+++ b/components/collective-page/sections/Location.js
@@ -8,7 +8,7 @@ import Container from '../../Container';
 import { Box } from '../../Grid';
 import LocationComponent from '../../Location';
 import { P } from '../../Text';
-import { useUser } from '../../UserProvider';
+import { useLoggedInUser } from '../../UserProvider';
 import ContainerSectionContent from '../ContainerSectionContent';
 import SectionTitle from '../SectionTitle';
 
@@ -17,7 +17,7 @@ const isEmptyOnlineLocation = event => {
 };
 
 const Location = ({ collective: event, refetch }) => {
-  const { LoggedInUser } = useUser();
+  const { LoggedInUser } = useLoggedInUser();
   const prevLoggedInUser = React.useRef(LoggedInUser);
 
   React.useEffect(() => {

--- a/components/collectives/Newsletter.js
+++ b/components/collectives/Newsletter.js
@@ -8,10 +8,10 @@ import { Box, Flex } from '../Grid';
 import StyledButton from '../StyledButton';
 import StyledInput from '../StyledInput';
 import { Span } from '../Text';
-import { useUser } from '../UserProvider';
+import { useLoggedInUser } from '../UserProvider';
 
 const Newsletter = ({ defaultEmail }) => {
-  const { LoggedInUser } = useUser();
+  const { LoggedInUser } = useLoggedInUser();
   return (
     <Container>
       <Flex>

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -21,7 +21,7 @@ import StyledAmountPicker, { OTHER_AMOUNT_KEY } from '../StyledAmountPicker';
 import StyledHr from '../StyledHr';
 import StyledInput from '../StyledInput';
 import { H5, P, Span } from '../Text';
-import { useUser } from '../UserProvider';
+import { useLoggedInUser } from '../UserProvider';
 
 import ChangeTierWarningModal from './ChangeTierWarningModal';
 import PlatformTipInput from './PlatformTipInput';
@@ -40,7 +40,7 @@ const StepDetails = ({ onChange, data, collective, tier, showFeesOnTop, router, 
   const getDefaultOtherAmountSelected = () => isNil(amount) || !presets?.includes(amount);
   const [isOtherAmountSelected, setOtherAmountSelected] = React.useState(getDefaultOtherAmountSelected);
   const [temporaryInterval, setTemporaryInterval] = React.useState(undefined);
-  const { LoggedInUser } = useUser();
+  const { LoggedInUser } = useLoggedInUser();
 
   const minAmount = getTierMinAmount(tier, currency);
   const hasQuantity = tier?.type === TierTypes.TICKET || tier?.type === TierTypes.PRODUCT;

--- a/components/contribution-flow/StepProfile.js
+++ b/components/contribution-flow/StepProfile.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Box } from '../Grid';
-import { useUser } from '../UserProvider';
+import { useLoggedInUser } from '../UserProvider';
 
 import StepProfileGuestForm from './StepProfileGuestForm';
 import StepProfileLoggedInForm from './StepProfileLoggedInForm';
@@ -19,7 +19,7 @@ const StepProfile = ({
   onSignInClick,
   isEmbed,
 }) => {
-  const { LoggedInUser } = useUser();
+  const { LoggedInUser } = useLoggedInUser();
   return (
     <Box width={1}>
       {LoggedInUser ? (

--- a/components/contribution-flow/StepProfileLoggedInForm.js
+++ b/components/contribution-flow/StepProfileLoggedInForm.js
@@ -9,7 +9,7 @@ import StyledInput from '../StyledInput';
 import StyledInputField from '../StyledInputField';
 import StyledInputLocation from '../StyledInputLocation';
 import { P, Span } from '../Text';
-import { useUser } from '../UserProvider';
+import { useLoggedInUser } from '../UserProvider';
 
 import ContributeProfilePicker from './ContributeProfilePicker';
 import StepProfileInfoMessage from './StepProfileInfoMessage';
@@ -54,7 +54,7 @@ const getProfileInfo = (stepProfile, profiles) => {
 };
 
 const StepProfileLoggedInForm = ({ defaultProfileSlug, onChange, canUseIncognito, collective, data, stepDetails }) => {
-  const { LoggedInUser } = useUser();
+  const { LoggedInUser } = useLoggedInUser();
   const getProfileArgs = [LoggedInUser, collective, canUseIncognito];
   const profiles = React.useMemo(() => getContributorProfiles(...getProfileArgs), getProfileArgs);
   const defaultProfile = getDefaultProfile(data, profiles, defaultProfileSlug);

--- a/components/expenses/ProcessExpenseButtons.js
+++ b/components/expenses/ProcessExpenseButtons.js
@@ -18,7 +18,7 @@ import Link from '../Link';
 import StyledButton from '../StyledButton';
 import StyledTooltip from '../StyledTooltip';
 import { TOAST_TYPE, useToasts } from '../ToastProvider';
-import { useUser } from '../UserProvider';
+import { useLoggedInUser } from '../UserProvider';
 
 import { expensePageExpenseFieldsFragment } from './graphql/fragments';
 import DeleteExpenseButton from './DeleteExpenseButton';
@@ -165,7 +165,7 @@ const ProcessExpenseButtons = ({
   const [processExpense, { loading, error }] = useMutation(processExpenseMutation, mutationOptions);
   const intl = useIntl();
   const { addToast } = useToasts();
-  const { LoggedInUser } = useUser();
+  const { LoggedInUser } = useLoggedInUser();
 
   const triggerAction = async (action, paymentParams) => {
     // Prevent submitting the action if another one is being submitted at the same time

--- a/components/help-and-support/ContactSection.js
+++ b/components/help-and-support/ContactSection.js
@@ -22,7 +22,7 @@ import StyledInput from '../StyledInput';
 import StyledInputField from '../StyledInputField';
 import StyledInputGroup from '../StyledInputGroup';
 import { P, Span } from '../Text';
-import { useUser } from '../UserProvider';
+import { useLoggedInUser } from '../UserProvider';
 
 const validate = values => {
   const errors = {};
@@ -56,7 +56,7 @@ const validate = values => {
 const ContactForm = () => {
   const intl = useIntl();
   const router = useRouter();
-  const { LoggedInUser } = useUser();
+  const { LoggedInUser } = useLoggedInUser();
   const [submitError, setSubmitError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { getFieldProps, handleSubmit, errors, touched, setFieldValue } = useFormik({

--- a/components/host-dashboard/AddFundsModal.js
+++ b/components/host-dashboard/AddFundsModal.js
@@ -34,7 +34,7 @@ import StyledSelect from '../StyledSelect';
 import StyledTooltip from '../StyledTooltip';
 import { P, Span } from '../Text';
 import { TOAST_TYPE, useToasts } from '../ToastProvider';
-import { useUser } from '../UserProvider';
+import { useLoggedInUser } from '../UserProvider';
 
 import illustration from '../contribution-flow/fees-on-top-illustration.png';
 
@@ -248,7 +248,7 @@ const getTiersOptions = (intl, tiers) => {
 };
 
 const AddFundsModal = ({ host, collective, ...props }) => {
-  const { LoggedInUser } = useUser();
+  const { LoggedInUser } = useLoggedInUser();
   const [fundDetails, setFundDetails] = useState({});
   const { addToast } = useToasts();
   const intl = useIntl();

--- a/components/oauth/ApplicationApproveScreen.js
+++ b/components/oauth/ApplicationApproveScreen.js
@@ -21,7 +21,7 @@ import RadialIconContainer from '../RadialIconContainer';
 import StyledButton from '../StyledButton';
 import StyledCard from '../StyledCard';
 import { P } from '../Text';
-import { useUser } from '../UserProvider';
+import { useLoggedInUser } from '../UserProvider';
 
 const TopAvatarsContainer = styled.div`
   display: flex;
@@ -62,7 +62,7 @@ const getAdministratedAccounts = user => {
 };
 
 export const ApplicationApproveScreen = ({ application, redirectUri, autoApprove, state }) => {
-  const { LoggedInUser } = useUser();
+  const { LoggedInUser } = useLoggedInUser();
   const intl = useIntl();
   const router = useRouter();
   const [isRedirecting, setRedirecting] = React.useState(autoApprove);

--- a/components/orders/OrdersWithData.js
+++ b/components/orders/OrdersWithData.js
@@ -20,7 +20,7 @@ import Pagination from '../Pagination';
 import SearchBar from '../SearchBar';
 import StyledHr from '../StyledHr';
 import { H1 } from '../Text';
-import { useUser } from '../UserProvider';
+import { useLoggedInUser } from '../UserProvider';
 
 import OrdersFilters from './OrdersFilters';
 import OrdersList from './OrdersList';
@@ -152,7 +152,7 @@ const OrdersWithData = ({ accountSlug, title, status, showPlatformTip }) => {
   const queryVariables = { accountSlug, ...getVariablesFromQuery(router.query, status) };
   const queryParams = { variables: queryVariables, context: API_V2_CONTEXT };
   const { data, error, loading, variables, refetch } = useQuery(accountOrdersQuery, queryParams);
-  const { LoggedInUser } = useUser();
+  const { LoggedInUser } = useLoggedInUser();
   const prevLoggedInUser = usePrevious(LoggedInUser);
 
   // Refetch data when user logs in

--- a/components/transactions/TransactionItem.js
+++ b/components/transactions/TransactionItem.js
@@ -31,7 +31,7 @@ import StyledTooltip from '../StyledTooltip';
 import { P, Span } from '../Text';
 import TransactionSign from '../TransactionSign';
 import TransactionStatusTag from '../TransactionStatusTag';
-import { useUser } from '../UserProvider';
+import { useLoggedInUser } from '../UserProvider';
 
 import TransactionDetails from './TransactionDetails';
 
@@ -141,7 +141,7 @@ const TransactionItem = ({ displayActions, collective, transaction, onMutationSu
     isOrderRejected,
   } = transaction;
 
-  const { LoggedInUser } = useUser();
+  const { LoggedInUser } = useLoggedInUser();
   const [isExpanded, setExpanded] = React.useState(false);
   const intl = useIntl();
 

--- a/lib/hooks/withLoggedInUser.js
+++ b/lib/hooks/withLoggedInUser.js
@@ -4,10 +4,10 @@ import * as Sentry from '@sentry/browser';
 import dayjs from 'dayjs';
 import jwt from 'jsonwebtoken';
 
-import { loggedInUserQuery } from './graphql/queries';
-import { refreshToken, refreshTokenWithTwoFactorCode, refreshTokenWithTwoFactorRecoveryCode } from './api';
-import { getFromLocalStorage, LOCAL_STORAGE_KEYS, setLocalStorage } from './local-storage';
-import LoggedInUser from './LoggedInUser';
+import { refreshToken, refreshTokenWithTwoFactorCode, refreshTokenWithTwoFactorRecoveryCode } from '../api';
+import { loggedInUserQuery } from '../graphql/queries';
+import { getFromLocalStorage, LOCAL_STORAGE_KEYS, setLocalStorage } from '../local-storage';
+import LoggedInUser from '../LoggedInUser';
 
 const maybeRefreshAccessToken = async currentToken => {
   const decodeResult = jwt.decode(currentToken);

--- a/pages/admin-panel.js
+++ b/pages/admin-panel.js
@@ -18,7 +18,7 @@ import MessageBox from '../components/MessageBox';
 import NotificationBar from '../components/NotificationBar';
 import Page from '../components/Page';
 import SignInOrJoinFreeV2 from '../components/SignInOrJoinFreeV2';
-import { useUser } from '../components/UserProvider';
+import { useLoggedInUser } from '../components/UserProvider';
 
 export const adminPanelQuery = gqlV2/* GraphQL */ `
   query AdminPanel($slug: String!) {
@@ -153,7 +153,7 @@ const AdminPanelPage = () => {
   const router = useRouter();
   const { slug, section } = router.query;
   const intl = useIntl();
-  const { LoggedInUser, loadingLoggedInUser } = useUser();
+  const { LoggedInUser, loadingLoggedInUser } = useLoggedInUser();
   const { data, loading } = useQuery(adminPanelQuery, { context: API_V2_CONTEXT, variables: { slug } });
 
   const account = data?.account;

--- a/pages/confirm-guest.js
+++ b/pages/confirm-guest.js
@@ -17,7 +17,7 @@ import MessageBoxGraphqlError from '../components/MessageBoxGraphqlError';
 import Page from '../components/Page';
 import StyledSpinner from '../components/StyledSpinner';
 import { P } from '../components/Text';
-import { useUser } from '../components/UserProvider';
+import { useLoggedInUser } from '../components/UserProvider';
 
 const STATUS = {
   SUBMITTING: 'SUBMITTING',
@@ -51,7 +51,7 @@ const ConfirmGuestPage = () => {
   const intl = useIntl();
   const theme = useTheme();
   const router = useRouter();
-  const { login } = useUser();
+  const { login } = useLoggedInUser();
   const [status, setStatus] = React.useState(STATUS.SUBMITTING);
   const [callConfirmGuestAccount, { error, data }] = useMutation(confirmGuestAccountMutation, MUTATION_OPTS);
   const { token, email } = router.query;

--- a/pages/guest-join.js
+++ b/pages/guest-join.js
@@ -20,7 +20,7 @@ import StyledButton from '../components/StyledButton';
 import StyledCard from '../components/StyledCard';
 import StyledRadioList from '../components/StyledRadioList';
 import { H4, P, Span } from '../components/Text';
-import { useUser } from '../components/UserProvider';
+import { useLoggedInUser } from '../components/UserProvider';
 
 const STATUS = {
   SUBMITTING: 'SUBMITTING',
@@ -192,7 +192,7 @@ const JoinAsGuest = () => {
 
 const JoinGuestPage = () => {
   const intl = useIntl();
-  const { LoggedInUser } = useUser();
+  const { LoggedInUser } = useLoggedInUser();
 
   return (
     <Page title={intl.formatMessage(MESSAGES.pageTitle, { service: 'Open Collective' })}>

--- a/pages/oauth/authorize.js
+++ b/pages/oauth/authorize.js
@@ -12,7 +12,7 @@ import MessageBox from '../../components/MessageBox';
 import MessageBoxGraphqlError from '../../components/MessageBoxGraphqlError';
 import { ApplicationApproveScreen } from '../../components/oauth/ApplicationApproveScreen';
 import SignInOrJoinFreeV2 from '../../components/SignInOrJoinFreeV2';
-import { useUser } from '../../components/UserProvider';
+import { useLoggedInUser } from '../../components/UserProvider';
 
 const applicationQuery = gqlV2`
   query OAuthAuthorization($clientId: String!) {
@@ -45,7 +45,7 @@ const isValidAuthorization = authorization => {
 
 const OAuthAuthorizePage = () => {
   const { query } = useRouter();
-  const { loadingLoggedInUser, LoggedInUser } = useUser();
+  const { loadingLoggedInUser, LoggedInUser } = useLoggedInUser();
   const missingParams = REQUIRED_URL_PARAMS.filter(key => !query[key]);
   const skipQuery = !LoggedInUser || loadingLoggedInUser || missingParams.length;
   const queryVariables = { clientId: query['client_id'] };

--- a/pages/welcome.js
+++ b/pages/welcome.js
@@ -9,7 +9,7 @@ import Image from '../components/Image';
 import Link from '../components/Link';
 import StyledCard from '../components/StyledCard';
 import StyledLink from '../components/StyledLink';
-import { useUser } from '../components/UserProvider';
+import { useLoggedInUser } from '../components/UserProvider';
 
 const WelcomeOptionContainer = styled(Container)`
   &:hover {
@@ -18,7 +18,7 @@ const WelcomeOptionContainer = styled(Container)`
 `;
 
 const Welcome = () => {
-  const { LoggedInUser } = useUser();
+  const { LoggedInUser } = useLoggedInUser();
   const intl = useIntl();
 
   return (


### PR DESCRIPTION
Resolve #5571

# Description

It's a small change, I just renamed `useUser`to `useLoggedInUser` and moved it to a dedicated directory.

I chose not to rename the hook `withLoggedInUser` so as not to have a name conflict in the module `UserProvider`. 
