### PR TITLE
feat: Allow removing team member invitations

### DIFF
--- a/components/edit-collective/sections/EditMemberModal.js
+++ b/components/edit-collective/sections/EditMemberModal.js
@@ -228,7 +228,12 @@ const EditMemberModal = props => {
 
         addToast({
           type: TOAST_TYPE.SUCCESS,
-          message: (
+          message: isInvitation ? (
+            <FormattedMessage
+              id="editTeam.memberInvitation.remove.success"
+              defaultMessage="Member invitation removed successfully."
+            />
+          ) : (
             <FormattedMessage id="editTeam.member.remove.success" defaultMessage="Member removed successfully." />
           ),
         });
@@ -242,7 +247,14 @@ const EditMemberModal = props => {
       } catch (error) {
         addToast({
           type: TOAST_TYPE.ERROR,
-          title: <FormattedMessage id="editTeam.member.remove.error" defaultMessage="Failed to remove member." />,
+          title: isInvitation ? (
+            <FormattedMessage id="editTeam.member.remove.error" defaultMessage="Failed to remove member." />
+          ) : (
+            <FormattedMessage
+              id="editTeam.memberInvitation.remove.error"
+              defaultMessage="Failed to remove member invitation."
+            />
+          ),
           message: i18nGraphqlException(intl, error),
         });
       }

--- a/components/edit-collective/sections/Members.js
+++ b/components/edit-collective/sections/Members.js
@@ -191,7 +191,7 @@ class Members extends React.Component {
               isLastAdmin={isLastAdmin}
               LoggedInUser={LoggedInUser}
               refetchLoggedInUser={refetchLoggedInUser}
-              canRemove={!(isInvitation || isLastAdmin)}
+              canRemove={!isLastAdmin}
             />
           ) : (
             <StyledRoundButton

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -982,6 +982,8 @@
   "editTeam.member.remove.success": "Member removed successfully.",
   "editTeam.memberInvitation.edit.error": "Failed to update member invitation.",
   "editTeam.memberInvitation.edit.success": "Member invitation updated successfully.",
+  "editTeam.memberInvitation.remove.error": "Failed to remove member invitation.",
+  "editTeam.memberInvitation.remove.success": "Member invitation removed successfully.",
   "EditUserEmailForm.reSend": "Re-send confirmation",
   "EditUserEmailForm.submit": "Confirm new email",
   "EditUserEmailForm.success": "An email with a confirmation link has been sent to {email}. Please click the link to validate your email address.",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -982,6 +982,8 @@
   "editTeam.member.remove.success": "Member removed successfully.",
   "editTeam.memberInvitation.edit.error": "Failed to update member invitation.",
   "editTeam.memberInvitation.edit.success": "Member invitation updated successfully.",
+  "editTeam.memberInvitation.remove.error": "Failed to remove member invitation.",
+  "editTeam.memberInvitation.remove.success": "Member invitation removed successfully.",
   "EditUserEmailForm.reSend": "Re-send confirmation",
   "EditUserEmailForm.submit": "Potvrdit nový email",
   "EditUserEmailForm.success": "An email with a confirmation link has been sent to {email}. Please click the link to validate your email address.",

--- a/lang/de.json
+++ b/lang/de.json
@@ -982,6 +982,8 @@
   "editTeam.member.remove.success": "Member removed successfully.",
   "editTeam.memberInvitation.edit.error": "Failed to update member invitation.",
   "editTeam.memberInvitation.edit.success": "Member invitation updated successfully.",
+  "editTeam.memberInvitation.remove.error": "Failed to remove member invitation.",
+  "editTeam.memberInvitation.remove.success": "Member invitation removed successfully.",
   "EditUserEmailForm.reSend": "Bestätigung erneut senden",
   "EditUserEmailForm.submit": "Neue E-Mail-Adresse bestätigen",
   "EditUserEmailForm.success": "An email with a confirmation link has been sent to {email}. Please click the link to validate your email address.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -982,6 +982,8 @@
   "editTeam.member.remove.success": "Member removed successfully.",
   "editTeam.memberInvitation.edit.error": "Failed to update member invitation.",
   "editTeam.memberInvitation.edit.success": "Member invitation updated successfully.",
+  "editTeam.memberInvitation.remove.error": "Failed to remove member invitation.",
+  "editTeam.memberInvitation.remove.success": "Member invitation removed successfully.",
   "EditUserEmailForm.reSend": "Re-send confirmation",
   "EditUserEmailForm.submit": "Confirm new email",
   "EditUserEmailForm.success": "An email with a confirmation link has been sent to {email}. Please click the link to validate your email address.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -982,6 +982,8 @@
   "editTeam.member.remove.success": "Miembro eliminado con éxito.",
   "editTeam.memberInvitation.edit.error": "Error al actualizar la invitación del miembro.",
   "editTeam.memberInvitation.edit.success": "Invitación de miembros actualizada con éxito.",
+  "editTeam.memberInvitation.remove.error": "Failed to remove member invitation.",
+  "editTeam.memberInvitation.remove.success": "Member invitation removed successfully.",
   "EditUserEmailForm.reSend": "Reenviar confirmación",
   "EditUserEmailForm.submit": "Confirme el nuevo email",
   "EditUserEmailForm.success": "Se ha enviado un correo electrónico con un enlace de confirmación a {email}. Por favor, haz clic en el enlace para verificar tu dirección de correo electrónico.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -982,6 +982,8 @@
   "editTeam.member.remove.success": "Membre supprimé avec succès.",
   "editTeam.memberInvitation.edit.error": "Failed to update member invitation.",
   "editTeam.memberInvitation.edit.success": "Member invitation updated successfully.",
+  "editTeam.memberInvitation.remove.error": "Failed to remove member invitation.",
+  "editTeam.memberInvitation.remove.success": "Member invitation removed successfully.",
   "EditUserEmailForm.reSend": "Ré-envoyer la confirmation",
   "EditUserEmailForm.submit": "Confirmer cette nouvelle adresse",
   "EditUserEmailForm.success": "An email with a confirmation link has been sent to {email}. Please click the link to validate your email address.",

--- a/lang/it.json
+++ b/lang/it.json
@@ -982,6 +982,8 @@
   "editTeam.member.remove.success": "Member removed successfully.",
   "editTeam.memberInvitation.edit.error": "Failed to update member invitation.",
   "editTeam.memberInvitation.edit.success": "Member invitation updated successfully.",
+  "editTeam.memberInvitation.remove.error": "Failed to remove member invitation.",
+  "editTeam.memberInvitation.remove.success": "Member invitation removed successfully.",
   "EditUserEmailForm.reSend": "Re-invia conferma",
   "EditUserEmailForm.submit": "Conferma nuova email",
   "EditUserEmailForm.success": "An email with a confirmation link has been sent to {email}. Please click the link to validate your email address.",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -982,6 +982,8 @@
   "editTeam.member.remove.success": "Member removed successfully.",
   "editTeam.memberInvitation.edit.error": "Failed to update member invitation.",
   "editTeam.memberInvitation.edit.success": "Member invitation updated successfully.",
+  "editTeam.memberInvitation.remove.error": "Failed to remove member invitation.",
+  "editTeam.memberInvitation.remove.success": "Member invitation removed successfully.",
   "EditUserEmailForm.reSend": "確認を再送信する",
   "EditUserEmailForm.submit": "新しいメールを確認してください",
   "EditUserEmailForm.success": "An email with a confirmation link has been sent to {email}. Please click the link to validate your email address.",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -982,6 +982,8 @@
   "editTeam.member.remove.success": "Member removed successfully.",
   "editTeam.memberInvitation.edit.error": "Failed to update member invitation.",
   "editTeam.memberInvitation.edit.success": "Member invitation updated successfully.",
+  "editTeam.memberInvitation.remove.error": "Failed to remove member invitation.",
+  "editTeam.memberInvitation.remove.success": "Member invitation removed successfully.",
   "EditUserEmailForm.reSend": "확인 메일 재전송",
   "EditUserEmailForm.submit": "새 이메일 확인",
   "EditUserEmailForm.success": "An email with a confirmation link has been sent to {email}. Please click the link to validate your email address.",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -982,6 +982,8 @@
   "editTeam.member.remove.success": "Member removed successfully.",
   "editTeam.memberInvitation.edit.error": "Failed to update member invitation.",
   "editTeam.memberInvitation.edit.success": "Member invitation updated successfully.",
+  "editTeam.memberInvitation.remove.error": "Failed to remove member invitation.",
+  "editTeam.memberInvitation.remove.success": "Member invitation removed successfully.",
   "EditUserEmailForm.reSend": "Re-send confirmation",
   "EditUserEmailForm.submit": "Confirm new email",
   "EditUserEmailForm.success": "An email with a confirmation link has been sent to {email}. Please click the link to validate your email address.",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -982,6 +982,8 @@
   "editTeam.member.remove.success": "Użytkownik usunięty pomyślnie.",
   "editTeam.memberInvitation.edit.error": "Nie udało się zaktualizować zaproszenia użytkownika.",
   "editTeam.memberInvitation.edit.success": "Zaproszenie użytkownika zostało zaktualizowane.",
+  "editTeam.memberInvitation.remove.error": "Failed to remove member invitation.",
+  "editTeam.memberInvitation.remove.success": "Member invitation removed successfully.",
   "EditUserEmailForm.reSend": "Wyślij ponownie potwierdzenie",
   "EditUserEmailForm.submit": "Potwierdź nowy email",
   "EditUserEmailForm.success": "Na adres {email} została wysłana wiadomość e-mail z linkiem potwierdzającym. Proszę kliknąć w link, aby zweryfikować swój adres e-mail.",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -982,6 +982,8 @@
   "editTeam.member.remove.success": "Member removed successfully.",
   "editTeam.memberInvitation.edit.error": "Failed to update member invitation.",
   "editTeam.memberInvitation.edit.success": "Member invitation updated successfully.",
+  "editTeam.memberInvitation.remove.error": "Failed to remove member invitation.",
+  "editTeam.memberInvitation.remove.success": "Member invitation removed successfully.",
   "EditUserEmailForm.reSend": "Reenviar confirmação",
   "EditUserEmailForm.submit": "Confirme o novo email",
   "EditUserEmailForm.success": "Um e-mail com um link de confirmação foi enviado para {email}. Por favor, clique no link para validar seu endereço de e-mail.",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -982,6 +982,8 @@
   "editTeam.member.remove.success": "Member removed successfully.",
   "editTeam.memberInvitation.edit.error": "Failed to update member invitation.",
   "editTeam.memberInvitation.edit.success": "Member invitation updated successfully.",
+  "editTeam.memberInvitation.remove.error": "Failed to remove member invitation.",
+  "editTeam.memberInvitation.remove.success": "Member invitation removed successfully.",
   "EditUserEmailForm.reSend": "Enviar confirmação novamente",
   "EditUserEmailForm.submit": "Confirmar novo e-mail",
   "EditUserEmailForm.success": "An email with a confirmation link has been sent to {email}. Please click the link to validate your email address.",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -982,6 +982,8 @@
   "editTeam.member.remove.success": "Member removed successfully.",
   "editTeam.memberInvitation.edit.error": "Failed to update member invitation.",
   "editTeam.memberInvitation.edit.success": "Member invitation updated successfully.",
+  "editTeam.memberInvitation.remove.error": "Failed to remove member invitation.",
+  "editTeam.memberInvitation.remove.success": "Member invitation removed successfully.",
   "EditUserEmailForm.reSend": "Выслать подтверждение повторно",
   "EditUserEmailForm.submit": "Подтвердить новый email",
   "EditUserEmailForm.success": "An email with a confirmation link has been sent to {email}. Please click the link to validate your email address.",

--- a/lang/sk-SK.json
+++ b/lang/sk-SK.json
@@ -982,6 +982,8 @@
   "editTeam.member.remove.success": "Člen bol úspešne odstránený.",
   "editTeam.memberInvitation.edit.error": "Nepodarilo sa aktualizovať pozvánku člena.",
   "editTeam.memberInvitation.edit.success": "Pozvánka člena bola úspešne aktualizovaná.",
+  "editTeam.memberInvitation.remove.error": "Failed to remove member invitation.",
+  "editTeam.memberInvitation.remove.success": "Member invitation removed successfully.",
   "EditUserEmailForm.reSend": "Opätovne zaslať potvrdenie",
   "EditUserEmailForm.submit": "Potvrdiť nový e-mail",
   "EditUserEmailForm.success": "E-mail s potvrdzovacím odkazom bol odoslaný na adresu {email}. Kliknutím na odkaz potvrďte svoju e-mailovú adresu.",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -982,6 +982,8 @@
   "editTeam.member.remove.success": "Учасника успішно вилучено.",
   "editTeam.memberInvitation.edit.error": "Не вдалося оновити запрошення учасників.",
   "editTeam.memberInvitation.edit.success": "Запрошення учасників успішно оновлено.",
+  "editTeam.memberInvitation.remove.error": "Failed to remove member invitation.",
+  "editTeam.memberInvitation.remove.success": "Member invitation removed successfully.",
   "EditUserEmailForm.reSend": "Надіслати підтвердження ще раз",
   "EditUserEmailForm.submit": "Підтвердити нову адресу електронної пошти",
   "EditUserEmailForm.success": "An email with a confirmation link has been sent to {email}. Please click the link to validate your email address.",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -982,6 +982,8 @@
   "editTeam.member.remove.success": "移除成员成功。",
   "editTeam.memberInvitation.edit.error": "更新成员邀请失败。",
   "editTeam.memberInvitation.edit.success": "更新成员邀请成功。",
+  "editTeam.memberInvitation.remove.error": "Failed to remove member invitation.",
+  "editTeam.memberInvitation.remove.success": "Member invitation removed successfully.",
   "EditUserEmailForm.reSend": "重新发送确认",
   "EditUserEmailForm.submit": "确认新电子邮件",
   "EditUserEmailForm.success": "一封含有确认链接的电子邮件已发送至 {email}。请点击链接来验证您的电子邮件地址。",


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/5878

# Description

This PR enables the button to remove a team member invite, and adds some more specific copy to better reflect that you are removing an invitation vs removing a team member in the toast messages.
