### PR TITLE
fix(StepDetails): change amount by 0.5 when using arrows

### DIFF
--- a/components/StyledInputAmount.js
+++ b/components/StyledInputAmount.js
@@ -158,7 +158,8 @@ const StyledInputAmount = ({
   return (
     <StyledInputGroup
       maxWidth="10em"
-      step="0.01"
+      // Increase/Decrease the amount by $0.5 instead of $0.01 when using the arrows
+      step="0.5"
       {...props}
       min={minAmount}
       max={isUndefined(max) ? max : max / 100}

--- a/components/StyledInputAmount.js
+++ b/components/StyledInputAmount.js
@@ -158,8 +158,7 @@ const StyledInputAmount = ({
   return (
     <StyledInputGroup
       maxWidth="10em"
-      // Increase/Decrease the amount by $0.5 instead of $0.01 when using the arrows
-      step="0.5"
+      step="0.01"
       {...props}
       min={minAmount}
       max={isUndefined(max) ? max : max / 100}

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -144,9 +144,9 @@ const StepDetails = ({ onChange, data, collective, tier, showPlatformTip, router
                     const valueChange = 49;
 
                     if (isTopArrowClicked) {
-                      value += valueChange;
+                      value = Math.round((value + valueChange)/50)*50;
                     } else if (isBottomArrowClicked) {
-                      value -= valueChange;
+                      value = Math.round((value - valueChange)/50) * 50;
                     }
                   }
                   dispatchChange('amount', value);

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -42,6 +42,7 @@ const StepDetails = ({ onChange, data, collective, tier, showPlatformTip, router
   const getDefaultOtherAmountSelected = () => isNil(amount) || !presets?.includes(amount);
   const [isOtherAmountSelected, setOtherAmountSelected] = React.useState(getDefaultOtherAmountSelected);
   const [temporaryInterval, setTemporaryInterval] = React.useState(undefined);
+  const [pressedKey, setPressedKey] = React.useState();
   const { LoggedInUser } = useLoggedInUser();
 
   const minAmount = getTierMinAmount(tier, currency);
@@ -126,21 +127,31 @@ const StepDetails = ({ onChange, data, collective, tier, showPlatformTip, router
                 currencyDisplay="full"
                 prependProps={{ color: 'black.500' }}
                 required
+                onKeyDown={event => {
+                  setPressedKey(event.key);
+                }}
                 onChange={value => {
-                  const previousValue = data?.amount;
                   // Increase/Decrease the amount by $0.5 instead of $0.01 when using the arrows
-                  const isTopArrowClicked = value - previousValue === 1;
-                  const isBottomArrowClicked = value - previousValue === -1;
+                  if (
+                    !pressedKey ||
+                    !(/[0-9]/g.test(pressedKey) || pressedKey === 'Backspace' || pressedKey === 'Delete')
+                  ) {
+                    const previousValue = data?.amount;
+                    const isTopArrowClicked = value - previousValue === 1;
+                    const isBottomArrowClicked = value - previousValue === -1;
+                    // We use value in cents, 1 cent is already increased/decreased by the input field itself when arrow was clicked
+                    // so we need to increase/decrease the value by 49 cents to get the desired increament/decreament of $0.5
+                    const valueChange = 49;
 
-                  // We use value in cents, 1 cent is already increased/decreased by the input field itself when arrow was clicked
-                  // so we need to increase/decrease the value by 49 cents to get the desired increament/decreament of $0.5
-                  if (isTopArrowClicked) {
-                    value = value + 49;
-                  } else if (isBottomArrowClicked) {
-                    value = value - 49;
+                    if (isTopArrowClicked) {
+                      value += valueChange;
+                    } else if (isBottomArrowClicked) {
+                      value -= valueChange;
+                    }
                   }
-
                   dispatchChange('amount', value);
+                  // Reset the pressed key
+                  setPressedKey(null);
                 }}
               />
               {Boolean(minAmount) && (

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -144,9 +144,9 @@ const StepDetails = ({ onChange, data, collective, tier, showPlatformTip, router
                     const valueChange = 49;
 
                     if (isTopArrowClicked) {
-                      value = Math.round((value + valueChange)/50)*50;
+                      value = Math.round((value + valueChange) / 50) * 50;
                     } else if (isBottomArrowClicked) {
-                      value = Math.round((value - valueChange)/50) * 50;
+                      value = Math.round((value - valueChange) / 50) * 50;
                     }
                   }
                   dispatchChange('amount', value);

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -128,10 +128,12 @@ const StepDetails = ({ onChange, data, collective, tier, showPlatformTip, router
                 required
                 onChange={value => {
                   const previousValue = data?.amount;
-                  // Increase/Decrease the amount by 0.5 instead of 0.01 when using the arrows
+                  // Increase/Decrease the amount by $0.5 instead of $0.01 when using the arrows
                   const isTopArrowClicked = value - previousValue === 1;
                   const isBottomArrowClicked = value - previousValue === -1;
 
+                  // We use value in cents, 1 cent is already increased/decreased by the input field itself when arrow was clicked
+                  // so we need to increase/decrease the value by 49 cents to get the desired increament/decreament of $0.5
                   if (isTopArrowClicked) {
                     value = value + 49;
                   } else if (isBottomArrowClicked) {

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -128,6 +128,7 @@ const StepDetails = ({ onChange, data, collective, tier, showPlatformTip, router
                 required
                 onChange={(value, event) => {
                   // Increase/Decrease the amount by $0.5 instead of $0.01 when using the arrows
+                  // inputEvent.inputType is `insertReplacementText` when the value is changed using the arrows
                   if (event.nativeEvent.inputType === 'insertReplacementText') {
                     const previousValue = data?.amount;
                     const isTopArrowClicked = value - previousValue === 1;

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -42,7 +42,6 @@ const StepDetails = ({ onChange, data, collective, tier, showPlatformTip, router
   const getDefaultOtherAmountSelected = () => isNil(amount) || !presets?.includes(amount);
   const [isOtherAmountSelected, setOtherAmountSelected] = React.useState(getDefaultOtherAmountSelected);
   const [temporaryInterval, setTemporaryInterval] = React.useState(undefined);
-  const [pressedKey, setPressedKey] = React.useState();
   const { LoggedInUser } = useLoggedInUser();
 
   const minAmount = getTierMinAmount(tier, currency);
@@ -127,15 +126,9 @@ const StepDetails = ({ onChange, data, collective, tier, showPlatformTip, router
                 currencyDisplay="full"
                 prependProps={{ color: 'black.500' }}
                 required
-                onKeyDown={event => {
-                  setPressedKey(event.key);
-                }}
-                onChange={value => {
+                onChange={(value, event) => {
                   // Increase/Decrease the amount by $0.5 instead of $0.01 when using the arrows
-                  if (
-                    !pressedKey ||
-                    !(/[0-9]/g.test(pressedKey) || pressedKey === 'Backspace' || pressedKey === 'Delete')
-                  ) {
+                  if (event.nativeEvent.inputType === 'insertReplacementText') {
                     const previousValue = data?.amount;
                     const isTopArrowClicked = value - previousValue === 1;
                     const isBottomArrowClicked = value - previousValue === -1;
@@ -150,8 +143,6 @@ const StepDetails = ({ onChange, data, collective, tier, showPlatformTip, router
                     }
                   }
                   dispatchChange('amount', value);
-                  // Reset the pressed key
-                  setPressedKey(null);
                 }}
               />
               {Boolean(minAmount) && (

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -42,7 +42,6 @@ const StepDetails = ({ onChange, data, collective, tier, showPlatformTip, router
   const getDefaultOtherAmountSelected = () => isNil(amount) || !presets?.includes(amount);
   const [isOtherAmountSelected, setOtherAmountSelected] = React.useState(getDefaultOtherAmountSelected);
   const [temporaryInterval, setTemporaryInterval] = React.useState(undefined);
-  const [pressedKey, setPressedKey] = React.useState();
   const { LoggedInUser } = useLoggedInUser();
 
   const minAmount = getTierMinAmount(tier, currency);
@@ -127,31 +126,8 @@ const StepDetails = ({ onChange, data, collective, tier, showPlatformTip, router
                 currencyDisplay="full"
                 prependProps={{ color: 'black.500' }}
                 required
-                onKeyDown={event => {
-                  setPressedKey(event.key);
-                }}
                 onChange={value => {
-                  // Increase/Decrease the amount by $0.5 instead of $0.01 when using the arrows
-                  if (
-                    !pressedKey ||
-                    !(/[0-9]/g.test(pressedKey) || pressedKey === 'Backspace' || pressedKey === 'Delete')
-                  ) {
-                    const previousValue = data?.amount;
-                    const isTopArrowClicked = value - previousValue === 1;
-                    const isBottomArrowClicked = value - previousValue === -1;
-                    // We use value in cents, 1 cent is already increased/decreased by the input field itself when arrow was clicked
-                    // so we need to increase/decrease the value by 49 cents to get the desired increament/decreament of $0.5
-                    const valueChange = 49;
-
-                    if (isTopArrowClicked) {
-                      value += valueChange;
-                    } else if (isBottomArrowClicked) {
-                      value -= valueChange;
-                    }
-                  }
                   dispatchChange('amount', value);
-                  // Reset the pressed key
-                  setPressedKey(null);
                 }}
               />
               {Boolean(minAmount) && (

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -42,6 +42,7 @@ const StepDetails = ({ onChange, data, collective, tier, showPlatformTip, router
   const getDefaultOtherAmountSelected = () => isNil(amount) || !presets?.includes(amount);
   const [isOtherAmountSelected, setOtherAmountSelected] = React.useState(getDefaultOtherAmountSelected);
   const [temporaryInterval, setTemporaryInterval] = React.useState(undefined);
+  const [pressedKey, setPressedKey] = React.useState();
   const { LoggedInUser } = useLoggedInUser();
 
   const minAmount = getTierMinAmount(tier, currency);
@@ -126,8 +127,31 @@ const StepDetails = ({ onChange, data, collective, tier, showPlatformTip, router
                 currencyDisplay="full"
                 prependProps={{ color: 'black.500' }}
                 required
+                onKeyDown={event => {
+                  setPressedKey(event.key);
+                }}
                 onChange={value => {
+                  // Increase/Decrease the amount by $0.5 instead of $0.01 when using the arrows
+                  if (
+                    !pressedKey ||
+                    !(/[0-9]/g.test(pressedKey) || pressedKey === 'Backspace' || pressedKey === 'Delete')
+                  ) {
+                    const previousValue = data?.amount;
+                    const isTopArrowClicked = value - previousValue === 1;
+                    const isBottomArrowClicked = value - previousValue === -1;
+                    // We use value in cents, 1 cent is already increased/decreased by the input field itself when arrow was clicked
+                    // so we need to increase/decrease the value by 49 cents to get the desired increament/decreament of $0.5
+                    const valueChange = 49;
+
+                    if (isTopArrowClicked) {
+                      value += valueChange;
+                    } else if (isBottomArrowClicked) {
+                      value -= valueChange;
+                    }
+                  }
                   dispatchChange('amount', value);
+                  // Reset the pressed key
+                  setPressedKey(null);
                 }}
               />
               {Boolean(minAmount) && (

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -127,6 +127,17 @@ const StepDetails = ({ onChange, data, collective, tier, showPlatformTip, router
                 prependProps={{ color: 'black.500' }}
                 required
                 onChange={value => {
+                  const previousValue = data?.amount;
+                  // Increase/Decrease the amount by 0.5 instead of 0.01 when using the arrows
+                  const isTopArrowClicked = value - previousValue === 1;
+                  const isBottomArrowClicked = value - previousValue === -1;
+
+                  if (isTopArrowClicked) {
+                    value = value + 49;
+                  } else if (isBottomArrowClicked) {
+                    value = value - 49;
+                  }
+
                   dispatchChange('amount', value);
                 }}
               />


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/6381


# Description

- Increase/Decrease the amount by 0.5 instead of 0.01 when using the arrows

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots

https://user-images.githubusercontent.com/46647141/215625584-f7312d40-e77b-4e24-8ec5-538bf3c2254f.mov


<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
