### PR TITLE
Fix currency symbol inconsistency in pay expense modal

### DIFF
--- a/components/expenses/PayExpenseModal.js
+++ b/components/expenses/PayExpenseModal.js
@@ -414,7 +414,7 @@ const PayExpenseModal = ({ onClose, onSubmit, expense, collective, host, error, 
                     showCurrencyCode={false}
                     amount={{
                       valueInCents: Math.round(totalAmount * expense.amountInAccountCurrency.exchangeRate.value),
-                      currency: expense.currency,
+                      currency: expense.amountInAccountCurrency.currency,
                       exchangeRate: expense.amountInAccountCurrency.exchangeRate,
                     }}
                   />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1556356/182956607-f079f950-1ea0-4243-87af-e70dd72bf72e.png)
