### PR TITLE
Expense Dashboard: Quick Mark as Incomplete

### DIFF
--- a/components/budget/ExpenseBudgetItem.js
+++ b/components/budget/ExpenseBudgetItem.js
@@ -103,6 +103,9 @@ const ExpenseBudgetItem = ({
   const pendingReceipt = isCharge && expense?.items?.every(i => i.url === null);
   const nbAttachedFiles = !isAdminView ? 0 : getNbAttachedFiles(expense);
   const isExpensePaidOrRejected = [expenseStatus.REJECTED, expenseStatus.PAID].includes(expense?.status);
+  const shouldDisplayStatusTagActions =
+    (isExpensePaidOrRejected || expense?.status === expenseStatus.APPROVED) &&
+    (hasProcessButtons(expense.permissions) || expense.permissions.canMarkAsIncomplete);
   const isMultiCurrency =
     expense?.amountInAccountCurrency && expense.amountInAccountCurrency?.currency !== expense.currency;
 
@@ -240,7 +243,7 @@ const ExpenseBudgetItem = ({
               {isAdminView && (
                 <ExpenseTypeTag type={expense.type} legacyId={expense.legacyId} mb={0} py={0} mr="2px" fontSize="9px" />
               )}
-              {isExpensePaidOrRejected && hasProcessButtons(expense.permissions) ? (
+              {shouldDisplayStatusTagActions ? (
                 <AdminExpenseStatusTag host={host} collective={expense.account} expense={expense} p="3px 8px" />
               ) : (
                 <ExpenseStatusTag

--- a/components/expenses/AdminExpenseStatusTag.js
+++ b/components/expenses/AdminExpenseStatusTag.js
@@ -139,6 +139,7 @@ const AdminExpenseStatusTag = ({ expense, host, collective, ...props }) => {
                         expense={expense}
                         permissions={expense.permissions}
                         onModalToggle={isOpen => setClosable(!isOpen)}
+                        onSuccess={() => setShowPopup(false)}
                       />
                     )}
                     {expense?.permissions?.canMarkAsIncomplete && (

--- a/components/expenses/AdminExpenseStatusTag.js
+++ b/components/expenses/AdminExpenseStatusTag.js
@@ -2,20 +2,23 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ChevronDown } from '@styled-icons/boxicons-regular/ChevronDown';
 import ReactDOM from 'react-dom';
-import { useIntl } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { Manager, Popper, Reference } from 'react-popper';
 import styled from 'styled-components';
 
+import expenseStatus from '../../lib/constants/expense-status';
 import useGlobalBlur from '../../lib/hooks/useGlobalBlur';
 import useKeyboardKey, { ESCAPE_KEY } from '../../lib/hooks/useKeyboardKey';
 import { i18nExpenseStatus } from '../../lib/i18n/expense';
 
 import { Box, Flex } from '../Grid';
+import StyledButton from '../StyledButton';
 import StyledSpinner from '../StyledSpinner';
 import StyledTag from '../StyledTag';
 
 import { getExpenseStatusMsgType } from './ExpenseStatusTag';
-import ProcessExpenseButtons from './ProcessExpenseButtons';
+import MarkExpenseAsIncompleteModal from './MarkExpenseAsIncompleteModal';
+import ProcessExpenseButtons, { ButtonLabel } from './ProcessExpenseButtons';
 
 const ExpenseStatusTag = styled(StyledTag)`
   cursor: pointer;
@@ -77,6 +80,9 @@ const AdminExpenseStatusTag = ({ expense, host, collective, ...props }) => {
   const wrapperRef = React.useRef();
   const [showPopup, setShowPopup] = React.useState(false);
   const [isClosable, setClosable] = React.useState(true);
+  const [showMarkAsIncompleteModal, setMarkAsIncompleteModal] = React.useState(false);
+  const hideProcessExpenseButtons = expense?.status === expenseStatus.APPROVED;
+  const buttonProps = { px: 2, py: 2, isBorderless: true, width: '100%', textAlign: 'left' };
 
   const onClick = () => {
     setShowPopup(true);
@@ -125,14 +131,28 @@ const AdminExpenseStatusTag = ({ expense, host, collective, ...props }) => {
               {({ ref, style, arrowProps }) => (
                 <PopupContainer ref={ref} style={style} onMouseEnter={onClick}>
                   <Flex alignItems="center" ref={wrapperRef} flexDirection="column" p={2}>
-                    <ProcessExpenseButtons
-                      host={host}
-                      buttonProps={{ px: 2, py: 2, isBorderless: true, width: '100%', textAlign: 'left' }}
-                      collective={collective}
-                      expense={expense}
-                      permissions={expense.permissions}
-                      onModalToggle={isOpen => setClosable(!isOpen)}
-                    />
+                    {!hideProcessExpenseButtons && (
+                      <ProcessExpenseButtons
+                        host={host}
+                        buttonProps={buttonProps}
+                        collective={collective}
+                        expense={expense}
+                        permissions={expense.permissions}
+                        onModalToggle={isOpen => setClosable(!isOpen)}
+                      />
+                    )}
+                    {expense?.permissions?.canMarkAsIncomplete && (
+                      <StyledButton
+                        {...buttonProps}
+                        onClick={() => {
+                          setMarkAsIncompleteModal(true);
+                        }}
+                      >
+                        <ButtonLabel>
+                          <FormattedMessage id="actions.markAsIncomplete" defaultMessage="Mark as Incomplete" />
+                        </ButtonLabel>
+                      </StyledButton>
+                    )}
                   </Flex>
                   <Arrow ref={arrowProps.ref} style={arrowProps.style} />
                 </PopupContainer>
@@ -141,6 +161,9 @@ const AdminExpenseStatusTag = ({ expense, host, collective, ...props }) => {
             document.body,
           )}
       </Manager>
+      {showMarkAsIncompleteModal && (
+        <MarkExpenseAsIncompleteModal expense={expense} onClose={() => setMarkAsIncompleteModal(false)} />
+      )}
     </React.Fragment>
   );
 };

--- a/components/expenses/MarkExpenseAsIncompleteModal.js
+++ b/components/expenses/MarkExpenseAsIncompleteModal.js
@@ -37,7 +37,7 @@ const MarkExpenseAsIncompleteModal = ({ expense, onClose }) => {
   const intl = useIntl();
   const [message, setMessage] = React.useState();
   const mutationOptions = { context: API_V2_CONTEXT };
-  const [processExpense] = useMutation(processExpenseMutation, mutationOptions);
+  const [processExpense, { loading }] = useMutation(processExpenseMutation, mutationOptions);
   const { addToast } = useToasts();
 
   const onConfirm = async () => {
@@ -83,7 +83,7 @@ const MarkExpenseAsIncompleteModal = ({ expense, onClose }) => {
       </ModalBody>
       <ModalFooter>
         <Flex gap="16px" justifyContent="flex-end">
-          <StyledButton buttonStyle="secondary" buttonSize="small" onClick={onConfirm}>
+          <StyledButton buttonStyle="secondary" buttonSize="small" onClick={onConfirm} minWidth={180} loading={loading}>
             <FormattedMessage defaultMessage="Confirm and mark as incomplete" />
           </StyledButton>
           <StyledButton buttonStyle="standard" buttonSize="small" onClick={onClose}>

--- a/components/expenses/ProcessExpenseButtons.js
+++ b/components/expenses/ProcessExpenseButtons.js
@@ -41,7 +41,7 @@ const processExpenseMutation = gqlV2/* GraphQL */ `
   ${expensePageExpenseFieldsFragment}
 `;
 
-const ButtonLabel = styled.span({ marginLeft: 6 });
+export const ButtonLabel = styled.span({ marginLeft: 6 });
 
 /**
  * A small helper to know if expense process buttons should be displayed

--- a/test/cypress/integration/29-host.dashboard.test.js
+++ b/test/cypress/integration/29-host.dashboard.test.js
@@ -67,7 +67,7 @@ describe('host dashboard', () => {
       // Defaults to pending, approve it
       cy.get('@currentExpense').find('[data-cy="expense-status-msg"]').contains('Pending');
       cy.get('@currentExpense').find('[data-cy="approve-button"]').click();
-      cy.get('@currentExpense').find('[data-cy="expense-status-msg"]').contains('Approved');
+      cy.get('@currentExpense').find('[data-cy="admin-expense-status-msg"]').contains('Approved');
 
       // Unapprove
       cy.get('@currentExpense').find('[data-cy="unapprove-button"]').click();
@@ -75,7 +75,7 @@ describe('host dashboard', () => {
 
       // Approve
       cy.get('@currentExpense').find('[data-cy="approve-button"]').click();
-      cy.get('@currentExpense').find('[data-cy="expense-status-msg"]').contains('Approved');
+      cy.get('@currentExpense').find('[data-cy="admin-expense-status-msg"]').contains('Approved');
 
       // Pay
       cy.get('@currentExpense').find('[data-cy="pay-button"]').click();
@@ -89,7 +89,7 @@ describe('host dashboard', () => {
       cy.getByDataCy('mark-as-unpaid-button').click();
       cy.getByDataCy('mark-expense-as-unpaid-modal').as('markAsUnpaidModal');
       cy.get('@markAsUnpaidModal').find('[data-cy="confirmation-modal-continue"]').click();
-      cy.get('@currentExpense').find('[data-cy="expense-status-msg"]').contains('Approved');
+      cy.get('@currentExpense').find('[data-cy="admin-expense-status-msg"]').contains('Approved');
 
       // Unapprove
       cy.get('@currentExpense').find('[data-cy="unapprove-button"]').click();


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/5713

This is a good quick solution, but to be honest I would like to see more consistency in the way we display "Mark as Incomplete".
The original idea of displaying this under the "More Actions" button is inconsistent since this is also a processExpense call.
We should make sure we have a solution for displaying multiple processExpense buttons without getting back to the Christmas tree issue.

https://user-images.githubusercontent.com/2119706/181341922-bad3d2f8-bbca-462a-b4df-36392b3fd83a.mov
