### PR TITLE
Parse node version from package.json in Github actions

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -5,12 +5,19 @@ inputs:
     description: The cache version, to manually invalidate the dependencies cache
     required: true
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
+    - name: Get Node version from package.json
+      shell: bash
+      id: parse_package_json
+      run: |
+        result=`jq -r '.engines.node' package.json`
+        echo "::set-output name=node_version::$result"
+
     - name: Setup node
       uses: actions/setup-node@v3
       with:
-        node-version: '16.x'
+        node-version: ${{steps.parse_package_json.outputs.node_version}}
 
     - name: Restore node_modules
       uses: actions/cache@v3


### PR DESCRIPTION
Depends on https://github.com/opencollective/opencollective-frontend/pull/8254

Automatically retrieves Node version from `package.json`