### PR TITLE
Feat: add visual indicator of frozen collective in host admin

### DIFF
--- a/components/StyledCollectiveCard.js
+++ b/components/StyledCollectiveCard.js
@@ -154,12 +154,12 @@ const StyledCollectiveCard = ({
         width="95%"
         right="0"
         pt="41.25%"
-        style={{ background: getBackground(collective) }}
+        style={{ background: getBackground(collective), filter: collective.isFrozen ? 'grayscale(1)' : undefined }}
       >
         <StyledBackgroundMask />
       </Container>
       <Container position="relative">
-        <Container height={74} px={3} pt={26}>
+        <Container height={74} px={3} pt={26} style={{ filter: collective.isFrozen ? 'grayscale(1)' : undefined }}>
           <Container borderRadius={borderRadius} background="white" width={48} border="3px solid white">
             <CollectiveContainer useLink={useLink} collective={collective}>
               <Avatar data-cy="collective-avatar" collective={collective} radius={48} />
@@ -223,6 +223,7 @@ StyledCollectiveCard.propTypes = {
     parent: PropTypes.shape({
       backgroundImageUrl: PropTypes.string,
     }),
+    isFrozen: PropTypes.bool,
   }).isRequired,
   borderRadius: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   showWebsite: PropTypes.bool,

--- a/components/StyledCollectiveCard.js
+++ b/components/StyledCollectiveCard.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
-import { injectIntl } from 'react-intl';
+import { injectIntl, useIntl } from 'react-intl';
 import styled from 'styled-components';
 
 import { getCollectiveMainTag } from '../lib/collective.lib';
@@ -147,6 +147,7 @@ const StyledCollectiveCard = ({
   useLink,
   ...props
 }) => {
+  const intl = useIntl();
   return (
     <StyledCard {...props} position="relative" borderRadius={borderRadius}>
       <Container
@@ -180,7 +181,11 @@ const StyledCollectiveCard = ({
                 </StyledLink>
               </P>
             )}
-            {tag === undefined ? (
+            {collective.isFrozen ? (
+              <StyledTag display="inline-block" variant="rounded-right" my={2}>
+                <I18nCollectiveTags tags={intl.formatMessage({ defaultMessage: 'This Collective is frozen' })} />
+              </StyledTag>
+            ) : tag === undefined ? (
               <StyledTag display="inline-block" variant="rounded-right" my={2}>
                 <I18nCollectiveTags
                   tags={getCollectiveMainTag(get(collective, 'host.id'), collective.tags, collective.type)}

--- a/components/host-dashboard/HostAdminCollectiveCardMoreButton.js
+++ b/components/host-dashboard/HostAdminCollectiveCardMoreButton.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { DotsVerticalRounded } from '@styled-icons/boxicons-regular/DotsVerticalRounded';
-import { Check } from '@styled-icons/feather/Check';
 import { Pause } from '@styled-icons/feather/Pause';
+import { Play } from '@styled-icons/feather/Play';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { Flex } from '../Grid';
@@ -21,7 +21,7 @@ const FreezeAccountButton = ({ collective, onClick }) => {
       onClick={onClick}
       borderRadius={0}
     >
-      {collective.isFrozen ? <Check size={18} color="#75777A" /> : <Pause size={16} />}
+      {collective.isFrozen ? <Play size={18} color="#75777A" /> : <Pause size={16} />}
       <Span ml={3} fontSize="14px" lineHeight="20px" css={{ verticalAlign: 'middle' }}>
         {collective.isFrozen ? (
           <FormattedMessage defaultMessage="Unfreeze Collective" />

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1359,6 +1359,7 @@
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",
   "GC33m/": "Are you sure want to freeze this collective?",
+  "gDbURz": "This Collective is frozen",
   "gdP2KJ": "They will also be notified of this freeze via auto-email notification.",
   "gefgLF": "Generate CSV report",
   "getHelp": "Get help",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1359,6 +1359,7 @@
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",
   "GC33m/": "Are you sure want to freeze this collective?",
+  "gDbURz": "This Collective is frozen",
   "gdP2KJ": "They will also be notified of this freeze via auto-email notification.",
   "gefgLF": "Generate CSV report",
   "getHelp": "Získat pomoc",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1359,6 +1359,7 @@
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",
   "GC33m/": "Are you sure want to freeze this collective?",
+  "gDbURz": "This Collective is frozen",
   "gdP2KJ": "They will also be notified of this freeze via auto-email notification.",
   "gefgLF": "Generate CSV report",
   "getHelp": "Get help",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1359,6 +1359,7 @@
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",
   "GC33m/": "Are you sure want to freeze this collective?",
+  "gDbURz": "This Collective is frozen",
   "gdP2KJ": "They will also be notified of this freeze via auto-email notification.",
   "gefgLF": "Generate CSV report",
   "getHelp": "Get help",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1359,6 +1359,7 @@
   "g0KLMH": "p. ej., Dirección de correo electrónico errónea",
   "gC0tFj": "Tasa de GST",
   "GC33m/": "¿Estás seguro de que quieres congelar este Colectivo?",
+  "gDbURz": "This Collective is frozen",
   "gdP2KJ": "También se les notificará esta congelación mediante una notificación automática por correo electrónico.",
   "gefgLF": "Generar un informe CSV",
   "getHelp": "Obtener ayuda",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1359,6 +1359,7 @@
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",
   "GC33m/": "Are you sure want to freeze this collective?",
+  "gDbURz": "This Collective is frozen",
   "gdP2KJ": "They will also be notified of this freeze via auto-email notification.",
   "gefgLF": "Generate CSV report",
   "getHelp": "Obtenir de l'aide",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1359,6 +1359,7 @@
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",
   "GC33m/": "Are you sure want to freeze this collective?",
+  "gDbURz": "This Collective is frozen",
   "gdP2KJ": "They will also be notified of this freeze via auto-email notification.",
   "gefgLF": "Generate CSV report",
   "getHelp": "Chiedi aiuto",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1359,6 +1359,7 @@
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",
   "GC33m/": "Are you sure want to freeze this collective?",
+  "gDbURz": "This Collective is frozen",
   "gdP2KJ": "They will also be notified of this freeze via auto-email notification.",
   "gefgLF": "Generate CSV report",
   "getHelp": "ヘルプを見る",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1359,6 +1359,7 @@
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",
   "GC33m/": "Are you sure want to freeze this collective?",
+  "gDbURz": "This Collective is frozen",
   "gdP2KJ": "They will also be notified of this freeze via auto-email notification.",
   "gefgLF": "Generate CSV report",
   "getHelp": "도움말",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1359,6 +1359,7 @@
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",
   "GC33m/": "Are you sure want to freeze this collective?",
+  "gDbURz": "This Collective is frozen",
   "gdP2KJ": "They will also be notified of this freeze via auto-email notification.",
   "gefgLF": "Generate CSV report",
   "getHelp": "Get help",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -1359,6 +1359,7 @@
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",
   "GC33m/": "Are you sure want to freeze this collective?",
+  "gDbURz": "This Collective is frozen",
   "gdP2KJ": "They will also be notified of this freeze via auto-email notification.",
   "gefgLF": "Generuj raport CSV",
   "getHelp": "Uzyskaj pomocy",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1359,6 +1359,7 @@
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",
   "GC33m/": "Are you sure want to freeze this collective?",
+  "gDbURz": "This Collective is frozen",
   "gdP2KJ": "They will also be notified of this freeze via auto-email notification.",
   "gefgLF": "Generate CSV report",
   "getHelp": "Obter ajuda",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1359,6 +1359,7 @@
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",
   "GC33m/": "Are you sure want to freeze this collective?",
+  "gDbURz": "This Collective is frozen",
   "gdP2KJ": "They will also be notified of this freeze via auto-email notification.",
   "gefgLF": "Generate CSV report",
   "getHelp": "Peça ajuda",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1359,6 +1359,7 @@
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "GST rate",
   "GC33m/": "Are you sure want to freeze this collective?",
+  "gDbURz": "This Collective is frozen",
   "gdP2KJ": "They will also be notified of this freeze via auto-email notification.",
   "gefgLF": "Generate CSV report",
   "getHelp": "Получить помощь",

--- a/lang/sk-SK.json
+++ b/lang/sk-SK.json
@@ -1359,6 +1359,7 @@
   "g0KLMH": "napr. E-mailová Adresa je nesprávna",
   "gC0tFj": "Sadzba GST",
   "GC33m/": "Skutočne si želáte zmraziť tento kolektív?",
+  "gDbURz": "This Collective is frozen",
   "gdP2KJ": "O tomto zmrazení budú informovaní aj prostredníctvom automatického e-mailového oznámenia.",
   "gefgLF": "Generovanie výkazu CSV",
   "getHelp": "Získať pomoc",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -1359,6 +1359,7 @@
   "g0KLMH": "напр. Адреса електронної пошти неправильна",
   "gC0tFj": "GST rate",
   "GC33m/": "Ви справді хочете заморозити цей колектив?",
+  "gDbURz": "This Collective is frozen",
   "gdP2KJ": "They will also be notified of this freeze via auto-email notification.",
   "gefgLF": "Згенерувати CSV-звіт",
   "getHelp": "Отримати допомогу",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1359,6 +1359,7 @@
   "g0KLMH": "e.g. Email Address is wrong",
   "gC0tFj": "消费税",
   "GC33m/": "Are you sure want to freeze this collective?",
+  "gDbURz": "This Collective is frozen",
   "gdP2KJ": "They will also be notified of this freeze via auto-email notification.",
   "gefgLF": "Generate CSV report",
   "getHelp": "获取帮助",

--- a/stories/design-system/StyledCollectiveCard.stories.mdx
+++ b/stories/design-system/StyledCollectiveCard.stories.mdx
@@ -1,0 +1,25 @@
+import { ArgsTable, Meta, Story } from '@storybook/addon-docs/blocks';
+import StyledCollectiveCard from '../../components/StyledCollectiveCard';
+import { webpackCollective } from '../mocks/collectives';
+
+<Meta title="Design system/StyledCollectiveCard" component={StyledCollectiveCard} argTypes={{}} />
+
+# StyledCollectiveCard
+
+## Default
+
+export const DefaultStory = props => <StyledCollectiveCard {...props} />;
+
+<Canvas>
+  <Story name="Default">
+    <StyledCollectiveCard collective={webpackCollective} />
+  </Story>
+</Canvas>
+
+## Frozen Collective
+
+<Canvas>
+  <Story name="Frozen Collective">
+    <StyledCollectiveCard collective={{ ...webpackCollective, isFrozen: true }} />
+  </Story>
+</Canvas>


### PR DESCRIPTION
Related https://github.com/opencollective/opencollective/issues/3330
Design https://www.figma.com/file/ZQBMWhnGGtRWeIZknFW1eP/%5BOC-Design%5D-Production-Ready-%E2%9C%85?node-id=18797%3A200561

# Description
Display greyed out collective card background and avatar when collective is frozen.

# Screenshots

Storybook:
Active
![image](https://user-images.githubusercontent.com/5448927/191251507-d9300eeb-3cec-49e8-88f1-156217a8facb.png)

Frozen
![image](https://user-images.githubusercontent.com/5448927/191251463-b973af5f-23f3-44a3-a18b-82c213e5446b.png)

In host admin
![image](https://user-images.githubusercontent.com/5448927/191251676-936f05b2-c6f2-4973-93ec-81679e0e8d17.png)

