### PR TITLE
Remove v2 expenses route parameter

### DIFF
--- a/rewrites.js
+++ b/rewrites.js
@@ -131,12 +131,11 @@ exports.REWRITES = [
     destination: '/create-expense',
   },
   {
-    source:
-      '/:parentCollectiveSlug?/:collectiveType(events|projects)?/:collectiveSlug/expenses/:ExpenseId([0-9]+)/:version(v2)?',
+    source: '/:parentCollectiveSlug?/:collectiveType(events|projects)?/:collectiveSlug/expenses/:ExpenseId([0-9]+)',
     destination: '/expense',
   },
   {
-    source: '/:parentCollectiveSlug?/:collectiveType(events|projects)?/:collectiveSlug/expenses/:version(v2)?',
+    source: '/:parentCollectiveSlug?/:collectiveType(events|projects)?/:collectiveSlug/expenses',
     destination: '/expenses',
   },
   {


### PR DESCRIPTION
We moved to the new expense flow and removed the old one a while ago, it's not useful to keep that flag.