### PR TITLE
Enable guests for multiple root actions

### DIFF
--- a/components/root-actions/BanAccounts.js
+++ b/components/root-actions/BanAccounts.js
@@ -58,7 +58,9 @@ const BanAccount = () => {
   return (
     <div>
       <StyledInputField htmlFor="ban-accounts-picker" label="Account" flex="1 1">
-        {({ id }) => <CollectivePickerAsync inputId={id} onChange={setSelectedAccountsOptions} isMulti />}
+        {({ id }) => (
+          <CollectivePickerAsync inputId={id} onChange={setSelectedAccountsOptions} isMulti skipGuests={false} />
+        )}
       </StyledInputField>
 
       <Flex flexWrap="wrap" px={1} mt={2}>

--- a/components/root-actions/ClearCacheForAccountForm.js
+++ b/components/root-actions/ClearCacheForAccountForm.js
@@ -36,7 +36,9 @@ const ClearCacheForAccountForm = () => {
   return (
     <div>
       <StyledInputField htmlFor="clear-cache-account" label="Account" flex="1 1">
-        {({ id }) => <CollectivePickerAsync inputId={id} onChange={({ value }) => setAccount(value)} />}
+        {({ id }) => (
+          <CollectivePickerAsync inputId={id} onChange={({ value }) => setAccount(value)} skipGuests={false} />
+        )}
       </StyledInputField>
 
       <P fontWeight="normal" fontSize="14px" color="black.800" mt={3} mb={2}>

--- a/components/root-actions/MergeAccountsForm.js
+++ b/components/root-actions/MergeAccountsForm.js
@@ -81,6 +81,7 @@ const MergeAccountsForm = () => {
               collective={fromAccount}
               isClearable
               noCache // Don't cache to prevent showing merged collectives
+              skipGuests={false}
             />
           )}
         </StyledInputField>
@@ -96,6 +97,7 @@ const MergeAccountsForm = () => {
               types={fromAccount ? [fromAccount.type] : undefined}
               isClearable
               noCache // Don't cache to prevent showing merged collectives
+              skipGuests={false}
             />
           )}
         </StyledInputField>

--- a/components/root-actions/MoveAuthoredContributions.js
+++ b/components/root-actions/MoveAuthoredContributions.js
@@ -250,6 +250,7 @@ const MoveAuthoredContributions = () => {
             onChange={option => setNewFromAccount(option?.value || null)}
             disabled={!fromAccount}
             customOptions={toAccountCustomOptions}
+            skipGuests={false}
           />
         )}
       </StyledInputField>


### PR DESCRIPTION
Multiple forms like the one to ban accounts were previously not letting you search for guest accounts. This PR adds support for that on multiple root actions.