### PR TITLE
Rollback LoggedInUser default state

### DIFF
--- a/components/UserProvider.js
+++ b/components/UserProvider.js
@@ -5,7 +5,7 @@ import { isEqual } from 'lodash';
 import Router from 'next/router';
 
 import withLoggedInUser from '../lib/hooks/withLoggedInUser';
-import { getFromLocalStorage, LOCAL_STORAGE_KEYS, removeFromLocalStorage } from '../lib/local-storage';
+import { LOCAL_STORAGE_KEYS, removeFromLocalStorage } from '../lib/local-storage';
 import UserClass from '../lib/LoggedInUser';
 
 export const UserContext = React.createContext({
@@ -32,7 +32,7 @@ class UserProvider extends React.Component {
   };
 
   state = {
-    loadingLoggedInUser: Boolean(getFromLocalStorage(LOCAL_STORAGE_KEYS.ACCESS_TOKEN)),
+    loadingLoggedInUser: true,
     LoggedInUser: null,
     errorLoggedInUser: null,
     enforceTwoFactorAuthForLoggedInUser: null,


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/6358
Fix https://github.com/opencollective/opencollective/issues/6359

Rollback on a change made in https://github.com/opencollective/opencollective-frontend/pull/8537 that caused the Server Side Rendering and Client Side Rendering to differ, resulting in broken re-hydration that caused https://github.com/opencollective/opencollective/issues/6358.

The main drawback of this PR is that, when linking directly to the payment step in the contribution flow **for guests** (e.g. http://localhost:3000/babel/contribute/backers-355/checkout/payment?interval=month&amount=10&name=OS+Fund&legalName=&email=benjamin%2Btest%40opencollective.com&paymentMethod=newCreditCard), users will be redirected back to the step profile. Thinking more about it, it's actually something we may want to enforce to make sure users verify their email/name before submitting the form; so I've kept the changes minimal.