### PR TITLE
Tiers: Enable button text customization for projects

### DIFF
--- a/components/edit-collective/sections/Tiers.js
+++ b/components/edit-collective/sections/Tiers.js
@@ -298,7 +298,7 @@ class Tiers extends React.Component {
         name: 'button',
         type: 'text',
         label: intl.formatMessage(this.messages['button.label']),
-        when: (tier, collective) => ![FUND, PROJECT].includes(collective.type),
+        when: (tier, collective) => ![FUND].includes(collective.type),
       },
       {
         name: 'goal',


### PR DESCRIPTION
Resolve https://opencollective.slack.com/archives/GFH4N961L/p1660693636237509

> A user wants to customise the contribute button on a Project tier but that field is just missing from the tier form?