### PR TITLE
Improve handling of zero-decimal currencies in the contribution flow

### DIFF
--- a/components/Currency.js
+++ b/components/Currency.js
@@ -15,7 +15,7 @@ const Currency = ({ formatWithSeparators, currency, precision, value, ...styles 
   const { locale } = useIntl();
   if (precision === 'auto') {
     precision = value % 100 === 0 ? 0 : 2;
-  } else if (precision < 2 && value < 100) {
+  } else if (value < 100 && (!precision || precision < 2)) {
     // Force precision if number is < $1 to never display $0 for small amounts
     precision = 2;
   }

--- a/components/StyledInputAmount.js
+++ b/components/StyledInputAmount.js
@@ -5,7 +5,7 @@ import { isNil, isUndefined } from 'lodash';
 import { useIntl } from 'react-intl';
 
 import { Currency } from '../lib/constants/currency';
-import { floatAmountToCents, getCurrencySymbol } from '../lib/currency-utils';
+import { floatAmountToCents, getCurrencySymbol, getStepForCurrency } from '../lib/currency-utils';
 import { getIntlDisplayNames } from '../lib/i18n';
 
 import Container from './Container';
@@ -156,7 +156,7 @@ const StyledInputAmount = ({
   return (
     <StyledInputGroup
       maxWidth="10em"
-      step="0.01"
+      step={getStepForCurrency(currency)}
       {...props}
       min={minAmount}
       max={isUndefined(max) ? max : max / 100}

--- a/components/__tests__/Currency.test.js
+++ b/components/__tests__/Currency.test.js
@@ -8,11 +8,17 @@ describe('Currency', () => {
   it('renders default options', () => {
     snapshot(<Currency value={4200} currency="USD" />);
     snapshot(<Currency value={1900000} currency="USD" />, { IntlProvider: { locale: 'fr' } });
+    snapshot(<Currency value={4221} currency="JPY" />);
   });
 
   it('currency format with separators', () => {
     snapshot(<Currency formatWithSeparators value={4200} currency="USD" />);
     snapshot(<Currency formatWithSeparators value={1900000} currency="USD" />, { IntlProvider: { locale: 'fr' } });
     snapshot(<Currency formatWithSeparators value={1900000} currency="USD" />, { IntlProvider: { locale: 'en' } });
+  });
+
+  it('overrides precision if amount is below 100', () => {
+    snapshot(<Currency value={99} currency="JPY" />);
+    snapshot(<Currency value={99} currency="USD" />);
   });
 });

--- a/components/__tests__/__snapshots__/Currency.test.js.snap
+++ b/components/__tests__/__snapshots__/Currency.test.js.snap
@@ -33,6 +33,26 @@ exports[`Currency currency format with separators 3`] = `
 </span>
 `;
 
+exports[`Currency overrides precision if amount is below 100 1`] = `
+<span
+  className="Text__P-sc-3suny7-0-span hdWHPl"
+  fontSize="inherit"
+  letterSpacing="-0.4px"
+>
+  ¥0.99
+</span>
+`;
+
+exports[`Currency overrides precision if amount is below 100 2`] = `
+<span
+  className="Text__P-sc-3suny7-0-span hdWHPl"
+  fontSize="inherit"
+  letterSpacing="-0.4px"
+>
+  $0.99
+</span>
+`;
+
 exports[`Currency renders default options 1`] = `
 <span
   className="Text__P-sc-3suny7-0-span hdWHPl"
@@ -50,5 +70,15 @@ exports[`Currency renders default options 2`] = `
   letterSpacing="-0.4px"
 >
   19 000 $
+</span>
+`;
+
+exports[`Currency renders default options 3`] = `
+<span
+  className="Text__P-sc-3suny7-0-span hdWHPl"
+  fontSize="inherit"
+  letterSpacing="-0.4px"
+>
+  ¥42
 </span>
 `;

--- a/lib/__tests__/currency-utils.test.js
+++ b/lib/__tests__/currency-utils.test.js
@@ -6,4 +6,34 @@ describe('currency utils lib', () => {
     expect(utils.getCurrencySymbol('EUR')).toEqual('€');
     expect(utils.getCurrencySymbol('JPY')).toEqual('¥');
   });
+
+  describe('getPrecisionForCurrency', () => {
+    it('returns known currency precisions', () => {
+      expect(utils.getPrecisionForCurrency('USD')).toEqual(2);
+      expect(utils.getPrecisionForCurrency('BRL')).toEqual(2);
+      expect(utils.getPrecisionForCurrency('KRW')).toEqual(0);
+      expect(utils.getPrecisionForCurrency('JPY')).toEqual(0);
+    });
+
+    it('returns default precision for unknown currency', () => {
+      expect(utils.getPrecisionForCurrency('')).toEqual(2);
+      expect(utils.getPrecisionForCurrency('123')).toEqual(2);
+      expect(utils.getPrecisionForCurrency('XYZ')).toEqual(2);
+    });
+  });
+
+  describe('getStepForCurrency', () => {
+    it('returns known currency step value', () => {
+      expect(utils.getStepForCurrency('USD')).toEqual(0.01);
+      expect(utils.getStepForCurrency('BRL')).toEqual(0.01);
+      expect(utils.getStepForCurrency('KRW')).toEqual(1);
+      expect(utils.getStepForCurrency('JPY')).toEqual(1);
+    });
+
+    it('returns default step value for unknown currency', () => {
+      expect(utils.getStepForCurrency('')).toEqual(0.01);
+      expect(utils.getStepForCurrency('123')).toEqual(0.01);
+      expect(utils.getStepForCurrency('XYZ')).toEqual(0.01);
+    });
+  });
 });

--- a/lib/constants/currency-precision.js
+++ b/lib/constants/currency-precision.js
@@ -2,4 +2,26 @@ export const CurrencyPrecision = {
   DEFAULT: 2,
 };
 
+/**
+ * Zero-decimal currencies for Stripe; https://stripe.com/docs/currencies#zero-decimal
+ */
+export const ZeroDecimalCurrencies = [
+  'BIF',
+  'CLP',
+  'DJF',
+  'GNF',
+  'JPY',
+  'KMF',
+  'KRW',
+  'MGA',
+  'PYG',
+  'RWF',
+  'UGX',
+  'VND',
+  'VUV',
+  'XAF',
+  'XOF',
+  'XPF',
+];
+
 export default CurrencyPrecision;

--- a/lib/currency-utils.js
+++ b/lib/currency-utils.js
@@ -46,6 +46,11 @@ export function formatCurrency(amount, currency = 'USD', options = {}) {
     maximumFractionDigits = options.precision;
   }
 
+  if (ZeroDecimalCurrencies.includes(currency) && amount >= 100) {
+    minimumFractionDigits = 0;
+    maximumFractionDigits = 0;
+  }
+
   const formatAmount = currencyDisplay => {
     return amount.toLocaleString(options.locale, {
       style: 'currency',

--- a/lib/currency-utils.js
+++ b/lib/currency-utils.js
@@ -24,8 +24,8 @@ export const getPrecisionFromAmount = amount => {
 
 export function formatCurrency(amount, currency = 'USD', options = {}) {
   amount = amount / 100;
-  let minimumFractionDigits = 2;
-  let maximumFractionDigits = 2;
+  let minimumFractionDigits;
+  let maximumFractionDigits;
   if (Object.prototype.hasOwnProperty.call(options, 'minimumFractionDigits')) {
     minimumFractionDigits = options.minimumFractionDigits;
   } else if (Object.prototype.hasOwnProperty.call(options, 'precision')) {
@@ -37,8 +37,8 @@ export function formatCurrency(amount, currency = 'USD', options = {}) {
     return amount.toLocaleString(options.locale, {
       style: 'currency',
       currency,
-      minimumFractionDigits: minimumFractionDigits,
-      maximumFractionDigits: maximumFractionDigits,
+      minimumFractionDigits,
+      maximumFractionDigits,
       currencyDisplay,
     });
   };

--- a/lib/currency-utils.js
+++ b/lib/currency-utils.js
@@ -1,7 +1,7 @@
 import getSymbolFromCurrency from 'currency-symbol-map';
 import { round } from 'lodash';
 
-import { CurrencyPrecision } from './constants/currency-precision';
+import { CurrencyPrecision, ZeroDecimalCurrencies } from './constants/currency-precision';
 
 function getCurrencySymbolFallback(currency) {
   return Number(0)
@@ -20,6 +20,19 @@ export function getCurrencySymbol(currency) {
 
 export const getPrecisionFromAmount = amount => {
   return amount.toString().slice(-2) === '00' ? 0 : CurrencyPrecision.DEFAULT;
+};
+
+export const getPrecisionForCurrency = currency => {
+  if (ZeroDecimalCurrencies.includes(currency)) {
+    return 0;
+  }
+
+  return CurrencyPrecision.DEFAULT;
+};
+
+export const getStepForCurrency = currency => {
+  const precision = getPrecisionForCurrency(currency);
+  return 1 / Math.pow(10, precision);
 };
 
 export function formatCurrency(amount, currency = 'USD', options = {}) {


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve https://github.com/opencollective/opencollective/issues/5730

# Description

Changes the currency formatting components and functions to use the currency decimal precision by default, this accommodates currencies such as JPY and KRW that do not have decimal places.

The precision can still be forced by passing the existing prop and/or option.

The amount input component also takes the minimum precision for the given currency for incrementing and decrementing the value via its controls.

# Screenshots

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
![5730-yen-amount-input-1](https://user-images.githubusercontent.com/5448927/177988453-789c62ed-ead7-4bbc-a31a-a9b2b289baac.png)

![5730-yen-amount-input-2](https://user-images.githubusercontent.com/5448927/177988465-1f2ced98-932a-456c-8745-4506dbc5878e.png)

