### PR TITLE
Visually distinguish Update drafts

### DIFF
--- a/components/StyledUpdate.js
+++ b/components/StyledUpdate.js
@@ -229,12 +229,12 @@ class StyledUpdate extends Component {
     if (mode === 'summary') {
       return (
         <Link href={`${getCollectivePageRoute(collective)}/updates/${update.slug}`}>
-          <H5 data-cy="updateTitle">{update.title}</H5>
+          <H5 data-cy="updateTitle" color={!update.publishedAt ? 'black.500' : 'black.900'} >{update.title}</H5>
         </Link>
       );
     } else {
       return (
-        <H5 data-cy="updateTitle" mb={2}>
+        <H5 data-cy="updateTitle" color={!update.publishedAt ? 'black.500' : 'black.900'} mb={2}>
           {update.title}
         </H5>
       );


### PR DESCRIPTION

Resolve ... https://github.com/opencollective/opencollective/issues/5444

# Description

`color={!update.publishedAt ? 'black.500' : 'black.900'}`

# Screenshots

![image](https://user-images.githubusercontent.com/4020744/182341303-430e3e1e-7fd6-4601-9d6f-1be6ae6e881b.png)
