### PR TITLE
Update eslint-plugin-styled-components-a11y to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -143,7 +143,7 @@
         "eslint-plugin-react": "^7.28.0",
         "eslint-plugin-react-hooks": "^4.3.0",
         "eslint-plugin-simple-import-sort": "^7.0.0",
-        "eslint-plugin-styled-components-a11y": "0.0.40",
+        "eslint-plugin-styled-components-a11y": "1.0.0",
         "file-loader": "^6.2.0",
         "html-loader": "^3.0.0",
         "husky": "^4.3.8",
@@ -16401,9 +16401,9 @@
       }
     },
     "node_modules/eslint-plugin-styled-components-a11y": {
-      "version": "0.0.40",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-styled-components-a11y/-/eslint-plugin-styled-components-a11y-0.0.40.tgz",
-      "integrity": "sha512-XuhyYwMHhXZJqX2N8lYNUp3nIelDMTr5sFBMI8vMrmD1zyAT+tiec3AcQnKNmdrHKExH4c2GrC7z5NGTe2ngog==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-styled-components-a11y/-/eslint-plugin-styled-components-a11y-1.0.0.tgz",
+      "integrity": "sha512-/vLwaH2hUn2mWd5vhIoA7rUBH1X28zFtnUFr5cIv8js/UGabdATSbysfVLBa5kD4GUXcJLhVoMkj07G5jkMxJQ==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.8.4",
@@ -48058,9 +48058,9 @@
       "dev": true
     },
     "eslint-plugin-styled-components-a11y": {
-      "version": "0.0.40",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-styled-components-a11y/-/eslint-plugin-styled-components-a11y-0.0.40.tgz",
-      "integrity": "sha512-XuhyYwMHhXZJqX2N8lYNUp3nIelDMTr5sFBMI8vMrmD1zyAT+tiec3AcQnKNmdrHKExH4c2GrC7z5NGTe2ngog==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-styled-components-a11y/-/eslint-plugin-styled-components-a11y-1.0.0.tgz",
+      "integrity": "sha512-/vLwaH2hUn2mWd5vhIoA7rUBH1X28zFtnUFr5cIv8js/UGabdATSbysfVLBa5kD4GUXcJLhVoMkj07G5jkMxJQ==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
-    "eslint-plugin-styled-components-a11y": "0.0.40",
+    "eslint-plugin-styled-components-a11y": "1.0.0",
     "file-loader": "^6.2.0",
     "html-loader": "^3.0.0",
     "husky": "^4.3.8",


### PR DESCRIPTION
Followup on https://github.com/opencollective/opencollective-frontend/pull/8060