### PR TITLE
Add share link for comment

### DIFF
--- a/components/conversations/Comment.js
+++ b/components/conversations/Comment.js
@@ -44,15 +44,17 @@ const Comment = ({
   canReply,
 }) => {
   const [isEditing, setEditing] = React.useState(false);
-  const hasActions = !isEditing && (canEdit || canDelete);
+  const hasActions = !isEditing;
+  const anchorHash = `comment-${new Date(comment.createdAt).getTime()}`;
 
   return (
-    <Container width="100%" data-cy="comment">
+    <Container width="100%" data-cy="comment" id={anchorHash}>
       <Flex mb={3} justifyContent="space-between">
         <CommentMetadata comment={comment} />
         {hasActions && (
           <CommentActions
             comment={comment}
+            anchorHash={anchorHash}
             isConversationRoot={isConversationRoot}
             canEdit={canEdit}
             canDelete={canDelete}

--- a/components/conversations/CommentActions.js
+++ b/components/conversations/CommentActions.js
@@ -56,7 +56,14 @@ const CommentBtn = styled(StyledButton).attrs({ buttonSize: 'small' })`
 /**
  * Action buttons for the comment owner. Styles change between mobile and desktop.
  */
-const AdminActionButtons = ({ canEdit, canDelete, openDeleteConfirmation, onEdit, copyToClipboard, closePopup }) => {
+const AdminActionButtons = ({
+  canEdit,
+  canDelete,
+  openDeleteConfirmation,
+  onEdit,
+  copyLinkToClipboard,
+  closePopup,
+}) => {
   return (
     <React.Fragment>
       {/** Buttons */}
@@ -64,7 +71,7 @@ const AdminActionButtons = ({ canEdit, canDelete, openDeleteConfirmation, onEdit
         data-cy="share-comment-btn"
         onClick={() => {
           closePopup();
-          copyToClipboard();
+          copyLinkToClipboard();
         }}
       >
         <ShareIcon size="1em" mr={2} />
@@ -107,7 +114,7 @@ AdminActionButtons.propTypes = {
   isConversationRoot: PropTypes.bool,
   canEdit: PropTypes.bool,
   canDelete: PropTypes.bool,
-  copyToClipboard: PropTypes.func,
+  copyLinkToClipboard: PropTypes.func,
 };
 
 const deleteCommentMutation = gql`
@@ -142,9 +149,9 @@ const CommentActions = ({ comment, anchorHash, isConversationRoot, canEdit, canD
     modifiers: REACT_POPPER_MODIFIERS,
   });
 
-  const copyToClipboard = () => {
+  const copyLinkToClipboard = () => {
     const [baseLink] = window.location.href.split('#');
-    const linkWithAnchorHash = `${baseLink}${anchorHash ? `#${anchorHash}` : ''}`;
+    const linkWithAnchorHash = `${baseLink}#${anchorHash}`;
     copy(linkWithAnchorHash);
   };
 
@@ -191,7 +198,7 @@ const CommentActions = ({ comment, anchorHash, isConversationRoot, canEdit, canD
               onEdit={onEditClick}
               canEdit={canEdit}
               canDelete={canDelete}
-              copyToClipboard={copyToClipboard}
+              copyLinkToClipboard={copyLinkToClipboard}
               closePopup={() => setShowAdminActions(false)}
             />
           </Flex>

--- a/components/conversations/CommentActions.js
+++ b/components/conversations/CommentActions.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { gql, useMutation } from '@apollo/client';
 import { DotsHorizontalRounded } from '@styled-icons/boxicons-regular/DotsHorizontalRounded';
+import { Share2 as ShareIcon } from '@styled-icons/feather/Share2';
 import { X } from '@styled-icons/feather/X';
 import { Edit } from '@styled-icons/material/Edit';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -10,6 +11,7 @@ import styled from 'styled-components';
 
 import { i18nGraphqlException } from '../../lib/errors';
 import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
+import useClipboard from '../../lib/hooks/useClipboard';
 import useGlobalBlur from '../../lib/hooks/useGlobalBlur';
 
 import ConfirmationModal from '../ConfirmationModal';
@@ -54,10 +56,20 @@ const CommentBtn = styled(StyledButton).attrs({ buttonSize: 'small' })`
 /**
  * Action buttons for the comment owner. Styles change between mobile and desktop.
  */
-const AdminActionButtons = ({ canEdit, canDelete, openDeleteConfirmation, onEdit, closePopup }) => {
+const AdminActionButtons = ({ canEdit, canDelete, openDeleteConfirmation, onEdit, copyToClipboard, closePopup }) => {
   return (
     <React.Fragment>
       {/** Buttons */}
+      <CommentBtn
+        data-cy="share-comment-btn"
+        onClick={() => {
+          closePopup();
+          copyToClipboard();
+        }}
+      >
+        <ShareIcon size="1em" mr={2} />
+        <FormattedMessage tagName="span" id="Share" defaultMessage="Share" />
+      </CommentBtn>
       {canEdit && (
         <CommentBtn
           data-cy="edit-comment-btn"
@@ -95,6 +107,7 @@ AdminActionButtons.propTypes = {
   isConversationRoot: PropTypes.bool,
   canEdit: PropTypes.bool,
   canDelete: PropTypes.bool,
+  copyToClipboard: PropTypes.func,
 };
 
 const deleteCommentMutation = gql`
@@ -116,8 +129,9 @@ const REACT_POPPER_MODIFIERS = [
 
 const mutationOptions = { context: API_V2_CONTEXT };
 
-const CommentActions = ({ comment, isConversationRoot, canEdit, canDelete, onDelete, onEditClick }) => {
+const CommentActions = ({ comment, anchorHash, isConversationRoot, canEdit, canDelete, onDelete, onEditClick }) => {
   const intl = useIntl();
+  const { copy } = useClipboard();
   const [isDeleting, setDeleting] = React.useState(null);
   const [showAdminActions, setShowAdminActions] = React.useState(false);
   const [refElement, setRefElement] = React.useState(null);
@@ -127,6 +141,12 @@ const CommentActions = ({ comment, isConversationRoot, canEdit, canDelete, onDel
     placement: 'bottom-end',
     modifiers: REACT_POPPER_MODIFIERS,
   });
+
+  const copyToClipboard = () => {
+    const [baseLink] = window.location.href.split('#');
+    const linkWithAnchorHash = `${baseLink}${anchorHash ? `#${anchorHash}` : ''}`;
+    copy(linkWithAnchorHash);
+  };
 
   useGlobalBlur(state?.elements.popper, outside => {
     if (outside && showAdminActions) {
@@ -171,6 +191,7 @@ const CommentActions = ({ comment, isConversationRoot, canEdit, canDelete, onDel
               onEdit={onEditClick}
               canEdit={canEdit}
               canDelete={canDelete}
+              copyToClipboard={copyToClipboard}
               closePopup={() => setShowAdminActions(false)}
             />
           </Flex>
@@ -228,6 +249,8 @@ CommentActions.propTypes = {
     html: PropTypes.string,
     createdAt: PropTypes.string,
   }).isRequired,
+  /** needed to copy the comment link */
+  anchorHash: PropTypes.string.isRequired,
   /** Can current user edit this comment? */
   canEdit: PropTypes.bool,
   /** Can current user delete this comment? */


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/2825

# Description

Added button `Share` for `CommentActions` component
Design from https://github.com/opencollective/opencollective/issues/2916#issuecomment-604381731


# Screenshots

Before: 

![before](https://user-images.githubusercontent.com/48645737/217940329-4225b2cf-0abb-41cc-9ab6-da80eb68d065.png)

After:

![after](https://user-images.githubusercontent.com/48645737/217948108-874fac6d-10c1-4d13-b229-75ae5ee2bbdc.png)

![test](https://user-images.githubusercontent.com/48645737/217940362-6967f0a6-79bf-44ae-8270-1d5803670241.gif)
