### PR TITLE
Allow flexible intervals for tickets & products

### DIFF
--- a/components/edit-collective/tiers/EditTierModal.js
+++ b/components/edit-collective/tiers/EditTierModal.js
@@ -120,7 +120,6 @@ function FormFields({ collective, values, hideTypeSelect }) {
     // No interval for products and tickets
     if ([PRODUCT, TICKET].includes(values.type)) {
       formik.setFieldValue('interval', null);
-      formik.setFieldValue('amountType', FIXED);
     }
   }, [values.interval, values.type]);
 


### PR DESCRIPTION
Not sure why we prevented this as it was permitted in the legacy page