### PR TITLE
Fix missing payoutMethods on expense payee host

### DIFF
--- a/components/expenses/graphql/fragments.ts
+++ b/components/expenses/graphql/fragments.ts
@@ -213,6 +213,14 @@ export const expensePageExpenseFieldsFragment = gql`
         isApproved
         host {
           id
+          # For Expenses across hosts
+          payoutMethods {
+            id
+            type
+            name
+            data
+            isSaved
+          }
         }
       }
 


### PR DESCRIPTION
Warning reported on https://opencollective.slack.com/archives/GFH4N961L/p1669678088189889 when editing an Expense across Hosts.