### PR TITLE
Center contributors on the tier page when the grid is not full

### DIFF
--- a/components/ContributorsGrid.js
+++ b/components/ContributorsGrid.js
@@ -101,6 +101,29 @@ const getItemsRepartition = (nbItems, width, maxNbRows) => {
 };
 
 /**
+ * Compute the proper padding left to center the content according to max width
+ */
+const computePaddingLeft = (width, rowWidth, nbRows, maxWidthWhenNotFull) => {
+  if (width < maxWidthWhenNotFull) {
+    // No need for padding on screens small enough so they don't have padding
+    return 0;
+  } else if (nbRows > 1) {
+    if (rowWidth <= width) {
+      // If multiline and possible center contributors cards
+      const cardsLeftOffset = COLLECTIVE_CARD_MARGIN_X / 2;
+      return (width - rowWidth) / 2 - cardsLeftOffset;
+    } else {
+      // Otherwise if multiline and the grid is full, just use the full screen
+      return 0;
+    }
+  } else {
+    // Otherwise add a normal section padding on the left
+    const cardsLeftOffset = COLLECTIVE_CARD_MARGIN_X / 2;
+    return (width - Math.max(maxWidthWhenNotFull, rowWidth)) / 2 - cardsLeftOffset;
+  }
+};
+
+/**
  * A grid to show contributors, with horizontal scroll to search them.
  */
 const ContributorsGrid = ({
@@ -108,7 +131,7 @@ const ContributorsGrid = ({
   width,
   maxNbRowsForViewports,
   viewport,
-  getPaddingLeft,
+  maxWidthWhenNotFull,
   currency,
   LoggedInUser,
   collectiveId,
@@ -119,7 +142,7 @@ const ContributorsGrid = ({
   // Preload more items when viewport width is unknown to avoid displaying blank spaces on SSR
   const viewWidth = viewport === VIEWPORTS.UNKNOWN ? width * 3 : width;
   const rowWidth = nbCols * COLLECTIVE_CARD_FULL_WIDTH + COLLECTIVE_CARD_MARGIN_X;
-  const paddingLeft = getPaddingLeft ? getPaddingLeft({ width, rowWidth, nbRows }) : 0;
+  const paddingLeft = computePaddingLeft(width, rowWidth, nbRows, maxWidthWhenNotFull);
   const hasScroll = rowWidth + paddingLeft > width;
   const loggedUserCollectiveId = get(LoggedInUser, 'CollectiveId');
   return (
@@ -179,9 +202,6 @@ ContributorsGrid.propTypes = {
     [VIEWPORTS.LARGE]: PropTypes.number,
   }).isRequired,
 
-  /** A callback to calculate left padding */
-  getPaddingLeft: PropTypes.func,
-
   /** Currency used for contributions */
   currency: PropTypes.string,
 
@@ -190,6 +210,9 @@ ContributorsGrid.propTypes = {
 
   /** @ignore from withViewport */
   width: PropTypes.number.isRequired,
+
+  /** To center the content when the grid is not full */
+  maxWidthWhenNotFull: PropTypes.number,
 
   /** @ignore from withUser */
   LoggedInUser: PropTypes.shape({

--- a/components/collective-page/sections/Contributors.js
+++ b/components/collective-page/sections/Contributors.js
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 
 import Container from '../../Container';
 import * as ContributorsFilter from '../../ContributorsFilter';
-import ContributorsGrid, { COLLECTIVE_CARD_MARGIN_X } from '../../ContributorsGrid';
+import ContributorsGrid from '../../ContributorsGrid';
 import { H3, P, Span } from '../../Text';
 // Local imports
 import { Dimensions } from '../_constants';
@@ -147,25 +147,7 @@ export default class SectionContributors extends React.PureComponent {
           contributors={contributors}
           collectiveId={collective.id}
           currency={collective.currency}
-          getPaddingLeft={({ width, rowWidth, nbRows }) => {
-            if (width < Dimensions.MAX_SECTION_WIDTH) {
-              // No need for padding on screens small enough so they don't have padding
-              return 0;
-            } else if (nbRows > 1) {
-              if (rowWidth <= width) {
-                // If multiline and possible center contributors cards
-                const cardsLeftOffset = COLLECTIVE_CARD_MARGIN_X / 2;
-                return (width - rowWidth) / 2 - cardsLeftOffset;
-              } else {
-                // Otherwise if multiline and the grid is full, just use the full screen
-                return 0;
-              }
-            } else {
-              // Otherwise add a normal section padding on the left
-              const cardsLeftOffset = COLLECTIVE_CARD_MARGIN_X / 2;
-              return (width - Math.max(Dimensions.MAX_SECTION_WIDTH, rowWidth)) / 2 - cardsLeftOffset;
-            }
-          }}
+          maxWidthWhenNotFull={Dimensions.MAX_SECTION_WIDTH}
         />
       </MainContainer>
     );

--- a/components/tier-page/TierContributors.js
+++ b/components/tier-page/TierContributors.js
@@ -8,6 +8,8 @@ import ContributorsGrid from '../ContributorsGrid';
 import { Box } from '../Grid';
 import { H2, P } from '../Text';
 
+const CONTENT_WIDTH = 1440;
+
 export default class TierContributors extends React.Component {
   static propTypes = {
     /** Contributors */
@@ -57,7 +59,7 @@ export default class TierContributors extends React.Component {
 
     return (
       <Box>
-        <Box m="0 auto" css={{ maxWidth: 1440 }}>
+        <Box m="0 auto" css={{ maxWidth: CONTENT_WIDTH }}>
           <H2 mb={3} px={3}>
             <FormattedMessage
               id="TierPage.ContributorsCountGoal"
@@ -82,7 +84,12 @@ export default class TierContributors extends React.Component {
           )}
         </Box>
         <Box mb={4}>
-          <ContributorsGrid contributors={filteredContributors} currency={currency} collectiveId={collectiveId} />
+          <ContributorsGrid
+            contributors={filteredContributors}
+            currency={currency}
+            collectiveId={collectiveId}
+            maxWidthWhenNotFull={CONTENT_WIDTH + 16} // Add 16 to compensate for the margin of the card
+          />
         </Box>
       </Box>
     );


### PR DESCRIPTION
Resolve https://opencollective.slack.com/archives/C1974QBNK/p1662991593715989
Unifies the behavior with the contributors' grid on the collective page

![image](https://user-images.githubusercontent.com/1556356/189902901-6b8431c8-9959-4703-8374-d4a64e84629c.png)
