### PR TITLE
Fix lost currency on recurring expense form

### DIFF
--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -352,7 +352,7 @@ const ExpenseFormBody = ({
 
   React.useEffect(() => {
     // If the currency is not supported anymore, we need to do something
-    if (!values.currency || !availableCurrencies.includes(values.currency)) {
+    if (!loading && (!values.currency || !availableCurrencies.includes(values.currency))) {
       const hasItemsWithAmounts = values.items.some(item => Boolean(item.amount));
       if (!hasItemsWithAmounts) {
         // If no items have amounts yet, we can safely set the default currency
@@ -362,7 +362,7 @@ const ExpenseFormBody = ({
         formik.setFieldValue('currency', null);
       }
     }
-  }, [values.payoutMethod]);
+  }, [loading, values.payoutMethod]);
 
   // Load values from localstorage
   React.useEffect(() => {

--- a/pages/expense.js
+++ b/pages/expense.js
@@ -195,7 +195,7 @@ class ExpensePage extends React.Component {
     super(props);
     this.expenseTopRef = React.createRef();
     this.state = {
-      isRefetchingDataForUser: false,
+      hasRefetchedDataForUser: Boolean(props.LoggedInUser), // If the page is loaded directly with a logged in user, we can consider the query was already authenticated
       error: null,
       status:
         this.props.draftKey && this.props.data.expense?.status === expenseStatus.DRAFT
@@ -306,10 +306,10 @@ class ExpensePage extends React.Component {
 
   async refetchDataForUser() {
     try {
-      this.setState({ isRefetchingDataForUser: true });
+      this.setState({ hasRefetchedDataForUser: false });
       await this.props.data.refetch();
     } finally {
-      this.setState({ isRefetchingDataForUser: false });
+      this.setState({ hasRefetchedDataForUser: true });
     }
   }
 
@@ -461,8 +461,9 @@ class ExpensePage extends React.Component {
   };
 
   render() {
-    const { collectiveSlug, data, loadingLoggedInUser, intl } = this.props;
-    const { isRefetchingDataForUser, error, status, editedExpense } = this.state;
+    const { collectiveSlug, data, LoggedInUser, loadingLoggedInUser, intl } = this.props;
+    const { hasRefetchedDataForUser, error, status, editedExpense } = this.state;
+    const isRefetchingDataForUser = LoggedInUser && !hasRefetchedDataForUser;
 
     if (!data.loading && !isRefetchingDataForUser) {
       if (!data || data.error) {


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/6379

TLDR; we no longer consider the form "ready" if a user is logged in and we haven't yet reloaded the data for him.

This happened because the 1st fetch, using the `draftKey` while not authenticated yet, did not return any `payoutMethod` because of permissions. I added a condition not to reset the currency in the ExpenseForm when `loading` is true, but there was then an intermediate state between the two that got the form to reset. It basically looked like that:

| Step | LoggedInUser | LoadingLoggedInUser | RefetchingDataForUser | Payout |
| ----- | ---- | ---- |---- | ---- |
| 1 | :x: | :heavy_check_mark: | :x: | :x: |
| 2 | :heavy_check_mark: | :x: | :x: | :x: |
| 3 | :heavy_check_mark: | :x: | :heavy_check_mark: | :x: |
| 4 | :heavy_check_mark: | :x: | :x: | :heavy_check_mark: |

This 2nd step was the problematic one, and it was happening because we set `RefetchingDataForUser` in a `componentDidUpdate`, which happens after the render. I changed the strategy to record a **hasRefetched**DataForUser rather than (**isRefetching**DataForUser). In `render`, `isRefetchingDataForUser` is now defined as: `LoggedInUser && !hasRefetchedDataForUser` which produce the following renders:

| Step | LoggedInUser | LoadingLoggedInUser | RefetchingDataForUser | Payout |
| ----- | ---- | ---- |---- | ---- |
| 1 | :x: | :heavy_check_mark: | :x: | :x: |
| 2 | :heavy_check_mark: | :x: | :heavy_check_mark: | :x: |
| 3 | :heavy_check_mark: | :x: | :heavy_check_mark: | :x: |
| 4 | :heavy_check_mark: | :x: | :x: | :heavy_check_mark: |

This will fix the root issue and prevent similar ones where we automatically update values based on `data`.