### PR TITLE
Increase the Tag Input Popup Width

### DIFF
--- a/components/StyledInputTags.js
+++ b/components/StyledInputTags.js
@@ -352,7 +352,7 @@ StyledInputTags.propTypes = {
 
 StyledInputTags.defaultProps = {
   maxHeight: ['50vh', null, '30vh'],
-  width: '240px',
+  minWidth: '240px',
   renderUpdatedTags: true,
 };
 


### PR DESCRIPTION
This is related to the slack thread; https://opencollective.slack.com/archives/C6JTTA4SK/p1664358083090799. It seems that there's a cutoff since we fix the tag input popup to 240px. 

![image](https://user-images.githubusercontent.com/12435965/193199284-7d9f8458-a56c-4703-95c7-92424201689b.png)

This PR corrects it and sets a minWidth instead;

![image](https://user-images.githubusercontent.com/12435965/193198989-8fdfab2e-883a-4540-932d-d974c2c8375c.png)
