### PR TITLE
Activity log: use dedicated component for description

### DIFF
--- a/components/admin-panel/sections/ActivityLog/ActivityDescription.js
+++ b/components/admin-panel/sections/ActivityLog/ActivityDescription.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { capitalize } from 'lodash';
+import { useIntl } from 'react-intl';
+
+import { ActivityDescriptionI18n } from '../../../../lib/i18n/activities';
+import formatMemberRole from '../../../../lib/i18n/member-role';
+import { getCollectivePageRoute } from '../../../../lib/url-helpers';
+
+import Link from '../../../Link';
+import LinkCollective from '../../../LinkCollective';
+import LinkExpense from '../../../LinkExpense';
+
+const ActivityDescription = ({ activity }) => {
+  const intl = useIntl();
+
+  if (!ActivityDescriptionI18n[activity.type]) {
+    return capitalize(activity.type.replace('_', ' '));
+  }
+
+  return intl.formatMessage(ActivityDescriptionI18n[activity.type], {
+    FromAccount: () => <LinkCollective collective={activity.fromAccount} openInNewTab />,
+    Account: () => <LinkCollective collective={activity.account} openInNewTab />,
+    Expense: msg =>
+      !activity.expense ? (
+        msg
+      ) : (
+        <LinkExpense
+          collective={activity.expense.account}
+          expense={activity.expense}
+          title={activity.expense.description}
+          openInNewTab
+        >
+          {msg} #{activity.expense.legacyId}
+        </LinkExpense>
+      ),
+    Order: msg =>
+      !activity.order ? (
+        msg
+      ) : (
+        <Link
+          href={`${getCollectivePageRoute(activity.order.toAccount)}/orders?searchTerm=%23${activity.order.legacyId}`}
+          title={activity.order.description}
+          openInNewTab
+        >
+          {msg} #{activity.order.legacyId}
+        </Link>
+      ),
+    Host: () => <LinkCollective collective={activity.host} openInNewTab />,
+    MemberRole: () => (activity.data?.member?.role ? formatMemberRole(intl, activity.data.member.role) : 'member'),
+  });
+};
+
+ActivityDescription.propTypes = {
+  activity: PropTypes.shape({
+    type: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default ActivityDescription;

--- a/components/admin-panel/sections/ActivityLog/index.js
+++ b/components/admin-panel/sections/ActivityLog/index.js
@@ -3,22 +3,17 @@ import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/client';
 import { isEmpty, omit, omitBy } from 'lodash';
 import { useRouter } from 'next/router';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 
 import { parseDateInterval } from '../../../../lib/date-utils';
 import { API_V2_CONTEXT, gqlV2 } from '../../../../lib/graphql/helpers';
-import { ActivityDescriptionI18n } from '../../../../lib/i18n/activities';
-import formatMemberRole from '../../../../lib/i18n/member-role';
-import { getCollectivePageRoute } from '../../../../lib/url-helpers';
 
 import Avatar from '../../../Avatar';
 import Container from '../../../Container';
 import DateTime from '../../../DateTime';
 import { Box, Flex } from '../../../Grid';
-import Link from '../../../Link';
 import LinkCollective from '../../../LinkCollective';
-import LinkExpense from '../../../LinkExpense';
 import LoadingPlaceholder from '../../../LoadingPlaceholder';
 import MessageBox from '../../../MessageBox';
 import MessageBoxGraphqlError from '../../../MessageBoxGraphqlError';
@@ -27,6 +22,7 @@ import StyledCard from '../../../StyledCard';
 import StyledLink from '../../../StyledLink';
 import { P, Span } from '../../../Text';
 
+import ActivityDescription from './ActivityDescription';
 import ActivityFilters from './ActivityFilters';
 import { getActivityTypeFilterValuesFromKey, isSupportedActivityTypeFilter } from './ActivityTypeFilter';
 
@@ -214,7 +210,6 @@ const getChangesThatRequireUpdate = (account, queryParams) => {
 };
 
 const ActivityLog = ({ accountSlug }) => {
-  const intl = useIntl();
   const router = useRouter();
   const routerQuery = omit(router.query, ['slug', 'section']);
   const offset = parseInt(routerQuery.offset) || 0;
@@ -269,42 +264,7 @@ const ActivityLog = ({ accountSlug }) => {
               {data.activities.nodes.map(activity => (
                 <Box key={activity.id} px="16px" py="14px">
                   <P color="black.900" fontWeight="500" fontSize="14px">
-                    {ActivityDescriptionI18n[activity.type]
-                      ? intl.formatMessage(ActivityDescriptionI18n[activity.type], {
-                          FromAccount: () => <LinkCollective collective={activity.fromAccount} openInNewTab />,
-                          Account: () => <LinkCollective collective={activity.account} openInNewTab />,
-                          Expense: msg =>
-                            !activity.expense ? (
-                              msg
-                            ) : (
-                              <LinkExpense
-                                collective={activity.expense.account}
-                                expense={activity.expense}
-                                title={activity.expense.description}
-                                openInNewTab
-                              >
-                                {msg} #{activity.expense.legacyId}
-                              </LinkExpense>
-                            ),
-                          Order: msg =>
-                            !activity.order ? (
-                              msg
-                            ) : (
-                              <Link
-                                href={`${getCollectivePageRoute(activity.order.toAccount)}/orders?searchTerm=%23${
-                                  activity.order.legacyId
-                                }`}
-                                title={activity.order.description}
-                                openInNewTab
-                              >
-                                {msg} #{activity.order.legacyId}
-                              </Link>
-                            ),
-                          Host: () => <LinkCollective collective={activity.host} openInNewTab />,
-                          MemberRole: () =>
-                            activity.data?.member?.role ? formatMemberRole(intl, activity.data.member.role) : 'member',
-                        })
-                      : activity.type}
+                    <ActivityDescription activity={activity} />
                   </P>
                   <MetadataContainer>
                     {activity.isSystem ? (


### PR DESCRIPTION
Refactor to isolate the complexity of building the description.

This PR also introduces a small change in the default description for unknown activities, we'll now capitalize the `type` to show something like `Collective edited` instead of `COLLECTIVE_EDITED`.