### PR TITLE
Ignore JetBrains files in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ storybook-static
 .vscode/*
 .history
 
+# JetBrains
+.idea/
+*.iml
+
 # Git time manager
 .gtm
 


### PR DESCRIPTION
It seems that we have to ignore JetBrains related files in out `.gitignore` just like we do for the API side;

https://github.com/opencollective/opencollective-api/blob/cb978ec4b2062b8ba4af3f3e76a755f65d9e83bc/.gitignore#L35-L37