### PR TITLE
Make sure private instructions for events can be cleared out

### DIFF
--- a/components/edit-collective/Form.js
+++ b/components/edit-collective/Form.js
@@ -84,14 +84,6 @@ class EditCollectiveForm extends React.Component {
 
     const { collective } = this.state;
 
-    this.showEditTiers = [COLLECTIVE, EVENT].includes(collective.type);
-    this.showExpenses = collective.type === COLLECTIVE || collective.isHost;
-    this.showEditGoals = collective.type === COLLECTIVE;
-    this.showHost = collective.type === COLLECTIVE;
-    this.defaultTierType = collective.type === EVENT ? 'TICKET' : 'TIER';
-    this.showEditMembers = [COLLECTIVE, ORGANIZATION].includes(collective.type);
-    this.showPaymentMethods = [USER, ORGANIZATION].includes(collective.type);
-
     this.messages = defineMessages({
       loading: { id: 'loading', defaultMessage: 'loading' },
       save: { id: 'save', defaultMessage: 'Save' },
@@ -750,7 +742,6 @@ class EditCollectiveForm extends React.Component {
           description: intl.formatMessage(this.messages.privateInstructionsDescription),
           type: 'textarea',
           maxLength: 10000,
-          defaultValue: collective.privateInstructions,
           when: () => collective.type === EVENT,
         },
         {


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/5834

⚠️ Require: https://github.com/opencollective/opencollective-api/pull/7964

[save-private-instrucations.webm](https://user-images.githubusercontent.com/12435965/190712935-bc099af8-ead7-415e-a5e7-919f2c83bbec.webm)
