### PR TITLE
Make sure user cannot submit invite modal if a user isn't selected

### DIFF
--- a/components/edit-collective/sections/team/InviteMemberModal.js
+++ b/components/edit-collective/sections/team/InviteMemberModal.js
@@ -168,6 +168,7 @@ const InviteMemberModal = props => {
               data-cy="confirmation-modal-continue"
               loading={isInviting}
               onClick={handleSubmitForm}
+              disabled={!member}
             >
               <FormattedMessage id="save" defaultMessage="Save" />
             </StyledButton>


### PR DESCRIPTION
Related to the support ticket, https://opencollective.freshdesk.com/a/tickets/163180. Here we disable the submit button until the user chose a user from the search. 

[invite-disable-save.webm](https://user-images.githubusercontent.com/12435965/215634537-487df14c-fba4-47ba-8e1d-bc9604d42986.webm)
