### PR TITLE
Adjust tests to not use expired adaptive paypal payment method

### DIFF
--- a/test/cypress/integration/27-expenses.test.js
+++ b/test/cypress/integration/27-expenses.test.js
@@ -44,8 +44,8 @@ describe('New expense flow', () => {
       cy.getByDataCy('radio-expense-type-RECEIPT').click();
       // Select Payout Method
       cy.getByDataCy('payout-method-select').click();
-      cy.contains('[data-cy="select-option"]', 'New PayPal account').click();
-      cy.get('input[name="payoutMethod.data.email"]').type('paypal-test@opencollective.com');
+      cy.contains('[data-cy="select-option"]', 'New custom payout method').click();
+      cy.get('textarea[name="payoutMethod.data.content"]').type('Bank Account: 007');
       cy.getByDataCy('expense-next').click();
 
       cy.get('input[name="description"]').type('Brussels January team retreat');
@@ -79,8 +79,8 @@ describe('New expense flow', () => {
       // Check summary
       cy.getByDataCy('expense-summary-payee').should('contain', 'Potatoes Lover');
       cy.getByDataCy('expense-summary-host').should('contain', 'Open Source Collective org');
-      cy.getByDataCy('expense-summary-payout-method-data').should('contain', 'paypal-test@opencollective.com');
-      cy.getByDataCy('expense-summary-payout-method-type').should('contain', 'PayPal');
+      cy.getByDataCy('expense-summary-payout-method-data').should('contain', 'Bank Account: 007');
+      cy.getByDataCy('expense-summary-payout-method-type').should('contain', 'Other');
       cy.getByDataCy('expense-items-total-amount').should('contain', '$275.50');
       cy.getByDataCy('expense-summary-items').should('contain', 'Fancy restaurant');
       cy.getByDataCy('expense-summary-items').should('contain', 'Potatoes for the giant raclette');
@@ -113,8 +113,8 @@ describe('New expense flow', () => {
       // Change payee - use a new organization
       cy.getByDataCy('expense-back').click();
       cy.getByDataCy('payout-method-select').click();
-      cy.contains('[data-cy="select-option"]', 'New PayPal account').click();
-      cy.get('input[name="payoutMethod.data.email"]').type('paypal-test-2@opencollective.com');
+      cy.contains('[data-cy="select-option"]', 'New custom payout method').click();
+      cy.get('textarea[name="payoutMethod.data.content"]').type('Bank Account: 007');
       cy.getByDataCy('expense-next').click();
       cy.getByDataCy('expense-summary-btn').click();
       cy.getByDataCy('save-expense-btn').click();
@@ -124,8 +124,8 @@ describe('New expense flow', () => {
       cy.contains('[data-cy="expense-page-content"]', 'Brussels January team retreat edited');
       cy.getByDataCy('expense-summary-payee').should('contain', 'Potatoes Lover');
       cy.getByDataCy('expense-summary-host').should('contain', 'Open Source Collective org');
-      cy.getByDataCy('expense-summary-payout-method-data').should('contain', 'paypal-test-2@opencollective.com');
-      cy.getByDataCy('expense-summary-payout-method-type').should('contain', 'PayPal');
+      cy.getByDataCy('expense-summary-payout-method-data').should('contain', 'Bank Account: 007');
+      cy.getByDataCy('expense-summary-payout-method-type').should('contain', 'Other');
       cy.getByDataCy('expense-items-total-amount').should('contain', '$237.50');
       cy.getByDataCy('expense-summary-items').should('contain', 'Fancy restaurant');
       cy.getByDataCy('expense-summary-items').should('contain', 'Potatoes for the giant raclette');
@@ -187,12 +187,12 @@ describe('New expense flow', () => {
       });
       cy.getByDataCy('radio-expense-type-INVOICE').click();
       cy.getByDataCy('payout-method-select').click();
-      cy.contains('[data-cy="select-option"]', 'New PayPal account').click();
+      cy.contains('[data-cy="select-option"]', 'New custom payout method').click();
       cy.getByDataCy('country-select').click();
       cy.contains('[data-cy="select-option"]', 'Angola').click();
       cy.get('input[data-cy="address-address1"]').type('Street Name, 123');
       cy.get('input[data-cy="address-city"]').type('Citycitycity');
-      cy.get('input[name="payoutMethod.data.email"]').type('paypal-test@opencollective.com');
+      cy.get('textarea[name="payoutMethod.data.content"]').type('Bank Account: 007');
       cy.getByDataCy('expense-next').click();
       // Fill the form with valid data
       cy.get('input[name="description"]').type('March invoice');
@@ -386,8 +386,8 @@ describe('New expense flow', () => {
 
       // Fill payee / payout method
       cy.getByDataCy('payout-method-select').click();
-      cy.contains('[data-cy="select-option"]', 'New PayPal account').click();
-      cy.get('input[name="payoutMethod.data.email"]').type('paypal-test@opencollective.com');
+      cy.contains('[data-cy="select-option"]', 'New custom payout method').click();
+      cy.get('textarea[name="payoutMethod.data.content"]').type('Bank Account: 007');
       cy.getByDataCy('country-select').click();
       cy.contains('[data-cy="select-option"]', 'Angola').click();
       cy.get('input[data-cy="address-address1"]').type('Street Name, 123');


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/5988

Related: https://github.com/opencollective/opencollective-api/pull/7976

As per the API pull request above, now that we check for `expiryDate` instead of `endDate` the data in the test db for adaptive payments (`PaymentMethod` table) is expired. So some of the tests will fail. For all these these tests that are failing I've changed the payout method to custom payout method; I believe this is justified since,

1) All these tests the intention was not to test specific payout method but other details in the expense flow.
2) We are deprecating the adaptive payout method anyways so I don't see any reason to use this in tests. 

However if you disagree let me know, I can add a specific test for adaptive payout method. 🤔 