### PR TITLE
ISSUE [5751] -- Fix Search Cards

### DIFF
--- a/components/StyledTag.js
+++ b/components/StyledTag.js
@@ -59,7 +59,12 @@ const StyledTagBase = styled.div`
   text-align: center;
   white-space: nowrap;
   letter-spacing: 0.06em;
-
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 80%;
+  &:hover {
+    max-width: 500px;
+  }
   ${variant({
     prop: 'variant',
     variants: {

--- a/components/search-page/SearchCollectiveCard.js
+++ b/components/search-page/SearchCollectiveCard.js
@@ -19,7 +19,7 @@ import StyledCollectiveCard from './StyledCollectiveCard';
 const SearchCollectiveCard = ({ collective, ...props }) => {
   return (
     <StyledCollectiveCard collective={collective} position="relative" {...props} data-cy="collective-card">
-      <Container p={3}>
+      <Container p={3} pt={2}>
         <Box data-cy="caption" mb={2}>
           {collective.isHost && collective.host ? (
             <React.Fragment>
@@ -92,7 +92,7 @@ const SearchCollectiveCard = ({ collective, ...props }) => {
           )}
           {collective.description && (
             <Container fontSize="12px">
-              <Flex alignItems="center" justifyContent="space-between" mt={21.5} mb={4.5}>
+              <Flex alignItems="center" justifyContent="space-between" mt={10} mb={4.5}>
                 <Span textTransform="uppercase" color="black.700" fontWeight={500}>
                   <FormattedMessage defaultMessage="About Us" />
                 </Span>

--- a/components/search-page/StyledCollectiveCard.js
+++ b/components/search-page/StyledCollectiveCard.js
@@ -201,7 +201,7 @@ const StyledCollectiveCard = ({
             )}
             <Container>
               {tag === undefined ? (
-                <StyledTag display="inline-block" variant="rounded-right" my={2} backgroundColor="blue.50">
+                <StyledTag display="inline-block" variant="rounded-right" mt={2} backgroundColor="blue.50">
                   <I18nCollectiveTags tags={getCollectiveMainTag(null, null, collective.type)} />
                 </StyledTag>
               ) : (
@@ -219,7 +219,14 @@ const StyledCollectiveCard = ({
                   .filter(tag => !IGNORED_TAGS.includes(tag))
                   .slice(0, 4)
                   .map(tag => (
-                    <StyledTag key={tag} display="inline-block" variant="rounded-right" m={1}>
+                    <StyledTag
+                      key={tag}
+                      display="inline-block"
+                      variant="rounded-right"
+                      m={1}
+                      maxHeight={'20px'}
+                      lineHeight={'16px'}
+                    >
                       {tag}
                     </StyledTag>
                   ))}


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/5751

# Description
Fixes a broken state on the search cards when tags are too long by fixing margins and reducing font size on tags
The tags have a limited width on the card, on hover the tags expand to full size
# Screenshots
Before: 
![image](https://user-images.githubusercontent.com/13011196/183219142-e6f505dc-d879-4512-aa08-ec6dca210aa1.png)
After:
![Screenshot from 2022-08-05 14-45-08](https://user-images.githubusercontent.com/13011196/183218807-c35ca97e-4f68-4db9-950f-1dec82400a3b.png)
![Screenshot from 2022-08-05 14-45-38](https://user-images.githubusercontent.com/13011196/183218809-3027423b-618b-41b2-82dc-a2d27a1d592f.png)

