### PR TITLE
test(e2e): use cypress command to get email from maildev until timeout

### DIFF
--- a/test/cypress/integration/22-collective.edit.test.js
+++ b/test/cypress/integration/22-collective.edit.test.js
@@ -59,12 +59,11 @@ describe('edit collective', () => {
     cy.getByDataCy('create-collective-mini-form').should('not.exist'); // Wait for form to be submitted
     cy.getByDataCy('confirmation-modal-continue').click();
     cy.get('[data-cy="member-1"] [data-cy="member-pending-tag"]').should('exist');
-    cy.getInbox().should('have.length', 2);
+    cy.getEmail(({ subject }) => subject.includes('Invitation to join CollectiveToEdit'));
 
     // Re-send the invitation email
+    cy.clearInbox();
     cy.getByDataCy('resend-invite-btn').should('exist').first().click({ force: true });
-    cy.wait(200); // Wait for email
-    cy.getInbox().should('have.length', 3);
 
     // Check invitation email
     cy.openEmail(({ subject }) => subject.includes('Invitation to join CollectiveToEdit'));


### PR DESCRIPTION
Resolves:
- [flaky test in e2e](https://github.com/opencollective/opencollective-api/runs/7388637102#step:31:204)
- [slack :thread:](https://opencollective.slack.com/archives/C0RMV6F8C/p1658232080404549)

# Description

The wait period is a bit flaky as the email might take longer to be delivered and available via maildev.
This change introduces a `getEmail` command to cypress to retry getting a maildev email until a configured timeout.

# Screenshots

N/A
