### PR TITLE
Remove duplicate useLoggedInUser

### DIFF
--- a/components/TwoFactorAuthRequiredMessage.tsx
+++ b/components/TwoFactorAuthRequiredMessage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import type { LoggedInUser } from '../lib/custom_typings/LoggedInUser';
+import useLoggedInUser from '../lib/hooks/useLoggedInUser';
 import { getSettingsRoute } from '../lib/url-helpers';
 
 import { Box, Flex } from './Grid';
@@ -11,7 +12,6 @@ import StyledButton from './StyledButton';
 import StyledCard from './StyledCard';
 import StyledHr from './StyledHr';
 import { P, Strong } from './Text';
-import { useLoggedInUser } from './UserProvider';
 
 type TwoFactorAuthRequiredMessageProps = {
   loggedInUser: LoggedInUser;

--- a/components/UserProvider.js
+++ b/components/UserProvider.js
@@ -158,8 +158,6 @@ const withUser = WrappedComponent => {
   return WithUser;
 };
 
-const useLoggedInUser = () => React.useContext(UserContext);
-
 export default withApollo(withLoggedInUser(UserProvider));
 
-export { UserConsumer, withUser, useLoggedInUser };
+export { UserConsumer, withUser };

--- a/components/edit-collective/EditVirtualCardModal.tsx
+++ b/components/edit-collective/EditVirtualCardModal.tsx
@@ -9,6 +9,7 @@ import roles from '../../lib/constants/roles';
 import { graphqlAmountValueInCents } from '../../lib/currency-utils';
 import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
 import { Account, VirtualCard, VirtualCardLimitInterval } from '../../lib/graphql/types/v2/graphql';
+import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
 import {
   VirtualCardLimitIntervalDescriptionsI18n,
   VirtualCardLimitIntervalI18n,
@@ -28,7 +29,6 @@ import StyledModal, { ModalBody, ModalFooter, ModalHeader } from '../StyledModal
 import StyledSelect from '../StyledSelect';
 import { P, Span } from '../Text';
 import { TOAST_TYPE, useToasts } from '../ToastProvider';
-import { useLoggedInUser } from '../UserProvider';
 
 const editVirtualCardMutation = gql`
   mutation editVirtualCard(


### PR DESCRIPTION
In https://github.com/opencollective/opencollective-frontend/pull/7946, we've renamed `useUser` to `useLoggedInUser` but left a duplicate `useLoggedInUser` hook in `components/UserProvider`.