### PR TITLE
Direct the discover more link to `/search` page

### DIFF
--- a/components/home/OpenCollectiveIsSection.js
+++ b/components/home/OpenCollectiveIsSection.js
@@ -114,7 +114,7 @@ const OpenCollectiveIs = () => {
           <Box display={['none', 'block']} width="100%">
             <ApplyToHostGrid color="white.full" />
           </Box>
-          <StyledLink as={Link} buttonStyle="standard" mt="48px" mb="64px" buttonSize="medium" href="/discover">
+          <StyledLink as={Link} buttonStyle="standard" mt="48px" mb="64px" buttonSize="medium" href="/search">
             <FormattedMessage id="home.discoverMoreHome" defaultMessage="Discover More Hosts" />
           </StyledLink>
         </Flex>


### PR DESCRIPTION
Reported at https://opencollective.slack.com/archives/CT9MM6Q5A/p1656457477603329?thread_ts=1656456637.206579&cid=CT9MM6Q5A

It seems that the `Discover More Hosts` button link in the homepage is not working. This PR fixes it. 