### PR TITLE
Make `scrollToTopOnChange` prop in Pagination Component default to `true`

### DIFF
--- a/components/Pagination.js
+++ b/components/Pagination.js
@@ -105,7 +105,7 @@ Pagination.propTypes = {
 };
 
 Pagination.defaultProps = {
-  scrollToTopOnChange: false,
+  scrollToTopOnChange: true,
 };
 
 export default Pagination;

--- a/components/admin-panel/sections/ActivityLog/index.js
+++ b/components/admin-panel/sections/ActivityLog/index.js
@@ -290,7 +290,6 @@ const ActivityLog = ({ accountSlug }) => {
             total={data.activities.totalCount}
             limit={ACTIVITY_LIMIT}
             ignoredQueryParams={['slug', 'section']}
-            scrollToTopOnChange
           />
         </Container>
       )}

--- a/components/admin-panel/sections/AuthorizedApps.js
+++ b/components/admin-panel/sections/AuthorizedApps.js
@@ -77,7 +77,6 @@ const AuthorizedAppsSection = () => {
             limit={variables.limit}
             offset={variables.offset}
             ignoredQueryParams={['slug', 'section']}
-            scrollToTopOnChange
           />
         </Flex>
       )}

--- a/components/edit-collective/sections/virtual-cards/VirtualCards.js
+++ b/components/edit-collective/sections/virtual-cards/VirtualCards.js
@@ -180,7 +180,6 @@ const VirtualCards = props => {
           limit={VIRTUAL_CARDS_PER_PAGE}
           offset={offset}
           ignoredQueryParams={['slug', 'section']}
-          scrollToTopOnChange
         />
       </Flex>
     </Box>

--- a/components/host-dashboard/HostDashboardExpenses.js
+++ b/components/host-dashboard/HostDashboardExpenses.js
@@ -303,7 +303,6 @@ const HostDashboardExpenses = ({ hostSlug, isNewAdmin }) => {
               limit={paginatedExpenses.limit}
               offset={paginatedExpenses.offset}
               ignoredQueryParams={ROUTE_PARAMS}
-              scrollToTopOnChange
             />
           </Flex>
         </React.Fragment>

--- a/components/host-dashboard/HostDashboardHostedCollectives.js
+++ b/components/host-dashboard/HostDashboardHostedCollectives.js
@@ -198,7 +198,6 @@ const HostDashboardHostedCollectives = ({ hostSlug }) => {
               limit={variables.limit}
               offset={variables.offset}
               ignoredQueryParams={ROUTE_PARAMS}
-              scrollToTopOnChange
             />
           </Flex>
         </React.Fragment>

--- a/components/host-dashboard/PendingApplications.js
+++ b/components/host-dashboard/PendingApplications.js
@@ -184,7 +184,6 @@ const PendingApplications = ({ hostSlug }) => {
               limit={variables.limit}
               offset={variables.offset}
               ignoredQueryParams={ROUTE_PARAMS}
-              scrollToTopOnChange
             />
           </Flex>
         </React.Fragment>

--- a/components/oauth/OAuthApplicationsList.js
+++ b/components/oauth/OAuthApplicationsList.js
@@ -142,7 +142,6 @@ const OAuthApplicationsList = ({ accountSlug, onApplicationCreated, offset = 0 }
             limit={variables.limit}
             offset={variables.offset}
             ignoredQueryParams={['slug', 'section']}
-            scrollToTopOnChange
           />
         </Flex>
       )}

--- a/components/orders/OrdersWithData.js
+++ b/components/orders/OrdersWithData.js
@@ -225,7 +225,6 @@ const OrdersWithData = ({ accountSlug, title, status, showPlatformTip }) => {
               limit={variables.limit}
               offset={variables.offset}
               ignoredQueryParams={ROUTE_PARAMS}
-              scrollToTopOnChanges
             />
           </Flex>
         </React.Fragment>

--- a/pages/expenses.js
+++ b/pages/expenses.js
@@ -299,7 +299,6 @@ class ExpensePage extends React.Component {
                         limit={data.variables.limit}
                         offset={data.variables.offset}
                         ignoredQueryParams={['collectiveSlug', 'parentCollectiveSlug']}
-                        scrollToTopOnChange
                       />
                     </Flex>
                   </React.Fragment>

--- a/pages/transactions.js
+++ b/pages/transactions.js
@@ -416,7 +416,6 @@ class TransactionsPage extends React.Component {
                     limit={variables.limit}
                     offset={variables.offset}
                     ignoredQueryParams={['collectiveSlug']}
-                    scrollToTopOnChange
                   />
                 </Flex>
               </React.Fragment>


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective-frontend/pull/8133#pullrequestreview-1086547894

@Betree : I've checked and all the places we use the pagination component I couldn't find any place where the pagination change should not scroll to top. Hence I've removed all the `scrollToTopOnChange` props from `<Pagination...` tags. 