### PR TITLE
e2e: Login to target test pages directly

### DIFF
--- a/test/cypress/integration/32-account-deletion.test.js
+++ b/test/cypress/integration/32-account-deletion.test.js
@@ -1,4 +1,5 @@
 import mockRecaptcha from '../mocks/recaptcha';
+import { randomSlug } from '../support/faker';
 
 describe('Account Deletion', () => {
   let collectiveSlug = null;
@@ -22,17 +23,17 @@ describe('Account Deletion', () => {
   });
 
   it('Should delete user', () => {
-    const userParams = { name: 'New Tester' };
+    const userSlug = randomSlug();
+    const userParams = { name: userSlug };
     const visitParams = { onBeforeLoad: mockRecaptcha };
-    cy.signup({ user: userParams, visitParams }).then(user => {
-      cy.visit(`/${user.collective.slug}/admin/advanced`);
-      cy.contains('button', 'Delete this account').click();
-      cy.get('[data-cy=delete]').click();
-      cy.wait(1000);
-      cy.location().should(location => {
-        expect(location.search).to.eq('?type=USER');
-      });
-      cy.contains('h1', 'Your account has been deleted.');
+
+    cy.signup({ user: userParams, visitParams, redirect: `/${userSlug}/admin/advanced` });
+    cy.contains('button', 'Delete this account').click();
+    cy.get('[data-cy=delete]').click();
+    cy.wait(1000);
+    cy.location().should(location => {
+      expect(location.search).to.eq('?type=USER');
     });
+    cy.contains('h1', 'Your account has been deleted.');
   });
 });

--- a/test/cypress/support/index.js
+++ b/test/cypress/support/index.js
@@ -31,7 +31,7 @@ Cypress.on('uncaught:exception', err => {
     // TODO: ideally we should go over these tests and remove these exceptions from occurring
     err.message.includes('S3 service object not initialized') ||
     err.message.includes('Invariant Violation: 19') ||
-    err.message.includes('No collective found with slug new-tester') ||
+    err.message.includes('No collective found with slug') ||
     err.message.includes('Please provide a slug or an id')
   ) {
     return false;


### PR DESCRIPTION
# Description

When using `cy.signin` and `cy.signup`, its better to specify the redirect param with the target test page to avoid a race condition that makes the test flaky.

The issue here comes from `cy.signin` followed by a `cy.visit`. the login token is sent to the `cy.signin` redirect parameter and some client side javascript code has to run to in order to update the sign-in token, this may be interrupted by the `cy.visit` command navigating to a different page.
