### PR TITLE
Add antialiasing to fonts

### DIFF
--- a/public/static/styles/app.css
+++ b/public/static/styles/app.css
@@ -113,6 +113,9 @@ html {
   font-size: 62.5%;
   height: 100%;
   width: 100%;
+
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 body {


### PR DESCRIPTION
We should consider adding `font-smoothing: antialiased`. This will make text appear slightly sharper and more importantly better match with what is designed in Figma. If you've noticed the slight discrepancy in font rendering, this is why, they use antialiasing.