### PR TITLE
Fix missing licenseSpdxId from GitHub breaking pending applications

### DIFF
--- a/components/host-dashboard/ValidatedRepositoryInfo.js
+++ b/components/host-dashboard/ValidatedRepositoryInfo.js
@@ -102,7 +102,7 @@ function ValidatedRepositoryInfo({ customData }) {
                 license:
                   !field?.value || field.value === 'NOASSERTION'
                     ? 'Not found'
-                    : `${field.value} (${spdxLicenses[field.value].name})`,
+                    : `${field.value} (${spdxLicenses[field.value]?.name || 'Unknown'})`,
               })}{' '}
               {licenseSpdxId && licenseSpdxId !== field?.value && (
                 <Span color="black.600">{intl.formatMessage(msg.licenseManually, { license: licenseSpdxId })}</Span>

--- a/components/host-dashboard/ValidatedRepositoryInfo.js
+++ b/components/host-dashboard/ValidatedRepositoryInfo.js
@@ -28,7 +28,7 @@ const FieldWithValidationBadge = ({ field, children }) => {
 
 const ValidatedFieldPropType = PropTypes.shape({
   isValid: PropTypes.bool,
-  value: PropTypes.string || PropTypes.number || PropTypes.bool,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
 });
 
 FieldWithValidationBadge.propTypes = {
@@ -100,9 +100,11 @@ function ValidatedRepositoryInfo({ customData }) {
             <React.Fragment>
               {intl.formatMessage(msg.license, {
                 license:
-                  field.value === 'NOASSERTION' ? 'Not found' : `${field.value} (${spdxLicenses[field.value].name})`,
+                  !field?.value || field.value === 'NOASSERTION'
+                    ? 'Not found'
+                    : `${field.value} (${spdxLicenses[field.value].name})`,
               })}{' '}
-              {licenseSpdxId && licenseSpdxId !== field.value && (
+              {licenseSpdxId && licenseSpdxId !== field?.value && (
                 <Span color="black.600">{intl.formatMessage(msg.licenseManually, { license: licenseSpdxId })}</Span>
               )}
             </React.Fragment>


### PR DESCRIPTION
## Description
If GitHub did not fetch a license, this would break the pending applications view:
![image](https://user-images.githubusercontent.com/1552194/196195749-9274cb00-e14a-4bda-a266-773e8ef53e4c.png)

This fix makes sure that the licenseSpdxId can be `undefined`.

Also fixing a prop type definition in the same component that was not correct.