### PR TITLE
Wrap contribute cards correctly on grid

### DIFF
--- a/components/edit-collective/sections/TiersRevamp.js
+++ b/components/edit-collective/sections/TiersRevamp.js
@@ -75,15 +75,10 @@ const getFinancialContributions = (collective, sortedTiers) => {
 };
 
 const CardsContainer = styled(Grid).attrs({
+  justifyItems: 'center',
   gridGap: '30px',
-  justifyContent: ['center', 'space-between'],
-  gridTemplateColumns: [
-    'minmax(280px, 400px)',
-    'repeat(2, minmax(280px, 350px))',
-    'repeat(3, minmax(240px, 350px))',
-    'repeat(3, minmax(280px, 350px))',
-    'repeat(4, 280px)',
-  ],
+  gridTemplateColumns: ['repeat(auto-fit, minmax(280px, 1fr))'],
+  gridAutoRows: ['1fr'],
 })`
   & > * {
     padding: 0;

--- a/components/edit-collective/tiers/EditTierModal.js
+++ b/components/edit-collective/tiers/EditTierModal.js
@@ -143,7 +143,7 @@ function FormFields({ collective, types, values }) {
         mt="3"
         required={false}
       >
-        {({ field }) => <StyledTextarea data-cy={field.name} maxLength={510} showCount {...field} />}
+        {({ field }) => <StyledTextarea data-cy={field.name} maxLength={510} width="100%" showCount {...field} />}
       </StyledInputFormikField>
       {[DONATION, MEMBERSHIP, TIER, SERVICE].includes(values.type) && (
         <StyledInputFormikField


### PR DESCRIPTION
Related https://github.com/opencollective/opencollective/issues/6092

# Description

Makes the contribute cards response in the edit tiers page.

# Screenshots

Wraps properly
![Screenshot from 2022-12-08 10-26-57](https://user-images.githubusercontent.com/5448927/206458216-e7f0827f-17cd-4d7e-9f2f-c32885397d85.png)

New tier card height matches grid
![Screenshot from 2022-12-08 10-27-48](https://user-images.githubusercontent.com/5448927/206458399-f3cc0c37-1ec1-40b3-a409-b9966a2d13e5.png)

