### PR TITLE
ConfirmOrder: Add support for optional slug in URL

### DIFF
--- a/rewrites.js
+++ b/rewrites.js
@@ -151,7 +151,7 @@ exports.REWRITES = [
     destination: '/order',
   },
   {
-    source: '/orders/:id([0-9]+)/confirm',
+    source: '/:collectiveSlug?/orders/:id([0-9]+)/confirm',
     destination: '/confirmOrder',
   },
   {


### PR DESCRIPTION
For https://github.com/opencollective/opencollective-api/pull/8231

We will later iterate in the frontend to make use of this new slug (e,g. reject if slug is not the same as the one of the account order). This PR is just there to ensure we support the new URL scheme.