### PR TITLE
fix(Messagebox): Make sure icon is inline when setting display property on MessageBox

### DIFF
--- a/components/MessageBox.tsx
+++ b/components/MessageBox.tsx
@@ -26,7 +26,7 @@ import {
 import { whiteSpace, WhiteSpaceProps } from '../lib/styled-system-custom-properties';
 import { MessageType, messageType } from '../lib/theme/variants/message';
 
-import { Box } from './Grid';
+import { Box, Flex } from './Grid';
 import StyledSpinner from './StyledSpinner';
 
 type MessageProps = BordersProps &
@@ -52,10 +52,6 @@ const Message = styled.div<MessageProps>`
   padding: ${themeGet('space.3')}px 24px;
   font-size: 13px;
   line-height: 20px;
-
-  display: flex;
-  align-items: center;
-  gap: 16px;
 
   box-shadow: 0px 1px 4px 1px rgba(49, 50, 51, 0.05);
 
@@ -110,13 +106,15 @@ const MessageBox = ({ type = 'white', withIcon = false, isLoading, children, ...
   const icon = withIcon ? icons[type] : null;
   return (
     <Message type={type} {...props}>
-      {(icon || isLoading) && (
-        <Box flexShrink={0} alignSelf={'start'} color={iconColors[type]}>
-          {isLoading ? <StyledSpinner size="1.2em" /> : icon}
-        </Box>
-      )}
+      <Flex gap="16px">
+        {(icon || isLoading) && (
+          <Box flexShrink={0} alignSelf="start" color={iconColors[type]}>
+            {isLoading ? <StyledSpinner size="1.2em" /> : icon}
+          </Box>
+        )}
 
-      <Box>{children}</Box>
+        <Box>{children}</Box>
+      </Flex>
     </Message>
   );
 };


### PR DESCRIPTION
# Description
A fix for a bug noticed by @Betree, icon not being inline with the message:
![image](https://user-images.githubusercontent.com/1552194/217572327-9b31c031-2334-4713-a5c0-012913cf2243.png)

This was caused by the display property being set on the MessageBox (to "inline-block", in order to have the message box not be full width), which overrode the "display: flex" that was already there on the outer container. This fix adds a new flex component inside the container that takes care of the flexing, so that the icon stays inline:

<img width="933" alt="Skärmavbild 2023-02-08 kl  16 17 54" src="https://user-images.githubusercontent.com/1552194/217572881-27dc441f-fcd1-4166-96cd-7ade047c3bff.png">