### PR TITLE
OAuth: add a minimal delay while redirecting

### DIFF
--- a/components/oauth/ApplicationApproveScreen.js
+++ b/components/oauth/ApplicationApproveScreen.js
@@ -83,14 +83,20 @@ export const ApplicationApproveScreen = ({ application, redirectUri, autoApprove
     const body = await response.json();
     if (response.ok) {
       setRedirecting(true);
-      return router.push(body['redirect_uri']);
+      if (autoApprove) {
+        setTimeout(() => {
+          return router.push(body['redirect_uri']);
+        }, 1000);
+      } else {
+        return router.push(body['redirect_uri']);
+      }
     } else {
       setRedirecting(false); // To show errors with autoApprove
       throw new Error(body['error_description'] || body['error']);
     }
   });
 
-  React.useState(() => {
+  React.useEffect(() => {
     if (autoApprove) {
       callAuthorize();
     }


### PR DESCRIPTION
<!-- If there's an issue associated with this pull request, add it here -->

Resolve [#5717](https://github.com/opencollective/opencollective/issues/5717).

# Description

Adds a small delay before redirecting from a succesful oauth authorization to prevent the screen flashing when the user is already authorized

# Screenshots

When approving access for the first time:
![redirect-delay-1](https://user-images.githubusercontent.com/5448927/178257908-805781c4-c68c-4704-84c5-d38a46995fec.gif)

When access is already approved:
![redirect-delay-2](https://user-images.githubusercontent.com/5448927/178257955-bc1d1e43-8a17-44cb-9fb2-25bb107e5e9e.gif)

