### PR TITLE
Fix ReferenceError Cannot access CONTRIBUTE_CARD_WIDTH before initialization

### DIFF
--- a/components/EditPublicMessagePopup.js
+++ b/components/EditPublicMessagePopup.js
@@ -14,7 +14,7 @@ import withViewport from '../lib/withViewport';
 import { collectivePageQuery } from '../components/collective-page/graphql/queries';
 import { tierPageQuery } from '../components/tier-page/graphql/queries';
 
-import { MAX_CONTRIBUTORS_PER_CONTRIBUTE_CARD } from './contribute-cards/Contribute';
+import { MAX_CONTRIBUTORS_PER_CONTRIBUTE_CARD } from './contribute-cards/constants';
 import { Box, Flex } from './Grid';
 import StyledButton from './StyledButton';
 import StyledInput from './StyledInput';

--- a/components/collective-page/graphql/queries.js
+++ b/components/collective-page/graphql/queries.js
@@ -1,6 +1,6 @@
 import { gqlV1 } from '../../../lib/graphql/helpers';
 
-import { MAX_CONTRIBUTORS_PER_CONTRIBUTE_CARD } from '../../contribute-cards/Contribute';
+import { MAX_CONTRIBUTORS_PER_CONTRIBUTE_CARD } from '../../contribute-cards/constants';
 
 import * as fragments from './fragments';
 

--- a/components/contribute-cards/Contribute.js
+++ b/components/contribute-cards/Contribute.js
@@ -15,10 +15,11 @@ import StyledHr from '../StyledHr';
 import StyledTag from '../StyledTag';
 import { P } from '../Text';
 
-/** Max number of contributors on each tier card */
-export const MAX_CONTRIBUTORS_PER_CONTRIBUTE_CARD = 4;
-export const CONTRIBUTE_CARD_WIDTH = 280;
-export const CONTRIBUTE_CARD_BORDER_RADIUS = 16;
+import {
+  CONTRIBUTE_CARD_BORDER_RADIUS,
+  CONTRIBUTE_CARD_WIDTH,
+  MAX_CONTRIBUTORS_PER_CONTRIBUTE_CARD,
+} from './constants';
 
 /** The main container */
 const StyledContributeCard = styled.div`

--- a/components/contribute-cards/constants.js
+++ b/components/contribute-cards/constants.js
@@ -1,0 +1,4 @@
+/** Max number of contributors on each tier card */
+export const MAX_CONTRIBUTORS_PER_CONTRIBUTE_CARD = 4;
+export const CONTRIBUTE_CARD_WIDTH = 280;
+export const CONTRIBUTE_CARD_BORDER_RADIUS = 16;

--- a/pages/contribute.js
+++ b/pages/contribute.js
@@ -19,7 +19,7 @@ import { NAVBAR_CATEGORIES } from '../components/collective-navbar/constants';
 import * as fragments from '../components/collective-page/graphql/fragments';
 import CollectiveThemeProvider from '../components/CollectiveThemeProvider';
 import Container from '../components/Container';
-import { MAX_CONTRIBUTORS_PER_CONTRIBUTE_CARD } from '../components/contribute-cards/Contribute';
+import { MAX_CONTRIBUTORS_PER_CONTRIBUTE_CARD } from '../components/contribute-cards/constants';
 import ContributeCollective from '../components/contribute-cards/ContributeCollective';
 import ContributeCrypto from '../components/contribute-cards/ContributeCrypto';
 import ContributeCustom from '../components/contribute-cards/ContributeCustom';


### PR DESCRIPTION
This error has been causing some weird error pages in the front and also a few logs on our console. Apparently, frontend could reach a state where the collectivePageQuery couldn't access this constant because it was being loaded before it was initialized.

```
ReferenceError: Cannot access 'CONTRIBUTE_CARD_WIDTH' before initialization
    at Object.TJ (/app/dist/.next/server/chunks/2352.js:10844:51)
    at /app/dist/.next/server/chunks/8141.js:1393:274
    at __webpack_require__.a (/app/dist/.next/server/webpack-runtime.js:89:13)
    at 48451 (/app/dist/.next/server/chunks/8141.js:1352:21)
    at __webpack_require__ (/app/dist/.next/server/webpack-runtime.js:25:42)
    at /app/dist/.next/server/pages/collective-page.js:6431:86
    at __webpack_require__.a (/app/dist/.next/server/webpack-runtime.js:89:13)
    at 53938 (/app/dist/.next/server/pages/collective-page.js:6393:21)
    at __webpack_require__ (/app/dist/.next/server/webpack-runtime.js:25:42)
    at /app/dist/.next/server/pages/collective-page.js:4420:79
    at __webpack_require__.a (/app/dist/.next/server/webpack-runtime.js:89:13)
    at 51016 (/app/dist/.next/server/pages/collective-page.js:4394:21)
    at __webpack_require__ (/app/dist/.next/server/webpack-runtime.js:25:42)
    at /app/dist/.next/server/pages/collective-page.js:12966:85
    at __webpack_require__.a (/app/dist/.next/server/webpack-runtime.js:89:13)
    at 77402 (/app/dist/.next/server/pages/collective-page.js:12948:21)
```