### PR TITLE
5571 use logged in user improvements

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -10,8 +10,7 @@ import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import styled from 'styled-components';
 
 import languages from '../lib/constants/locales';
-
-import { useLoggedInUser } from '../components/UserProvider';
+import useLoggedInUser from '../lib/hooks/useLoggedInUser';
 
 import TranslateIcon from './icons/TranslateIcon';
 import Container from './Container';

--- a/components/GlobalWarnings.js
+++ b/components/GlobalWarnings.js
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 
+import useLoggedInUser from '../lib/hooks/useLoggedInUser';
+
 import I18nFormatters from './I18nFormatters';
 import { P } from './Text';
-import { useLoggedInUser } from './UserProvider';
 
 const GlobalWarningContainer = styled.div`
   width: 100;

--- a/components/admin-panel/sections/AccountSettings.js
+++ b/components/admin-panel/sections/AccountSettings.js
@@ -10,12 +10,12 @@ import { getErrorFromGraphqlException } from '../../../lib/errors';
 import { API_V2_CONTEXT } from '../../../lib/graphql/helpers';
 import { editCollectiveMutation } from '../../../lib/graphql/mutations';
 import { editCollectivePageQuery } from '../../../lib/graphql/queries';
+import useLoggedInUser from '../../../lib/hooks/useLoggedInUser';
 
 import { adminPanelQuery } from '../../../pages/admin-panel';
 import SettingsForm from '../../edit-collective/Form';
 import Loading from '../../Loading';
 import { TOAST_TYPE, useToasts } from '../../ToastProvider';
-import { useLoggedInUser } from '../../UserProvider';
 
 const AccountSettings = ({ account, section }) => {
   const { LoggedInUser, refetchLoggedInUser } = useLoggedInUser();

--- a/components/admin-panel/sections/AuthorizedApps.js
+++ b/components/admin-panel/sections/AuthorizedApps.js
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import { FormattedMessage } from 'react-intl';
 
 import { API_V2_CONTEXT } from '../../../lib/graphql/helpers';
+import useLoggedInUser from '../../../lib/hooks/useLoggedInUser';
 
 import { Box, Flex } from '../../Grid';
 import { I18nSupportLink } from '../../I18nFormatters';
@@ -15,7 +16,6 @@ import { authorizedAppsQuery } from '../../oauth/queries';
 import Pagination from '../../Pagination';
 import StyledHr from '../../StyledHr';
 import { P } from '../../Text';
-import { useLoggedInUser } from '../../UserProvider';
 
 const AuthorizedAppsSection = () => {
   const router = useRouter() || {};

--- a/components/collective-navbar/index.js
+++ b/components/collective-navbar/index.js
@@ -22,6 +22,7 @@ import { CollectiveType } from '../../lib/constants/collectives';
 import roles from '../../lib/constants/roles';
 import { getEnvVar } from '../../lib/env-utils';
 import useGlobalBlur from '../../lib/hooks/useGlobalBlur';
+import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
 import { getCollectivePageRoute, getSettingsRoute } from '../../lib/url-helpers';
 import { parseToBoolean } from '../../lib/utils';
 
@@ -39,7 +40,6 @@ import LoadingPlaceholder from '../LoadingPlaceholder';
 import StyledButton from '../StyledButton';
 import { fadeIn } from '../StyledKeyframes';
 import { Span } from '../Text';
-import { useLoggedInUser } from '../UserProvider';
 
 import CollectiveNavbarActionsMenu from './ActionsMenu';
 import { NAVBAR_CATEGORIES } from './constants';

--- a/components/collective-page/hero/Hero.js
+++ b/components/collective-page/hero/Hero.js
@@ -11,6 +11,7 @@ import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import styled from 'styled-components';
 
 import { CollectiveType } from '../../../lib/constants/collectives';
+import useLoggedInUser from '../../../lib/hooks/useLoggedInUser';
 import { twitterProfileUrl } from '../../../lib/url-helpers';
 
 import CodeRepositoryIcon from '../../CodeRepositoryIcon';
@@ -31,7 +32,6 @@ import StyledTag from '../../StyledTag';
 import { H1, Span } from '../../Text';
 import TruncatedTextWithTooltip from '../../TruncatedTextWithTooltip';
 import UserCompany from '../../UserCompany';
-import { useLoggedInUser } from '../../UserProvider';
 import ContainerSectionContent from '../ContainerSectionContent';
 
 import CollectiveColorPicker from './CollectiveColorPicker';

--- a/components/collective-page/sections/Location.js
+++ b/components/collective-page/sections/Location.js
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
 import { isEmptyCollectiveLocation } from '../../../lib/collective.lib';
+import useLoggedInUser from '../../../lib/hooks/useLoggedInUser';
 
 import Container from '../../Container';
 import { Box } from '../../Grid';
 import LocationComponent from '../../Location';
 import { P } from '../../Text';
-import { useLoggedInUser } from '../../UserProvider';
 import ContainerSectionContent from '../ContainerSectionContent';
 import SectionTitle from '../SectionTitle';
 

--- a/components/collectives/Newsletter.js
+++ b/components/collectives/Newsletter.js
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import { Envelope } from '@styled-icons/fa-solid/Envelope';
 import { FormattedMessage } from 'react-intl';
 
+import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
+
 import Container from '../Container';
 import { Box, Flex } from '../Grid';
 import StyledButton from '../StyledButton';
 import StyledInput from '../StyledInput';
 import { Span } from '../Text';
-import { useLoggedInUser } from '../UserProvider';
 
 const Newsletter = ({ defaultEmail }) => {
   const { LoggedInUser } = useLoggedInUser();

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -8,6 +8,7 @@ import { canContributeRecurring, hostIsTaxDeductibeInTheUs } from '../../lib/col
 import INTERVALS from '../../lib/constants/intervals';
 import { AmountTypes, TierTypes } from '../../lib/constants/tiers-types';
 import { formatCurrency } from '../../lib/currency-utils';
+import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
 import { i18nInterval } from '../../lib/i18n/interval';
 import { getTierMinAmount, getTierPresets } from '../../lib/tier-utils';
 
@@ -21,7 +22,6 @@ import StyledAmountPicker, { OTHER_AMOUNT_KEY } from '../StyledAmountPicker';
 import StyledHr from '../StyledHr';
 import StyledInput from '../StyledInput';
 import { H5, P, Span } from '../Text';
-import { useLoggedInUser } from '../UserProvider';
 
 import ChangeTierWarningModal from './ChangeTierWarningModal';
 import PlatformTipInput from './PlatformTipInput';

--- a/components/contribution-flow/StepProfile.js
+++ b/components/contribution-flow/StepProfile.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
+
 import { Box } from '../Grid';
-import { useLoggedInUser } from '../UserProvider';
 
 import StepProfileGuestForm from './StepProfileGuestForm';
 import StepProfileLoggedInForm from './StepProfileLoggedInForm';

--- a/components/contribution-flow/StepProfileLoggedInForm.js
+++ b/components/contribution-flow/StepProfileLoggedInForm.js
@@ -2,6 +2,8 @@ import React, { Fragment, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
+import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
+
 import { Box, Flex } from '../Grid';
 import PrivateInfoIcon from '../icons/PrivateInfoIcon';
 import StyledHr from '../StyledHr';
@@ -9,7 +11,6 @@ import StyledInput from '../StyledInput';
 import StyledInputField from '../StyledInputField';
 import StyledInputLocation from '../StyledInputLocation';
 import { P, Span } from '../Text';
-import { useLoggedInUser } from '../UserProvider';
 
 import ContributeProfilePicker from './ContributeProfilePicker';
 import StepProfileInfoMessage from './StepProfileInfoMessage';

--- a/components/expenses/ProcessExpenseButtons.js
+++ b/components/expenses/ProcessExpenseButtons.js
@@ -11,6 +11,7 @@ import styled from 'styled-components';
 import PERMISSION_CODES, { ReasonMessage } from '../../lib/constants/permissions';
 import { i18nGraphqlException } from '../../lib/errors';
 import { API_V2_CONTEXT, gqlV2 } from '../../lib/graphql/helpers';
+import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
 
 import { EDIT_COLLECTIVE_SECTIONS } from '../edit-collective/Menu';
 import { getI18nLink } from '../I18nFormatters';
@@ -18,7 +19,6 @@ import Link from '../Link';
 import StyledButton from '../StyledButton';
 import StyledTooltip from '../StyledTooltip';
 import { TOAST_TYPE, useToasts } from '../ToastProvider';
-import { useLoggedInUser } from '../UserProvider';
 
 import { expensePageExpenseFieldsFragment } from './graphql/fragments';
 import DeleteExpenseButton from './DeleteExpenseButton';

--- a/components/help-and-support/ContactSection.js
+++ b/components/help-and-support/ContactSection.js
@@ -9,6 +9,7 @@ import { isURL } from 'validator';
 import { sendContactMessage } from '../../lib/api';
 import { createError, ERROR, i18nGraphqlException } from '../../lib/errors';
 import { formatFormErrorMessage } from '../../lib/form-utils';
+import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
 import { isValidEmail } from '../../lib/utils';
 
 import Container from '../Container';
@@ -22,7 +23,6 @@ import StyledInput from '../StyledInput';
 import StyledInputField from '../StyledInputField';
 import StyledInputGroup from '../StyledInputGroup';
 import { P, Span } from '../Text';
-import { useLoggedInUser } from '../UserProvider';
 
 const validate = values => {
   const errors = {};

--- a/components/home/GetToKnowUsSection.js
+++ b/components/home/GetToKnowUsSection.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import themeGet from '@styled-system/theme-get';
+import { themeGet } from '@styled-system/theme-get';
 import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 

--- a/components/host-dashboard/AddFundsModal.js
+++ b/components/host-dashboard/AddFundsModal.js
@@ -10,6 +10,7 @@ import styled, { css } from 'styled-components';
 import { formatCurrency } from '../../lib/currency-utils';
 import { requireFields } from '../../lib/form-utils';
 import { API_V2_CONTEXT, gqlV2 } from '../../lib/graphql/helpers';
+import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
 import { getCollectivePageRoute } from '../../lib/url-helpers';
 
 import { collectivePageQuery, getCollectivePageQueryVariables } from '../collective-page/graphql/queries';
@@ -34,7 +35,6 @@ import StyledSelect from '../StyledSelect';
 import StyledTooltip from '../StyledTooltip';
 import { P, Span } from '../Text';
 import { TOAST_TYPE, useToasts } from '../ToastProvider';
-import { useLoggedInUser } from '../UserProvider';
 
 import illustration from '../contribution-flow/fees-on-top-illustration.png';
 

--- a/components/oauth/ApplicationApproveScreen.js
+++ b/components/oauth/ApplicationApproveScreen.js
@@ -9,6 +9,7 @@ import styled from 'styled-components';
 import { addAuthTokenToHeader } from '../../lib/api';
 import { ERROR, formatErrorType } from '../../lib/errors';
 import { useAsyncCall } from '../../lib/hooks/useAsyncCall';
+import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
 
 import Avatar from '../Avatar';
 import Container from '../Container';
@@ -21,7 +22,6 @@ import RadialIconContainer from '../RadialIconContainer';
 import StyledButton from '../StyledButton';
 import StyledCard from '../StyledCard';
 import { P } from '../Text';
-import { useLoggedInUser } from '../UserProvider';
 
 const TopAvatarsContainer = styled.div`
   display: flex;

--- a/components/orders/OrdersWithData.js
+++ b/components/orders/OrdersWithData.js
@@ -8,6 +8,7 @@ import { FormattedMessage } from 'react-intl';
 import { ORDER_STATUS } from '../../lib/constants/order-status';
 import { parseDateInterval } from '../../lib/date-utils';
 import { API_V2_CONTEXT, gqlV2 } from '../../lib/graphql/helpers';
+import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
 import { usePrevious } from '../../lib/hooks/usePrevious';
 
 import { parseAmountRange } from '../budget/filters/AmountFilter';
@@ -20,7 +21,6 @@ import Pagination from '../Pagination';
 import SearchBar from '../SearchBar';
 import StyledHr from '../StyledHr';
 import { H1 } from '../Text';
-import { useLoggedInUser } from '../UserProvider';
 
 import OrdersFilters from './OrdersFilters';
 import OrdersList from './OrdersList';

--- a/components/transactions/TransactionItem.js
+++ b/components/transactions/TransactionItem.js
@@ -10,6 +10,7 @@ import styled from 'styled-components';
 import expenseStatus from '../../lib/constants/expense-status';
 import { TransactionKind, TransactionTypes } from '../../lib/constants/transactions';
 import { formatCurrency } from '../../lib/currency-utils';
+import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
 import { i18nTransactionKind, i18nTransactionType } from '../../lib/i18n/transaction';
 import { getCollectivePageRoute } from '../../lib/url-helpers';
 
@@ -31,7 +32,6 @@ import StyledTooltip from '../StyledTooltip';
 import { P, Span } from '../Text';
 import TransactionSign from '../TransactionSign';
 import TransactionStatusTag from '../TransactionStatusTag';
-import { useLoggedInUser } from '../UserProvider';
 
 import TransactionDetails from './TransactionDetails';
 

--- a/lib/hooks/useLoggedInUser.js
+++ b/lib/hooks/useLoggedInUser.js
@@ -1,3 +1,5 @@
-import { useLoggedInUser } from '../../components/UserProvider';
+import { UserContext } from '../../components/UserProvider';
+
+const useLoggedInUser = () => React.useContext(UserContext);
 
 export default useLoggedInUser;

--- a/lib/hooks/useLoggedInUser.js
+++ b/lib/hooks/useLoggedInUser.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { UserContext } from '../../components/UserProvider';
 
 const useLoggedInUser = () => React.useContext(UserContext);

--- a/lib/hooks/useLoggedInUser.js
+++ b/lib/hooks/useLoggedInUser.js
@@ -1,0 +1,3 @@
+import { useLoggedInUser } from '../../components/UserProvider';
+
+export default useLoggedInUser;

--- a/pages/admin-panel.js
+++ b/pages/admin-panel.js
@@ -6,6 +6,7 @@ import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { isHostAccount } from '../lib/collective.lib';
 import roles from '../lib/constants/roles';
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
+import useLoggedInUser from '../lib/hooks/useLoggedInUser';
 
 import { AdminPanelContext } from '../components/admin-panel/AdminPanelContext';
 import AdminPanelSection from '../components/admin-panel/AdminPanelSection';
@@ -18,7 +19,6 @@ import MessageBox from '../components/MessageBox';
 import NotificationBar from '../components/NotificationBar';
 import Page from '../components/Page';
 import SignInOrJoinFree from '../components/SignInOrJoinFree';
-import { useLoggedInUser } from '../components/UserProvider';
 
 export const adminPanelQuery = gqlV2/* GraphQL */ `
   query AdminPanel($slug: String!) {

--- a/pages/confirm-guest.js
+++ b/pages/confirm-guest.js
@@ -7,6 +7,7 @@ import { useTheme } from 'styled-components';
 
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
 import { removeGuestTokens } from '../lib/guest-accounts';
+import useLoggedInUser from '../lib/hooks/useLoggedInUser';
 
 import Container from '../components/Container';
 import { Box } from '../components/Grid';
@@ -17,7 +18,6 @@ import MessageBoxGraphqlError from '../components/MessageBoxGraphqlError';
 import Page from '../components/Page';
 import StyledSpinner from '../components/StyledSpinner';
 import { P } from '../components/Text';
-import { useLoggedInUser } from '../components/UserProvider';
 
 const STATUS = {
   SUBMITTING: 'SUBMITTING',

--- a/pages/guest-join.js
+++ b/pages/guest-join.js
@@ -8,6 +8,7 @@ import styled, { useTheme } from 'styled-components';
 
 import { API_V2_CONTEXT, gqlV2 } from '../lib/graphql/helpers';
 import { getAllGuestEmails } from '../lib/guest-accounts';
+import useLoggedInUser from '../lib/hooks/useLoggedInUser';
 
 import Container from '../components/Container';
 import { Box } from '../components/Grid';
@@ -20,7 +21,6 @@ import StyledButton from '../components/StyledButton';
 import StyledCard from '../components/StyledCard';
 import StyledRadioList from '../components/StyledRadioList';
 import { H4, P, Span } from '../components/Text';
-import { useLoggedInUser } from '../components/UserProvider';
 
 const STATUS = {
   SUBMITTING: 'SUBMITTING',

--- a/pages/oauth/authorize.js
+++ b/pages/oauth/authorize.js
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import { FormattedMessage } from 'react-intl';
 
 import { API_V2_CONTEXT, gqlV2 } from '../../lib/graphql/helpers';
+import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
 
 import EmbeddedPage from '../../components/EmbeddedPage';
 import { Flex } from '../../components/Grid';
@@ -12,7 +13,6 @@ import MessageBox from '../../components/MessageBox';
 import MessageBoxGraphqlError from '../../components/MessageBoxGraphqlError';
 import { ApplicationApproveScreen } from '../../components/oauth/ApplicationApproveScreen';
 import SignInOrJoinFree from '../../components/SignInOrJoinFree';
-import { useLoggedInUser } from '../../components/UserProvider';
 
 const applicationQuery = gqlV2`
   query OAuthAuthorization($clientId: String!) {

--- a/pages/welcome.js
+++ b/pages/welcome.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import styled from 'styled-components';
 
+import useLoggedInUser from '../lib/hooks/useLoggedInUser';
+
 import AuthenticatedPage from '../components/AuthenticatedPage';
 import Container from '../components/Container';
 import { Box, Flex } from '../components/Grid';
@@ -9,7 +11,6 @@ import Image from '../components/Image';
 import Link from '../components/Link';
 import StyledCard from '../components/StyledCard';
 import StyledLink from '../components/StyledLink';
-import { useLoggedInUser } from '../components/UserProvider';
 
 const WelcomeOptionContainer = styled(Container)`
   &:hover {


### PR DESCRIPTION
Related #7946

# Description

Improvements required by @kewitz:

> Keep `withLoggedInUser` in `lib/`, technically this is a high-order component and not the actual hook.
> Create a new file `lib/hooks/useLoggedInUser.js` that only declare and exports the `useLoggedInUser` that you currently have in `components/UserProvider.js`
> This file will just import the `UserProvider`, declare `useLoggedInUser` as it is and export that

