### PR TITLE
Enable webhooks for all profile types

### DIFF
--- a/components/admin-panel/Menu.js
+++ b/components/admin-panel/Menu.js
@@ -216,11 +216,7 @@ const Menu = ({ collective, isAccountantOnly }) => {
               isOneOfTypes(collective, [COLLECTIVE, FUND, EVENT, PROJECT])
             }
           />
-          <MenuLink
-            collective={collective}
-            section={COLLECTIVE_SECTIONS.WEBHOOKS}
-            if={isOneOfTypes(collective, [COLLECTIVE, USER, EVENT])}
-          />
+          <MenuLink collective={collective} section={COLLECTIVE_SECTIONS.WEBHOOKS} />
           <MenuLink
             collective={collective}
             section={COLLECTIVE_SECTIONS.AUTHORIZED_APPS}

--- a/components/edit-collective/Menu.js
+++ b/components/edit-collective/Menu.js
@@ -203,7 +203,6 @@ const sectionsDisplayConditions = {
   [EDIT_COLLECTIVE_SECTIONS.TIERS]: c =>
     isOneOfTypes(c, COLLECTIVE, FUND, EVENT, PROJECT) || (c.type === ORGANIZATION && c.isActive),
   [EDIT_COLLECTIVE_SECTIONS.GIFT_CARDS]: c => isType(c, ORGANIZATION) || c.createdGiftCards.total > 0,
-  [EDIT_COLLECTIVE_SECTIONS.WEBHOOKS]: c => isOneOfTypes(c, COLLECTIVE, ORGANIZATION, USER, EVENT, PROJECT),
   [EDIT_COLLECTIVE_SECTIONS.ADVANCED]: () => true,
   [EDIT_COLLECTIVE_SECTIONS.TWO_FACTOR_AUTH]: c => isType(c, USER),
   // Fiscal Host


### PR DESCRIPTION
After feedback from https://github.com/opencollective/opencollective/issues/6018, it appeared that webhooks were not available to projects, even though the code clearly intended to do so (see https://github.com/opencollective/opencollective-frontend/pull/6921). It seems that we broke it with the introduction of the new admin panel.

As of today, there's no clear reason why we'd want to disable webhooks for some profile types - apart from simplification. I'm therefore removing all conditions.