### PR TITLE
Add wallet icon for payment methods

### DIFF
--- a/lib/payment-method-utils.js
+++ b/lib/payment-method-utils.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Bank } from '@styled-icons/boxicons-solid';
+import { ApplePay, GooglePay } from '@styled-icons/fa-brands';
 import { Alipay } from '@styled-icons/fa-brands/Alipay';
 import { ExchangeAlt } from '@styled-icons/fa-solid/ExchangeAlt';
 import { MoneyCheck } from '@styled-icons/fa-solid/MoneyCheck';
@@ -24,6 +25,13 @@ export const getPaymentMethodIcon = (pm, collective, size) => {
   const service = pm.service;
 
   if (type === PAYMENT_METHOD_TYPE.CREDITCARD) {
+    const walletType = pm?.data?.wallet?.type;
+    if (walletType === 'google_pay') {
+      return <GooglePay size={size} />;
+    } else if (walletType === 'apple_pay') {
+      return <ApplePay size={size} />;
+    }
+
     return <CreditCard size={size} />;
   } else if (type === PAYMENT_METHOD_TYPE.GIFTCARD) {
     return <GiftCard size={size} />;


### PR DESCRIPTION
Related https://github.com/opencollective/opencollective/issues/4974
Require https://github.com/opencollective/opencollective-api/pull/8546

# Description

Adds wallet icons to saved card payment methods

# Screenshots

Apple Pay
![image](https://user-images.githubusercontent.com/5448927/218608315-dc94f437-f39d-4e60-8e69-5feb9528ad2b.png)

Google Pay
![image](https://user-images.githubusercontent.com/5448927/218608399-5bea5c24-4b63-4139-b56f-2feaf0e19ed9.png)


