### PR TITLE
Preserve next cache directory on build

### DIFF
--- a/scripts/build_next.sh
+++ b/scripts/build_next.sh
@@ -11,5 +11,5 @@ next build || exit 1
 
 echo "> Copying .next to dist folder"
 
-shx rm -rf .next/cache
 shx cp -R .next $DIST
+shx rm -rf $DIST/cache


### PR DESCRIPTION
Keeps the .next/cache directory intact to be used in the CI. Removes it only from the build directory.