### PR TITLE
fix(UploadedFilePreview): improve attachment icon view on mobile

### DIFF
--- a/components/UploadedFilePreview.js
+++ b/components/UploadedFilePreview.js
@@ -130,14 +130,7 @@ const UploadedFilePreview = ({
   } else if (!url) {
     content = <FileText color="#dcdee0" size="60%" />;
   } else if (isText) {
-    const icon = <FileTextIcon color="#dcdee0" size="60%" />;
-    content = url ? (
-      <StyledLink href={url} key={url} textAlign="center" openInNewTab>
-        {icon}
-      </StyledLink>
-    ) : (
-      icon
-    );
+    content = <FileTextIcon color="#dcdee0" size="60%" />;
   } else {
     const resizeWidth = Array.isArray(size) ? max(size) : size;
     content = <img src={imagePreview(url, null, { width: resizeWidth })} alt={alt || fileName} />;


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/4099

# Description

Improve attachment icon view on mobile.

The `MainContainer` is already a link if the `url` prop is available.

https://github.com/opencollective/opencollective-frontend/blob/56e4df659d3636656be7bc359fa442aa270ab2a3/components/UploadedFilePreview.js#L147-L151

<img width="948" alt="Screenshot 2022-09-04 at 7 36 32 AM" src="https://user-images.githubusercontent.com/46647141/188293989-dd7a4622-84d5-4aea-9bb7-6249654d2c97.png">


<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots

<img width="374" alt="Screenshot 2022-09-04 at 7 34 07 AM" src="https://user-images.githubusercontent.com/46647141/188293941-3c4b9e2b-6451-4b3c-8007-263a77adab4a.png">

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
