### PR TITLE
Do not include default i18n messages for English

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -119,7 +119,7 @@ class OpenCollectiveFrontendApp extends App {
   render() {
     const { client, Component, pageProps, scripts, locale, messages } = this.props;
 
-    const intl = createIntl({ locale: locale || 'en', messages }, cache);
+    const intl = createIntl({ locale: locale || 'en', defaultLocale: 'en', messages }, cache);
 
     return (
       <Fragment>

--- a/server/intl.js
+++ b/server/intl.js
@@ -55,7 +55,10 @@ function middleware() {
 
     logger.debug('url %s locale %s', req.url, req.locale);
     req.localeDataScript = getLocaleDataScript(req.locale);
-    req.messages = getMessages(req.locale);
+    if (req.locale !== 'en') {
+      req.messages = getMessages(req.locale);
+    }
+
     next();
   };
 }


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/6036

Since all our strings are formatted in English by default, we don't need to include the English translations in `__NEXT_DATA__`.

This will:
- Reduce the page size when using English by roughly 220kb (221kb -> 728b), reducing its load time
- Remove the NextJS warning `Warning: data for page ___ is 221 kB which exceeds the threshold of 128 kB, this amount of data can reduce performance.`

