### PR TITLE
ActivityLog: Move 'View details' button to match design

### DIFF
--- a/components/admin-panel/sections/ActivityLog/ActivityListItem.js
+++ b/components/admin-panel/sections/ActivityLog/ActivityListItem.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import themeGet from '@styled-system/theme-get';
+import { ChevronDown } from '@styled-icons/feather/ChevronDown';
+import { ChevronUp } from '@styled-icons/feather/ChevronUp';
+import { themeGet } from '@styled-system/theme-get';
 import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 
@@ -20,7 +22,6 @@ const MetadataContainer = styled.div`
   align-items: center;
   grid-gap: 8px;
   color: #4d4f51;
-  margin-top: 10px;
   a {
     color: #4d4f51;
     text-decoration: none;
@@ -48,43 +49,54 @@ const ActivityListItem = ({ activity }) => {
       <P color="black.900" fontWeight="500" fontSize="14px">
         <ActivityDescription activity={activity} />
       </P>
-      <MetadataContainer>
-        {activity.isSystem ? (
-          <Span>
-            <FormattedMessage defaultMessage="System Activity" />
-          </Span>
-        ) : (
-          <FormattedMessage
-            id="ByUser"
-            defaultMessage="By {userName}"
-            values={{
-              userName: !activity.individual ? (
-                <Span>
-                  <FormattedMessage id="user.unknown" defaultMessage="Unknown" />
-                </Span>
-              ) : (
-                <StyledLink as={LinkCollective} color="black.700" collective={activity.individual}>
-                  <Flex alignItems="center" gridGap="8px">
-                    <Avatar radius={24} collective={activity.individual} />
-                    {activity.individual.name}
-                  </Flex>
-                </StyledLink>
-              ),
-            }}
-          />
-        )}
-        •
-        <DateTime value={activity.createdAt} dateStyle="medium" />
+      <Flex justifyContent="space-between" alignItems="center" mt="10px">
+        <MetadataContainer>
+          {activity.isSystem ? (
+            <Span>
+              <FormattedMessage defaultMessage="System Activity" />
+            </Span>
+          ) : (
+            <FormattedMessage
+              id="ByUser"
+              defaultMessage="By {userName}"
+              values={{
+                userName: !activity.individual ? (
+                  <Span>
+                    <FormattedMessage id="user.unknown" defaultMessage="Unknown" />
+                  </Span>
+                ) : (
+                  <StyledLink as={LinkCollective} color="black.700" collective={activity.individual}>
+                    <Flex alignItems="center" gridGap="8px">
+                      <Avatar radius={24} collective={activity.individual} />
+                      {activity.individual.name}
+                    </Flex>
+                  </StyledLink>
+                ),
+              }}
+            />
+          )}
+          •
+          <DateTime value={activity.createdAt} dateStyle="medium" />
+        </MetadataContainer>
         {DETAILED_ACTIVITY_TYPES.includes(activity.type) && (
-          <StyledButton ml={12} buttonSize="tiny" onClick={() => setShowDetails(!showDetails)}>
+          <StyledButton
+            ml={12}
+            isBorderless
+            buttonStyle="secondary"
+            buttonSize="tiny"
+            onClick={() => setShowDetails(!showDetails)}
+          >
             {!showDetails ? (
-              <FormattedMessage id="viewDetails" defaultMessage="View Details" />
+              <FormattedMessage defaultMessage="Show Details" />
             ) : (
               <FormattedMessage defaultMessage="Hide Details" />
             )}
+            <Span ml={1}>
+              {showDetails ? <ChevronUp size="1em" strokeWidth="3px" /> : <ChevronDown size="1em" strokeWidth="3px" />}
+            </Span>
           </StyledButton>
         )}
-      </MetadataContainer>
+      </Flex>
       {showDetails && (
         <DetailsContainer>
           <ActivityDetails activity={activity} />


### PR DESCRIPTION
As reported in https://opencollective.slack.com/archives/C020ZQSLM5M/p1668543927534259?thread_ts=1668523947.994949&cid=C020ZQSLM5M

![image](https://user-images.githubusercontent.com/1556356/203034900-5fd21de1-0174-4af6-a6bd-0efad8472e55.png)
