### PR TITLE
Handle error when ACH and SEPA are not available

### DIFF
--- a/components/contribution-flow/PaymentMethodList.tsx
+++ b/components/contribution-flow/PaymentMethodList.tsx
@@ -162,8 +162,10 @@ export default function PaymentMethodList(props: PaymentMethodListProps) {
 
   const hostSupportedPaymentMethods = props.host?.supportedPaymentMethods ?? [];
   const hostHasStripe = hostSupportedPaymentMethods.includes(PaymentMethodLegacyType.CREDIT_CARD);
+  const collectiveHasStripePaymentIntent = get(props.toAccount, 'settings.features.stripePaymentIntent', false)
+
   React.useEffect(() => {
-    if (hostHasStripe) {
+    if (hostHasStripe && collectiveHasStripePaymentIntent) {
       createPaymentIntent();
     }
   }, [hostHasStripe]);
@@ -190,7 +192,7 @@ export default function PaymentMethodList(props: PaymentMethodListProps) {
     stripeAccount,
   ]);
 
-  const loading = loadingPaymentMethods || (hostHasStripe && loadingPaymentIntent);
+  const loading = loadingPaymentMethods || (collectiveHasStripePaymentIntent && loadingPaymentIntent);
   const error = paymentMethodsError;
 
   const setNewPaymentMethod = React.useCallback(

--- a/components/contribution-flow/PaymentMethodList.tsx
+++ b/components/contribution-flow/PaymentMethodList.tsx
@@ -142,6 +142,7 @@ export default function PaymentMethodList(props: PaymentMethodListProps) {
           toAccount: pick(props.toAccount, 'id'),
         },
       },
+      errorPolicy: 'all',
     });
 
   const {
@@ -190,7 +191,7 @@ export default function PaymentMethodList(props: PaymentMethodListProps) {
   ]);
 
   const loading = loadingPaymentMethods || (hostHasStripe && loadingPaymentIntent);
-  const error = paymentMethodsError || (hostHasStripe && paymentIntentError);
+  const error = paymentMethodsError;
 
   const setNewPaymentMethod = React.useCallback(
     (key, paymentMethod) => {
@@ -315,7 +316,7 @@ export default function PaymentMethodList(props: PaymentMethodListProps) {
     clientSecret: paymentIntentClientSecret,
   };
 
-  if (hostHasStripe) {
+  if (hostHasStripe && !paymentIntentError) {
     return (
       <Elements options={options} stripe={stripe}>
         {list}

--- a/components/contribution-flow/PaymentMethodList.tsx
+++ b/components/contribution-flow/PaymentMethodList.tsx
@@ -162,7 +162,7 @@ export default function PaymentMethodList(props: PaymentMethodListProps) {
 
   const hostSupportedPaymentMethods = props.host?.supportedPaymentMethods ?? [];
   const hostHasStripe = hostSupportedPaymentMethods.includes(PaymentMethodLegacyType.CREDIT_CARD);
-  const collectiveHasStripePaymentIntent = get(props.toAccount, 'settings.features.stripePaymentIntent', false)
+  const collectiveHasStripePaymentIntent = get(props.toAccount, 'settings.features.stripePaymentIntent', false);
 
   React.useEffect(() => {
     if (hostHasStripe && collectiveHasStripePaymentIntent) {

--- a/components/contribution-flow/utils.js
+++ b/components/contribution-flow/utils.js
@@ -243,7 +243,8 @@ export const generatePaymentMethodOptions = (
       supportedPaymentMethods.includes(GQLV2_SUPPORTED_PAYMENT_METHOD_TYPES.PAYMENT_INTENT) &&
       !interval &&
       get(collective, 'settings.features.stripePaymentIntent', false) &&
-      ['USD', 'EUR'].includes(stepDetails.currency)
+      ['USD', 'EUR'].includes(stepDetails.currency) &&
+      stripeAccount
     ) {
       let subtitle;
       if (stepDetails.currency === 'USD') {


### PR DESCRIPTION
Resolve https://sentry.io/organizations/open-collective/issues/3776493233/?referrer=slack

# Description

When ACH/SEPA are not enabled in the connected stripe account, the payment intent create mutation fails.
This PR handles it by rendering the payment method list without the ACH/SEPA options

