### PR TITLE
feat: redirect 'contact' to 'help' for opencollective (#5460)

### DIFF
--- a/components/ContactCollectiveBtn.js
+++ b/components/ContactCollectiveBtn.js
@@ -9,9 +9,17 @@ import StyledButton from './StyledButton';
 const ContactCollectiveBtn = ({ children, collective, LoggedInUser }) => {
   const [showModal, setShowModal] = React.useState(false);
   const router = useRouter();
+  const isOpenCollective = collective.slug === 'opencollective';
   return (
     <Fragment>
-      {children({ onClick: () => (LoggedInUser ? setShowModal(true) : router.push(`/${collective.slug}/contact`)) })}
+      {children({
+        onClick: () =>
+          isOpenCollective
+            ? router.push('/help')
+            : LoggedInUser
+            ? setShowModal(true)
+            : router.push(`/${collective.slug}/contact`),
+      })}
       {showModal && <ContactCollectiveModal collective={collective} onClose={() => setShowModal(null)} />}
     </Fragment>
   );


### PR DESCRIPTION
Resolve #5460
https://github.com/opencollective/opencollective/issues/5460

# Description

For OpenCollective, if a user clicks the 'contact' button they will be redirected to the '/help' page. For all other organizations, it will continue to open the contact form.

# Screenshots

![contact-opencollective](https://user-images.githubusercontent.com/107730483/179337266-3e32dd2d-d3e0-4448-b6d0-be58a664c4c6.png)
![contact-not-opencollective](https://user-images.githubusercontent.com/107730483/179337263-36cce854-0cab-469c-8c4b-7b07fc416c27.png)