### PR TITLE
Fix using account balance as a payout method

### DIFF
--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -125,6 +125,11 @@ export const prepareExpenseForSubmit = expenseData => {
     ? pick(expenseData.payeeLocation, ['address', 'country', 'structured'])
     : null;
 
+  const payoutMethod = pick(expenseData.payoutMethod, ['id', 'name', 'data', 'isSaved', 'type']);
+  if (payoutMethod.id === 'new') {
+    payoutMethod.id = null;
+  }
+
   return {
     ...pick(expenseData, [
       'id',
@@ -138,7 +143,7 @@ export const prepareExpenseForSubmit = expenseData => {
     ]),
     payee,
     payeeLocation,
-    payoutMethod: pick(expenseData.payoutMethod, ['id', 'name', 'data', 'isSaved', 'type']),
+    payoutMethod,
     attachedFiles: isInvoice ? expenseData.attachedFiles?.map(file => pick(file, ['id', 'url', 'name'])) : [],
     tax: expenseData.taxes?.filter(tax => !tax.isDisabled).map(tax => pick(tax, ['type', 'rate', 'idNumber'])),
     items: expenseData.items.map(item => {


### PR DESCRIPTION
Fix https://opencollective.slack.com/archives/GSNDVCC4F/p1668369446948709

In https://github.com/opencollective/opencollective-api/pull/8124, we started rejecting invalid `id` rather than returning `undefined` because, in most cases, it would create unexpected errors. But this code relied on passing `id: 'new'` to the API which returned `undefined` as a payout method.