### PR TITLE
feat: Show 'since' date on team member cards on Collective page

### DIFF
--- a/components/ContributorCard.js
+++ b/components/ContributorCard.js
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
-import { truncate } from 'lodash';
-import { FormattedMessage, injectIntl } from 'react-intl';
+import { get, truncate } from 'lodash';
+import { FormattedDate, FormattedMessage, injectIntl } from 'react-intl';
 import styled, { css } from 'styled-components';
 
 import { CollectiveType } from '../lib/constants/collectives';
@@ -137,7 +137,13 @@ const ContributorCard = ({
         </LinkContributor>
         <Box mt={2}>
           {contributor.isAdmin || contributor.isCore ? (
-            <ContributorTag>{formatMemberRole(intl, getMainContributorRole(contributor))}</ContributorTag>
+            <React.Fragment>
+              <ContributorTag>{formatMemberRole(intl, getMainContributorRole(contributor))}</ContributorTag>
+              <P fontSize="10px" lineHeight="14px" fontWeight={400} color="#9D9FA3" mb={2}>
+                <FormattedMessage id="user.since.label" defaultMessage="Since" />:{' '}
+                <FormattedDate value={get(contributor, 'since')} />
+              </P>
+            </React.Fragment>
           ) : truncatedDescription ? (
             <P fontSize="12px" fontWeight="700" title={description} mb={1} textAlign="center">
               {truncatedDescription}


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/5922

# Description

Shows the since date on team members on the Collective page, similarly to how it is shown in the team settings.

# Screenshots

<img width="290" alt="image" src="https://user-images.githubusercontent.com/1552194/190639324-cea7471b-b30c-4f29-9fa3-f56f077bb0f7.png">

