### PR TITLE
Place new payment method option before other options

### DIFF
--- a/components/contribution-flow/utils.js
+++ b/components/contribution-flow/utils.js
@@ -175,6 +175,20 @@ export const generatePaymentMethodOptions = (
 
   // adding payment methods
   if (!balanceOnlyCollectiveTypes.includes(stepProfile.type)) {
+    if (paymentIntent) {
+      const title = <FormattedMessage defaultMessage="New payment method" />;
+
+      uniquePMs.push({
+        key: STRIPE_PAYMENT_ELEMENT_KEY,
+        title: title,
+        icon: <CreditCard color="#c9ced4" size={'1.5em'} />,
+        paymentMethod: {
+          service: PAYMENT_METHOD_SERVICE.STRIPE,
+          type: PAYMENT_METHOD_TYPE.STRIPE_ELEMENTS,
+        },
+      });
+    }
+
     const paymentIntentIncludesCard = paymentIntent && paymentIntent.payment_method_types.includes('card');
 
     if (hostHasStripe && !paymentIntentIncludesCard) {
@@ -216,20 +230,6 @@ export const generatePaymentMethodOptions = (
         },
         title: <FormattedMessage id="Stripe.PaymentMethod.Label.alipay" defaultMessage="Alipay" />,
         icon: getPaymentMethodIcon({ service: PAYMENT_METHOD_SERVICE.STRIPE, type: PAYMENT_METHOD_TYPE.ALIPAY }),
-      });
-    }
-
-    if (paymentIntent) {
-      const title = <FormattedMessage defaultMessage="New payment method" />;
-
-      uniquePMs.push({
-        key: STRIPE_PAYMENT_ELEMENT_KEY,
-        title: title,
-        icon: <CreditCard color="#c9ced4" size={'1.5em'} />,
-        paymentMethod: {
-          service: PAYMENT_METHOD_SERVICE.STRIPE,
-          type: PAYMENT_METHOD_TYPE.STRIPE_ELEMENTS,
-        },
       });
     }
 

--- a/lib/stripe/confirm-payment.ts
+++ b/lib/stripe/confirm-payment.ts
@@ -44,7 +44,7 @@ export async function confirmPayment(stripe: Stripe, clientSecret: string, payme
   }
 
   if (paymentIntentResult.error) {
-    throw new Error('Payment Intent Error', { cause: paymentIntentResult.error });
+    throw new Error(paymentIntentResult.error.message, { cause: paymentIntentResult.error });
   }
 
   return paymentIntentResult.paymentIntent;


### PR DESCRIPTION
Related https://github.com/opencollective/opencollective/issues/4974

# Description

Displays the new payment method option before other options on the contribution flow.

![image](https://user-images.githubusercontent.com/5448927/214298285-1bb5d4c4-7b56-4ef3-9fed-0ba7bf698725.png)
