### PR TITLE
Fix emptying quantity in the contribution flow

### DIFF
--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -190,9 +190,12 @@ const StepDetails = ({ onChange, data, collective, tier, showPlatformTip, router
                   max={tier.availableQuantity}
                   value={data?.quantity}
                   maxWidth={80}
-                  onChange={e => dispatchChange('quantity', parseInt(e.target.value))}
                   fontSize="15px"
                   minWidth={100}
+                  onChange={e => {
+                    const newValue = parseInt(e.target.value);
+                    dispatchChange('quantity', isNaN(newValue) ? null : newValue);
+                  }}
                 />
               </div>
             )}


### PR DESCRIPTION
Fix https://sentry.io/organizations/open-collective/issues/3731095570/

Fix an annoying issue that was creating an infinite loop (but thanks to NextJS's protection on Router, that was only slowing the page for a few seconds, not crashing it) when emptying the `quantity` input in the contribution flow. 