### PR TITLE
Remove expense invoice from expense attachments and use ExpenseAttachedFile name

### DIFF
--- a/components/FilesPreviewModal.js
+++ b/components/FilesPreviewModal.js
@@ -19,6 +19,7 @@ export default class FilesPreviewModal extends React.Component {
     files: PropTypes.arrayOf(
       PropTypes.shape({
         url: PropTypes.string,
+        name: PropTypes.string,
         /** An alternative to `url` */
         onClick: PropTypes.func,
       }),

--- a/components/UploadedFilePreview.js
+++ b/components/UploadedFilePreview.js
@@ -83,6 +83,11 @@ const MainContainer = styled(Container)`
     `}
 `;
 
+const FileName = styled(P)`
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
 const PrivateIconContainer = styled.div`
   text-align: center;
   svg {
@@ -143,19 +148,20 @@ const UploadedFilePreview = ({
       maxWidth={size}
       as={url ? Link : 'div'}
       href={url}
+      title={fileName}
       openInNewTab
     >
       <CardContainer size={size} maxHeight={maxHeight} title={fileName} border={border}>
         {content}
       </CardContainer>
       {showFileName && (
-        <Container mt="6px" maxWidth={100}>
+        <Container mt="6px" maxWidth={size || 100}>
           {isLoading ? (
             <LoadingPlaceholder height={12} />
           ) : fileName ? (
-            <P fontSize="12px" color="black.600" fontWeight="500">
+            <FileName fontSize="12px" color="black.600" fontWeight="500">
               {fileName}
-            </P>
+            </FileName>
           ) : (
             <P fontStyle="italic" fontSize="12px" color="black.600">
               <FormattedMessage id="File.NoFilename" defaultMessage="No filename" />

--- a/components/budget/ExpenseBudgetItem.js
+++ b/components/budget/ExpenseBudgetItem.js
@@ -79,7 +79,7 @@ const getNbAttachedFiles = expense => {
   if (!expense) {
     return 0;
   } else if (expense.type === expenseTypes.INVOICE) {
-    return 1 + size(expense.attachedFiles);
+    return size(expense.attachedFiles);
   } else {
     return size(expense.attachedFiles) + size(expense.items.filter(({ url }) => Boolean(url)));
   }

--- a/components/expenses/ExpenseAttachedFiles.js
+++ b/components/expenses/ExpenseAttachedFiles.js
@@ -39,7 +39,12 @@ const ExpenseAttachedFiles = ({ files, onRemove, showInvoice, collective, expens
       )}
       {files.map((file, idx) => (
         <Box key={file.id || file.url} mr={3} mb={3}>
-          <UploadedFilePreview size={88} url={file.url} fileName={getFileName(intl, idx, files.length)} showFileName />
+          <UploadedFilePreview
+            size={88}
+            url={file.url}
+            fileName={file.name || getFileName(intl, idx, files.length)}
+            showFileName
+          />
           {onRemove && (
             <StyledLinkButton variant="danger" fontSize="12px" mt={1} onClick={() => onRemove(idx)}>
               <FormattedMessage id="Remove" defaultMessage="Remove" />

--- a/components/expenses/ExpenseFilesPreviewModal.js
+++ b/components/expenses/ExpenseFilesPreviewModal.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { Download as DownloadIcon } from '@styled-icons/feather/Download';
 import { saveAs } from 'file-saver';
 import { FormattedDate, FormattedMessage } from 'react-intl';
-import { v4 as uuid } from 'uuid';
 
 import expenseTypes from '../../lib/constants/expenseTypes';
 
@@ -61,16 +60,7 @@ const getFilesFromExpense = (collective, expense) => {
   }
 
   if (expense.type === expenseTypes.INVOICE) {
-    return [
-      {
-        id: uuid(),
-        amount: expense.amount,
-        description: <FormattedMessage id="Expense.Type.Invoice" defaultMessage="Invoice" />,
-        title: getExpenseInvoiceFilename(collective, expense),
-        type: 'EXPENSE_INVOICE',
-      },
-      ...expense.attachedFiles,
-    ];
+    return expense.attachedFiles || [];
   } else {
     const items = expense.items?.filter(({ url }) => Boolean(url)) || [];
     return [...items, ...expense.attachedFiles];

--- a/components/expenses/ExpenseFilesPreviewModal.js
+++ b/components/expenses/ExpenseFilesPreviewModal.js
@@ -21,9 +21,9 @@ import UploadedFilePreview from '../UploadedFilePreview';
 const FileInfo = ({ collective, expense, item, invoiceBlob }) => (
   <Flex justifyContent="space-between" px={25} mt={2}>
     <Box flex="1 1 65%">
-      {item.description && (
+      {(item.description || item.name) && (
         <P fontSize="14px" lineHeight="21px" color="black.900" mb={1}>
-          {item.description}
+          {item.description || item.name}
         </P>
       )}
       <P fontSize="11px" color="black.500">
@@ -132,7 +132,7 @@ const ExpenseFilesPreviewModal = ({ collective, expense, onClose }) => {
             <ExpenseInvoicePreview isLoading={!invoiceFile} fileURL={invoiceFile} />
           )
         ) : (
-          <UploadedFilePreview url={item.url} size={350} title={item.title} />
+          <UploadedFilePreview url={item.url} size={350} title={item.title} fileName={item.name} />
         )
       }
     />

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -139,7 +139,7 @@ export const prepareExpenseForSubmit = expenseData => {
     payee,
     payeeLocation,
     payoutMethod: pick(expenseData.payoutMethod, ['id', 'name', 'data', 'isSaved', 'type']),
-    attachedFiles: isInvoice ? expenseData.attachedFiles?.map(file => pick(file, ['id', 'url'])) : [],
+    attachedFiles: isInvoice ? expenseData.attachedFiles?.map(file => pick(file, ['id', 'url', 'name'])) : [],
     tax: expenseData.taxes?.filter(tax => !tax.isDisabled).map(tax => pick(tax, ['type', 'rate', 'idNumber'])),
     items: expenseData.items.map(item => {
       return pick(item, [

--- a/components/expenses/graphql/fragments.js
+++ b/components/expenses/graphql/fragments.js
@@ -178,6 +178,7 @@ export const expensePageExpenseFieldsFragment = gql`
     attachedFiles {
       id
       url
+      name
     }
     payee {
       id
@@ -525,6 +526,7 @@ export const expensesListAdminFieldsFragment = gql`
     attachedFiles {
       id
       url
+      name
     }
     securityChecks {
       level

--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -2100,6 +2100,11 @@ type ExpenseAttachedFile {
   """
   id: String!
   url: URL
+
+  """
+  The original filename
+  """
+  name: String
 }
 
 """
@@ -13537,6 +13542,11 @@ input ExpenseAttachedFileInput {
   ID of the file
   """
   id: String
+
+  """
+  Original filename
+  """
+  name: String
 
   """
   URL of the file


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/3865
Requires https://github.com/opencollective/opencollective-api/pull/8147

Scope-creeped a little bit and also added ExpenseAttachedFile name.