### PR TITLE
Fix website URL in Vercel deploy previews

### DIFF
--- a/components/CreateGiftCardsSuccess.js
+++ b/components/CreateGiftCardsSuccess.js
@@ -7,6 +7,7 @@ import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 
 import { giftCardsDownloadUrl } from '../lib/url-helpers';
+import { getWebsiteUrl } from '../lib/utils';
 
 import FileDownloader from './FileDownloader';
 import { Box, Flex } from './Grid';
@@ -48,7 +49,7 @@ export default class CreateGiftCardsSuccess extends React.Component {
 
   getRedeemLinkFromVC = vc => {
     const code = vc.uuid.split('-')[0];
-    return `${process.env.WEBSITE_URL}/${this.props.collectiveSlug}/redeem/${code}`;
+    return `${getWebsiteUrl()}/${this.props.collectiveSlug}/redeem/${code}`;
   };
 
   copyLinksToClipboard = () => {

--- a/components/contribution-flow/ContributionFlowSuccess.js
+++ b/components/contribution-flow/ContributionFlowSuccess.js
@@ -15,6 +15,7 @@ import { formatCurrency } from '../../lib/currency-utils';
 import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
 import { formatManualInstructions } from '../../lib/payment-method-utils';
 import { facebookShareURL, getCollectivePageRoute, tweetURL } from '../../lib/url-helpers';
+import { getWebsiteUrl } from '../../lib/utils';
 
 import Container from '../../components/Container';
 import { formatAccountDetails } from '../../components/edit-collective/utils';
@@ -220,7 +221,7 @@ class ContributionFlowSuccess extends React.Component {
   render() {
     const { LoggedInUser, collective, data, intl, isEmbed } = this.props;
     const { order } = data;
-    const shareURL = `${process.env.WEBSITE_URL}/${collective.slug}`;
+    const shareURL = `${getWebsiteUrl()}/${collective.slug}`;
 
     if (!data.loading && !order) {
       return (

--- a/components/contribution-flow/utils.js
+++ b/components/contribution-flow/utils.js
@@ -17,6 +17,7 @@ import {
   getPaymentMethodMetadata,
   isPaymentMethodDisabled,
 } from '../../lib/payment-method-utils';
+import { getWebsiteUrl } from '../../lib/utils';
 
 import CreditCardInactive from '../icons/CreditCardInactive';
 
@@ -251,12 +252,12 @@ export const getGQLV2AmountInput = (valueInCents, defaultValue) => {
 
 const getCanonicalURL = (collective, tier) => {
   if (!tier) {
-    return `${process.env.WEBSITE_URL}/${collective.slug}/donate`;
+    return `${getWebsiteUrl()}/${collective.slug}/donate`;
   } else if (collective.type === CollectiveType.EVENT) {
     const parentSlug = get(collective.parent, 'slug', collective.slug);
-    return `${process.env.WEBSITE_URL}/${parentSlug}/events/${collective.slug}/order/${tier.id}`;
+    return `${getWebsiteUrl()}/${parentSlug}/events/${collective.slug}/order/${tier.id}`;
   } else {
-    return `${process.env.WEBSITE_URL}/${collective.slug}/contribute/${tier.slug}-${tier.id}/checkout`;
+    return `${getWebsiteUrl()}/${collective.slug}/contribute/${tier.slug}-${tier.id}/checkout`;
   }
 };
 

--- a/components/edit-collective/sections/Host.js
+++ b/components/edit-collective/sections/Host.js
@@ -6,7 +6,7 @@ import { FormattedMessage, injectIntl } from 'react-intl';
 import styled from 'styled-components';
 
 import { formatCurrency } from '../../../lib/currency-utils';
-import { formatDate } from '../../../lib/utils';
+import { formatDate, getWebsiteUrl } from '../../../lib/utils';
 
 import CollectiveCard from '../../CollectiveCard';
 import Container from '../../Container';
@@ -424,7 +424,7 @@ class Host extends React.Component {
                         collective={collective}
                         service="stripe"
                         options={{
-                          redirect: `${process.env.WEBSITE_URL}/${collective.slug}/admin/host?selectedOption=selfHost`,
+                          redirect: `${getWebsiteUrl()}/${collective.slug}/admin/host?selectedOption=selfHost`,
                         }}
                       />
                     </Box>

--- a/components/host-dashboard/ScheduledExpensesBanner.js
+++ b/components/host-dashboard/ScheduledExpensesBanner.js
@@ -6,6 +6,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 import { addAuthTokenToHeader } from '../../lib/api';
 import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
+import { getWebsiteUrl } from '../../lib/utils';
 
 import ConfirmationModal from '../ConfirmationModal';
 import { Box, Flex } from '../Grid';
@@ -54,7 +55,7 @@ const ScheduledExpensesBanner = ({ host, onSubmit, secondButton, expenses }) => 
   const handlePayBatch = async () => {
     const expenseIds = scheduledExpenses.data.expenses.nodes.map(e => e.id);
     try {
-      await request(`${process.env.WEBSITE_URL}/api/services/transferwise/pay-batch`, {
+      await request(`${getWebsiteUrl()}/api/services/transferwise/pay-batch`, {
         method: 'POST',
         body: JSON.stringify({ expenseIds, hostId: host.id }),
         headers: addAuthTokenToHeader(),

--- a/lib/url-helpers.js
+++ b/lib/url-helpers.js
@@ -1,6 +1,7 @@
 import { isEmpty, pickBy } from 'lodash';
 
 import { CollectiveType } from './constants/collectives';
+import { getWebsiteUrl } from './utils';
 
 export const invoiceServiceURL = process.env.PDF_SERVICE_URL;
 
@@ -125,7 +126,7 @@ export const getOauthAppSettingsRoute = (account, app) => {
 };
 
 export const getCollectivePageCanonicalURL = account => {
-  return process.env.WEBSITE_URL + getCollectivePageRoute(account);
+  return getWebsiteUrl() + getCollectivePageRoute(account);
 };
 
 export const getCollectivePageRoute = account => {

--- a/pages/contribute.js
+++ b/pages/contribute.js
@@ -11,6 +11,7 @@ import { sortEvents } from '../lib/events';
 import { gqlV1 } from '../lib/graphql/helpers';
 import { sortTiersForCollective } from '../lib/tier-utils';
 import { getCollectivePageRoute } from '../lib/url-helpers';
+import { getWebsiteUrl } from '../lib/utils';
 
 import Body from '../components/Body';
 import CollectiveNavbar from '../components/collective-navbar';
@@ -85,7 +86,7 @@ class TiersPage extends React.Component {
         ...baseMetadata,
         title: `Contribute to ${collective.name}`,
         description: 'These are all the ways you can help make our community sustainable. ',
-        canonicalURL: `${process.env.WEBSITE_URL}/${collective.slug}/contribute`,
+        canonicalURL: `${getWebsiteUrl()}/${collective.slug}/contribute`,
         noRobots: false,
       };
     }

--- a/pages/tier.js
+++ b/pages/tier.js
@@ -7,6 +7,7 @@ import { withRouter } from 'next/router';
 import { getCollectivePageMetadata } from '../lib/collective.lib';
 import { CollectiveType } from '../lib/constants/collectives';
 import { addParentToURLIfMissing, getCollectivePageRoute } from '../lib/url-helpers';
+import { getWebsiteUrl } from '../lib/utils';
 
 import CollectiveThemeProvider from '../components/CollectiveThemeProvider';
 import ErrorPage from '../components/ErrorPage';
@@ -57,9 +58,7 @@ class TierPage extends React.Component {
     const baseMetadata = getCollectivePageMetadata(tier?.collective);
     if (tier && tier.collective) {
       const collective = tier.collective;
-      canonicalURL = `${process.env.WEBSITE_URL}/${getCollectivePageRoute(collective)}/contribute/${tier.slug}-${
-        tier.id
-      }`;
+      canonicalURL = `${getWebsiteUrl()}/${getCollectivePageRoute(collective)}/contribute/${tier.slug}-${tier.id}`;
       return {
         ...baseMetadata,
         title: `${collective.name} - ${tier.name}`,
@@ -69,9 +68,13 @@ class TierPage extends React.Component {
       };
     } else {
       if ([CollectiveType.EVENT, CollectiveType.PROJECT].includes(this.props.collectiveType)) {
-        canonicalURL = `${process.env.WEBSITE_URL}/${this.props.parentCollectiveSlug}/${this.props.collectiveType}/${this.props.collectiveSlug}/contribute/${this.props.tierSlug}-${this.props.tierId}`;
+        canonicalURL = `${getWebsiteUrl()}/${this.props.parentCollectiveSlug}/${this.props.collectiveType}/${
+          this.props.collectiveSlug
+        }/contribute/${this.props.tierSlug}-${this.props.tierId}`;
       } else {
-        canonicalURL = `${process.env.WEBSITE_URL}/${this.props.collectiveSlug}/contribute/${this.props.tierSlug}-${this.props.tierId}`;
+        canonicalURL = `${getWebsiteUrl()}/${this.props.collectiveSlug}/contribute/${this.props.tierSlug}-${
+          this.props.tierId
+        }`;
       }
       return { ...baseMetadata, title: 'Tier', canonicalURL };
     }


### PR DESCRIPTION
An attempt at fixing an issue on Vercel with the filters in places like the transactions page, where filtering by date brings you to http://localhost:3000/babel/transactions?period=2022-10-10T22%3A00%3A00.000Z%E2%86%92all.