### PR TITLE
Remove `menuItem` props and rename `menuItemV2` to `menuItem`

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -32,7 +32,6 @@ class Header extends React.Component {
     showProfileAndChangelogMenu: PropTypes.bool,
     withTopBar: PropTypes.bool,
     menuItems: PropTypes.object,
-    menuItemsV2: PropTypes.object,
     /** If true, a no-robots meta will be added to the page */
     noRobots: PropTypes.bool,
     /** @ignore from injectIntl */
@@ -122,7 +121,7 @@ class Header extends React.Component {
         {withTopBar && (
           <TopBar
             showSearch={this.props.showSearch}
-            menuItems={this.props.menuItemsV2}
+            menuItems={this.props.menuItems}
             showProfileAndChangelogMenu={this.props.showProfileAndChangelogMenu}
           />
         )}

--- a/components/Page.js
+++ b/components/Page.js
@@ -20,10 +20,9 @@ const Page = ({
   noRobots,
   twitterHandle,
   showSearch,
-  menuItems,
   canonicalURL,
   collective,
-  menuItemsV2,
+  menuItems,
   showFooter = true,
   showProfileAndChangelogMenu = true,
 }) => {
@@ -46,7 +45,6 @@ const Page = ({
         canonicalURL={canonicalURL}
         collective={collective}
         menuItems={menuItems}
-        menuItemsV2={menuItemsV2}
         LoggedInUser={LoggedInUser}
         showProfileAndChangelogMenu={showProfileAndChangelogMenu}
       />
@@ -75,7 +73,6 @@ Page.propTypes = {
   twitterHandle: PropTypes.string,
   collective: PropTypes.object,
   menuItems: PropTypes.object,
-  menuItemsV2: PropTypes.object,
   showFooter: PropTypes.bool,
   showProfileAndChangelogMenu: PropTypes.bool,
 };

--- a/pages/become-a-host.js
+++ b/pages/become-a-host.js
@@ -8,8 +8,6 @@ import WhoAreFiscalHosts from '../components/become-a-host/WhoAreFiscalHostsSect
 import JoinUs from '../components/collectives/sections/JoinUs';
 import Page from '../components/Page';
 
-const menuItems = { pricing: true, howItWorks: true };
-
 const messages = defineMessages({
   defaultTitle: {
     id: 'OC.tagline',
@@ -20,7 +18,7 @@ const messages = defineMessages({
 const BecomeAHost = () => {
   const { formatMessage } = useIntl();
   return (
-    <Page menuItems={menuItems} description={formatMessage(messages.defaultTitle)}>
+    <Page description={formatMessage(messages.defaultTitle)}>
       <FiscalSponsorship />
       <WhoAreFiscalHosts />
       <WhatAreTheBenefits />

--- a/pages/become-a-sponsor.js
+++ b/pages/become-a-sponsor.js
@@ -8,8 +8,6 @@ import SupportProjectsSection from '../components/become-a-sponsor/SupportProjec
 import TransparencySection from '../components/become-a-sponsor/TransparencySection';
 import Page from '../components/Page';
 
-const menuItems = { pricing: true, howItWorks: true };
-
 const messages = defineMessages({
   defaultTitle: {
     id: 'OC.tagline',
@@ -20,7 +18,7 @@ const messages = defineMessages({
 const BecomeASponsor = () => {
   const { formatMessage } = useIntl();
   return (
-    <Page menuItems={menuItems} description={formatMessage(messages.defaultTitle)}>
+    <Page description={formatMessage(messages.defaultTitle)}>
       <SupportProjectsSection />
       <SupportCommunitiesSection />
       <TransparencySection />

--- a/pages/collectives.js
+++ b/pages/collectives.js
@@ -12,8 +12,6 @@ import WeAreOpenSection from '../components/collectives/sections/WeAreOpen';
 import WhatCanYouDoSection from '../components/collectives/sections/WhatCanYouDo';
 import Page from '../components/Page';
 
-const menuItems = { pricing: true, howItWorks: true };
-
 const messages = defineMessages({
   defaultTitle: {
     id: 'OC.tagline',
@@ -24,7 +22,7 @@ const messages = defineMessages({
 const CollectivesPage = () => {
   const { formatMessage } = useIntl();
   return (
-    <Page menuItems={menuItems} description={formatMessage(messages.defaultTitle)}>
+    <Page description={formatMessage(messages.defaultTitle)}>
       <MakeCommunitySection />
       <WhatCanYouDoSection />
       <FeaturesSection />

--- a/pages/e2c.js
+++ b/pages/e2c.js
@@ -11,8 +11,6 @@ import ResourcesSection from '../components/e2c/ResourcesSection';
 import WhatDoesE2CMean from '../components/e2c/WhatDoesE2CMeanSection';
 import Page from '../components/Page';
 
-const menuItems = { pricing: true };
-
 const messages = defineMessages({
   defaultTitle: {
     id: 'OC.e2c',
@@ -23,7 +21,7 @@ const messages = defineMessages({
 const E2C = () => {
   const { formatMessage } = useIntl();
   return (
-    <Page menuItems={menuItems} description={formatMessage(messages.defaultTitle)}>
+    <Page description={formatMessage(messages.defaultTitle)}>
       <ExitToCommunity />
       <WhatDoesE2CMean />
       <InvestingInTheCommons />

--- a/pages/fiscal-hosting.js
+++ b/pages/fiscal-hosting.js
@@ -11,8 +11,6 @@ import WhatIsFiscalHost from '../components/fiscal-hosting/WhatIsFiscalHostSecti
 import WhoIsFiscalHosting from '../components/fiscal-hosting/WhoIsFiscalHostingForSection';
 import Page from '../components/Page';
 
-const menuItems = { pricing: true, howItWorks: true };
-
 const messages = defineMessages({
   defaultTitle: {
     id: 'OC.tagline',
@@ -23,7 +21,7 @@ const messages = defineMessages({
 const FiscalHosting = () => {
   const { formatMessage } = useIntl();
   return (
-    <Page menuItems={menuItems} description={formatMessage(messages.defaultTitle)}>
+    <Page description={formatMessage(messages.defaultTitle)}>
       <APlaceToGrowAndThrive />
       <WhatIsFiscalHost />
       <WhatAreTheBenefits />

--- a/pages/help-and-support.js
+++ b/pages/help-and-support.js
@@ -16,8 +16,6 @@ import Page from '../components/Page';
 import StyledButton from '../components/StyledButton';
 import StyledLink from '../components/StyledLink';
 
-const menuItems = { pricing: true };
-
 const messages = defineMessages({
   defaultTitle: {
     id: 'OC.helpAndSupport',
@@ -74,7 +72,7 @@ const HelpAndSupport = ({ action, formConfirmation }) => {
   const { formatMessage } = useIntl();
 
   return (
-    <Page menuItems={menuItems} description={formatMessage(messages.defaultTitle)}>
+    <Page description={formatMessage(messages.defaultTitle)}>
       {action === 'contact' ? (
         renderFormContent(formConfirmation)
       ) : (

--- a/pages/home.js
+++ b/pages/home.js
@@ -11,8 +11,6 @@ import RaiseMoney from '../components/home/RaiseMoneySection';
 import TheFutureIsCollective from '../components/home/TheFutureIsCollectiveSection';
 import Page from '../components/Page';
 
-const menuItems = { pricing: true, howItWorks: true };
-
 const messages = defineMessages({
   defaultTitle: {
     defaultMessage: 'Raise and spend money with full transparency.',
@@ -27,7 +25,6 @@ const HomePage = () => {
   const { formatMessage } = useIntl();
   return (
     <Page
-      menuItems={menuItems}
       metaTitle={formatMessage(messages.defaultTitle)}
       title={formatMessage(messages.defaultTitle)}
       description={formatMessage(messages.defaultDescription)}

--- a/pages/how-it-works.js
+++ b/pages/how-it-works.js
@@ -9,8 +9,6 @@ import HowOCWorks from '../components/how-it-works/HowOCWorksSection';
 import MoreAboutFiscalHosting from '../components/how-it-works/MoreAboutFHSection';
 import Page from '../components/Page';
 
-const menuItems = { pricing: true };
-
 const messages = defineMessages({
   defaultTitle: {
     id: 'OC.howItWorks',
@@ -29,7 +27,7 @@ const messages = defineMessages({
 const HowItWorks = () => {
   const { formatMessage } = useIntl();
   return (
-    <Page menuItems={menuItems} description={formatMessage(messages.defaultTitle)}>
+    <Page description={formatMessage(messages.defaultTitle)}>
       <HowOCWorks />
       <HowOCIsDifferent />
       <MoreAboutFiscalHosting />

--- a/pages/marketingPage.js
+++ b/pages/marketingPage.js
@@ -33,10 +33,6 @@ function importAll(r) {
   return map;
 }
 
-function getmenuItem() {
-  return { pricing: false, howItWorks: false };
-}
-
 class MarketingPage extends React.Component {
   static getInitialProps({ query: { pageSlug } }) {
     return { pageSlug };
@@ -85,7 +81,7 @@ class MarketingPage extends React.Component {
     return (
       <Fragment>
         <div>
-          <Header LoggedInUser={LoggedInUser} menuItems={getmenuItem()} />
+          <Header LoggedInUser={LoggedInUser} />
           <Body>
             <style type="text/css" dangerouslySetInnerHTML={{ __html: style }} />
             <div className={className} dangerouslySetInnerHTML={{ __html: html }} />

--- a/pages/signin.js
+++ b/pages/signin.js
@@ -220,8 +220,7 @@ class SigninV2Page extends React.Component {
         <Header
           title={this.props.form === 'signin' ? 'Sign In' : 'Create Account'}
           description="Create your profile on Open Collective and show the world the open collectives that you are contributing to."
-          menuItemsV2={{ solutions: false, product: false, company: false, docs: false }}
-          menuItems={{ discover: false, docs: false, howItWorks: false, pricing: false }}
+          menuItems={{ solutions: false, product: false, company: false, docs: false }}
           showSearch={false}
           showProfileAndChangelogMenu={false}
         />


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/5610

Some technical debt that I've missed during the migration to the new `TopBar.js` component. 🤯 