### PR TITLE
Prevent hosts from disabling PayPal

### DIFF
--- a/components/edit-collective/EditPayPalAccount.js
+++ b/components/edit-collective/EditPayPalAccount.js
@@ -8,7 +8,7 @@ import { FormattedMessage } from 'react-intl';
 import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
 import { editCollectivePageQuery } from '../../lib/graphql/queries';
 
-import { getI18nLink } from '../I18nFormatters';
+import { getI18nLink, I18nSignInLink } from '../I18nFormatters';
 import StyledButton from '../StyledButton';
 import StyledInput from '../StyledInput';
 import StyledInputField from '../StyledInputField';
@@ -26,14 +26,6 @@ const createConnectedAccountMutation = gql`
   }
 `;
 
-const deleteConnectedAccountMutation = gql`
-  mutation deleteConnectedAccount($connectedAccount: ConnectedAccountReferenceInput!) {
-    deleteConnectedAccount(connectedAccount: $connectedAccount) {
-      id
-    }
-  }
-`;
-
 const EditPayPalAccount = props => {
   const isReceiving = props.variation === 'RECEIVING';
   const mutationOptions = {
@@ -44,10 +36,6 @@ const EditPayPalAccount = props => {
   const [connectedAccount, setConnectedAccount] = React.useState(props.connectedAccount);
   const [createConnectedAccount, { loading: isCreating, error: createError }] = useMutation(
     createConnectedAccountMutation,
-    mutationOptions,
-  );
-  const [deleteConnectedAccount, { loading: isDeleting }] = useMutation(
-    deleteConnectedAccountMutation,
     mutationOptions,
   );
   const formik = useFormik({
@@ -81,11 +69,6 @@ const EditPayPalAccount = props => {
       return errors;
     },
   });
-
-  const handleDelete = async () => {
-    await deleteConnectedAccount({ variables: { connectedAccount: { legacyId: props.connectedAccount.id } } });
-    setConnectedAccount();
-  };
 
   if (!connectedAccount) {
     return (
@@ -155,10 +138,11 @@ const EditPayPalAccount = props => {
             }}
           />
         </P>
-        <P>
-          <StyledButton type="submit" mt={2} loading={isDeleting} onClick={handleDelete}>
-            <FormattedMessage id="collective.connectedAccounts.disconnect.button" defaultMessage="Disconnect" />
-          </StyledButton>
+        <P mt={3} fontStyle="italic">
+          <FormattedMessage
+            defaultMessage="Please contact <SupportLink>support</SupportLink> to disconnect PayPal."
+            values={{ SupportLink: I18nSignInLink }}
+          />
         </P>
       </React.Fragment>
     );

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1707,6 +1707,7 @@
   "iPy92R": "Go to {accountName}'s page",
   "iuXArs": "VAT rate",
   "iUxV8v": "Get Involved",
+  "ivhAav": "Please contact <SupportLink>support</SupportLink> to disconnect PayPal.",
   "ivPWip": "Are you sure you want to cancel the edits?",
   "IVw0RN": "Freezing this collective means temporarily limiting what a collective (and their connected Projects & Events) can and cannot do on the platform.",
   "IxEr/J": "Drag and drop your image or <Link>click here</Link> to select it.",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1707,6 +1707,7 @@
   "iPy92R": "Go to {accountName}'s page",
   "iuXArs": "VAT rate",
   "iUxV8v": "Zapojte se",
+  "ivhAav": "Please contact <SupportLink>support</SupportLink> to disconnect PayPal.",
   "ivPWip": "Are you sure you want to cancel the edits?",
   "IVw0RN": "Freezing this collective means temporarily limiting what a collective (and their connected Projects & Events) can and cannot do on the platform.",
   "IxEr/J": "Drag and drop your image or <Link>click here</Link> to select it.",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1707,6 +1707,7 @@
   "iPy92R": "Go to {accountName}'s page",
   "iuXArs": "VAT rate",
   "iUxV8v": "Get Involved",
+  "ivhAav": "Please contact <SupportLink>support</SupportLink> to disconnect PayPal.",
   "ivPWip": "Are you sure you want to cancel the edits?",
   "IVw0RN": "Freezing this collective means temporarily limiting what a collective (and their connected Projects & Events) can and cannot do on the platform.",
   "IxEr/J": "Drag and drop your image or <Link>click here</Link> to select it.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1707,6 +1707,7 @@
   "iPy92R": "Go to {accountName}'s page",
   "iuXArs": "VAT rate",
   "iUxV8v": "Get Involved",
+  "ivhAav": "Please contact <SupportLink>support</SupportLink> to disconnect PayPal.",
   "ivPWip": "Are you sure you want to cancel the edits?",
   "IVw0RN": "Freezing this collective means temporarily limiting what a collective (and their connected Projects & Events) can and cannot do on the platform.",
   "IxEr/J": "Drag and drop your image or <Link>click here</Link> to select it.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1707,6 +1707,7 @@
   "iPy92R": "Ir a la página de {accountName}",
   "iuXArs": "Tasa de IVA",
   "iUxV8v": "Involúcrate",
+  "ivhAav": "Please contact <SupportLink>support</SupportLink> to disconnect PayPal.",
   "ivPWip": "¿Estás seguro de que quieres cancelar las ediciones?",
   "IVw0RN": "Congelar este Colectivo significa limitar temporalmente lo que un Colectivo (y sus Proyectos y Eventos relacionados) puede y no puede hacer en la plataforma.",
   "IxEr/J": "Arrastra y suelta tu imagen o <Link>haz clic aquí</Link> para seleccionarla.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1707,6 +1707,7 @@
   "iPy92R": "Aller à la page de {accountName}",
   "iuXArs": "VAT rate",
   "iUxV8v": "Get Involved",
+  "ivhAav": "Please contact <SupportLink>support</SupportLink> to disconnect PayPal.",
   "ivPWip": "Are you sure you want to cancel the edits?",
   "IVw0RN": "Freezing this collective means temporarily limiting what a collective (and their connected Projects & Events) can and cannot do on the platform.",
   "IxEr/J": "Drag and drop your image or <Link>click here</Link> to select it.",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1707,6 +1707,7 @@
   "iPy92R": "Go to {accountName}'s page",
   "iuXArs": "VAT rate",
   "iUxV8v": "Get Involved",
+  "ivhAav": "Please contact <SupportLink>support</SupportLink> to disconnect PayPal.",
   "ivPWip": "Are you sure you want to cancel the edits?",
   "IVw0RN": "Freezing this collective means temporarily limiting what a collective (and their connected Projects & Events) can and cannot do on the platform.",
   "IxEr/J": "Drag and drop your image or <Link>click here</Link> to select it.",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1707,6 +1707,7 @@
   "iPy92R": "Go to {accountName}'s page",
   "iuXArs": "VAT rate",
   "iUxV8v": "Get Involved",
+  "ivhAav": "Please contact <SupportLink>support</SupportLink> to disconnect PayPal.",
   "ivPWip": "Are you sure you want to cancel the edits?",
   "IVw0RN": "Freezing this collective means temporarily limiting what a collective (and their connected Projects & Events) can and cannot do on the platform.",
   "IxEr/J": "画像をドラッグ＆ドロップするか、 <Link>こちらをクリック</Link> して画像を選択してください。",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1707,6 +1707,7 @@
   "iPy92R": "Go to {accountName}'s page",
   "iuXArs": "VAT rate",
   "iUxV8v": "Get Involved",
+  "ivhAav": "Please contact <SupportLink>support</SupportLink> to disconnect PayPal.",
   "ivPWip": "Are you sure you want to cancel the edits?",
   "IVw0RN": "Freezing this collective means temporarily limiting what a collective (and their connected Projects & Events) can and cannot do on the platform.",
   "IxEr/J": "Drag and drop your image or <Link>click here</Link> to select it.",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1707,6 +1707,7 @@
   "iPy92R": "Go to {accountName}'s page",
   "iuXArs": "VAT rate",
   "iUxV8v": "Get Involved",
+  "ivhAav": "Please contact <SupportLink>support</SupportLink> to disconnect PayPal.",
   "ivPWip": "Are you sure you want to cancel the edits?",
   "IVw0RN": "Freezing this collective means temporarily limiting what a collective (and their connected Projects & Events) can and cannot do on the platform.",
   "IxEr/J": "Drag and drop your image or <Link>click here</Link> to select it.",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -1707,6 +1707,7 @@
   "iPy92R": "Go to {accountName}'s page",
   "iuXArs": "VAT rate",
   "iUxV8v": "Zaangażuj się",
+  "ivhAav": "Please contact <SupportLink>support</SupportLink> to disconnect PayPal.",
   "ivPWip": "Czy na pewno chcesz anulować edycje?",
   "IVw0RN": "Freezing this collective means temporarily limiting what a collective (and their connected Projects & Events) can and cannot do on the platform.",
   "IxEr/J": "Drag and drop your image or <Link>click here</Link> to select it.",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1707,6 +1707,7 @@
   "iPy92R": "Go to {accountName}'s page",
   "iuXArs": "VAT rate",
   "iUxV8v": "Get Involved",
+  "ivhAav": "Please contact <SupportLink>support</SupportLink> to disconnect PayPal.",
   "ivPWip": "Are you sure you want to cancel the edits?",
   "IVw0RN": "Freezing this collective means temporarily limiting what a collective (and their connected Projects & Events) can and cannot do on the platform.",
   "IxEr/J": "Drag and drop your image or <Link>click here</Link> to select it.",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1707,6 +1707,7 @@
   "iPy92R": "Go to {accountName}'s page",
   "iuXArs": "VAT rate",
   "iUxV8v": "Get Involved",
+  "ivhAav": "Please contact <SupportLink>support</SupportLink> to disconnect PayPal.",
   "ivPWip": "Are you sure you want to cancel the edits?",
   "IVw0RN": "Freezing this collective means temporarily limiting what a collective (and their connected Projects & Events) can and cannot do on the platform.",
   "IxEr/J": "Drag and drop your image or <Link>click here</Link> to select it.",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1707,6 +1707,7 @@
   "iPy92R": "Go to {accountName}'s page",
   "iuXArs": "VAT rate",
   "iUxV8v": "Get Involved",
+  "ivhAav": "Please contact <SupportLink>support</SupportLink> to disconnect PayPal.",
   "ivPWip": "Are you sure you want to cancel the edits?",
   "IVw0RN": "Freezing this collective means temporarily limiting what a collective (and their connected Projects & Events) can and cannot do on the platform.",
   "IxEr/J": "Drag and drop your image or <Link>click here</Link> to select it.",

--- a/lang/sk-SK.json
+++ b/lang/sk-SK.json
@@ -1707,6 +1707,7 @@
   "iPy92R": "Prejsť na stránku účtu {accountName}",
   "iuXArs": "Sadzba DPH",
   "iUxV8v": "Zapojiť sa",
+  "ivhAav": "Please contact <SupportLink>support</SupportLink> to disconnect PayPal.",
   "ivPWip": "Skutočne si želáte zrušiť úpravy?",
   "IVw0RN": "Zablokovanie tohto kolektívu znamená dočasné obmedzenie toho, čo kolektív (a s ním spojené Projekty a Podujatia) môže a nemôže robiť na platforme.",
   "IxEr/J": "Potiahnite a pustite obrázok alebo <Link>kliknite sem</Link> a vyberte ho.",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -1707,6 +1707,7 @@
   "iPy92R": "Перейти на сторінку {accountName}",
   "iuXArs": "Ставка ПДВ",
   "iUxV8v": "Долучитися",
+  "ivhAav": "Please contact <SupportLink>support</SupportLink> to disconnect PayPal.",
   "ivPWip": "Ви впевнені, що хочете скасувати зміни?",
   "IVw0RN": "Freezing this collective means temporarily limiting what a collective (and their connected Projects & Events) can and cannot do on the platform.",
   "IxEr/J": "Перетягніть зображення або <Link>натисніть тут</Link>, щоб вибрати його.",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1707,6 +1707,7 @@
   "iPy92R": "前往 {accountName} 的页面",
   "iuXArs": "增值税",
   "iUxV8v": "参与进来",
+  "ivhAav": "Please contact <SupportLink>support</SupportLink> to disconnect PayPal.",
   "ivPWip": "Are you sure you want to cancel the edits?",
   "IVw0RN": "Freezing this collective means temporarily limiting what a collective (and their connected Projects & Events) can and cannot do on the platform.",
   "IxEr/J": "Drag and drop your image or <Link>click here</Link> to select it.",


### PR DESCRIPTION
There's a risk of having hosts disabling PayPal while some recurring contributions are still active.

I will publish a follow-up issue to propose a proper flow for this feature.