### PR TITLE
Fix permissions checks for LoggedInUser

### DIFF
--- a/components/CreateEvent.js
+++ b/components/CreateEvent.js
@@ -99,7 +99,7 @@ class CreateEvent extends React.Component {
 
   render() {
     const { parentCollective, LoggedInUser } = this.props;
-    const isAdmin = LoggedInUser && LoggedInUser.isAdminOfCollectiveOrHost(parentCollective);
+    const isAdmin = LoggedInUser && LoggedInUser.isAdminOfCollective(parentCollective);
     const collective = parentCollective || {};
     const title = `Create a New ${collective.name} Event`;
 

--- a/components/collective-navbar/index.js
+++ b/components/collective-navbar/index.js
@@ -444,7 +444,7 @@ const CollectiveNavbar = ({
   const [isExpanded, setExpanded] = React.useState(false);
   const { LoggedInUser } = useLoggedInUser();
   const isAccountant = LoggedInUser?.hasRole(roles.ACCOUNTANT, collective);
-  isAdmin = isAdmin || LoggedInUser?.isAdminOfCollectiveOrHost(collective);
+  isAdmin = isAdmin || LoggedInUser?.isAdminOfCollective(collective);
   const isHostAdmin = LoggedInUser?.isHostAdmin(collective);
   const { data, dataLoading } = useQuery(accountPermissionsQuery, {
     context: API_V2_CONTEXT,

--- a/components/conversations/Thread.js
+++ b/components/conversations/Thread.js
@@ -39,7 +39,7 @@ const Thread = ({ collective, items, onCommentDeleted, LoggedInUser, theme, hasM
     return null;
   }
 
-  const isAdmin = LoggedInUser && LoggedInUser.isAdminOfCollectiveOrHost(collective);
+  const isAdmin = LoggedInUser && LoggedInUser.isAdminOfCollective(collective);
 
   const handleLoadMore = async () => {
     setLoading(true);

--- a/components/recurring-contributions/RecurringContributionsContainer.js
+++ b/components/recurring-contributions/RecurringContributionsContainer.js
@@ -38,7 +38,7 @@ const filterContributions = (contributions, filterName) => {
 };
 
 const RecurringContributionsContainer = ({ recurringContributions, filter, account, LoggedInUser }) => {
-  const isAdmin = Boolean(LoggedInUser?.isAdminOfCollectiveOrHost(account));
+  const isAdmin = Boolean(LoggedInUser?.isAdminOfCollective(account));
   const [editingContributionId, setEditingContributionId] = React.useState();
   const displayedRecurringContributions = React.useMemo(() => {
     const filteredContributions = filterContributions(recurringContributions.nodes, filter);

--- a/components/tier-page/index.js
+++ b/components/tier-page/index.js
@@ -165,7 +165,7 @@ class TierPage extends Component {
 
   render() {
     const { collective, tier, contributors, contributorsStats, redirect, LoggedInUser } = this.props;
-    const canEdit = LoggedInUser && LoggedInUser.isAdminOfCollectiveOrHost(collective);
+    const canEdit = LoggedInUser && LoggedInUser.isAdminOfCollective(collective);
     const isFlexibleInterval = tier.interval === INTERVALS.flexible;
     const amountRaisedKey = tier.interval && !isFlexibleInterval ? 'totalRecurringDonations' : 'totalDonated';
     const amountRaised = tier.stats?.[amountRaisedKey] || 0;

--- a/lib/LoggedInUser.js
+++ b/lib/LoggedInUser.js
@@ -37,12 +37,12 @@ LoggedInUser.prototype.hasRole = function (roles, collective) {
 };
 
 /**
- * CanEditCollective if LoggedInUser is
+ * isAdminOfCollective if LoggedInUser is
  * - its own USER collective
  * - is admin of the collective
  * - is host of the collective
  */
-LoggedInUser.prototype.isAdminOfCollectiveOrHost = function (collective) {
+LoggedInUser.prototype.isAdminOfCollective = function (collective) {
   if (!collective) {
     return false;
   } else if (collective.type === CollectiveType.EVENT) {
@@ -53,9 +53,24 @@ LoggedInUser.prototype.isAdminOfCollectiveOrHost = function (collective) {
     return (
       collective.id === this.CollectiveId ||
       collective.slug === get(this, 'collective.slug') ||
-      this.hasRole([ROLES.HOST, ROLES.ADMIN], collective) ||
-      this.isHostAdmin(collective)
+      this.hasRole(ROLES.ADMIN, collective)
     );
+  }
+};
+
+/**
+ * isAdminOfCollectiveOrHost if LoggedInUser is
+ * - its own USER collective
+ * - is admin of the collective
+ * - is host of the collective
+ */
+LoggedInUser.prototype.isAdminOfCollectiveOrHost = function (collective) {
+  if (!collective) {
+    return false;
+  } else if (this.isAdminOfCollective(collective)) {
+    return true;
+  } else {
+    return this.hasRole([ROLES.HOST, ROLES.ADMIN], collective) || this.isHostAdmin(collective);
   }
 };
 

--- a/lib/__tests__/LoggedInUser.test.js
+++ b/lib/__tests__/LoggedInUser.test.js
@@ -91,7 +91,7 @@ describe('General permissions', () => {
 });
 
 describe('Collectives', () => {
-  describe('canEditCollective', () => {
+  describe('isAdminOfCollectiveOrHost', () => {
     it('returns true if user can edit collective', () => {
       expect(testUser.isAdminOfCollectiveOrHost(null)).toBe(false);
       expect(testUser.isAdminOfCollectiveOrHost(randomCollective)).toBe(false);
@@ -103,6 +103,21 @@ describe('Collectives', () => {
       expect(testUser.isAdminOfCollectiveOrHost(adminEventCollective)).toBe(true);
       expect(testUser.isAdminOfCollectiveOrHost(adminEventCollectiveParent)).toBe(true);
       expect(testUser.isAdminOfCollectiveOrHost(testUser.collective)).toBe(true);
+    });
+  });
+
+  describe('isAdminOfCollective', () => {
+    it('returns true if user can edit collective', () => {
+      expect(testUser.isAdminOfCollective(null)).toBe(false);
+      expect(testUser.isAdminOfCollective(randomCollective)).toBe(false);
+      expect(testUser.isAdminOfCollective(backedCollective)).toBe(false);
+      expect(testUser.isAdminOfCollective(memberCollective)).toBe(false);
+      expect(testUser.isAdminOfCollective(randomEventCollective)).toBe(false);
+
+      expect(testUser.isAdminOfCollective(adminCollective)).toBe(true);
+      expect(testUser.isAdminOfCollective(adminEventCollective)).toBe(true);
+      expect(testUser.isAdminOfCollective(adminEventCollectiveParent)).toBe(true);
+      expect(testUser.isAdminOfCollective(testUser.collective)).toBe(true);
     });
   });
 });

--- a/lib/collective.lib.js
+++ b/lib/collective.lib.js
@@ -242,7 +242,7 @@ export const loggedInUserCanAccessFinancialData = (user, collective) => {
   } else if (!user) {
     return false;
   } else {
-    return user.isRoot() || user.isAdminOfCollectiveOrHost(collective) || !user.isHostAdmin(collective);
+    return user.isRoot() || user.isAdminOfCollectiveOrHost(collective);
   }
 };
 

--- a/pages/admin-panel.js
+++ b/pages/admin-panel.js
@@ -104,7 +104,7 @@ const getDefaultSectionForAccount = (account, loggedInUser) => {
     return ALL_SECTIONS.INFO;
   }
 
-  const isAdmin = loggedInUser?.isAdminOfCollectiveOrHost(account);
+  const isAdmin = loggedInUser?.isAdminOfCollective(account);
   const isAccountant = loggedInUser?.hasRole(roles.ACCOUNTANT, account);
   const isAccountantOnly = !isAdmin && isAccountant;
   if (isHostAccount(account)) {
@@ -145,7 +145,7 @@ function getBlocker(LoggedInUser, account, section) {
   }
 
   // Check permissions
-  const isAdmin = LoggedInUser.isAdminOfCollectiveOrHost(account);
+  const isAdmin = LoggedInUser.isAdminOfCollective(account);
   if (SECTIONS_ACCESSIBLE_TO_ACCOUNTANTS.includes(section)) {
     if (!isAdmin && !LoggedInUser.hasRole(roles.ACCOUNTANT, account)) {
       return <FormattedMessage defaultMessage="You need to be logged in as an admin or accountant to view this page" />;
@@ -156,9 +156,7 @@ function getBlocker(LoggedInUser, account, section) {
 }
 
 const getIsAccountantOnly = (LoggedInUser, account) => {
-  return (
-    LoggedInUser && !LoggedInUser.isAdminOfCollectiveOrHost(account) && LoggedInUser.hasRole(roles.ACCOUNTANT, account)
-  );
+  return LoggedInUser && !LoggedInUser.isAdminOfCollective(account) && LoggedInUser.hasRole(roles.ACCOUNTANT, account);
 };
 
 const AdminPanelPage = () => {

--- a/pages/collective-page.js
+++ b/pages/collective-page.js
@@ -205,8 +205,8 @@ class CollectivePage extends React.Component {
                   updates={collective.updates}
                   conversations={collective.conversations}
                   LoggedInUser={LoggedInUser}
-                  isAdmin={Boolean(LoggedInUser && LoggedInUser.isAdminOfCollectiveOrHost(collective))}
-                  isHostAdmin={Boolean(LoggedInUser && LoggedInUser.isAdminOfCollectiveOrHost(collective.host))}
+                  isAdmin={Boolean(LoggedInUser && LoggedInUser.isAdminOfCollective(collective))}
+                  isHostAdmin={Boolean(LoggedInUser && LoggedInUser.isHostAdmin(collective))}
                   isRoot={Boolean(LoggedInUser && LoggedInUser.isRoot())}
                   onPrimaryColorChange={onPrimaryColorChange}
                   step={step}
@@ -215,7 +215,7 @@ class CollectivePage extends React.Component {
                 />
               )}
             </CollectiveThemeProvider>
-            {mode === 'onboarding' && LoggedInUser?.isAdminOfCollectiveOrHost(collective) && (
+            {mode === 'onboarding' && LoggedInUser?.isAdminOfCollective(collective) && (
               <OnboardingModal
                 showOnboardingModal={showOnboardingModal}
                 setShowOnboardingModal={this.setShowOnboardingModal}

--- a/pages/contribute.js
+++ b/pages/contribute.js
@@ -275,14 +275,14 @@ class TiersPage extends React.Component {
                       <H2 fontWeight="normal" mb={2}>
                         {title}
                       </H2>
-                      {LoggedInUser?.isAdminOfCollectiveOrHost(collective) && verb === 'events' && (
+                      {LoggedInUser?.isAdminOfCollective(collective) && verb === 'events' && (
                         <Link href={`/${collective.slug}/events/new`}>
                           <StyledButton buttonStyle="primary">
                             <FormattedMessage id="event.create.btn" defaultMessage="Create Event" />
                           </StyledButton>
                         </Link>
                       )}
-                      {LoggedInUser?.isAdminOfCollectiveOrHost(collective) && verb === 'projects' && (
+                      {LoggedInUser?.isAdminOfCollective(collective) && verb === 'projects' && (
                         <Link href={`/${collective.slug}/projects/new`}>
                           <StyledButton buttonStyle="primary">
                             <FormattedMessage id="SectionProjects.CreateProject" defaultMessage="Create Project" />

--- a/pages/conversation.js
+++ b/pages/conversation.js
@@ -328,7 +328,7 @@ class ConversationPage extends React.Component {
     const followers = get(conversation, 'followers');
     const hasFollowers = followers && followers.nodes && followers.nodes.length > 0;
     const canEdit = LoggedInUser && body && LoggedInUser.canEditComment(body);
-    const canDelete = canEdit || (LoggedInUser && LoggedInUser.isAdminOfCollectiveOrHost(collective));
+    const canDelete = canEdit || (LoggedInUser && LoggedInUser.isAdminOfCollective(collective));
     return (
       <Page collective={collective} {...this.getPageMetaData(collective, conversation)}>
         {data.loading ? (

--- a/pages/createUpdate.js
+++ b/pages/createUpdate.js
@@ -138,7 +138,7 @@ class CreateUpdatePage extends React.Component {
     }
 
     const collective = data.account;
-    const isAdmin = LoggedInUser && LoggedInUser.isAdminOfCollectiveOrHost(collective);
+    const isAdmin = LoggedInUser && LoggedInUser.isAdminOfCollective(collective);
 
     return (
       <div>

--- a/pages/expenses.js
+++ b/pages/expenses.js
@@ -149,7 +149,7 @@ class ExpensePage extends React.Component {
   componentDidUpdate(oldProps) {
     const { LoggedInUser, data } = this.props;
     if (!oldProps.LoggedInUser && LoggedInUser) {
-      if (LoggedInUser.isAdminOfCollectiveOrHost(data.account) || LoggedInUser.isHostAdmin(data.account)) {
+      if (LoggedInUser.isAdminOfCollectiveOrHost(data.account)) {
         data.refetch();
       }
     }

--- a/pages/orders.js
+++ b/pages/orders.js
@@ -36,7 +36,7 @@ class OrdersPage extends React.Component {
             <CollectiveNavbar
               isLoading={data.loading}
               collective={data.account}
-              isAdmin={LoggedInUser?.isAdminOfCollectiveOrHost(collective)}
+              isAdmin={LoggedInUser?.isAdminOfCollective(collective)}
             />
           </Container>
         )}

--- a/pages/recurring-contributions.js
+++ b/pages/recurring-contributions.js
@@ -145,7 +145,7 @@ class recurringContributionsPage extends React.Component {
     }
 
     const collective = data && data.account;
-    const canEditCollective = Boolean(LoggedInUser?.isAdminOfCollectiveOrHost(collective));
+    const canEditCollective = Boolean(LoggedInUser?.isAdminOfCollective(collective));
     const recurringContributions = collective && collective.orders;
     const groupedAdminOf = this.getAdministratedAccounts(LoggedInUser);
     const isAdminOfGroups = !isEmpty(groupedAdminOf);

--- a/pages/submitted-expenses.tsx
+++ b/pages/submitted-expenses.tsx
@@ -87,7 +87,7 @@ class SubmittedExpensesPage extends React.Component<SubmittedExpensesPageProps> 
   async componentDidUpdate(oldProps) {
     const { LoggedInUser, data } = this.props;
     if (!oldProps.LoggedInUser && LoggedInUser) {
-      if (LoggedInUser.isAdminOfCollectiveOrHost(data.account) || LoggedInUser.isHostAdmin(data.account)) {
+      if (LoggedInUser.isAdminOfCollectiveOrHost(data.account)) {
         data.refetch();
       }
     }

--- a/pages/transactions.js
+++ b/pages/transactions.js
@@ -233,7 +233,6 @@ class TransactionsPage extends React.Component {
       return false;
     } else {
       return (
-        LoggedInUser.isHostAdmin(collective) ||
         LoggedInUser.isAdminOfCollectiveOrHost(collective) ||
         LoggedInUser.hasRole(roles.ACCOUNTANT, collective) ||
         LoggedInUser.hasRole(roles.ACCOUNTANT, collective.host)
@@ -289,7 +288,7 @@ class TransactionsPage extends React.Component {
         <Body>
           <CollectiveNavbar
             collective={collective}
-            isAdmin={LoggedInUser && LoggedInUser.isAdminOfCollectiveOrHost(collective)}
+            isAdmin={LoggedInUser && LoggedInUser.isAdminOfCollective(collective)}
             selectedCategory={NAVBAR_CATEGORIES.BUDGET}
             selectedSection={collective.type === CollectiveType.COLLECTIVE ? Sections.BUDGET : Sections.TRANSACTIONS}
           />

--- a/pages/update.js
+++ b/pages/update.js
@@ -135,7 +135,7 @@ class UpdatePage extends React.Component {
       >
         <CollectiveNavbar
           collective={account}
-          isAdmin={LoggedInUser && LoggedInUser.isAdminOfCollectiveOrHost(account)}
+          isAdmin={LoggedInUser && LoggedInUser.isAdminOfCollective(account)}
           selectedCategory={NAVBAR_CATEGORIES.CONNECT}
         />
 
@@ -144,7 +144,7 @@ class UpdatePage extends React.Component {
             key={update.id}
             collective={account}
             update={update}
-            editable={Boolean(LoggedInUser?.isAdminOfCollectiveOrHost(account))}
+            editable={Boolean(LoggedInUser?.isAdminOfCollective(account))}
             LoggedInUser={LoggedInUser}
             compact={false}
             reactions={update.reactions}

--- a/pages/updates.js
+++ b/pages/updates.js
@@ -54,7 +54,7 @@ class UpdatesPage extends React.Component {
   componentDidUpdate(prevProps) {
     const { data, LoggedInUser } = this.props;
     const collective = data.account;
-    if (!prevProps.LoggedInUser && LoggedInUser && LoggedInUser.isAdminOfCollectiveOrHost(collective)) {
+    if (!prevProps.LoggedInUser && LoggedInUser && LoggedInUser.isAdminOfCollective(collective)) {
       // We refetch the data to get the updates that are not published yet
       data.refetch({ options: { fetchPolicy: 'network-only' } });
     }
@@ -86,7 +86,7 @@ class UpdatesPage extends React.Component {
         <Body>
           <CollectiveNavbar
             collective={collective}
-            isAdmin={LoggedInUser && LoggedInUser.isAdminOfCollectiveOrHost(collective)}
+            isAdmin={LoggedInUser && LoggedInUser.isAdminOfCollective(collective)}
             selectedCategory={NAVBAR_CATEGORIES.CONNECT}
           />
 
@@ -103,7 +103,7 @@ class UpdatesPage extends React.Component {
                   />
                 </P>
               </Container>
-              {LoggedInUser?.isAdminOfCollectiveOrHost(collective) && (
+              {LoggedInUser?.isAdminOfCollective(collective) && (
                 <Link href={`${getCollectivePageRoute(collective)}/updates/new`}>
                   <StyledButton buttonStyle="primary" m={2}>
                     <FormattedMessage id="sections.update.new" defaultMessage="Create an Update" />


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/6199

Introduced in https://github.com/opencollective/opencollective-frontend/pull/8373, which solved an old bug that multiple pages actually relied on. 

Solved here by introducing a more granular helper with `isAdminOfCollective`.

This has no security implications since the bug was frontend-only.