### PR TITLE
fix(OSC onboarding): Skip validation in ApplyToHostModal for OSC blocking the form

### DIFF
--- a/components/ApplyToHostModal.js
+++ b/components/ApplyToHostModal.js
@@ -313,6 +313,12 @@ const ApplyToHostModal = ({ hostSlug, collective, onClose, onSuccess, router, ..
             if (!values.collective && contentRef.current) {
               contentRef.current.scrollIntoView({ behavior: 'smooth' });
             }
+
+            // Since the OSC flow is using a standalone form, without any TOS checkbox in this modal, skip validation here
+            if (isOSCHost) {
+              return {};
+            }
+
             return requireFields(values, host.termsUrl ? ['areTosChecked', 'collective'] : ['collective']);
           }}
           onSubmit={async values => {


### PR DESCRIPTION
Bug reported on Twitter: https://twitter.com/networkmycelium/status/1581273437871316992

# Description
This was caused by the `ApplyToHostModal` trying to validate that the terms of service checkbox in the modal is checked, but as OSC has its own standalone flow, it is removed from this modal. However, the modal is still trying to validate that since the OSC collective has a terms of service URL (which it did not have in development, oops).

This fix bypasses the validation in the `ApplyToHostModal` for OSC (while still having validation in its own form)