### PR TITLE
Move invoices and receipts section to `admin-panel/sections`

### DIFF
--- a/components/admin-panel/AdminPanelSection.js
+++ b/components/admin-panel/AdminPanelSection.js
@@ -16,7 +16,13 @@ import NotFound from '../NotFound';
 import AccountSettings from './sections/AccountSettings';
 import FinancialContributions from './sections/FinancialContributions';
 import HostVirtualCards from './sections/HostVirtualCards';
-import { HOST_DASHBOARD_SECTIONS, LEGACY_COLLECTIVE_SETTINGS_SECTIONS, SECTION_LABELS } from './constants';
+import InvoicesReceipts from './sections/InvoicesReceipts';
+import {
+  FISCAL_HOST_SECTIONS,
+  HOST_DASHBOARD_SECTIONS,
+  LEGACY_COLLECTIVE_SETTINGS_SECTIONS,
+  SECTION_LABELS,
+} from './constants';
 
 const HOST_ADMIN_SECTIONS = {
   [HOST_DASHBOARD_SECTIONS.HOSTED_COLLECTIVES]: HostDashboardHostedCollectives,
@@ -25,6 +31,10 @@ const HOST_ADMIN_SECTIONS = {
   [HOST_DASHBOARD_SECTIONS.PENDING_APPLICATIONS]: PendingApplications,
   [HOST_DASHBOARD_SECTIONS.REPORTS]: HostDashboardReports,
   [HOST_DASHBOARD_SECTIONS.HOST_VIRTUAL_CARDS]: HostVirtualCards,
+};
+
+const FISCAL_HOST_SETTINGS_SECTIONS = {
+  [FISCAL_HOST_SECTIONS.INVOICES_RECEIPTS]: InvoicesReceipts,
 };
 
 const Title = styled(Box)`
@@ -51,6 +61,16 @@ const AdminPanelSection = ({ collective, isLoading, section }) => {
     return (
       <Container width="100%">
         <AdminSectionComponent hostSlug={collective.slug} isNewAdmin />
+      </Container>
+    );
+  }
+
+  // Fiscal Host Settings
+  const FiscalHostSettingsComponent = FISCAL_HOST_SETTINGS_SECTIONS[section];
+  if (FiscalHostSettingsComponent) {
+    return (
+      <Container width="100%">
+        <FiscalHostSettingsComponent collective={collective} />
       </Container>
     );
   }

--- a/components/admin-panel/sections/InvoicesReceipts.js
+++ b/components/admin-panel/sections/InvoicesReceipts.js
@@ -251,7 +251,7 @@ const InvoicesReceipts = ({ collective }) => {
           onClick={() => {
             setSettings({
               variables: {
-                id: collective.id,
+                id: collective.legacyId,
                 settings: {
                   ...collective.settings,
                   invoice: getInvoiceTemplatesObj(),
@@ -283,7 +283,7 @@ const InvoicesReceipts = ({ collective }) => {
 
 InvoicesReceipts.propTypes = {
   collective: PropTypes.shape({
-    id: PropTypes.number.isRequired,
+    legacyId: PropTypes.number.isRequired,
     settings: PropTypes.object,
   }).isRequired,
 };

--- a/components/admin-panel/sections/InvoicesReceipts.js
+++ b/components/admin-panel/sections/InvoicesReceipts.js
@@ -18,6 +18,7 @@ import StyledHr from '../../StyledHr';
 import StyledInput from '../../StyledInput';
 import StyledTextarea from '../../StyledTextarea';
 import { P, Span } from '../../Text';
+import { TOAST_TYPE, useToasts } from '../../ToastProvider';
 
 const messages = defineMessages({
   extraInfoPlaceholder: {
@@ -29,6 +30,7 @@ const messages = defineMessages({
 
 const InvoicesReceipts = ({ collective }) => {
   const intl = useIntl();
+  const { addToast } = useToasts();
 
   // For invoice Title
   const defaultReceiptTitlePlaceholder = 'Payment Receipt';
@@ -44,7 +46,7 @@ const InvoicesReceipts = ({ collective }) => {
   const [isFieldChanged, setIsFieldChanged] = React.useState(false);
   const isSaved =
     get(data, 'editCollective.settings.invoice.templates.default.title') === receiptTitle &&
-    get(data, 'editCollective.settings.invoice.templates.alternative.title') === alternativeReceiptTitle;
+    get(data, 'editCollective.settings.invoice.templates.alternative.title', null) === alternativeReceiptTitle;
 
   // For invoice extra info
   const defaultInfo = get(collective.settings, 'invoice.templates.default.info');
@@ -259,6 +261,10 @@ const InvoicesReceipts = ({ collective }) => {
               },
             });
             setIsFieldChanged(false);
+            addToast({
+              type: TOAST_TYPE.SUCCESS,
+              message: <FormattedMessage defaultMessage="Invoices updated successfully" />,
+            });
           }}
         >
           {isSaved && infoIsSaved ? (

--- a/components/admin-panel/sections/InvoicesReceipts.js
+++ b/components/admin-panel/sections/InvoicesReceipts.js
@@ -7,7 +7,9 @@ import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
 import { i18nGraphqlException } from '../../../lib/errors';
 
+import { editCollectiveSettingsMutation } from '../../collective-page/graphql/mutations';
 import Container from '../../Container';
+import SettingsSectionTitle from '../../edit-collective/sections/SettingsSectionTitle';
 import { Box, Flex } from '../../Grid';
 import MessageBox from '../../MessageBox';
 import PreviewModal from '../../PreviewModal';
@@ -16,9 +18,6 @@ import StyledHr from '../../StyledHr';
 import StyledInput from '../../StyledInput';
 import StyledTextarea from '../../StyledTextarea';
 import { P, Span } from '../../Text';
-import { editCollectiveSettingsMutation } from '../mutations';
-
-import SettingsSectionTitle from './SettingsSectionTitle';
 
 const messages = defineMessages({
   extraInfoPlaceholder: {

--- a/components/edit-collective/Form.js
+++ b/components/edit-collective/Form.js
@@ -17,7 +17,6 @@ import { convertDateFromApiUtc, convertDateToApiUtc } from '../../lib/date-utils
 
 import AuthorizedApps from '../admin-panel/sections/AuthorizedApps';
 import ForDevelopers from '../admin-panel/sections/ForDevelopers';
-import InvoicesReceipts from '../admin-panel/sections/InvoicesReceipts';
 import CodeRepositoryIcon from '../CodeRepositoryIcon';
 import Container from '../Container';
 import CreateGiftCardsForm from '../CreateGiftCardsForm';
@@ -515,9 +514,6 @@ class EditCollectiveForm extends React.Component {
 
       case EDIT_COLLECTIVE_SECTIONS.FISCAL_HOSTING:
         return <FiscalHosting collective={collective} LoggedInUser={LoggedInUser} />;
-
-      case EDIT_COLLECTIVE_SECTIONS.INVOICES_RECEIPTS:
-        return <InvoicesReceipts collective={collective} />;
 
       case EDIT_COLLECTIVE_SECTIONS.RECEIVING_MONEY:
         return <ReceivingMoney collective={collective} />;

--- a/components/edit-collective/Form.js
+++ b/components/edit-collective/Form.js
@@ -17,6 +17,7 @@ import { convertDateFromApiUtc, convertDateToApiUtc } from '../../lib/date-utils
 
 import AuthorizedApps from '../admin-panel/sections/AuthorizedApps';
 import ForDevelopers from '../admin-panel/sections/ForDevelopers';
+import InvoicesReceipts from '../admin-panel/sections/InvoicesReceipts';
 import CodeRepositoryIcon from '../CodeRepositoryIcon';
 import Container from '../Container';
 import CreateGiftCardsForm from '../CreateGiftCardsForm';
@@ -43,7 +44,6 @@ import GiftCards from './sections/GiftCards';
 import Host from './sections/Host';
 import HostTwoFactorAuth from './sections/HostTwoFactorAuth';
 import HostVirtualCardsSettings from './sections/HostVirtualCardsSettings';
-import InvoicesReceipts from './sections/InvoicesReceipts';
 import Members from './sections/Members';
 import PaymentMethods from './sections/PaymentMethods';
 import PaymentReceipts from './sections/PaymentReceipts';

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -58,6 +58,7 @@
   "5xcFnU": "Comptabilitzat com",
   "692Mpo": "Join us as we transition from a privately owned company to a structure that allows us to share power and revenue with you.",
   "6DCLcI": "Si us plau, introdueix una data vàlida",
+  "6P4LG/": "Invoices updated successfully",
   "6zdt+y": "Continue with your email",
   "6ZJG0I": "Quantitat neta per a {collectiveName}: {netExpenseAmount}",
   "70Nuf5": "Pricing and Business Model",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -58,6 +58,7 @@
   "5xcFnU": "Zúčtováno jako",
   "692Mpo": "Join us as we transition from a privately owned company to a structure that allows us to share power and revenue with you.",
   "6DCLcI": "Zadejte platné datum",
+  "6P4LG/": "Invoices updated successfully",
   "6zdt+y": "Pokračovat pomocí e-mailu",
   "6ZJG0I": "Čistá částka pro {collectiveName}: {netExpenseAmount}",
   "70Nuf5": "Cenový a obchodní model",

--- a/lang/de.json
+++ b/lang/de.json
@@ -58,6 +58,7 @@
   "5xcFnU": "Abgerechnet als",
   "692Mpo": "Join us as we transition from a privately owned company to a structure that allows us to share power and revenue with you.",
   "6DCLcI": "Bitte geben Sie ein gültiges Datum ein",
+  "6P4LG/": "Invoices updated successfully",
   "6zdt+y": "Mit E-Mail fortfahren",
   "6ZJG0I": "Nettobetrag für {collectiveName}: {netExpenseAmount}",
   "70Nuf5": "Pricing and Business Model",

--- a/lang/en.json
+++ b/lang/en.json
@@ -58,6 +58,7 @@
   "5xcFnU": "Accounted as",
   "692Mpo": "Join us as we transition from a privately owned company to a structure that allows us to share power and revenue with you.",
   "6DCLcI": "Please enter a valid date",
+  "6P4LG/": "Invoices updated successfully",
   "6zdt+y": "Continue with your email",
   "6ZJG0I": "Net Amount for {collectiveName}: {netExpenseAmount}",
   "70Nuf5": "Pricing and Business Model",

--- a/lang/es.json
+++ b/lang/es.json
@@ -58,6 +58,7 @@
   "5xcFnU": "Contabilizado como",
   "692Mpo": "Join us as we transition from a privately owned company to a structure that allows us to share power and revenue with you.",
   "6DCLcI": "Por favor, introduce una fecha válida",
+  "6P4LG/": "Invoices updated successfully",
   "6zdt+y": "Continue with your email",
   "6ZJG0I": "Cantidad neta para {collectiveName}: {netExpenseAmount}",
   "70Nuf5": "Pricing and Business Model",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -58,6 +58,7 @@
   "5xcFnU": "Enregistré comme",
   "692Mpo": "Join us as we transition from a privately owned company to a structure that allows us to share power and revenue with you.",
   "6DCLcI": "Veuillez entrer une date valide",
+  "6P4LG/": "Invoices updated successfully",
   "6zdt+y": "Continue with your email",
   "6ZJG0I": "Montant net pour {collectiveName} : {netExpenseAmount}",
   "70Nuf5": "Pricing and Business Model",

--- a/lang/it.json
+++ b/lang/it.json
@@ -58,6 +58,7 @@
   "5xcFnU": "Contabilizzato come",
   "692Mpo": "Join us as we transition from a privately owned company to a structure that allows us to share power and revenue with you.",
   "6DCLcI": "Per favore inserisci una data valida",
+  "6P4LG/": "Invoices updated successfully",
   "6zdt+y": "Continue with your email",
   "6ZJG0I": "Importo Netto per {collectiveName}: {netExpenseAmount}",
   "70Nuf5": "Pricing and Business Model",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -58,6 +58,7 @@
   "5xcFnU": "Accounted as",
   "692Mpo": "Join us as we transition from a privately owned company to a structure that allows us to share power and revenue with you.",
   "6DCLcI": "有効な日付を入力してください。",
+  "6P4LG/": "Invoices updated successfully",
   "6zdt+y": "Continue with your email",
   "6ZJG0I": "Net Amount for {collectiveName}: {netExpenseAmount}",
   "70Nuf5": "Pricing and Business Model",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -58,6 +58,7 @@
   "5xcFnU": "Accounted as",
   "692Mpo": "Join us as we transition from a privately owned company to a structure that allows us to share power and revenue with you.",
   "6DCLcI": "유효한 날짜를 입력하십시오",
+  "6P4LG/": "Invoices updated successfully",
   "6zdt+y": "Continue with your email",
   "6ZJG0I": "Net Amount for {collectiveName}: {netExpenseAmount}",
   "70Nuf5": "Pricing and Business Model",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -58,6 +58,7 @@
   "5xcFnU": "Accounted as",
   "692Mpo": "Join us as we transition from a privately owned company to a structure that allows us to share power and revenue with you.",
   "6DCLcI": "Voer een geldige datum in",
+  "6P4LG/": "Invoices updated successfully",
   "6zdt+y": "Continue with your email",
   "6ZJG0I": "Net Amount for {collectiveName}: {netExpenseAmount}",
   "70Nuf5": "Pricing and Business Model",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -58,6 +58,7 @@
   "5xcFnU": "Accounted as",
   "692Mpo": "Join us as we transition from a privately owned company to a structure that allows us to share power and revenue with you.",
   "6DCLcI": "Proszę wpisać poprawną datę",
+  "6P4LG/": "Invoices updated successfully",
   "6zdt+y": "Continue with your email",
   "6ZJG0I": "Net Amount for {collectiveName}: {netExpenseAmount}",
   "70Nuf5": "Pricing and Business Model",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -58,6 +58,7 @@
   "5xcFnU": "Contabilizado como",
   "692Mpo": "Join us as we transition from a privately owned company to a structure that allows us to share power and revenue with you.",
   "6DCLcI": "Por favor, insira uma data válida",
+  "6P4LG/": "Invoices updated successfully",
   "6zdt+y": "Continuar com seu e-mail",
   "6ZJG0I": "Valor líquido para {collectiveName}: {netExpenseAmount}",
   "70Nuf5": "Pricing and Business Model",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -58,6 +58,7 @@
   "5xcFnU": "Contado como",
   "692Mpo": "Join us as we transition from a privately owned company to a structure that allows us to share power and revenue with you.",
   "6DCLcI": "Por favor, insira uma data válida",
+  "6P4LG/": "Invoices updated successfully",
   "6zdt+y": "Continue with your email",
   "6ZJG0I": "Valor líquido para {collectiveName}: {netExpenseAmount}",
   "70Nuf5": "Pricing and Business Model",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -58,6 +58,7 @@
   "5xcFnU": "Accounted as",
   "692Mpo": "Join us as we transition from a privately owned company to a structure that allows us to share power and revenue with you.",
   "6DCLcI": "Пожалуйста, введите правильную дату",
+  "6P4LG/": "Invoices updated successfully",
   "6zdt+y": "Continue with your email",
   "6ZJG0I": "Net Amount for {collectiveName}: {netExpenseAmount}",
   "70Nuf5": "Pricing and Business Model",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -58,6 +58,7 @@
   "5xcFnU": "Accounted as",
   "692Mpo": "Join us as we transition from a privately owned company to a structure that allows us to share power and revenue with you.",
   "6DCLcI": "Будь ласка, введіть правильну дату",
+  "6P4LG/": "Invoices updated successfully",
   "6zdt+y": "Продовжити за допомогою електронної пошти",
   "6ZJG0I": "Net Amount for {collectiveName}: {netExpenseAmount}",
   "70Nuf5": "Pricing and Business Model",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -58,6 +58,7 @@
   "5xcFnU": "记账为",
   "692Mpo": "Join us as we transition from a privately owned company to a structure that allows us to share power and revenue with you.",
   "6DCLcI": "请输入有效日期",
+  "6P4LG/": "Invoices updated successfully",
   "6zdt+y": "Continue with your email",
   "6ZJG0I": "{collectiveName} 的净金额: {netExpenseAmount}",
   "70Nuf5": "Pricing and Business Model",

--- a/lib/graphql/schema.graphql
+++ b/lib/graphql/schema.graphql
@@ -3499,16 +3499,6 @@ type InvoiceType {
   slug: String
 
   """
-  Title for the invoice. Depending on the type of legal entity, a host should issue an Invoice or a Receipt.
-  """
-  title: String @deprecated(reason: "Replaced by host.settings.invoice.templates.[templateName].title")
-
-  """
-  more info about the invoice, which is then printed on receipts that go to financial contributors.
-  """
-  extraInfo: String @deprecated(reason: "Replaced by host.settings.invoice.templates.[templateName].info")
-
-  """
   dateFrom and dateTo will be set for any invoice over a period of time. They will not be set for an invoice for a single transaction.
   """
   dateFrom: IsoDateString

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -279,6 +279,11 @@ interface Account {
     """
     orderByRoles: Boolean
   ): MemberOfCollection
+
+  """
+  Returns the emails of the account. Individuals only have one, but organizations can have multiple emails.
+  """
+  emails: [EmailAddress!]
   transactions(
     """
     The number of results to fetch (default 10, max 1000)
@@ -2182,18 +2187,18 @@ type ExpensePermissions {
   Whether the current user can unschedule this expense payment
   """
   canUnschedulePayment: Boolean!
-  edit: Permission
-  editTags: Permission
-  delete: Permission
-  seeInvoiceInfo: Permission
-  pay: Permission
-  approve: Permission
-  unapprove: Permission
-  reject: Permission
-  markAsSpam: Permission
-  markAsUnpaid: Permission
-  comment: Permission
-  unschedulePayment: Permission
+  edit: Permission!
+  editTags: Permission!
+  delete: Permission!
+  seeInvoiceInfo: Permission!
+  pay: Permission!
+  approve: Permission!
+  unapprove: Permission!
+  reject: Permission!
+  markAsSpam: Permission!
+  markAsUnpaid: Permission!
+  comment: Permission!
+  unschedulePayment: Permission!
 }
 
 type Permission {
@@ -2268,6 +2273,7 @@ enum ActivityType {
   COLLECTIVE_UNFROZEN
   COLLECTIVE_MEMBER_INVITED
   COLLECTIVE_MEMBER_CREATED
+  COLLECTIVE_MONTHLY_REPORT
   COLLECTIVE_CORE_MEMBER_ADDED
   COLLECTIVE_CORE_MEMBER_INVITED
   COLLECTIVE_CORE_MEMBER_INVITATION_DECLINED
@@ -2293,9 +2299,13 @@ enum ActivityType {
   WEBHOOK_STRIPE_RECEIVED
   WEBHOOK_PAYPAL_RECEIVED
   COLLECTIVE_MONTHLY
-  ORDERS_SUSPICIOUS
+  ORDER_CANCELED_ARCHIVED_COLLECTIVE
   ORDER_PROCESSING
   ORDER_PROCESSING_CRYPTO
+  ORDER_PENDING_CONTRIBUTION_NEW
+  ORDER_PENDING_CONTRIBUTION_REMINDER
+  ORDER_THANKYOU
+  ORDERS_SUSPICIOUS
   BACKYOURSTACK_DISPATCH_CONFIRMED
   ACTIVATED_COLLECTIVE_AS_HOST
   ACTIVATED_COLLECTIVE_AS_INDEPENDENT
@@ -2303,6 +2313,7 @@ enum ActivityType {
   VIRTUAL_CARD_REQUESTED
   VIRTUAL_CARD_CHARGE_DECLINED
   PAYMENT_FAILED
+  PAYMENT_CREDITCARD_CONFIRMATION
   PAYMENT_CREDITCARD_EXPIRING
   TAXFORM_REQUEST
   CONVERSATION_COMMENT_CREATED
@@ -2621,6 +2632,11 @@ type Host implements Account & AccountWithContributions {
     """
     orderByRoles: Boolean
   ): MemberOfCollection!
+
+  """
+  Returns the emails of the account. Individuals only have one, but organizations can have multiple emails.
+  """
+  emails: [EmailAddress!]
   transactions(
     """
     The number of results to fetch (default 10, max 1000)
@@ -2943,6 +2959,11 @@ type Host implements Account & AccountWithContributions {
     offset: Int! = 0
     account: AccountReferenceInput!
   ): WebhookCollection!
+
+  """
+  Logged-in user permissions on an account
+  """
+  permissions: AccountPermissions!
 
   """
   Number of unique financial contributors.
@@ -3882,6 +3903,18 @@ type Webhook {
 }
 
 """
+Fields for the user permissions on an account
+"""
+type AccountPermissions {
+  id: String!
+
+  """
+  Whether the current user can mark this order as expired
+  """
+  addFunds: Permission!
+}
+
+"""
 The name of the current plan and its characteristics.
 """
 type HostPlan {
@@ -4580,6 +4613,11 @@ type Bot implements Account {
     """
     orderByRoles: Boolean
   ): MemberOfCollection!
+
+  """
+  Returns the emails of the account. Individuals only have one, but organizations can have multiple emails.
+  """
+  emails: [EmailAddress!]
   transactions(
     """
     The number of results to fetch (default 10, max 1000)
@@ -4902,6 +4940,11 @@ type Bot implements Account {
     offset: Int! = 0
     account: AccountReferenceInput!
   ): WebhookCollection!
+
+  """
+  Logged-in user permissions on an account
+  """
+  permissions: AccountPermissions!
 }
 
 """
@@ -5061,6 +5104,11 @@ type Collective implements Account & AccountWithHost & AccountWithContributions 
     """
     orderByRoles: Boolean
   ): MemberOfCollection!
+
+  """
+  Returns the emails of the account. Individuals only have one, but organizations can have multiple emails.
+  """
+  emails: [EmailAddress!]
   transactions(
     """
     The number of results to fetch (default 10, max 1000)
@@ -5383,6 +5431,11 @@ type Collective implements Account & AccountWithHost & AccountWithContributions 
     offset: Int! = 0
     account: AccountReferenceInput!
   ): WebhookCollection!
+
+  """
+  Logged-in user permissions on an account
+  """
+  permissions: AccountPermissions!
 
   """
   Returns the Fiscal Host
@@ -5870,6 +5923,11 @@ type Event implements Account & AccountWithHost & AccountWithContributions & Acc
     """
     orderByRoles: Boolean
   ): MemberOfCollection!
+
+  """
+  Returns the emails of the account. Individuals only have one, but organizations can have multiple emails.
+  """
+  emails: [EmailAddress!]
   transactions(
     """
     The number of results to fetch (default 10, max 1000)
@@ -6194,6 +6252,11 @@ type Event implements Account & AccountWithHost & AccountWithContributions & Acc
   ): WebhookCollection!
 
   """
+  Logged-in user permissions on an account
+  """
+  permissions: AccountPermissions!
+
+  """
   Returns the Fiscal Host
   """
   host: Host
@@ -6464,6 +6527,11 @@ type Individual implements Account {
     """
     orderByRoles: Boolean
   ): MemberOfCollection!
+
+  """
+  Returns the emails of the account. Individuals only have one, but organizations can have multiple emails.
+  """
+  emails: [EmailAddress!]
   transactions(
     """
     The number of results to fetch (default 10, max 1000)
@@ -6786,6 +6854,11 @@ type Individual implements Account {
   ): WebhookCollection!
 
   """
+  Logged-in user permissions on an account
+  """
+  permissions: AccountPermissions!
+
+  """
   Email for the account. For authenticated user: scope: "email".
   """
   email: String
@@ -7034,6 +7107,11 @@ type Organization implements Account & AccountWithContributions {
     """
     orderByRoles: Boolean
   ): MemberOfCollection!
+
+  """
+  Returns the emails of the account. Individuals only have one, but organizations can have multiple emails.
+  """
+  emails: [EmailAddress!]
   transactions(
     """
     The number of results to fetch (default 10, max 1000)
@@ -7356,6 +7434,11 @@ type Organization implements Account & AccountWithContributions {
   ): WebhookCollection!
 
   """
+  Logged-in user permissions on an account
+  """
+  permissions: AccountPermissions!
+
+  """
   Number of unique financial contributors.
   """
   totalFinancialContributors(
@@ -7635,6 +7718,11 @@ type Vendor implements Account & AccountWithHost & AccountWithContributions {
     """
     orderByRoles: Boolean
   ): MemberOfCollection!
+
+  """
+  Returns the emails of the account. Individuals only have one, but organizations can have multiple emails.
+  """
+  emails: [EmailAddress!]
   transactions(
     """
     The number of results to fetch (default 10, max 1000)
@@ -7957,6 +8045,11 @@ type Vendor implements Account & AccountWithHost & AccountWithContributions {
     offset: Int! = 0
     account: AccountReferenceInput!
   ): WebhookCollection!
+
+  """
+  Logged-in user permissions on an account
+  """
+  permissions: AccountPermissions!
 
   """
   Returns the Fiscal Host
@@ -10150,6 +10243,11 @@ type Fund implements Account & AccountWithHost & AccountWithContributions {
     """
     orderByRoles: Boolean
   ): MemberOfCollection!
+
+  """
+  Returns the emails of the account. Individuals only have one, but organizations can have multiple emails.
+  """
+  emails: [EmailAddress!]
   transactions(
     """
     The number of results to fetch (default 10, max 1000)
@@ -10472,6 +10570,11 @@ type Fund implements Account & AccountWithHost & AccountWithContributions {
     offset: Int! = 0
     account: AccountReferenceInput!
   ): WebhookCollection!
+
+  """
+  Logged-in user permissions on an account
+  """
+  permissions: AccountPermissions!
 
   """
   Returns the Fiscal Host
@@ -10731,6 +10834,11 @@ type Project implements Account & AccountWithHost & AccountWithContributions & A
     """
     orderByRoles: Boolean
   ): MemberOfCollection!
+
+  """
+  Returns the emails of the account. Individuals only have one, but organizations can have multiple emails.
+  """
+  emails: [EmailAddress!]
   transactions(
     """
     The number of results to fetch (default 10, max 1000)
@@ -11053,6 +11161,11 @@ type Project implements Account & AccountWithHost & AccountWithContributions & A
     offset: Int! = 0
     account: AccountReferenceInput!
   ): WebhookCollection!
+
+  """
+  Logged-in user permissions on an account
+  """
+  permissions: AccountPermissions!
 
   """
   Returns the Fiscal Host

--- a/pages/admin-panel.js
+++ b/pages/admin-panel.js
@@ -24,6 +24,7 @@ export const adminPanelQuery = gqlV2/* GraphQL */ `
   query AdminPanel($slug: String!) {
     account(slug: $slug) {
       id
+      legacyId
       slug
       name
       isHost


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/5368

Quote from @kewitz in original issue above; 

> Tech-debt: delete and recreate this page in the new admin-panel/sections folder following the new standards (useMutation hook + light arrow function component)

I've moved this to the `admin-panel/sections`. We already use the `useMutation` within this component or is there anything more to be done? 🤔 