### PR TITLE
Enhancements on activity type filter

### DIFF
--- a/components/admin-panel/sections/ActivityLog/index.js
+++ b/components/admin-panel/sections/ActivityLog/index.js
@@ -33,7 +33,7 @@ const activityLogQuery = gqlV2/* GraphQL */ `
     $offset: Int
     $dateFrom: DateTime
     $dateTo: DateTime
-    $type: [ActivityAndClassesType]
+    $type: [ActivityAndClassesType!]
     $attribution: ActivityAttribution
   ) {
     account(slug: $accountSlug) {

--- a/components/admin-panel/sections/ActivityLog/index.js
+++ b/components/admin-panel/sections/ActivityLog/index.js
@@ -33,7 +33,7 @@ const activityLogQuery = gqlV2/* GraphQL */ `
     $offset: Int
     $dateFrom: DateTime
     $dateTo: DateTime
-    $activityType: [ActivityAndClassesType]
+    $type: [ActivityAndClassesType]
     $attribution: ActivityAttribution
   ) {
     account(slug: $accountSlug) {
@@ -46,7 +46,7 @@ const activityLogQuery = gqlV2/* GraphQL */ `
       offset: $offset
       dateFrom: $dateFrom
       dateTo: $dateTo
-      activityType: $activityType
+      type: $type
       attribution: $attribution
     ) {
       offset
@@ -99,7 +99,7 @@ const getQueryVariables = (accountSlug, router) => {
     dateTo,
     limit: ACTIVITY_LIMIT,
     offset,
-    activityType: type,
+    type,
     attribution,
   };
 };

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1308,6 +1308,7 @@
   "fundEvents.description": "Recevie emails when a fund or event is created, tickets confirmation and events reminders.",
   "fundEvents.title": "Funds and Events",
   "funds": "My Funds",
+  "FvanT6": "Accounts",
   "FVO2wx": "My Projects",
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1308,6 +1308,7 @@
   "fundEvents.description": "Recevie emails when a fund or event is created, tickets confirmation and events reminders.",
   "fundEvents.title": "Funds and Events",
   "funds": "My Funds",
+  "FvanT6": "Accounts",
   "FVO2wx": "My Projects",
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1308,6 +1308,7 @@
   "fundEvents.description": "Recevie emails when a fund or event is created, tickets confirmation and events reminders.",
   "fundEvents.title": "Funds and Events",
   "funds": "My Funds",
+  "FvanT6": "Accounts",
   "FVO2wx": "My Projects",
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1308,6 +1308,7 @@
   "fundEvents.description": "Recevie emails when a fund or event is created, tickets confirmation and events reminders.",
   "fundEvents.title": "Funds and Events",
   "funds": "My Funds",
+  "FvanT6": "Accounts",
   "FVO2wx": "My Projects",
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1308,6 +1308,7 @@
   "fundEvents.description": "Recevie emails when a fund or event is created, tickets confirmation and events reminders.",
   "fundEvents.title": "Funds and Events",
   "funds": "Mis fondos",
+  "FvanT6": "Accounts",
   "FVO2wx": "Mis Proyectos",
   "g0KLMH": "p. ej., Dirección de correo electrónico errónea",
   "gC0tFj": "Tasa de GST",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1308,6 +1308,7 @@
   "fundEvents.description": "Recevie emails when a fund or event is created, tickets confirmation and events reminders.",
   "fundEvents.title": "Funds and Events",
   "funds": "My Funds",
+  "FvanT6": "Accounts",
   "FVO2wx": "Mes Projets",
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1308,6 +1308,7 @@
   "fundEvents.description": "Recevie emails when a fund or event is created, tickets confirmation and events reminders.",
   "fundEvents.title": "Funds and Events",
   "funds": "My Funds",
+  "FvanT6": "Accounts",
   "FVO2wx": "My Projects",
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1308,6 +1308,7 @@
   "fundEvents.description": "Recevie emails when a fund or event is created, tickets confirmation and events reminders.",
   "fundEvents.title": "Funds and Events",
   "funds": "My Funds",
+  "FvanT6": "Accounts",
   "FVO2wx": "My Projects",
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1308,6 +1308,7 @@
   "fundEvents.description": "Recevie emails when a fund or event is created, tickets confirmation and events reminders.",
   "fundEvents.title": "Funds and Events",
   "funds": "My Funds",
+  "FvanT6": "Accounts",
   "FVO2wx": "My Projects",
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1308,6 +1308,7 @@
   "fundEvents.description": "Recevie emails when a fund or event is created, tickets confirmation and events reminders.",
   "fundEvents.title": "Funds and Events",
   "funds": "My Funds",
+  "FvanT6": "Accounts",
   "FVO2wx": "My Projects",
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -1308,6 +1308,7 @@
   "fundEvents.description": "Recevie emails when a fund or event is created, tickets confirmation and events reminders.",
   "fundEvents.title": "Funds and Events",
   "funds": "Moje środki",
+  "FvanT6": "Accounts",
   "FVO2wx": "Moje projekty",
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1308,6 +1308,7 @@
   "fundEvents.description": "Recevie emails when a fund or event is created, tickets confirmation and events reminders.",
   "fundEvents.title": "Funds and Events",
   "funds": "Meus fundos",
+  "FvanT6": "Accounts",
   "FVO2wx": "My Projects",
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1308,6 +1308,7 @@
   "fundEvents.description": "Recevie emails when a fund or event is created, tickets confirmation and events reminders.",
   "fundEvents.title": "Funds and Events",
   "funds": "My Funds",
+  "FvanT6": "Accounts",
   "FVO2wx": "My Projects",
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1308,6 +1308,7 @@
   "fundEvents.description": "Recevie emails when a fund or event is created, tickets confirmation and events reminders.",
   "fundEvents.title": "Funds and Events",
   "funds": "My Funds",
+  "FvanT6": "Accounts",
   "FVO2wx": "My Projects",
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",

--- a/lang/sk-SK.json
+++ b/lang/sk-SK.json
@@ -1308,6 +1308,7 @@
   "fundEvents.description": "Recevie emails when a fund or event is created, tickets confirmation and events reminders.",
   "fundEvents.title": "Funds and Events",
   "funds": "Moje Fondy",
+  "FvanT6": "Accounts",
   "FVO2wx": "Moje Projekty",
   "g0KLMH": "napr. E-mailová Adresa je nesprávna",
   "gC0tFj": "Sadzba GST",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -1308,6 +1308,7 @@
   "fundEvents.description": "Recevie emails when a fund or event is created, tickets confirmation and events reminders.",
   "fundEvents.title": "Funds and Events",
   "funds": "Мої кошти",
+  "FvanT6": "Accounts",
   "FVO2wx": "Мої проєкти",
   "g0KLMH": "напр. Адреса електронної пошти неправильна",
   "gC0tFj": "GST rate",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1308,6 +1308,7 @@
   "fundEvents.description": "Recevie emails when a fund or event is created, tickets confirmation and events reminders.",
   "fundEvents.title": "Funds and Events",
   "funds": "我的资金",
+  "FvanT6": "Accounts",
   "FVO2wx": "我的项目",
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "消费税",

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -8466,9 +8466,9 @@ type Query {
     dateTo: DateTime = null
 
     """
-    Only return activities that are of this type
+    Only return activities that are of this class/type
     """
-    type: [ActivityAndClassesType] = null
+    type: [ActivityAndClassesType!] = null
   ): ActivityCollection!
   application(
     """

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -8468,7 +8468,7 @@ type Query {
     """
     Only return activities that are of this type
     """
-    activityType: [ActivityAndClassesType] = null
+    type: [ActivityAndClassesType] = null
   ): ActivityCollection!
   application(
     """

--- a/lib/i18n/activities.js
+++ b/lib/i18n/activities.js
@@ -56,8 +56,7 @@ export const ActivityCategoryLabelI18n = defineMessages({
     defaultMessage: 'All',
   },
   COLLECTIVE: {
-    id: 'Collective',
-    defaultMessage: 'Collective',
+    defaultMessage: 'Accounts',
   },
   EXPENSES: {
     id: 'Expenses',


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-api/pull/7880

- Rename `activityType` arg to `type` and use the latest type
- Re-word `Collective` to `Accounts` in the type filter since it's supposed to surface all activities associated to accounts, but they're not necessarily "Collectives" - can be organization changes, collective, projects, etc.

![image](https://user-images.githubusercontent.com/1556356/186637559-ea49d9f9-944e-49c3-ad2d-2b03558c6e59.png)
