### PR TITLE
feat: Add host fee to default transaction filters (#5549)

### DIFF
--- a/components/transactions/filters/TransactionsKindFilter.js
+++ b/components/transactions/filters/TransactionsKindFilter.js
@@ -20,6 +20,7 @@ export const getDefaultKinds = () => {
     TransactionKind.CONTRIBUTION,
     TransactionKind.EXPENSE,
     TransactionKind.PLATFORM_TIP,
+    TransactionKind.HOST_FEE,
   ];
 };
 


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->
Resolve https://github.com/opencollective/opencollective/issues/5549

# Description

Adds "Host Fee" to the default transaction filters for the frontend.
Based on [this comment](https://github.com/opencollective/opencollective-frontend/blob/main/components/transactions/filters/TransactionsKindFilter.js?#L15) it sounds like there is a backend change needed as well.

# Screenshots

![Screenshot_20220629_175312](https://user-images.githubusercontent.com/107730483/176555469-d3c72eee-78c4-443c-8ac6-a49cb545876a.png)

