### PR TITLE
Allow children collectives to edit Policies settings

### DIFF
--- a/components/admin-panel/Menu.js
+++ b/components/admin-panel/Menu.js
@@ -146,7 +146,7 @@ const Menu = ({ collective, isAccountantOnly }) => {
           <MenuLink
             collective={collective}
             section={COLLECTIVE_SECTIONS.POLICIES}
-            if={isOneOfTypes(collective, [COLLECTIVE, FUND])}
+            if={isOneOfTypes(collective, [COLLECTIVE, FUND, PROJECT, EVENT])}
           />
           <MenuLink
             collective={collective}

--- a/components/edit-collective/sections/Policies.js
+++ b/components/edit-collective/sections/Policies.js
@@ -130,6 +130,7 @@ const Policies = ({ collective, showOnlyExpensePolicy }) => {
   const { formatMessage } = useIntl();
   const [selected, setSelected] = React.useState([]);
   const { addToast } = useToasts();
+  const inheritsPolicies = Boolean(collective.parentCollective);
 
   // GraphQL
   const { loading, data } = useQuery(getSettingsQuery, {
@@ -456,7 +457,8 @@ const Policies = ({ collective, showOnlyExpensePolicy }) => {
             disabled={
               isSettingPolicies ||
               (numberOfAdmins < 2 && Boolean(!formik.values.policies?.['EXPENSE_AUTHOR_CANNOT_APPROVE']?.enabled)) ||
-              authorCannotApproveExpenseEnforcedByHost
+              authorCannotApproveExpenseEnforcedByHost ||
+              inheritsPolicies
             }
           />
           <Flex
@@ -473,7 +475,8 @@ const Policies = ({ collective, showOnlyExpensePolicy }) => {
               disabled={
                 isSettingPolicies ||
                 authorCannotApproveExpenseEnforcedByHost ||
-                !formik.values.policies?.['EXPENSE_AUTHOR_CANNOT_APPROVE']?.enabled
+                !formik.values.policies?.['EXPENSE_AUTHOR_CANNOT_APPROVE']?.enabled ||
+                inheritsPolicies
               }
               currency={data?.account?.currency}
               currencyDisplay="CODE"
@@ -661,6 +664,7 @@ Policies.propTypes = {
     id: PropTypes.number,
     slug: PropTypes.string,
     isHost: PropTypes.bool,
+    parentCollective: PropTypes.any,
     members: PropTypes.arrayOf(
       PropTypes.shape({
         role: PropTypes.string,


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/5954

- Most things in the policy panel are actually settings
- Actual Policies are still inherited and disabled to edit in Events and Projects

It turns out `disablePublicExpenseSubmission` is a setting and not technically a policy. That's why it is not inherited.
I think it makes sense to have this set independently from the parent collective so I implemented it as requested in the issue.
There are several scenarios where this makes sense:
  - A private project in a public collective. 
  - A private event on a public collective. (Engineering collective allows everyone to submit Expenses for bounties but on our Engineering Meetup we only want core team members submitting receipts)
  - A public event on a private collective.