### PR TITLE
Fix `access` prop for DropZones

### DIFF
--- a/components/StyledDropzone.js
+++ b/components/StyledDropzone.js
@@ -17,6 +17,10 @@ import StyledSpinner from './StyledSpinner';
 import { P, Span } from './Text';
 import UploadedFilePreview from './UploadedFilePreview';
 
+export const DROPZONE_ACCEPT_IMAGES = { 'image/*': ['.jpeg', '.png'] };
+export const DROPZONE_ACCEPT_PDF = { 'application/pdf': ['.pdf'] };
+export const DROPZONE_ACCEPT_ALL = { ...DROPZONE_ACCEPT_IMAGES, ...DROPZONE_ACCEPT_PDF };
+
 const Dropzone = styled(Container)`
   border: 1px dashed #c4c7cc;
   border-radius: 10px;

--- a/components/collective-page/hero/HeroAvatar.js
+++ b/components/collective-page/hero/HeroAvatar.js
@@ -19,6 +19,7 @@ import Container from '../../Container';
 import { Box } from '../../Grid';
 import LoadingPlaceholder from '../../LoadingPlaceholder';
 import StyledButton from '../../StyledButton';
+import { DROPZONE_ACCEPT_IMAGES } from '../../StyledDropzone';
 import { P, Span } from '../../Text';
 import { TOAST_TYPE, useToasts } from '../../ToastProvider';
 import { editCollectiveAvatarMutation } from '../graphql/mutations';
@@ -146,7 +147,7 @@ const HeroAvatar = ({ collective, isAdmin, intl }) => {
         <Dropzone
           style={{}}
           multiple={false}
-          accept="image/jpeg, image/png"
+          accept={DROPZONE_ACCEPT_IMAGES}
           disabled={submitting}
           inputProps={{ style: { width: 1 } }}
           onDrop={onDropImage}

--- a/components/collective-page/hero/HeroBackgroundCropperModal.js
+++ b/components/collective-page/hero/HeroBackgroundCropperModal.js
@@ -18,6 +18,7 @@ import Container from '../../Container';
 import ContainerOverlay from '../../ContainerOverlay';
 import { Box, Flex } from '../../Grid';
 import StyledButton from '../../StyledButton';
+import { DROPZONE_ACCEPT_IMAGES } from '../../StyledDropzone';
 import StyledInputSlider from '../../StyledInputSlider';
 import StyledModal, { ModalBody, ModalFooter, ModalHeader } from '../../StyledModal';
 import { Span } from '../../Text';
@@ -92,7 +93,7 @@ const HeroBackgroundCropperModal = ({ onClose, collective }) => {
         </Span>
       </ModalHeader>
 
-      <Dropzone onDrop={onDrop} multiple={false} accept="image/jpeg, image/png">
+      <Dropzone onDrop={onDrop} multiple={false} accept={DROPZONE_ACCEPT_IMAGES}>
         {({ isDragActive, isDragAccept, getRootProps, getInputProps, open }) => {
           const rootProps = getRootProps();
           return (

--- a/components/expenses/lib/attachments.js
+++ b/components/expenses/lib/attachments.js
@@ -1,7 +1,9 @@
 import expenseTypes from '../../../lib/constants/expenseTypes';
 
+import { DROPZONE_ACCEPT_ALL } from '../../StyledDropzone';
+
 export const attachmentDropzoneParams = {
-  accept: { 'image/jpeg': [], 'image/png': [], 'application/pdf': [] },
+  accept: DROPZONE_ACCEPT_ALL,
   minSize: 1024, // in bytes, =1ko
   maxSize: 10000 * 1024, // in bytes, =10mo
 };


### PR DESCRIPTION
Followup on https://github.com/opencollective/opencollective-frontend/pull/7844

We missed the update in 2 components, which triggered a proptype warning and filetypes not being enforced in the frontend (but we have an API check for that as well).