### PR TITLE
fix: improve rendering of private instructions

### DIFF
--- a/components/collective-page/sections/Location.js
+++ b/components/collective-page/sections/Location.js
@@ -48,9 +48,17 @@ const Location = ({ collective: event, refetch }) => {
             <P fontWeight="bold" fontSize="18px">
               <FormattedMessage id="event.privateInstructions.label" defaultMessage="Private instructions" />
             </P>
-            <P mt={3} fontSize="14px">
+            <pre
+              style={{
+                whiteSpace: 'pre-wrap',
+                fontSize: '14px',
+                marginTop: 3,
+                background: 'transparent',
+                border: 'none',
+              }}
+            >
               {event.privateInstructions}
-            </P>
+            </pre>
           </Container>
         )}
       </ContainerSectionContent>

--- a/components/collective-page/sections/Location.js
+++ b/components/collective-page/sections/Location.js
@@ -55,6 +55,7 @@ const Location = ({ collective: event, refetch }) => {
                 marginTop: 3,
                 background: 'transparent',
                 border: 'none',
+                fontFamily: "'Inter', sans-serif",
               }}
             >
               {event.privateInstructions}

--- a/components/collective-page/sections/Location.js
+++ b/components/collective-page/sections/Location.js
@@ -48,18 +48,9 @@ const Location = ({ collective: event, refetch }) => {
             <P fontWeight="bold" fontSize="18px">
               <FormattedMessage id="event.privateInstructions.label" defaultMessage="Private instructions" />
             </P>
-            <pre
-              style={{
-                whiteSpace: 'pre-wrap',
-                fontSize: '14px',
-                marginTop: 3,
-                background: 'transparent',
-                border: 'none',
-                fontFamily: "'Inter', sans-serif",
-              }}
-            >
+            <P mt={3} fontSize="14px" whiteSpace="pre-wrap">
               {event.privateInstructions}
-            </pre>
+            </P>
           </Container>
         )}
       </ContainerSectionContent>


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/5468
Related API PR - https://github.com/opencollective/opencollective-api/pull/7724
# Description

Private instructions on Events should render as pre so that Line endings, especially, are preserved.

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots

<img width="1248" alt="Screenshot 2022-07-09 at 3 45 48 PM" src="https://user-images.githubusercontent.com/46647141/178101444-f5c67787-318f-4d1b-8526-cfe10c981878.png">


<!--
  We love screenshots! If applicable, please try to include some here.
  You can also post animated screencasts in GIF format.
-->
