### PR TITLE
fix(OSC onboarding): Redirect to collective page onboarding if automatically approved

### DIFF
--- a/components/osc-host-application/ApplicationForm.js
+++ b/components/osc-host-application/ApplicationForm.js
@@ -53,6 +53,7 @@ const createCollectiveMutation = gqlV2/* GraphQL */ `
     ) {
       id
       slug
+      isApproved
       host {
         id
         slug
@@ -78,6 +79,7 @@ const applyToHostMutation = gqlV2/* GraphQL */ `
     ) {
       id
       slug
+      isApproved
       ... on AccountWithHost {
         host {
           id
@@ -184,8 +186,14 @@ const ApplicationForm = ({
     };
 
     const response = await submitApplication({ variables });
-    if (response.data.createCollective || response.data.applyToHost) {
-      await router.push('/opensource/apply/success');
+    const resCollective = response.data.createCollective || response.data.applyToHost;
+
+    if (resCollective) {
+      if (resCollective.isApproved) {
+        await router.push(`/${resCollective.slug}/onboarding`);
+      } else {
+        await router.push('/opensource/apply/success');
+      }
       window.scrollTo(0, 0);
     }
   };


### PR DESCRIPTION

# Description

Fix for a regression in the OSC application flow where you were sent to a "We will review you application" page regardless whether it was automatically approved or not.

If you are approved it will instead send you to the collective page with the onboarding modal: `/collectiveSlug/onboarding` as it were previously.

# Screenshots

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
