### PR TITLE
Hide 0 tip on Contribution Flow success page

### DIFF
--- a/components/contribution-flow/ContributorCardWithTier.js
+++ b/components/contribution-flow/ContributorCardWithTier.js
@@ -75,7 +75,7 @@ const ContributorCardWithTier = ({ contribution, ...props }) => {
                   frequency={contribution.frequency}
                 />
               </P>
-              {!isNil(contribution.platformTipAmount?.valueInCents) && (
+              {Boolean(contribution.platformTipAmount?.valueInCents) && (
                 <StyledTooltip
                   content={() => (
                     <FormattedMessage


### PR DESCRIPTION
Introduced in https://github.com/opencollective/opencollective-frontend/pull/6520/files#diff-443a6cb3352ad81d898f6c13514d8f27a1ee89affbf23a1240e72de08ef031dcR78, but it's unclear if were trying to fix something by doing that.

Previously:

![image](https://user-images.githubusercontent.com/1556356/178268747-549d5ac1-4fc9-4d7b-9954-be3090282da6.png)
