### PR TITLE
limit size of tags and truncate text + smaller font size

### DIFF
--- a/components/StyledTag.js
+++ b/components/StyledTag.js
@@ -86,6 +86,18 @@ const StyledTagBase = styled.div`
         borderRadius: '12px 12px 12px 12px',
         padding: '3px 6px 3px 10px',
       },
+      truncated: {
+        ...defaultRoundedStyleProps,
+        borderRadius: '2px 12px 12px 2px',
+        padding: '3px 10px 3px 6px',
+        maxWidth: '10em',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        fontSize: '10px',
+        '&:hover': {
+          maxWidth: '100%',
+        },
+      },
     },
   })}
 

--- a/components/search-page/StyledCollectiveCard.js
+++ b/components/search-page/StyledCollectiveCard.js
@@ -219,7 +219,7 @@ const StyledCollectiveCard = ({
                   .filter(tag => !IGNORED_TAGS.includes(tag))
                   .slice(0, 4)
                   .map(tag => (
-                    <StyledTag key={tag} display="inline-block" variant="rounded-right" m={1}>
+                    <StyledTag key={tag} display="inline-block" variant="truncated" m={1}>
                       {tag}
                     </StyledTag>
                   ))}


### PR DESCRIPTION
https://github.com/opencollective/opencollective/issues/5751
Follow up to the review on this PR: https://github.com/opencollective/opencollective-frontend/pull/8071

Fixes a broken state on search cards when tags are too long and push the description off of the card.
The fix limits the size of the tags and truncated the text when it overflows.  on hover the tag expands to full size.
the new styles are implemented in a variant that is only used on the search card so there shouldn't be any side effects elsewhere,
also lowers the font size.

# Screenshots
Before: 
![image](https://user-images.githubusercontent.com/13011196/183219142-e6f505dc-d879-4512-aa08-ec6dca210aa1.png)
After:
![Screenshot from 2022-08-11 16-00-51](https://user-images.githubusercontent.com/13011196/184257537-4a1df379-7fd3-4617-98d7-1364663dc1ac.png)
![Screenshot from 2022-08-11 16-01-10](https://user-images.githubusercontent.com/13011196/184257547-85c08034-0617-41be-83bb-395e810dff42.png)

