### PR TITLE
Remove `alt` Strings from Open Collective Logos

### DIFF
--- a/components/CreateProfile.js
+++ b/components/CreateProfile.js
@@ -190,7 +190,7 @@ const CreateProfile = ({
           <React.Fragment>
             <Flex justifyContent="center" mb={40}>
               <Box minWidth={104}>
-                <Image src="/static/images/oc-logo-oauth.png" alt="Open Collective logo" height={104} width={104} />
+                <Image src="/static/images/oc-logo-oauth.png" height={104} width={104} />
               </Box>
               <Box ml={24} mr={24} mt={32} minWidth={40}>
                 <Image src="/static/images/oauth-flow-connect.png" alt="OAuth Connect" height={40} width={40} />
@@ -202,7 +202,7 @@ const CreateProfile = ({
           </React.Fragment>
         ) : (
           <Box>
-            <Image src="/static/images/oc-logo-watercolor-256.png" alt="Open Collective logo" height={96} width={96} />
+            <Image src="/static/images/oc-logo-watercolor-256.png" height={96} width={96} />
           </Box>
         )}
         <Box pt="48px" fontSize="32px" fontWeight="700" color="black.900" lineHeight="40px">

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -256,7 +256,7 @@ const Footer = () => {
             <Flex my="12px">
               <Image
                 src="/static/images/opencollectivelogo-footer-n.svg"
-                alt="Open Collective logo"
+                alt="Open Collective"
                 height={28}
                 width={167}
               />

--- a/components/NotificationBar.js
+++ b/components/NotificationBar.js
@@ -157,7 +157,7 @@ class NotificationBar extends React.Component {
       <NotificationBarContainer className={classNames(status, 'NotificationBar')} data-cy="notification-bar">
         {status === 'error' && (
           <ErrorMessageContainer>
-            <CollectiveLogo src={logo} alt="Open Collective logo" />
+            <CollectiveLogo src={logo} alt="" />
             {error && <p>{error}</p>}
           </ErrorMessageContainer>
         )}

--- a/components/SignIn.js
+++ b/components/SignIn.js
@@ -115,7 +115,7 @@ export default class SignIn extends React.Component {
             <React.Fragment>
               <Flex justifyContent="center" mb={40}>
                 <Box minWidth={104}>
-                  <Image src="/static/images/oc-logo-oauth.png" alt="Open Collective logo" height={104} width={104} />
+                  <Image src="/static/images/oc-logo-oauth.png" height={104} width={104} />
                 </Box>
                 <Box ml={24} mr={24} mt={32} minWidth={40}>
                   <Image src="/static/images/oauth-flow-connect.png" alt="OAuth Connect" height={40} width={40} />
@@ -136,7 +136,6 @@ export default class SignIn extends React.Component {
               <Flex justifyContent="center" mb="48px">
                 <Image
                   src="/static/images/oc-logo-watercolor-256.png"
-                  alt="Open Collective logo"
                   height={128}
                   width={128}
                 />

--- a/components/SignIn.js
+++ b/components/SignIn.js
@@ -134,11 +134,7 @@ export default class SignIn extends React.Component {
           ) : (
             this.props.showOCLogo && (
               <Flex justifyContent="center" mb="48px">
-                <Image
-                  src="/static/images/oc-logo-watercolor-256.png"
-                  height={128}
-                  width={128}
-                />
+                <Image src="/static/images/oc-logo-watercolor-256.png" height={128} width={128} />
               </Flex>
             )
           )}

--- a/components/TopBar.js
+++ b/components/TopBar.js
@@ -86,7 +86,7 @@ const TopBar = ({ showSearch, menuItems, showProfileAndChangelogMenu }) => {
     >
       <Link href="/">
         <Flex alignItems="center">
-          <Image width="36" height="36" src="/static/images/opencollective-icon.png" alt="Open Collective logo" />
+          <Image width="36" height="36" src="/static/images/opencollective-icon.png" alt="Open Collective" />
           <Hide xs sm md>
             <Box mx={2}>
               <Image height={21} width={141} src="/static/images/logotype.svg" alt="Open Collective" />

--- a/components/e2c/OCIsATechPlatformSection.js
+++ b/components/e2c/OCIsATechPlatformSection.js
@@ -70,12 +70,7 @@ enables a network of:"
         </StyledLink>
       </Box>
       <Box my={['56px', '80px', '104px']}>
-        <NextIllustration
-          alt="Open collective logo illustration"
-          src="/static/images/e2c/oc-logo-illustration.png"
-          width={88}
-          height={87}
-        />
+        <NextIllustration src="/static/images/e2c/oc-logo-illustration.png" width={88} height={87} />
       </Box>
       <Box width={['288px', '100%', '784px']} mt="55px">
         <H2
@@ -95,12 +90,7 @@ enables a network of:"
         </H2>
       </Box>
       <Box width={['286px', '432px']} height={['168px', '317px']}>
-        <NextIllustration
-          alt="Open collective logo illustration"
-          src="/static/images/e2c/e2c-logo-illustration.png"
-          width={431}
-          height={317}
-        />
+        <NextIllustration src="/static/images/e2c/e2c-logo-illustration.png" width={431} height={317} />
       </Box>
     </Flex>
   );

--- a/pages/welcome.js
+++ b/pages/welcome.js
@@ -33,7 +33,7 @@ const Welcome = () => {
       <Flex flexDirection={['column', 'row']} mb="61px" mt="112px" justifyContent="center" alignItems="center">
         <Flex textAlign="center" flexDirection="column" pr={[0, '48px']}>
           <Box>
-            <Image src="/static/images/oc-logo-watercolor-256.png" alt="Open Collective logo" height={96} width={96} />
+            <Image src="/static/images/oc-logo-watercolor-256.png" height={96} width={96} />
           </Box>
           <Container pt="40px" pl="16px" pr={['16px', 0]} width={['100%', '404px']}>
             <Flex fontSize="32px" fontWeight="700" color="black.900" lineHeight="40px">


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective-frontend/pull/7996#discussion_r916243152

Removes some useless accessibility strings from Open collective logo images. 