### PR TITLE
Add `onClose` attribute to Ban Confirmation modal

### DIFF
--- a/components/root-actions/BanAccounts.js
+++ b/components/root-actions/BanAccounts.js
@@ -65,6 +65,7 @@ const BanAccount = () => {
 
       <Flex flexWrap="wrap" px={1} mt={2}>
         <StyledCheckbox
+          name="associated-accounts"
           label="Include all associated accounts"
           checked={includeAssociatedAccounts}
           onChange={({ checked }) => {
@@ -98,7 +99,7 @@ const BanAccount = () => {
           isDanger
           continueLabel="Ban accounts"
           header="Ban accounts"
-          cancelHandler={() => setDryRunData(null)}
+          onClose={() => setDryRunData(null)}
           disableSubmit={!dryRunData.isAllowed}
           continueHandler={async () => {
             try {


### PR DESCRIPTION
While looking at the Ban accounts root action menus I realized that we are missing the `onClose` attribute for the ban confirmation modal, which makes the close icon not work. 

[cclose-ban-modal.webm](https://user-images.githubusercontent.com/12435965/190688153-777c5eda-d91d-46e1-89e2-4c6967098b47.webm)
