### PR TITLE
docs: update links in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To update:
 
 ## Styleguide
 
-We use [Storybook](https://storybook.js.org/docs/react/get-started/introduction) to develop and document our React components in isolation with [styled-components](https://www.styled-components.com/) and [styled-system](https://jxnblk.com/styled-system/).
+We use [Storybook](https://storybook.js.org/docs/react/get-started/introduction) to develop and document our React components in isolation with [styled-components](https://www.styled-components.com/) and [styled-system](https://styled-system.com/).
 
 More info: [docs/styleguide.md](docs/styleguide.md)
 

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -1,6 +1,6 @@
 # Styleguide
 
-We use [Storybook](https://storybook.js.org/) to develop and document our React components in isolation with [styled-components](https://www.styled-components.com/) and [styled-system](https://jxnblk.com/styled-system/).
+We use [Storybook](https://storybook.js.org/) to develop and document our React components in isolation with [styled-components](https://www.styled-components.com/) and [styled-system](https://styled-system.com/).
 
 ## Start
 


### PR DESCRIPTION
# Description

Link https://jxnblk.com/styled-system/ leads to 404 page. Replaced by https://styled-system.com/


