### PR TITLE
Add `LoadingGrid.js` to style guide

### DIFF
--- a/stories/design-system/LoadingGrid.stories.mdx
+++ b/stories/design-system/LoadingGrid.stories.mdx
@@ -1,0 +1,54 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import LoadingGrid from '../../components/LoadingGrid';
+import { Box } from '../../components/Grid';
+
+<Meta
+  title="Design system/LoadingGrid"
+  component={LoadingGrid}
+  argTypes={{
+    color: { defaultValue: '#3385FF' },
+    size: { defaultValue: 100 },
+  }}
+/>
+
+# LoadingGrid
+
+## Default
+
+export const DefaultStory = props => <LoadingGrid {...props} />;
+
+<Story name="Default">{DefaultStory.bind({})}</Story>
+
+<ArgsTable story="Default" />
+
+### Colors
+
+<Canvas>
+  <Story name="Loading Grid Colors">
+    <Box mb={4}>
+      <LoadingGrid color="red" />
+    </Box>
+    <Box mb={4}>
+      <LoadingGrid color="yellow" />
+    </Box>
+    <Box mb={4}>
+      <LoadingGrid color="orange" />
+    </Box>
+  </Story>
+</Canvas>
+
+### Sizes
+
+<Canvas>
+  <Story name="Loading Grid Sizes">
+    <Box mb={4}>
+      <LoadingGrid size={100} />
+    </Box>
+    <Box mb={4}>
+      <LoadingGrid size={150} />
+    </Box>
+    <Box mb={4}>
+      <LoadingGrid size={200} />
+    </Box>
+  </Story>
+</Canvas>


### PR DESCRIPTION
Working on another issue I realized that the `LoadingGrid.js` is not included in the style guide. This PR adds it to the style guide.

https://user-images.githubusercontent.com/12435965/176059532-839c58fc-2957-4acd-a0a9-0c4173427daa.mp4


