### PR TITLE
Revert "VirtualCards: remove `expireDate`"

### DIFF
--- a/components/edit-collective/AssignVirtualCardModal.js
+++ b/components/edit-collective/AssignVirtualCardModal.js
@@ -91,6 +91,8 @@ const AssignVirtualCardModal = ({ collective, host, onSuccess, onClose, ...modal
         cardNumber: values.cardNumber.replace(/\s+/g, ''),
         cvv: values.cvv,
         expiryDate: values.expiryDate,
+        // Should be removed once https://github.com/opencollective/opencollective-api/pull/7307 is deployed to production
+        expireDate: values.expiryDate,
       };
 
       try {

--- a/components/edit-collective/VirtualCard.js
+++ b/components/edit-collective/VirtualCard.js
@@ -320,9 +320,19 @@ const VirtualCard = props => {
             <Flex>
               <Box mt="19px" mr={4}>
                 <P fontSize="18px" fontWeight="700" lineHeight="26px">
-                  {props.privateData.expiryDate}
+                  {
+                    // expireDate should be removed once https://github.com/opencollective/opencollective-api/pull/7307 is deployed to production
+                    props.privateData.expireDate || props.privateData.expiryDate
+                  }
 
-                  <Action color="black" ml={2} onClick={handleCopy(props.privateData.expiryDate)}>
+                  <Action
+                    color="black"
+                    ml={2}
+                    onClick={
+                      // expireDate should be removed once https://github.com/opencollective/opencollective-api/pull/7307 is deployed to production
+                      handleCopy(props.privateData.expireDate || props.privateData.expiryDate)
+                    }
+                  >
                     <Copy size="18px" />
                   </Action>
                 </P>


### PR DESCRIPTION
Reverts opencollective/opencollective-frontend#8043

Seems this is problematic and the migration didn't work properly.