### PR TITLE
Clear expense currency and amounts when Payout Method changes

### DIFF
--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -349,6 +349,18 @@ const ExpenseFormBody = ({
     }
   }, [values.payeeLocation]);
 
+  React.useEffect(() => {
+    if (
+      values.currency &&
+      values.payoutMethod?.data?.currency &&
+      values.payoutMethod.data.currency !== values.currency
+    ) {
+      const items = values.items.map(item => ({ ...item, amount: null }));
+      formik.setFieldValue('currency', null);
+      formik.setFieldValue('items', items);
+    }
+  }, [values.payoutMethod]);
+
   // Load values from localstorage
   React.useEffect(() => {
     if (shouldLoadValuesFromPersister && formPersister && !dirty && !isDraft) {


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/6362

Small edge-case that would allow an expense to be created with a different currency than the bank account or the host collective.