### PR TITLE
Show the `LoadingGrid.js` if `token` is in URL

### DIFF
--- a/pages/signinv2.js
+++ b/pages/signinv2.js
@@ -169,7 +169,7 @@ class SigninV2Page extends React.Component {
 
     const error = errorLoggedInUser || this.state.error;
 
-    if (loadingLoggedInUser || this.state.redirecting) {
+    if (loadingLoggedInUser || this.state.redirecting || (token && !error)) {
       return <LoadingGrid />;
     }
 


### PR DESCRIPTION
It was noted (in private message; https://opencollective.slack.com/archives/D01EA8GBHEZ/p1656343926222769) that there is a regression in the new sign-in flow such that there's a flashing sign-in screen when the user clicks on the magic link. This fixes that issue. 

https://user-images.githubusercontent.com/12435965/176011318-857a62ac-6267-45e5-a111-c8eae875b92b.mp4



