### PR TITLE
Only added funds and Bank Transfers have fund received date

### DIFF
--- a/components/ContributionConfirmationModal.js
+++ b/components/ContributionConfirmationModal.js
@@ -1,6 +1,7 @@
 import React, { Fragment, useState } from 'react';
 import PropTypes from 'prop-types';
 import { gql, useMutation } from '@apollo/client';
+import { InfoCircle } from '@styled-icons/boxicons-regular/InfoCircle';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { i18nGraphqlException } from '../lib/errors';
@@ -15,6 +16,7 @@ import StyledInput from './StyledInput';
 import StyledInputAmount from './StyledInputAmount';
 import StyledInputPercentage from './StyledInputPercentage';
 import StyledModal, { ModalBody, ModalFooter, ModalHeader } from './StyledModal';
+import StyledTooltip from './StyledTooltip';
 import { P, Span } from './Text';
 import { TOAST_TYPE, useToasts } from './ToastProvider';
 
@@ -49,7 +51,7 @@ const ContributionConfirmationModal = ({ order, onClose }) => {
   const [platformTip, setPlatformTip] = useState(platformTipAmount);
   const [paymentProcessorFee, setPaymentProcessorFee] = useState(0);
   const [hostFeePercent, setHostFeePercent] = useState(defaultHostFeePercent);
-  const [processedAt, setProcessedAt] = useState();
+  const [processedAt, setProcessedAt] = useState(new Date().toISOString().split('T')[0]);
   const intl = useIntl();
   const { addToast } = useToasts();
   const [confirmOrder, { loading }] = useMutation(confirmContributionMutation, { context: API_V2_CONTEXT });
@@ -197,12 +199,19 @@ const ContributionConfirmationModal = ({ order, onClose }) => {
         <Container>
           <Flex justifyContent="space-between" alignItems={['left', 'center']} flexDirection={['column', 'row']}>
             <Span fontSize="14px" lineHeight="20px" fontWeight="400">
-              <FormattedMessage id="processedAt" defaultMessage="Fund received date" />
+              <span>
+                <FormattedMessage id="expense.incurredAt" defaultMessage="Date" />
+                {` `}
+                <StyledTooltip content={() => <FormattedMessage defaultMessage="Date the funds were received." />}>
+                  <InfoCircle size={16} />
+                </StyledTooltip>
+              </span>
             </Span>
             <StyledInput
               name="processedAt"
               type="date"
               data-cy="processedAt"
+              defaultValue={processedAt}
               onChange={e => setProcessedAt(e.target.value)}
             />
           </Flex>

--- a/components/ContributionConfirmationModal.js
+++ b/components/ContributionConfirmationModal.js
@@ -6,6 +6,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 import { i18nGraphqlException } from '../lib/errors';
 import { API_V2_CONTEXT } from '../lib/graphql/helpers';
+import { getCurrentDateInUTC } from '../lib/utils';
 
 import Container from './Container';
 import FormattedMoneyAmount from './FormattedMoneyAmount';
@@ -51,7 +52,7 @@ const ContributionConfirmationModal = ({ order, onClose }) => {
   const [platformTip, setPlatformTip] = useState(platformTipAmount);
   const [paymentProcessorFee, setPaymentProcessorFee] = useState(0);
   const [hostFeePercent, setHostFeePercent] = useState(defaultHostFeePercent);
-  const [processedAt, setProcessedAt] = useState(new Date().toISOString().split('T')[0]);
+  const [processedAt, setProcessedAt] = useState(getCurrentDateInUTC());
   const intl = useIntl();
   const { addToast } = useToasts();
   const [confirmOrder, { loading }] = useMutation(confirmContributionMutation, { context: API_V2_CONTEXT });

--- a/components/host-dashboard/AddFundsModal.js
+++ b/components/host-dashboard/AddFundsModal.js
@@ -13,6 +13,7 @@ import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
 import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
 import { require2FAForAdmins } from '../../lib/policies';
 import { getCollectivePageRoute } from '../../lib/url-helpers';
+import { getCurrentDateInUTC } from '../../lib/utils';
 
 import { collectivePageQuery, getCollectivePageQueryVariables } from '../collective-page/graphql/queries';
 import { getBudgetSectionQuery, getBudgetSectionQueryVariables } from '../collective-page/sections/Budget';
@@ -217,7 +218,7 @@ const getInitialValues = values => ({
   hostFeePercent: null,
   description: '',
   memo: null,
-  processedAt: new Date().toISOString().split('T')[0],
+  processedAt: getCurrentDateInUTC(),
   fromAccount: null,
   tier: null,
   ...values,

--- a/components/transactions/TransactionDetails.js
+++ b/components/transactions/TransactionDetails.js
@@ -180,7 +180,7 @@ const TransactionDetails = ({ displayActions, transaction, onMutationSuccess }) 
               <DetailDescription>{order.memo}</DetailDescription>
             </React.Fragment>
           )}
-          {order?.processedAt && transaction.kind === 'ADDED_FUNDS' && (
+          {order?.processedAt && (transaction.kind === 'ADDED_FUNDS' || !paymentMethod) && (
             <React.Fragment>
               <DetailTitle>
                 <span>

--- a/components/transactions/TransactionDetails.js
+++ b/components/transactions/TransactionDetails.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { InfoCircle } from '@styled-icons/boxicons-regular/InfoCircle';
 import { Info } from '@styled-icons/feather/Info';
 import { FormattedMessage, useIntl } from 'react-intl';
 import styled, { css } from 'styled-components';
@@ -182,11 +183,17 @@ const TransactionDetails = ({ displayActions, transaction, onMutationSuccess }) 
           {order?.processedAt && transaction.kind === 'ADDED_FUNDS' && (
             <React.Fragment>
               <DetailTitle>
-                <Span textTransform="capitalize">
-                  <FormattedMessage id="processedAt" defaultMessage="Fund received date" />
-                </Span>
+                <span>
+                  <FormattedMessage id="expense.incurredAt" defaultMessage="Date" />
+                  {` `}
+                  <StyledTooltip content={() => <FormattedMessage defaultMessage="Date the funds were received." />}>
+                    <InfoCircle size={13} />
+                  </StyledTooltip>
+                </span>
               </DetailTitle>
-              <DetailDescription>{intl.formatDate(order.processedAt, { timeZone: 'UTC' })}</DetailDescription>
+              <DetailDescription>
+                {intl.formatDate(order.processedAt, { dateStyle: 'long', timeZone: 'UTC' })}
+              </DetailDescription>
             </React.Fragment>
           )}
         </Flex>

--- a/components/transactions/TransactionDetails.js
+++ b/components/transactions/TransactionDetails.js
@@ -179,7 +179,7 @@ const TransactionDetails = ({ displayActions, transaction, onMutationSuccess }) 
               <DetailDescription>{order.memo}</DetailDescription>
             </React.Fragment>
           )}
-          {order?.processedAt && (
+          {order?.processedAt && transaction.kind === 'ADDED_FUNDS' && (
             <React.Fragment>
               <DetailTitle>
                 <Span textTransform="capitalize">

--- a/components/transactions/TransactionDetails.js
+++ b/components/transactions/TransactionDetails.js
@@ -180,22 +180,24 @@ const TransactionDetails = ({ displayActions, transaction, onMutationSuccess }) 
               <DetailDescription>{order.memo}</DetailDescription>
             </React.Fragment>
           )}
-          {order?.processedAt && (transaction.kind === 'ADDED_FUNDS' || !paymentMethod) && (
-            <React.Fragment>
-              <DetailTitle>
-                <span>
-                  <FormattedMessage id="expense.incurredAt" defaultMessage="Date" />
-                  {` `}
-                  <StyledTooltip content={() => <FormattedMessage defaultMessage="Date the funds were received." />}>
-                    <InfoCircle size={13} />
-                  </StyledTooltip>
-                </span>
-              </DetailTitle>
-              <DetailDescription>
-                {intl.formatDate(order.processedAt, { dateStyle: 'long', timeZone: 'UTC' })}
-              </DetailDescription>
-            </React.Fragment>
-          )}
+          {order?.processedAt &&
+            (transaction.kind === TransactionKind.ADDED_FUNDS ||
+              (!paymentMethod && transaction.kind === TransactionKind.CONTRIBUTION)) && (
+              <React.Fragment>
+                <DetailTitle>
+                  <span>
+                    <FormattedMessage id="expense.incurredAt" defaultMessage="Date" />
+                    {` `}
+                    <StyledTooltip content={() => <FormattedMessage defaultMessage="Date the funds were received." />}>
+                      <InfoCircle size={13} />
+                    </StyledTooltip>
+                  </span>
+                </DetailTitle>
+                <DetailDescription>
+                  {intl.formatDate(order.processedAt, { dateStyle: 'long', timeZone: 'UTC' })}
+                </DetailDescription>
+              </React.Fragment>
+            )}
         </Flex>
       )}
       <Flex flexDirection="column" width={[1, 0.35]}>

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -249,3 +249,5 @@ export const omitDeep = (obj, keys) =>
     (acc, next) => ({ ...acc, [next]: isObject(obj[next]) ? omitDeep(obj[next], keys) : obj[next] }),
     {},
   );
+
+export const getCurrentDateInUTC = () => new Date().toISOString().split('T')[0];


### PR DESCRIPTION
It seems that currently we show the "Fund Received Date" for all transactions. 

![image](https://user-images.githubusercontent.com/12435965/210457912-21b3df63-5365-4e41-a5ad-ebe61278a555.png)

This is unnecessary and should only be shown on Added funds. 

![image](https://user-images.githubusercontent.com/12435965/210457947-4e6235e1-c353-41de-9c64-9a94753433ff.png)
