### PR TITLE
Improve DefinedTerm accessibility

### DIFF
--- a/components/DefinedTerm.js
+++ b/components/DefinedTerm.js
@@ -126,8 +126,8 @@ const UnderlinedTerm = styled.span`
   ${textTransform}
 
   &:hover {
-    color: ${themeGet('colors.primary.400')};
-    border-color: ${themeGet('colors.primary.400')};
+    color: ${themeGet('colors.primary.500')};
+    border-color: ${themeGet('colors.primary.500')};
   }
 `;
 
@@ -172,7 +172,7 @@ DefinedTerm.propTypes = {
 };
 
 DefinedTerm.defaultProps = {
-  color: 'black.500',
+  color: 'black.700',
 };
 
 export default injectIntl(DefinedTerm);


### PR DESCRIPTION
The previous color was not matching accessibility standards:

![image](https://user-images.githubusercontent.com/1556356/212273556-ee12d01e-977d-49b0-a058-4f56af2cf9b1.png)
