### PR TITLE
Fix pending host flag on create expense page

### DIFF
--- a/pages/create-expense.js
+++ b/pages/create-expense.js
@@ -498,6 +498,7 @@ const createExpensePageQuery = gqlV2/* GraphQL */ `
       twitterHandle
       currency
       isArchived
+      isActive
       expensePolicy
       features {
         id


### PR DESCRIPTION
Followup on https://github.com/opencollective/opencollective-frontend/pull/7881

In https://github.com/opencollective/opencollective-frontend/pull/7881 we resolved the issue of the `(pending)` flag mistakenly appearing next to the host's name, but forgot to fetch the field on the create-expense page which left it affected by this bug.