### PR TITLE
Display social link form on info section only

### DIFF
--- a/components/edit-collective/Form.js
+++ b/components/edit-collective/Form.js
@@ -893,11 +893,13 @@ class EditCollectiveForm extends React.Component {
                       required={field.required}
                     />
                   ))}
-                  <SocialLinksFormField
-                    value={this.state.collective?.socialLinks}
-                    touched={this.state.modified}
-                    onChange={value => this.handleChange('socialLinks', value)}
-                  />
+                  {section === 'info' && (
+                    <SocialLinksFormField
+                      value={this.state.collective?.socialLinks}
+                      touched={this.state.modified}
+                      onChange={value => this.handleChange('socialLinks', value)}
+                    />
+                  )}
                 </div>
               </div>
             )}


### PR DESCRIPTION
This component is used for the info and fiscalHost section of the admin pages. The social link components should render only on `info`
