### PR TITLE
Do not clean next build folder when updating languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "langs:build": "formatjs extract \"{components,lib,pages}/**/*.{js,ts,tsx}\" --ignore='**/*.d.ts' --out-file \"dist/messages/messages.json\" --throws",
     "langs:check": "cross-env scripts/check_translations.sh",
     "langs:translate": "babel-node scripts/translate.js",
-    "langs:update": "npm-run-all build:clean langs:build langs:translate",
+    "langs:update": "npm-run-all langs:build langs:translate",
     "lint": "eslint . --ignore-path .gitignore --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "npm run lint -- --fix",
     "lint:quiet": "npm run lint -- --quiet",


### PR DESCRIPTION
The issue was briefly discussed in https://github.com/opencollective/opencollective/issues/3704#issuecomment-733736040

This PR removes the `build:clean` command from `npm run build:langs` that was removing the `.next` folder, crashing the app and forcing developers to restart their frontend server.

The app was crashing with `Cannot destructure property `components` of 'undefined' or 'null'`, or more recently messages like `uncaughtException: ENOENT: no such file or directory, stat '/home/betree/Workspace/Projects/opencollective/opencollective-frontend/.next/cache/webpack/client-development/15.pack'`. 

Cleaning does not seem necessary at all, as `formatjs` will override `dist/messages/messages.json` if it exists.

cc @znarf as the command was introduced in https://github.com/opencollective/opencollective-frontend/pull/2213; though it doesn't really look like this change was intentional.