### PR TITLE
Move new payment method option to start of form

### DIFF
--- a/components/contribution-flow/PaymentMethodList.tsx
+++ b/components/contribution-flow/PaymentMethodList.tsx
@@ -134,6 +134,7 @@ export default function PaymentMethodList(props: PaymentMethodListProps) {
 
   const paymentMethodOptions = React.useMemo(() => {
     return generatePaymentMethodOptions(
+      intl,
       paymentMethodsData?.account?.paymentMethods ?? [],
       props.fromAccount,
       props.stepDetails,

--- a/components/contribution-flow/utils.js
+++ b/components/contribution-flow/utils.js
@@ -19,6 +19,7 @@ import {
   getPaymentMethodMetadata,
   isPaymentMethodDisabled,
 } from '../../lib/payment-method-utils';
+import { StripePaymentMethodsLabels } from '../../lib/stripe/payment-methods';
 import { getWebsiteUrl } from '../../lib/utils';
 
 import CreditCardInactive from '../icons/CreditCardInactive';
@@ -65,6 +66,7 @@ export const getContributeProfiles = (loggedInUser, collective) => {
 };
 
 export const generatePaymentMethodOptions = (
+  intl,
   paymentMethods,
   stepProfile,
   stepDetails,
@@ -176,9 +178,22 @@ export const generatePaymentMethodOptions = (
   // adding payment methods
   if (!balanceOnlyCollectiveTypes.includes(stepProfile.type)) {
     if (paymentIntent) {
-      const title = <FormattedMessage defaultMessage="New payment method" />;
+      let availableMethodLabels = paymentIntent.payment_method_types.map(method => {
+        return intl.formatMessage(StripePaymentMethodsLabels[method]);
+      });
 
-      uniquePMs.push({
+      if (availableMethodLabels.length > 3) {
+        availableMethodLabels = [...availableMethodLabels.slice(0, 3), 'etc'];
+      }
+
+      const title = (
+        <FormattedMessage
+          defaultMessage="New payment method: {methods}"
+          values={{ methods: availableMethodLabels.join(', ') }}
+        />
+      );
+
+      uniquePMs.unshift({
         key: STRIPE_PAYMENT_ELEMENT_KEY,
         title: title,
         icon: <CreditCard color="#c9ced4" size={'1.5em'} />,

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1766,6 +1766,7 @@
   "join.becomeASponsor": "Become a sponsor",
   "join.findAFiscalHost": "Find a Fiscal Host",
   "jRacqf": "Add a custom message to be included in the email sent to financial contributors of your Collective, Project, or Event.",
+  "jwtunf": "New payment method: {methods}",
   "JYgdfC": "Discover active Collectives in the platform, contribute and engage with the communities that represent you.",
   "JYMdjW": "Are you sure you want to un-host {collectiveName}?",
   "Jzh8eo": "Collective finances. Collective technology. Collective power.",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1766,6 +1766,7 @@
   "join.becomeASponsor": "Staňte se sponzorem",
   "join.findAFiscalHost": "Find a Fiscal Host",
   "jRacqf": "Add a custom message to be included in the email sent to financial contributors of your Collective, Project, or Event.",
+  "jwtunf": "New payment method: {methods}",
   "JYgdfC": "Discover active Collectives in the platform, contribute and engage with the communities that represent you.",
   "JYMdjW": "Are you sure you want to un-host {collectiveName}?",
   "Jzh8eo": "Collective finances. Collective technology. Collective power.",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1766,6 +1766,7 @@
   "join.becomeASponsor": "Sponsor werden",
   "join.findAFiscalHost": "Finde einen Finanzträger",
   "jRacqf": "Add a custom message to be included in the email sent to financial contributors of your Collective, Project, or Event.",
+  "jwtunf": "New payment method: {methods}",
   "JYgdfC": "Discover active Collectives in the platform, contribute and engage with the communities that represent you.",
   "JYMdjW": "Are you sure you want to un-host {collectiveName}?",
   "Jzh8eo": "Kollektive Finanzen. Kollektive Technologie. Kollektive Macht.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1766,6 +1766,7 @@
   "join.becomeASponsor": "Become a sponsor",
   "join.findAFiscalHost": "Find a Fiscal Host",
   "jRacqf": "Add a custom message to be included in the email sent to financial contributors of your Collective, Project, or Event.",
+  "jwtunf": "New payment method: {methods}",
   "JYgdfC": "Discover active Collectives in the platform, contribute and engage with the communities that represent you.",
   "JYMdjW": "Are you sure you want to un-host {collectiveName}?",
   "Jzh8eo": "Collective finances. Collective technology. Collective power.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1766,6 +1766,7 @@
   "join.becomeASponsor": "Hazte patrocinador",
   "join.findAFiscalHost": "Encuentra un Anfitrión Fiscal",
   "jRacqf": "Añade un mensaje personalizado que se incluirá en el correo electrónico enviado a colaboradores financieros de tu Colectivo, Proyecto o Evento.",
+  "jwtunf": "New payment method: {methods}",
   "JYgdfC": "Descubre los Colectivos activos en la plataforma, contribuye y participa en las comunidades que te representan.",
   "JYMdjW": "¿Estás seguro de que quieres quitarle a {collectiveName} el hosting?",
   "Jzh8eo": "Finanzas colectivas. Tecnología colectiva. Poder colectivo.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1766,6 +1766,7 @@
   "join.becomeASponsor": "Devenez sponsor",
   "join.findAFiscalHost": "Trouver un Hôte Fiscal",
   "jRacqf": "Ajoutez un message personnalisé à inclure dans l'e-mail envoyé aux contributeurs financiers de votre Collectif, Projet ou Événement.",
+  "jwtunf": "New payment method: {methods}",
   "JYgdfC": "Discover active Collectives in the platform, contribute and engage with the communities that represent you.",
   "JYMdjW": "Êtes-vous sûr de vouloir dé-héberger {collectiveName} ?",
   "Jzh8eo": "Finances collectives. Technologie collective. Puissance collective.",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1766,6 +1766,7 @@
   "join.becomeASponsor": "Become a sponsor",
   "join.findAFiscalHost": "Find a Fiscal Host",
   "jRacqf": "Add a custom message to be included in the email sent to financial contributors of your Collective, Project, or Event.",
+  "jwtunf": "New payment method: {methods}",
   "JYgdfC": "Discover active Collectives in the platform, contribute and engage with the communities that represent you.",
   "JYMdjW": "Are you sure you want to un-host {collectiveName}?",
   "Jzh8eo": "Collective finances. Collective technology. Collective power.",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1766,6 +1766,7 @@
   "join.becomeASponsor": "スポンサーになる",
   "join.findAFiscalHost": "財務ホストを見つける",
   "jRacqf": "Add a custom message to be included in the email sent to financial contributors of your Collective, Project, or Event.",
+  "jwtunf": "New payment method: {methods}",
   "JYgdfC": "Discover active Collectives in the platform, contribute and engage with the communities that represent you.",
   "JYMdjW": "Are you sure you want to un-host {collectiveName}?",
   "Jzh8eo": "コレクティブなファイナンスに。コレクティブなテクノロジーに。コレクティブなパワーに。",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1766,6 +1766,7 @@
   "join.becomeASponsor": "후원자 되기",
   "join.findAFiscalHost": "재정 호스트 찾기",
   "jRacqf": "Add a custom message to be included in the email sent to financial contributors of your Collective, Project, or Event.",
+  "jwtunf": "New payment method: {methods}",
   "JYgdfC": "Discover active Collectives in the platform, contribute and engage with the communities that represent you.",
   "JYMdjW": "Are you sure you want to un-host {collectiveName}?",
   "Jzh8eo": "Collective finances. Collective technology. Collective power.",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1766,6 +1766,7 @@
   "join.becomeASponsor": "Become a sponsor",
   "join.findAFiscalHost": "Find a Fiscal Host",
   "jRacqf": "Add a custom message to be included in the email sent to financial contributors of your Collective, Project, or Event.",
+  "jwtunf": "New payment method: {methods}",
   "JYgdfC": "Discover active Collectives in the platform, contribute and engage with the communities that represent you.",
   "JYMdjW": "Are you sure you want to un-host {collectiveName}?",
   "Jzh8eo": "Collective finances. Collective technology. Collective power.",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -1766,6 +1766,7 @@
   "join.becomeASponsor": "Zostań sponsorem",
   "join.findAFiscalHost": "Znajdź gospodarza",
   "jRacqf": "Dodaj własną wiadomość, która będzie zawarta w e-mailu wysyłanym do osób finansujących Twój zbiór, projekt lub wydarzenie.",
+  "jwtunf": "New payment method: {methods}",
   "JYgdfC": "Odkryj aktywne Zbiory na platformie, przyczyniaj się i angażuj w społeczności, które Cię reprezentują.",
   "JYMdjW": "Czy na pewno chcesz odłączyć gospodarza {collectiveName}?",
   "Jzh8eo": "Finanse zbiorowe. Technologia zbiorowa. Siła zbiorowa.",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1766,6 +1766,7 @@
   "join.becomeASponsor": "Torne-se um patrocinador",
   "join.findAFiscalHost": "Encontre um Administrador Fiscal",
   "jRacqf": "Add a custom message to be included in the email sent to financial contributors of your Collective, Project, or Event.",
+  "jwtunf": "New payment method: {methods}",
   "JYgdfC": "Discover active Collectives in the platform, contribute and engage with the communities that represent you.",
   "JYMdjW": "Are you sure you want to un-host {collectiveName}?",
   "Jzh8eo": "Collective finances. Collective technology. Collective power.",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1766,6 +1766,7 @@
   "join.becomeASponsor": "Become a sponsor",
   "join.findAFiscalHost": "Find a Fiscal Host",
   "jRacqf": "Add a custom message to be included in the email sent to financial contributors of your Collective, Project, or Event.",
+  "jwtunf": "New payment method: {methods}",
   "JYgdfC": "Discover active Collectives in the platform, contribute and engage with the communities that represent you.",
   "JYMdjW": "Are you sure you want to un-host {collectiveName}?",
   "Jzh8eo": "Collective finances. Collective technology. Collective power.",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1766,6 +1766,7 @@
   "join.becomeASponsor": "Стать спонсором",
   "join.findAFiscalHost": "Найти Фискальный хост",
   "jRacqf": "Add a custom message to be included in the email sent to financial contributors of your Collective, Project, or Event.",
+  "jwtunf": "New payment method: {methods}",
   "JYgdfC": "Discover active Collectives in the platform, contribute and engage with the communities that represent you.",
   "JYMdjW": "Are you sure you want to un-host {collectiveName}?",
   "Jzh8eo": "Коллективные финансы. Коллективные технологии. Коллективная сила.",

--- a/lang/sk-SK.json
+++ b/lang/sk-SK.json
@@ -1766,6 +1766,7 @@
   "join.becomeASponsor": "Stať sa sponzorom",
   "join.findAFiscalHost": "Nájsť fiškálneho hostiteľa",
   "jRacqf": "Pridajte prispôsobenú správu, ktorá bude súčasťou e-mailu zasielaného finančným prispievateľom vášho Kolektívu, Projektu alebo Podujatia.",
+  "jwtunf": "New payment method: {methods}",
   "JYgdfC": "Objavte aktívne Kolektívy na platforme, prispievajte a zapojte sa do komunít, ktoré vás vystihujú.",
   "JYMdjW": "Are you sure you want to un-host {collectiveName}?",
   "Jzh8eo": "Kolektívne financie. Kolektívne technológie. Kolektívna moc.",

--- a/lang/sv-SE.json
+++ b/lang/sv-SE.json
@@ -1766,6 +1766,7 @@
   "join.becomeASponsor": "Bli sponsor",
   "join.findAFiscalHost": "Hitta en värd",
   "jRacqf": "Lägg till ett anpassat meddelande som inkluderas i e-postmeddelandet som skickas till bidragsgivare för ditt kollektiv, projekt eller events.",
+  "jwtunf": "New payment method: {methods}",
   "JYgdfC": "Upptäck aktiva kollektiv på plattformen, bidra och samarbeta med de projekt som representerar dig.",
   "JYMdjW": "Är du säker på att du vill ta bort värden för {collectiveName}?",
   "Jzh8eo": "Gemensam ekonomi. Gemensam teknik. Gemensam makt.",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -1766,6 +1766,7 @@
   "join.becomeASponsor": "Стати спонсором",
   "join.findAFiscalHost": "Знайти фіскальний вузол",
   "jRacqf": "Add a custom message to be included in the email sent to financial contributors of your Collective, Project, or Event.",
+  "jwtunf": "New payment method: {methods}",
   "JYgdfC": "Discover active Collectives in the platform, contribute and engage with the communities that represent you.",
   "JYMdjW": "Are you sure you want to un-host {collectiveName}?",
   "Jzh8eo": "Collective finances. Collective technology. Collective power.",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1766,6 +1766,7 @@
   "join.becomeASponsor": "成为赞助者",
   "join.findAFiscalHost": "寻找财务托管人",
   "jRacqf": "Add a custom message to be included in the email sent to financial contributors of your Collective, Project, or Event.",
+  "jwtunf": "New payment method: {methods}",
   "JYgdfC": "Discover active Collectives in the platform, contribute and engage with the communities that represent you.",
   "JYMdjW": "Are you sure you want to un-host {collectiveName}?",
   "Jzh8eo": "Collective finances. Collective technology. Collective power.",


### PR DESCRIPTION
Related https://github.com/opencollective/opencollective/issues/4974

# Description

Moves the new payment method option to the start of the payment method list and displays the first 3 new available methods as part of the option label.

# Screenshots

![image](https://user-images.githubusercontent.com/5448927/216059499-069d99fd-3622-4ac8-b88a-0e6f52e8f837.png)

![image](https://user-images.githubusercontent.com/5448927/216059530-97d76e2c-f02f-455a-a190-aacfa99ef85b.png)
