### PR TITLE
Preserve query params on redirect

### DIFF
--- a/pages/contribution-flow.js
+++ b/pages/contribution-flow.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from '@apollo/client/react/hoc';
-import { get } from 'lodash';
+import { get, omit } from 'lodash';
 import { withRouter } from 'next/router';
 import { injectIntl } from 'react-intl';
 
@@ -64,8 +64,10 @@ class NewContributionFlowPage extends React.Component {
     this.loadExternalScripts();
     const { router, data } = this.props;
     const account = data?.account;
-    const path = router.asPath;
-    addParentToURLIfMissing(router, account, path.replace(new RegExp(`^/${account?.slug}/`), '/'));
+    const queryParameters = {
+      ...omit(router.query, ['verb', 'step', 'collectiveSlug']),
+    };
+    addParentToURLIfMissing(router, account, `/${router.query.verb}/${router.query.step}`, queryParameters);
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
Resolve https://opencollective.freshdesk.com/a/tickets/163647

# Description

When a payment on a project tier the user is redirected to `/{project-slug}/donate/success`. The page component then redirects the user to `/{collective-slug}/{project-slug}/donate/success`.

These redirect need to preserve original query params added by Stripe.
