### PR TITLE
Fix crash in Activity Log with some type of COLLECTIVE_EDITED

### DIFF
--- a/components/admin-panel/sections/ActivityLog/CollectiveEditedDetails.js
+++ b/components/admin-panel/sections/ActivityLog/CollectiveEditedDetails.js
@@ -28,8 +28,8 @@ const deepCompare = (prev, next) => {
   const addedKeys = Object.keys(next).filter(key => !has(prev, key));
   const changedValues = pickBy(next, (value, key) => !addedKeys.includes(key) && prev[key] !== value);
   return [
-    ...removedKeys.map(key => ({ action: 'remove', key, prevValue: prev[key] })),
-    ...addedKeys.map(key => ({ action: 'add', key, newValue: next[key] })),
+    ...removedKeys.map(key => ({ action: 'remove', key, prevValue: JSON.stringify(prev[key]) })),
+    ...addedKeys.map(key => ({ action: 'add', key, newValue: JSON.stringify(next[key]) })),
     ...Object.keys(changedValues).map(key => ({
       action: 'update',
       key,


### PR DESCRIPTION
Fix a crash when a payload like this is diffed:

```json
{
  "newData": {
    "policies": {
      "REQUIRE_2FA_FOR_ADMINS": true
    }
  },
  "previousData": {}
}
```