### PR TITLE
Implement optimistic Notification toggle switch

### DIFF
--- a/components/admin-panel/sections/NotificationsSettings/ActivitySwitch.js
+++ b/components/admin-panel/sections/NotificationsSettings/ActivitySwitch.js
@@ -38,7 +38,7 @@ const ActivitySwitch = ({ account, activityType }) => {
   const isIndeterminate =
     activityType === 'ACTIVITY_ALL' &&
     account.activitySubscriptions?.some(notification => notification.type !== ActivityTypes.ACTIVITY_ALL);
-  const subscribed = existingSetting ? existingSetting.active : true;
+  const [isSubscribed, setSubscribed] = React.useState(existingSetting ? existingSetting.active : true);
   const isOverridedByAll = activityType !== 'ACTIVITY_ALL' && existingSetting?.type === ActivityTypes.ACTIVITY_ALL;
 
   const [setEmailNotification] = useMutation(setEmailNotificationMutation, {
@@ -48,6 +48,7 @@ const ActivitySwitch = ({ account, activityType }) => {
 
   const handleToggle = async variables => {
     try {
+      setSubscribed(variables.active);
       await setEmailNotification({ variables });
     } catch (e) {
       addToast({
@@ -69,7 +70,7 @@ const ActivitySwitch = ({ account, activityType }) => {
   return (
     <InputSwitch
       name={`${activityType}-switch`}
-      checked={subscribed}
+      checked={isSubscribed}
       disabled={isIndeterminate || isOverridedByAll}
       onChange={event =>
         handleToggle({ type: activityType, account: { id: account.id }, active: event.target.checked })


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/5853

Had to implement an optimistic switch using an internal state because we're not really enabling/disabling activities by `id`. Also, to enable an activity is to delete its settings from the database, which returns null as a result.