### PR TITLE
fix: Add rewrite for /contribute page for events and projects

### DIFF
--- a/pages/contribute.js
+++ b/pages/contribute.js
@@ -9,6 +9,7 @@ import styled from 'styled-components';
 import { TierTypes } from '../lib/constants/tiers-types';
 import { sortEvents } from '../lib/events';
 import { sortTiersForCollective } from '../lib/tier-utils';
+import { getCollectivePageRoute } from '../lib/url-helpers';
 
 import Body from '../components/Body';
 import CollectiveNavbar from '../components/collective-navbar';
@@ -295,7 +296,7 @@ class TiersPage extends React.Component {
                       </P>
                     )}
                     {waysToContribute.length > 0 && (
-                      <Link href={`/${slug}`}>
+                      <Link href={getCollectivePageRoute(collective)}>
                         <StyledButton buttonSize="small" mt={3}>
                           ←&nbsp;
                           <FormattedMessage

--- a/rewrites.js
+++ b/rewrites.js
@@ -178,7 +178,7 @@ exports.REWRITES = [
   },
   {
     source:
-      '/:parentCollectiveSlug?/:collectiveType(events|projects)?/:collectiveSlug/:verb(tiers|contribute|events|projects|connected-collectives)',
+      '/:parentCollectiveSlug?/:collectiveType(events|projects)?/:collectiveSlug/:verb(tiers|contribute|connected-collectives)',
     destination: '/contribute',
   },
   // Embed

--- a/rewrites.js
+++ b/rewrites.js
@@ -176,6 +176,10 @@ exports.REWRITES = [
     source: '/:collectiveSlug/:verb(tiers|contribute|events|projects|connected-collectives)',
     destination: '/contribute',
   },
+  {
+    source: '/:parentCollectiveSlug?/:collectiveType(events|projects)?/:collectiveSlug/contribute',
+    destination: '/contribute',
+  },
   // Embed
   {
     source: `/embed/:parentCollectiveSlug?/:collectiveType(events|projects)?/:collectiveSlug/:verb(donate)/:paymentFlow(crypto)?/:step(${contributionFlowSteps})?`,

--- a/rewrites.js
+++ b/rewrites.js
@@ -177,7 +177,8 @@ exports.REWRITES = [
     destination: '/contribute',
   },
   {
-    source: '/:parentCollectiveSlug?/:collectiveType(events|projects)?/:collectiveSlug/contribute',
+    source:
+      '/:parentCollectiveSlug?/:collectiveType(events|projects)?/:collectiveSlug/:verb(tiers|contribute|events|projects|connected-collectives)',
     destination: '/contribute',
   },
   // Embed


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/5865

# Description

This adds a rewrite to add the `/contribute` page for events and projects, fixing the broken link reported in the issue.

It's also adjusting the "Go back to {name}'s page" link on this page to use the `getCollectivePageRoute` helper to get the full path including the parent collective slug when viewing an event or project's `/contribute` page.
