### PR TITLE
Make Sure `AddFundsModal.js` works correctly when Adding Funds to Host

### DIFF
--- a/components/collective-navbar/ActionsMenu.js
+++ b/components/collective-navbar/ActionsMenu.js
@@ -271,7 +271,7 @@ const CollectiveNavbarActionsMenu = ({ collective, callsToAction, hiddenActionFo
                       </MenuItem>
                     )}
                     {callsToAction.addFunds && (
-                      <AddFundsBtn collective={collective} host={collective.host}>
+                      <AddFundsBtn collective={collective}>
                         {btnProps => (
                           <MenuItem py={1} isHiddenOnMobile={hiddenActionForNonMobile === NAVBAR_ACTION_TYPE.ADD_FUNDS}>
                             <StyledButton

--- a/components/collective-navbar/index.js
+++ b/components/collective-navbar/index.js
@@ -404,7 +404,7 @@ const getMainAction = (collective, callsToAction, LoggedInUser) => {
     return {
       type: NAVBAR_ACTION_TYPE.ADD_FUNDS,
       component: (
-        <AddFundsBtn collective={collective} host={collective.host}>
+        <AddFundsBtn collective={collective}>
           {btnProps => (
             <ActionButton {...btnProps}>
               <AttachMoney size="1em" />

--- a/components/host-dashboard/AddFundsModal.js
+++ b/components/host-dashboard/AddFundsModal.js
@@ -277,7 +277,6 @@ const AddFundsModal = ({ collective, ...props }) => {
   const { data, loading } = useQuery(addFundsAccountQuery, {
     context: API_V2_CONTEXT,
     variables: { slug: collective.slug },
-    skip: !collective,
   });
   const account = data?.account;
   const currency = account?.currency;
@@ -293,7 +292,7 @@ const AddFundsModal = ({ collective, ...props }) => {
       {
         context: API_V2_CONTEXT,
         query: getBudgetSectionQuery(true),
-        variables: getBudgetSectionQueryVariables(collective.slug, account?.host?.slug),
+        variables: getBudgetSectionQueryVariables(collective.slug, collective.host?.slug),
       },
       { query: collectivePageQuery, variables: getCollectivePageQueryVariables(collective.slug) },
     ],
@@ -318,11 +317,11 @@ const AddFundsModal = ({ collective, ...props }) => {
 
   // From the Collective page we pass host and collective as API v1 objects
   // From the Host dashboard we pass host and collective as API v2 objects
-  const canAddHostFee = account?.host?.plan?.hostFees && collective.id !== account?.host?.id;
+  const canAddHostFee = collective.host?.plan?.hostFees && collective.id !== account?.host?.id;
   const hostFeePercent = account?.addedFundsHostFeePercent || collective.hostFeePercent;
   const defaultHostFeePercent = canAddHostFee ? hostFeePercent : 0;
-  const canAddPlatformTip = account?.host?.isTrustedHost;
-  const receiptTemplates = account?.host?.settings?.invoice?.templates;
+  const canAddPlatformTip = collective.host?.isTrustedHost;
+  const receiptTemplates = collective.host?.settings?.invoice?.templates;
 
   const receiptTemplateTitles = [];
   if (receiptTemplates?.default?.title?.length > 0) {
@@ -421,10 +420,10 @@ const AddFundsModal = ({ collective, ...props }) => {
 
           const defaultSources = [];
           defaultSources.push({
-            value: account?.host,
-            label: <DefaultCollectiveLabel value={account?.host} />,
+            value: collective.host,
+            label: <DefaultCollectiveLabel value={collective.host} />,
           });
-          if (account?.host?.id !== collective.id) {
+          if (collective.host?.id !== collective.id) {
             defaultSources.push({ value: collective, label: <DefaultCollectiveLabel value={collective} /> });
           }
 
@@ -758,6 +757,7 @@ AddFundsModal.propTypes = {
     id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     hostFeePercent: PropTypes.number,
     slug: PropTypes.string,
+    host: PropTypes.object.isRequired,
   }).isRequired,
   onClose: PropTypes.func,
 };

--- a/components/host-dashboard/AddFundsModal.js
+++ b/components/host-dashboard/AddFundsModal.js
@@ -295,13 +295,7 @@ const AddFundsModal = ({ collective, ...props }) => {
   });
   const account = data?.account;
   const currency = account?.currency;
-  let host;
-
-  if (account?.isHost) {
-    host = account;
-  } else {
-    host = account?.host;
-  }
+  const host = account?.isHost ? account : account?.host;
 
   const options = React.useMemo(
     () => getOptions(fundDetails.fundAmount, currency, intl),


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/6030

[add-funds-modal-fix.webm](https://user-images.githubusercontent.com/12435965/194187405-d70cfecc-6474-4da9-ad8b-9f99428b19c9.webm)

In https://github.com/opencollective/opencollective-frontend/pull/8035 we've introduced a bug as I've described in https://github.com/opencollective/opencollective/issues/6030. This bug only applies when adding funds to a Host. The problem is that we use different props (`collective` and `host`) passed down from the parent to and rely on these values within the `AddFundsModal`. Here I've tried to minimize this and further refactored the code to make sure we use the graphql query within the `AddFundsModal` so that we have a consistent AddFundsModal throughout. 