### PR TITLE
Ignore CSP warnings from Sentry

### DIFF
--- a/server/sentry.js
+++ b/server/sentry.js
@@ -25,6 +25,7 @@ Sentry.init({
     /instantSearchSDKJSBridgeClearHighlight/, // Bug on Edge for IOS, see https://stackoverflow.com/questions/69261499/what-is-instantsearchsdkjsbridgeclearhighlight
     /^No collective found with slug/, // We throw exceptions for these, but they're not really errors
     /Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this/, // Creates a lot of noise in Sentry but it does not seem to have a real impact
+    /Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive/,
   ],
   denyUrls: [
     // Chrome extensions


### PR DESCRIPTION
Issues like https://sentry.io/organizations/open-collective/issues/3905163935 are spamming Sentry and most (all?) of them seem generated by 3rd party browser extensions trying to inject their JS in the page.