### PR TITLE
Change text position for private instructions

### DIFF
--- a/components/collective-page/sections/Location.js
+++ b/components/collective-page/sections/Location.js
@@ -44,7 +44,7 @@ const Location = ({ collective: event, refetch }) => {
           showTitle={false}
         />
         {event.privateInstructions && (
-          <Container mt={4} textAlign="center">
+          <Container maxWidth={700} mx="auto" mt={4}>
             <P fontWeight="bold" fontSize="18px">
               <FormattedMessage id="event.privateInstructions.label" defaultMessage="Private instructions" />
             </P>


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/5757

# Description

Change text position for private instructions

# Screenshots

Before:

![before](https://user-images.githubusercontent.com/48645737/218507416-8b1bd8d3-eeed-4ee5-ab49-def89dfab0d7.png)

After:

![after](https://user-images.githubusercontent.com/48645737/218507800-231a7cf5-748a-44ab-b802-b686a74bd918.png)


