### PR TITLE
Revert "preserve next cache (#8656)"

### DIFF
--- a/scripts/build_next.sh
+++ b/scripts/build_next.sh
@@ -11,5 +11,5 @@ next build || exit 1
 
 echo "> Copying .next to dist folder"
 
+shx rm -rf .next/cache
 shx cp -R .next $DIST
-shx rm -rf $DIST/cache


### PR DESCRIPTION
This reverts commit 93cc160079c47d979c4beafad7c5cc63e5961fba.

This change is causing the heroku slug size to go over the limit, reverting it while looking for a solution.
