### PR TITLE
fix(OSC onboarding): Update "too few admins" message and refetch user so that it is displayed

### DIFF
--- a/components/collective-page/CollectiveNotificationBar.js
+++ b/components/collective-page/CollectiveNotificationBar.js
@@ -86,7 +86,7 @@ const messages = defineMessages({
   tooFewAdmins: {
     id: 'collective.tooFewAdmins',
     defaultMessage:
-      'You need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.',
+      'Your collective was approved but you need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.',
   },
   tooFewAdminsDescription: {
     id: 'collective.tooFewAdmins.description',
@@ -148,6 +148,7 @@ const getNotification = (intl, status, collective, host, LoggedInUser) => {
     };
   } else if (
     LoggedInUser?.isAdminOfCollectiveOrHost(collective) &&
+    collective.isApproved &&
     host?.policies?.COLLECTIVE_MINIMUM_ADMINS?.freeze &&
     host?.policies?.COLLECTIVE_MINIMUM_ADMINS?.numberOfAdmins > collective?.admins?.length &&
     collective?.features?.RECEIVE_FINANCIAL_CONTRIBUTIONS === 'DISABLED'

--- a/components/osc-host-application/ApplicationForm.js
+++ b/components/osc-host-application/ApplicationForm.js
@@ -215,6 +215,7 @@ const ApplicationForm = ({
   router,
   collective: collectiveWithSlug,
   host,
+  refetchLoggedInUser,
 }) => {
   const intl = useIntl();
   const [submitApplication, { loading: submitting, error }] = useApplicationMutation(canApplyWithCollective);
@@ -267,6 +268,8 @@ const ApplicationForm = ({
 
     if (resCollective) {
       if (resCollective.isApproved) {
+        await refetchLoggedInUser();
+
         await router.push(`/${resCollective.slug}/onboarding`);
       } else {
         await router.push('/opensource/apply/success');
@@ -873,6 +876,7 @@ const ApplicationForm = ({
 ApplicationForm.propTypes = {
   loadingLoggedInUser: PropTypes.bool,
   LoggedInUser: PropTypes.object,
+  refetchLoggedInUser: PropTypes.func,
   initialValues: PropTypes.object,
   setInitialValues: PropTypes.func,
   collective: PropTypes.shape({

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -492,7 +492,7 @@
   "collective.subtitle.opensource": "Open source projects are invited to join the Open Source Collective Fiscal Host.",
   "collective.subtitle.seeRepo": "Don't see the repository you're looking for? {helplink}.",
   "collective.tags.edit.description": "Help people find you",
-  "collective.tooFewAdmins": "You need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
+  "collective.tooFewAdmins": "Your collective was approved but you need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
   "collective.tooFewAdmins.description": "You will automatically be able to accept contributions when {missingAdminsCount, plural, one {an invited administrator} other {# invited administrators} } has joined.",
   "collective.tos.description": "Link to the terms under which this Host collects and holds funds.",
   "collective.type.label": "Tipus",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -492,7 +492,7 @@
   "collective.subtitle.opensource": "Open source projects are invited to join the Open Source Collective Fiscal Host.",
   "collective.subtitle.seeRepo": "Nevidíte repozitář, který hledáte? {helplink}.",
   "collective.tags.edit.description": "Pomozte lidem Vás najít",
-  "collective.tooFewAdmins": "You need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
+  "collective.tooFewAdmins": "Your collective was approved but you need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
   "collective.tooFewAdmins.description": "You will automatically be able to accept contributions when {missingAdminsCount, plural, one {an invited administrator} other {# invited administrators} } has joined.",
   "collective.tos.description": "Link to the terms under which this Host collects and holds funds.",
   "collective.type.label": "Typ",

--- a/lang/de.json
+++ b/lang/de.json
@@ -492,7 +492,7 @@
   "collective.subtitle.opensource": "Open Source-Projekte sind eingeladen, dem Open Source Collective Fiscal Host beizutreten.",
   "collective.subtitle.seeRepo": "Finden sie nicht das Repository, das Sie suchen? {helplink}.",
   "collective.tags.edit.description": "Hilf den Leuten, dich zu finden",
-  "collective.tooFewAdmins": "You need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
+  "collective.tooFewAdmins": "Your collective was approved but you need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
   "collective.tooFewAdmins.description": "You will automatically be able to accept contributions when {missingAdminsCount, plural, one {an invited administrator} other {# invited administrators} } has joined.",
   "collective.tos.description": "Link zu den Bedingungen, unter denen dieser Host Gelder sammelt und hält.",
   "collective.type.label": "Typ",

--- a/lang/en.json
+++ b/lang/en.json
@@ -492,7 +492,7 @@
   "collective.subtitle.opensource": "Open source projects are invited to join the Open Source Collective Fiscal Host.",
   "collective.subtitle.seeRepo": "Don't see the repository you're looking for? {helplink}.",
   "collective.tags.edit.description": "Help people find you",
-  "collective.tooFewAdmins": "You need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
+  "collective.tooFewAdmins": "Your collective was approved but you need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
   "collective.tooFewAdmins.description": "You will automatically be able to accept contributions when {missingAdminsCount, plural, one {an invited administrator} other {# invited administrators} } has joined.",
   "collective.tos.description": "Link to the terms under which this Host collects and holds funds.",
   "collective.type.label": "Type",

--- a/lang/es.json
+++ b/lang/es.json
@@ -492,7 +492,7 @@
   "collective.subtitle.opensource": "Los proyectos de código abierto están invitados a unirse al Anfitrión Fiscal de Open Source Collective.",
   "collective.subtitle.seeRepo": "¿No ves el repositorio que estás buscando? {helplink}.",
   "collective.tags.edit.description": "Haz que la gente te encuentre",
-  "collective.tooFewAdmins": "You need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
+  "collective.tooFewAdmins": "Your collective was approved but you need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
   "collective.tooFewAdmins.description": "You will automatically be able to accept contributions when {missingAdminsCount, plural, one {an invited administrator} other {# invited administrators} } has joined.",
   "collective.tos.description": "Enlace a los términos bajo los cuales este Anfitrión recoge y sostiene fondos.",
   "collective.type.label": "Tipo",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -492,7 +492,7 @@
   "collective.subtitle.opensource": "Les projets Open Source sont invités à rejoindre l'hôte fiscal « Open Source Collective ».",
   "collective.subtitle.seeRepo": "Vous ne voyez pas le dépôt que vous cherchez ? {helplink}.",
   "collective.tags.edit.description": "Aidez les gens à vous trouver",
-  "collective.tooFewAdmins": "You need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
+  "collective.tooFewAdmins": "Your collective was approved but you need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
   "collective.tooFewAdmins.description": "You will automatically be able to accept contributions when {missingAdminsCount, plural, one {an invited administrator} other {# invited administrators} } has joined.",
   "collective.tos.description": "Link to the terms under which this Host collects and holds funds.",
   "collective.type.label": "Type",

--- a/lang/it.json
+++ b/lang/it.json
@@ -492,7 +492,7 @@
   "collective.subtitle.opensource": "Open source projects are invited to join the Open Source Collective Fiscal Host.",
   "collective.subtitle.seeRepo": "Non trovi il repository che stai cercando? {helplink}.",
   "collective.tags.edit.description": "Aiuta le persone a trovarti",
-  "collective.tooFewAdmins": "You need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
+  "collective.tooFewAdmins": "Your collective was approved but you need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
   "collective.tooFewAdmins.description": "You will automatically be able to accept contributions when {missingAdminsCount, plural, one {an invited administrator} other {# invited administrators} } has joined.",
   "collective.tos.description": "Link to the terms under which this Host collects and holds funds.",
   "collective.type.label": "Tipo",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -492,7 +492,7 @@
   "collective.subtitle.opensource": "Open source projects are invited to join the Open Source Collective Fiscal Host.",
   "collective.subtitle.seeRepo": "Don't see the repository you're looking for? {helplink}.",
   "collective.tags.edit.description": "Help people find you",
-  "collective.tooFewAdmins": "You need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
+  "collective.tooFewAdmins": "Your collective was approved but you need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
   "collective.tooFewAdmins.description": "You will automatically be able to accept contributions when {missingAdminsCount, plural, one {an invited administrator} other {# invited administrators} } has joined.",
   "collective.tos.description": "Link to the terms under which this Host collects and holds funds.",
   "collective.type.label": "タイプ",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -492,7 +492,7 @@
   "collective.subtitle.opensource": "Open source projects are invited to join the Open Source Collective Fiscal Host.",
   "collective.subtitle.seeRepo": "찾고 계신 리포지터리가 없나요? {helplink}.",
   "collective.tags.edit.description": "Help people find you",
-  "collective.tooFewAdmins": "You need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
+  "collective.tooFewAdmins": "Your collective was approved but you need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
   "collective.tooFewAdmins.description": "You will automatically be able to accept contributions when {missingAdminsCount, plural, one {an invited administrator} other {# invited administrators} } has joined.",
   "collective.tos.description": "Link to the terms under which this Host collects and holds funds.",
   "collective.type.label": "유형",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -492,7 +492,7 @@
   "collective.subtitle.opensource": "Open source projects are invited to join the Open Source Collective Fiscal Host.",
   "collective.subtitle.seeRepo": "Don't see the repository you're looking for? {helplink}.",
   "collective.tags.edit.description": "Help people find you",
-  "collective.tooFewAdmins": "You need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
+  "collective.tooFewAdmins": "Your collective was approved but you need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
   "collective.tooFewAdmins.description": "You will automatically be able to accept contributions when {missingAdminsCount, plural, one {an invited administrator} other {# invited administrators} } has joined.",
   "collective.tos.description": "Link to the terms under which this Host collects and holds funds.",
   "collective.type.label": "Type",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -492,7 +492,7 @@
   "collective.subtitle.opensource": "Projekty open source są zapraszane do dołączenia gospodarza podatkowy w Open Source Collective.",
   "collective.subtitle.seeRepo": "Nie widzisz repozytorium, którego szukasz? {helplink}.",
   "collective.tags.edit.description": "Pomóż innym Cię odnaleźć",
-  "collective.tooFewAdmins": "You need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
+  "collective.tooFewAdmins": "Your collective was approved but you need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
   "collective.tooFewAdmins.description": "You will automatically be able to accept contributions when {missingAdminsCount, plural, one {an invited administrator} other {# invited administrators} } has joined.",
   "collective.tos.description": "Link do warunków, zgodnie z którymi ten Gospodarz gromadzi i przechowuje fundusze.",
   "collective.type.label": "Typ",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -492,7 +492,7 @@
   "collective.subtitle.opensource": "Projetos de código aberto são convidados a participar do Administradores Fiscais de Coletivos de Código Aberto.",
   "collective.subtitle.seeRepo": "Não vê o repositório que você está procurando? {helplink}.",
   "collective.tags.edit.description": "Ajude pessoas a te encontrarem",
-  "collective.tooFewAdmins": "You need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
+  "collective.tooFewAdmins": "Your collective was approved but you need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
   "collective.tooFewAdmins.description": "You will automatically be able to accept contributions when {missingAdminsCount, plural, one {an invited administrator} other {# invited administrators} } has joined.",
   "collective.tos.description": "Link para os termos nos quais este administrador coleta e detém fundos.",
   "collective.type.label": "Tipo",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -492,7 +492,7 @@
   "collective.subtitle.opensource": "Open source projects are invited to join the Open Source Collective Fiscal Host.",
   "collective.subtitle.seeRepo": "Não encontra o repositório que você está procurando? {helplink}.",
   "collective.tags.edit.description": "Help people find you",
-  "collective.tooFewAdmins": "You need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
+  "collective.tooFewAdmins": "Your collective was approved but you need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
   "collective.tooFewAdmins.description": "You will automatically be able to accept contributions when {missingAdminsCount, plural, one {an invited administrator} other {# invited administrators} } has joined.",
   "collective.tos.description": "Link to the terms under which this Host collects and holds funds.",
   "collective.type.label": "Tipo",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -492,7 +492,7 @@
   "collective.subtitle.opensource": "Проекты с открытым исходным кодом приглашаются присоединиться к фискальному представителю Open Source Collective.",
   "collective.subtitle.seeRepo": "Не видите интересующий репозиторий? {helplink}.",
   "collective.tags.edit.description": "Помогите людям найти вас",
-  "collective.tooFewAdmins": "You need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
+  "collective.tooFewAdmins": "Your collective was approved but you need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
   "collective.tooFewAdmins.description": "You will automatically be able to accept contributions when {missingAdminsCount, plural, one {an invited administrator} other {# invited administrators} } has joined.",
   "collective.tos.description": "Link to the terms under which this Host collects and holds funds.",
   "collective.type.label": "Тип",

--- a/lang/sk-SK.json
+++ b/lang/sk-SK.json
@@ -492,7 +492,7 @@
   "collective.subtitle.opensource": "Projekty s otvoreným zdrojovým kódom sa môžu zapojiť do fiškálneho hostingu Open Source Collective.",
   "collective.subtitle.seeRepo": "Nevidíte úložisko, ktoré hľadáte? {helplink}.",
   "collective.tags.edit.description": "Pomôžte ľuďom, aby vás našli",
-  "collective.tooFewAdmins": "You need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
+  "collective.tooFewAdmins": "Your collective was approved but you need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
   "collective.tooFewAdmins.description": "You will automatically be able to accept contributions when {missingAdminsCount, plural, one {an invited administrator} other {# invited administrators} } has joined.",
   "collective.tos.description": "Odkaz na podmienky, podľa ktorých tento hostiteľ zhromažďuje a uchováva finančné prostriedky.",
   "collective.type.label": "Typ",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -492,7 +492,7 @@
   "collective.subtitle.opensource": "Проєкти з відкритим джерельним кодом запрошено приєднатися до фіскального вузла Колективу.",
   "collective.subtitle.seeRepo": "Не знайшли репозиторій, який шукаєте? {helplink}.",
   "collective.tags.edit.description": "Допоможіть людям знайти вас",
-  "collective.tooFewAdmins": "You need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
+  "collective.tooFewAdmins": "Your collective was approved but you need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
   "collective.tooFewAdmins.description": "You will automatically be able to accept contributions when {missingAdminsCount, plural, one {an invited administrator} other {# invited administrators} } has joined.",
   "collective.tos.description": "Посилання на умови, за яких цей фіскальний вузол збирає та тримає кошти.",
   "collective.type.label": "Тип",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -492,7 +492,7 @@
   "collective.subtitle.opensource": "我们欢迎开源项目加入 Open Source Collective Fiscal Host（开源集体财政托管）。",
   "collective.subtitle.seeRepo": "找不到你想要的仓库吗？ {helplink}。",
   "collective.tags.edit.description": "帮助人们找到你",
-  "collective.tooFewAdmins": "You need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
+  "collective.tooFewAdmins": "Your collective was approved but you need {missingAdminsCount, plural, one {one more admin} other {# more admins} } before you can accept financial contributions.",
   "collective.tooFewAdmins.description": "You will automatically be able to accept contributions when {missingAdminsCount, plural, one {an invited administrator} other {# invited administrators} } has joined.",
   "collective.tos.description": "Link to the terms under which this Host collects and holds funds.",
   "collective.type.label": "类型",

--- a/pages/osc-host-application.js
+++ b/pages/osc-host-application.js
@@ -90,7 +90,7 @@ const formatNameFromSlug = repoName => {
   return repoName.replace(/[-_]/g, ' ').replace(/(?:^|\s)\S/g, words => words.toUpperCase());
 };
 
-const OSCHostApplication = ({ loadingLoggedInUser, LoggedInUser }) => {
+const OSCHostApplication = ({ loadingLoggedInUser, LoggedInUser, refetchLoggedInUser }) => {
   const [checkedTermsOfFiscalSponsorship, setCheckedTermsOfFiscalSponsorship] = useState(false);
   const [initialValues, setInitialValues] = useState(formValues);
 
@@ -179,6 +179,7 @@ const OSCHostApplication = ({ loadingLoggedInUser, LoggedInUser }) => {
           host={hostData?.account}
           loadingCollective={loadingCollective}
           canApplyWithCollective={canApplyWithCollective && !hasHost}
+          refetchLoggedInUser={refetchLoggedInUser}
         />
       )}
       {step === 'success' && <YourInitiativeIsNearlyThere />}
@@ -189,6 +190,7 @@ const OSCHostApplication = ({ loadingLoggedInUser, LoggedInUser }) => {
 OSCHostApplication.propTypes = {
   loadingLoggedInUser: PropTypes.bool,
   LoggedInUser: PropTypes.object,
+  refetchLoggedInUser: PropTypes.func,
 };
 
 export default withUser(OSCHostApplication);


### PR DESCRIPTION
# Description
This updates the messaging to let the user know that their application was approved (but has too few admins to accept financial contribtuions).

Also fixing an issue where the message was not displayed on first page load after successful application, since the user needed to be refetched to see that he is a member/admin of the collective.

# Screenshots

<img width="1196" alt="image" src="https://user-images.githubusercontent.com/1552194/197524512-f26e58b0-8dc7-4e2c-9303-f1e0e4acb9dd.png">