### PR TITLE
Fix missing GST for hosted collectives on expense form

### DIFF
--- a/components/expenses/ExpenseFormItems.js
+++ b/components/expenses/ExpenseFormItems.js
@@ -161,9 +161,9 @@ class ExpenseFormItems extends React.PureComponent {
   getApplicableTaxType() {
     const { collective, form } = this.props;
     if (form.values.type === expenseTypes.INVOICE) {
-      if (accountHasVAT(collective)) {
+      if (accountHasVAT(collective, collective.host)) {
         return TaxType.VAT;
-      } else if (accountHasGST(collective)) {
+      } else if (accountHasGST(collective.host || collective)) {
         return TaxType.GST;
       }
     }


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/6334

Bug introduced in the latest tax library update.