### PR TITLE
Reduce the number of fields fetched for LoggedInUser

### DIFF
--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -137,10 +137,6 @@ export const loggedInUserQuery = gqlV1/* GraphQL */ `
           name
           isSaved
         }
-        connectedAccounts {
-          id
-          service
-        }
       }
       memberOf {
         id

--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -131,12 +131,6 @@ export const loggedInUserQuery = gqlV1/* GraphQL */ `
           country
           structured
         }
-        payoutMethods {
-          id
-          type
-          name
-          isSaved
-        }
       }
       memberOf {
         id

--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -124,7 +124,6 @@ export const loggedInUserQuery = gqlV1/* GraphQL */ `
         imageUrl
         settings
         currency
-        isDeletable
         categories
         location {
           id
@@ -480,7 +479,6 @@ export const legacyCollectiveQuery = gqlV1/* GraphQL */ `
       isArchived
       isFrozen
       isApproved
-      isDeletable
       host {
         id
         slug


### PR DESCRIPTION
Resolve of https://github.com/opencollective/opencollective/issues/2126
Part of https://github.com/opencollective/opencollective/issues/4991

- `isDeletable`: already fetched from `editCollectivePageFieldsFragment` to be used in `components/edit-collective/actions/Delete.js`, not used elsewhere. It was expensive, almost 2 seconds in some cases:
![image](https://user-images.githubusercontent.com/1556356/195694761-78fa59be-bca3-452e-bd03-81f542a27abd.png)
- `connectedAccounts`: did not find any real usage. Already fetched from `editCollectivePageFieldsFragment`
- `payoutMethods` this was [introduced](https://github.com/opencollective/opencollective-frontend/pull/3414#discussion_r576245820) on the legacy expense form, and we moved away from that when we introduced the new expense form that fetches all the data it needs from V2
