### PR TITLE
RichTextEditor: Reject invalid attachments

### DIFF
--- a/components/RichTextEditor.js
+++ b/components/RichTextEditor.js
@@ -293,6 +293,7 @@ export default class RichTextEditor extends React.Component {
   };
 
   /** ---- Trix handlers ---- */
+
   replaceEmbeddedIFrames = value => {
     const iframeRegex = new RegExp(`<iframe.+?iframe>`, 'ig');
     let match;
@@ -444,6 +445,7 @@ export default class RichTextEditor extends React.Component {
   handleUpload = e => {
     const { attachment } = e;
     if (!attachment.file) {
+      attachment.remove(); // Remove unknown stuff, for example when copy-pasting HTML
       return;
     }
 


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/5728
Should be merged before https://github.com/opencollective/opencollective-api/pull/7952

This will remove images when pasted from HTML, which turned into blank spaces because 3rd party domains are not allowed by our Content Security Policy.