### PR TITLE
Show `For Collective` menu in mobile

### DIFF
--- a/components/TopBarMobileMenu.js
+++ b/components/TopBarMobileMenu.js
@@ -79,12 +79,11 @@ const TopBarMobileMenu = props => {
             </Flex>
             {state.viewSolutionsMenu && (
               <Box as="ul" my={2} pl="12px">
-                {/* TODO: Add this part back when the /collectives page is designed*/}
-                {/* <ListItem>*/}
-                {/*  <Link href="/collectives" onClick={closeMenu}>*/}
-                {/*    <FormattedMessage id="pricing.forCollective" defaultMessage="For Collectives" />*/}
-                {/*  </Link>*/}
-                {/* </ListItem>*/}
+                <SubListItem>
+                  <Link href="/collectives" onClick={closeMenu}>
+                    <FormattedMessage id="pricing.forCollective" defaultMessage="For Collectives" />
+                  </Link>
+                </SubListItem>
                 <SubListItem>
                   <Link href="/become-a-sponsor" onClick={closeMenu}>
                     <FormattedMessage defaultMessage="For Contributors" />


### PR DESCRIPTION
Seems we have missed removing some commented code while revamping the top nav bar. 

![Screen Shot 2022-12-23 at 07 24 01](https://user-images.githubusercontent.com/12435965/209359600-cac442ee-fe78-4d33-99fe-562376674fd3.png)
