### PR TITLE
Fix npm version for CI

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -12,6 +12,10 @@ runs:
       with:
         node-version-file: 'package.json'
 
+    - name: Force NPM version (this step can be moved once Vercel defaults to node 18.14)
+      shell: bash
+      run: npm install -g npm@8.19.2
+
     - name: Restore node_modules
       uses: actions/cache@v3
       id: node-modules


### PR DESCRIPTION
See https://opencollective.slack.com/archives/C0RMV6F8C/p1676013594978189

CI was failing with:

```
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: opencollective-frontend@2.2.0
npm ERR! notsup Not compatible with your version of node/npm: opencollective-frontend@2.2.0
npm ERR! notsup Required: {"node":"18.x","npm":"8.x"}
npm ERR! notsup Actual:   {"npm":"9.3.1","node":"v18.14.0"}
```