### PR TITLE
Check parent for 2FA required message

### DIFF
--- a/components/contribution-flow/StepPayment.js
+++ b/components/contribution-flow/StepPayment.js
@@ -8,6 +8,7 @@ import styled, { css } from 'styled-components';
 
 import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
 import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
+import { require2FAForAdmins } from '../../lib/policies';
 
 import Container from '../Container';
 import { Box, Flex } from '../Grid';
@@ -136,7 +137,7 @@ const StepPayment = ({
     }
   }, [paymentOptions, stepPayment, loading]);
 
-  if (stepProfile.policies?.REQUIRE_2FA_FOR_ADMINS && !LoggedInUser?.hasTwoFactorAuth) {
+  if (require2FAForAdmins(stepProfile) && !LoggedInUser?.hasTwoFactorAuth) {
     return <TwoFactorAuthRequiredMessage borderWidth={0} noTitle />;
   }
 

--- a/components/expenses/ExpenseFormPayeeStep.js
+++ b/components/expenses/ExpenseFormPayeeStep.js
@@ -12,6 +12,7 @@ import { PayoutMethodType } from '../../lib/constants/payout-method';
 import { EMPTY_ARRAY } from '../../lib/constants/utils';
 import { ERROR, isErrorType } from '../../lib/errors';
 import { formatFormErrorMessage } from '../../lib/form-utils';
+import { require2FAForAdmins } from '../../lib/policies';
 import { flattenObjectDeep } from '../../lib/utils';
 import { checkRequiresAddress } from './lib/utils';
 
@@ -202,7 +203,7 @@ const ExpenseFormPayeeStep = ({
   const intl = useIntl();
   const { formatMessage } = intl;
   const { values, errors } = formik;
-  const isMissing2FA = Boolean(values.payee?.policies?.REQUIRE_2FA_FOR_ADMINS && !loggedInAccount?.hasTwoFactorAuth);
+  const isMissing2FA = require2FAForAdmins(values.payee) && !loggedInAccount?.hasTwoFactorAuth;
   const stepOneCompleted = checkStepOneCompleted(values, isOnBehalf, isMissing2FA);
   const allPayoutMethods = React.useMemo(
     () => getPayoutMethodsFromPayee(values.payee),

--- a/components/expenses/graphql/fragments.ts
+++ b/components/expenses/graphql/fragments.ts
@@ -39,6 +39,14 @@ export const loggedInAccountExpensePayoutFieldsFragment = gql`
           policies {
             REQUIRE_2FA_FOR_ADMINS
           }
+          ... on AccountWithParent {
+            parent {
+              id
+              policies {
+                REQUIRE_2FA_FOR_ADMINS
+              }
+            }
+          }
           ... on AccountWithHost {
             host {
               id

--- a/components/host-dashboard/AddFundsModal.js
+++ b/components/host-dashboard/AddFundsModal.js
@@ -11,6 +11,7 @@ import { formatCurrency } from '../../lib/currency-utils';
 import { requireFields } from '../../lib/form-utils';
 import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
 import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
+import { require2FAForAdmins } from '../../lib/policies';
 import { getCollectivePageRoute } from '../../lib/url-helpers';
 
 import { collectivePageQuery, getCollectivePageQueryVariables } from '../collective-page/graphql/queries';
@@ -381,7 +382,7 @@ const AddFundsModal = ({ collective, ...props }) => {
       <CollectiveModalHeader collective={collective} onClick={handleClose} />
       {loading ? (
         <LoadingPlaceholder mt={2} height={200} />
-      ) : host?.policies?.REQUIRE_2FA_FOR_ADMINS && !LoggedInUser.hasTwoFactorAuth ? (
+      ) : require2FAForAdmins(host) && !LoggedInUser.hasTwoFactorAuth ? (
         <TwoFactorAuthRequiredMessage borderWidth={0} noTitle />
       ) : (
         <Formik

--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -150,6 +150,12 @@ export const loggedInUserQuery = gqlV1/* GraphQL */ `
           policies {
             REQUIRE_2FA_FOR_ADMINS
           }
+          parentCollective {
+            id
+            policies {
+              REQUIRE_2FA_FOR_ADMINS
+            }
+          }
           host {
             id
           }

--- a/lib/policies.ts
+++ b/lib/policies.ts
@@ -1,0 +1,12 @@
+/**
+ * Returns true if the account requires 2FA for admins. Parent must be preloaded.
+ */
+export const require2FAForAdmins = (collective): boolean => {
+  if (!collective) {
+    return false;
+  }
+
+  const parent = collective.parent || collective.parentCollective;
+  const accountToCheck = parent || collective;
+  return Boolean(accountToCheck.policies?.REQUIRE_2FA_FOR_ADMINS);
+};

--- a/pages/admin-panel.js
+++ b/pages/admin-panel.js
@@ -7,6 +7,7 @@ import { isHostAccount } from '../lib/collective.lib';
 import roles from '../lib/constants/roles';
 import { API_V2_CONTEXT } from '../lib/graphql/helpers';
 import useLoggedInUser from '../lib/hooks/useLoggedInUser';
+import { require2FAForAdmins } from '../lib/policies';
 
 import { AdminPanelContext } from '../components/admin-panel/AdminPanelContext';
 import AdminPanelSection from '../components/admin-panel/AdminPanelSection';
@@ -49,6 +50,9 @@ export const adminPanelQuery = gql`
         parent {
           id
           slug
+          policies {
+            REQUIRE_2FA_FOR_ADMINS
+          }
         }
       }
       ... on AccountWithHost {
@@ -216,7 +220,7 @@ const AdminPanelPage = () => {
               display={['none', null, 'block']}
               isAccountantOnly={getIsAccountantOnly(LoggedInUser, account)}
             />
-            {account?.policies?.REQUIRE_2FA_FOR_ADMINS && LoggedInUser && !LoggedInUser.hasTwoFactorAuth ? (
+            {require2FAForAdmins(account) && LoggedInUser && !LoggedInUser.hasTwoFactorAuth ? (
               <TwoFactorAuthRequiredMessage mt={[null, null, '64px']} />
             ) : (
               <AdminPanelSection


### PR DESCRIPTION
The "2FA required" message was not properly displayed for projects & events; because we need to fetch it on the parent.

As a future improvement on this, it could be nice to enable a dedicated `twoFactorAuthenticationRequired` field on `Accounts`.