### PR TITLE
Make sure StyledSelect work within modals

### DIFF
--- a/components/StyledModal.tsx
+++ b/components/StyledModal.tsx
@@ -209,6 +209,7 @@ const DefaultTrapContainer = props => {
   return <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }} {...props} />;
 };
 
+export const ModalReferenceContext = React.createContext(null);
 /**
  * Modal component. Will pass down additional props to `ModalWrapper`, which is
  * a styled `Container`.
@@ -223,6 +224,7 @@ const StyledModal = ({
   ...props
 }) => {
   const intl = useIntl();
+  const modalRef = React.useRef(null);
   const TrapContainer = trapFocus ? DefaultTrapContainer : React.Fragment;
   const closeHandler = React.useCallback(() => {
     if (
@@ -251,13 +253,15 @@ const StyledModal = ({
         {hasUnsavedChanges && <WarnIfUnsavedChanges hasUnsavedChanges />}
         <Wrapper>
           <TrapContainer>
-            <Modal {...props}>
-              {React.Children.map(children, child => {
-                if (child?.type?.displayName === 'Header') {
-                  return React.cloneElement(child, { onClose: closeHandler });
-                }
-                return child;
-              })}
+            <Modal ref={modalRef} {...props}>
+              <ModalReferenceContext.Provider value={modalRef}>
+                {React.Children.map(children, child => {
+                  if (child?.type?.displayName === 'Header') {
+                    return React.cloneElement(child, { onClose: closeHandler });
+                  }
+                  return child;
+                })}
+              </ModalReferenceContext.Provider>
             </Modal>
           </TrapContainer>
         </Wrapper>
@@ -271,13 +275,15 @@ const StyledModal = ({
         {hasUnsavedChanges && <WarnIfUnsavedChanges hasUnsavedChanges />}
         <Wrapper zindex={props.zindex}>
           <TrapContainer>
-            <Modal {...props}>
-              {React.Children.map(children, child => {
-                if (child?.type?.displayName === 'Header') {
-                  return React.cloneElement(child, { onClose: closeHandler });
-                }
-                return child;
-              })}
+            <Modal ref={modalRef} {...props}>
+              <ModalReferenceContext.Provider value={modalRef}>
+                {React.Children.map(children, child => {
+                  if (child?.type?.displayName === 'Header') {
+                    return React.cloneElement(child, { onClose: closeHandler });
+                  }
+                  return child;
+                })}
+              </ModalReferenceContext.Provider>
             </Modal>
           </TrapContainer>
           <ModalOverlay

--- a/components/StyledSelect.tsx
+++ b/components/StyledSelect.tsx
@@ -17,6 +17,7 @@ import Container from './Container';
 import { Flex } from './Grid';
 import SearchIcon from './SearchIcon';
 import StyledHr from './StyledHr';
+import { ModalReferenceContext } from './StyledModal';
 import StyledTag from './StyledTag';
 import { P } from './Text';
 
@@ -189,9 +190,13 @@ export const makeStyledSelect = SelectComponent => styled(SelectComponent).attrs
     options,
   }) => {
     isSearchable = isSearchable ?? options?.length > 8;
+    // If a StyledSelect is rendered within a modal, make sure we use the modal as the portal target
+    const modalRef = React.useContext(ModalReferenceContext);
+
     return {
       isSearchable,
-      menuPortalTarget: menuPortalTarget === null || typeof document === 'undefined' ? undefined : document.body,
+      menuPortalTarget:
+        menuPortalTarget === null || typeof document === 'undefined' ? undefined : modalRef?.current || document.body,
       isDisabled: disabled || isDisabled,
       placeholder: placeholder || intl.formatMessage(Messages.placeholder),
       loadingMessage: () => intl.formatMessage(Messages.loading),


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/5599
Related to https://github.com/opencollective/opencollective/issues/5940

I'm solving this by ensuring modals always provide their reference as a context to their children and making sure the abstract StyledSelect component uses this if available.

![](https://media.giphy.com/media/NmerZ36iBkmKk/giphy.gif)