### PR TITLE
enhancement: alphabetise filter menu items

### DIFF
--- a/components/expenses/filters/ExpensesPayoutTypeFilter.js
+++ b/components/expenses/filters/ExpensesPayoutTypeFilter.js
@@ -4,17 +4,19 @@ import { useIntl } from 'react-intl';
 
 import { PayoutMethodType } from '../../../lib/constants/payout-method';
 import i18nPayoutMethodType from '../../../lib/i18n/payout-method-type';
+import { sortSelectOptions } from '../../../lib/utils';
 
 import { StyledSelectFilter } from '../../StyledSelectFilter';
 
 const ExpensesPayoutTypeFilter = ({ onChange, value, ...props }) => {
   const intl = useIntl();
   const getOption = value => ({ label: i18nPayoutMethodType(intl, value), value });
+  const options = [getOption('ALL'), ...Object.values(PayoutMethodType).map(getOption)];
 
   return (
     <StyledSelectFilter
       inputId="expenses-payout-type-filter"
-      options={[getOption('ALL'), ...Object.values(PayoutMethodType).map(getOption)]}
+      options={options.sort(sortSelectOptions)}
       onChange={({ value }) => onChange(value)}
       value={getOption(value || 'ALL')}
       {...props}

--- a/components/expenses/filters/ExpensesStatusFilter.js
+++ b/components/expenses/filters/ExpensesStatusFilter.js
@@ -23,12 +23,13 @@ const getOptions = (intl, ignoredExpenseStatus) => {
 const ExpenseStatusFilter = ({ value, onChange, ignoredExpenseStatus = IGNORED_EXPENSE_STATUS, ...props }) => {
   const intl = useIntl();
   const options = React.useMemo(() => getOptions(intl, ignoredExpenseStatus), [ignoredExpenseStatus]);
+  const sortedOptions = React.useMemo(() => options.sort(sortSelectOptions), [options]);
 
   return (
     <StyledSelectFilter
       inputId="expenses-status-filter"
       data-cy="expenses-filter-status"
-      options={options.sort(sortSelectOptions)}
+      options={sortedOptions}
       onChange={({ value }) => onChange(value)}
       value={getOption(intl, value || 'ALL')}
       {...props}

--- a/components/expenses/filters/ExpensesStatusFilter.js
+++ b/components/expenses/filters/ExpensesStatusFilter.js
@@ -4,6 +4,7 @@ import { useIntl } from 'react-intl';
 
 import expenseStatus from '../../../lib/constants/expense-status';
 import { i18nExpenseStatus } from '../../../lib/i18n/expense';
+import { sortSelectOptions } from '../../../lib/utils';
 
 import { StyledSelectFilter } from '../../StyledSelectFilter';
 
@@ -27,7 +28,7 @@ const ExpenseStatusFilter = ({ value, onChange, ignoredExpenseStatus = IGNORED_E
     <StyledSelectFilter
       inputId="expenses-status-filter"
       data-cy="expenses-filter-status"
-      options={options}
+      options={options.sort(sortSelectOptions)}
       onChange={({ value }) => onChange(value)}
       value={getOption(intl, value || 'ALL')}
       {...props}

--- a/components/expenses/filters/ExpensesStatusFilter.js
+++ b/components/expenses/filters/ExpensesStatusFilter.js
@@ -22,8 +22,10 @@ const getOptions = (intl, ignoredExpenseStatus) => {
 
 const ExpenseStatusFilter = ({ value, onChange, ignoredExpenseStatus = IGNORED_EXPENSE_STATUS, ...props }) => {
   const intl = useIntl();
-  const options = React.useMemo(() => getOptions(intl, ignoredExpenseStatus), [ignoredExpenseStatus]);
-  const sortedOptions = React.useMemo(() => options.sort(sortSelectOptions), [options]);
+  const sortedOptions = React.useMemo(
+    () => getOptions(intl, ignoredExpenseStatus).sort(sortSelectOptions),
+    [ignoredExpenseStatus],
+  );
 
   return (
     <StyledSelectFilter

--- a/components/expenses/filters/ExpensesTypeFilter.js
+++ b/components/expenses/filters/ExpensesTypeFilter.js
@@ -4,6 +4,7 @@ import { useIntl } from 'react-intl';
 
 import expenseTypes from '../../../lib/constants/expenseTypes';
 import { i18nExpenseType } from '../../../lib/i18n/expense';
+import { sortSelectOptions } from '../../../lib/utils';
 
 import { StyledSelectFilter } from '../../StyledSelectFilter';
 
@@ -13,13 +14,14 @@ const ExpenseTypeFilter = ({ onChange, value, ...props }) => {
 
   const expenseTypeKeys = Object.keys(expenseTypes);
   expenseTypeKeys.unshift('ALL');
+  const options = expenseTypeKeys.map(getOption);
 
   return (
     <StyledSelectFilter
       inputId="expenses-type-filter"
       onChange={({ value }) => onChange(value)}
       value={getOption(value || 'ALL')}
-      options={expenseTypeKeys.map(getOption)}
+      options={options.sort(sortSelectOptions)}
       {...props}
     />
   );

--- a/components/orders/OrderStatusFilter.js
+++ b/components/orders/OrderStatusFilter.js
@@ -4,12 +4,14 @@ import { useIntl } from 'react-intl';
 
 import { ORDER_STATUS } from '../../lib/constants/order-status';
 import i18nOrderStatus from '../../lib/i18n/order-status';
+import { sortSelectOptions } from '../../lib/utils';
 
 import { StyledSelectFilter } from '../StyledSelectFilter';
 
 const OrderStatusFilter = ({ onChange, value, ...props }) => {
   const intl = useIntl();
   const getOption = value => ({ label: i18nOrderStatus(intl, value), value });
+  const options = [getOption('ALL'), ...Object.values(ORDER_STATUS).map(getOption)];
 
   return (
     <StyledSelectFilter
@@ -17,7 +19,7 @@ const OrderStatusFilter = ({ onChange, value, ...props }) => {
       isSearchable={false}
       onChange={({ value }) => onChange(value)}
       value={getOption(value || 'ALL')}
-      options={[getOption('ALL'), ...Object.values(ORDER_STATUS).map(getOption)]}
+      options={options.sort(sortSelectOptions)}
       {...props}
     />
   );

--- a/components/transactions/filters/TransactionsPaymentMethodTypeFilter.js
+++ b/components/transactions/filters/TransactionsPaymentMethodTypeFilter.js
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { maxWidth } from 'styled-system';
 
 import { i18nPaymentMethodType } from '../../../lib/i18n/payment-method-type';
+import { sortSelectOptions } from '../../../lib/utils';
 
 import { StyledSelectFilter } from '../../StyledSelectFilter';
 import { Span } from '../../Text';
@@ -64,27 +65,10 @@ const REACT_SELECT_COMPONENT_OVERRIDE = {
   MultiValue: () => null, // Items will be displayed as a truncated string in `TruncatedValueContainer `
 };
 
-/**
- * Sort options as: All, then by alphabetical order, then "No payment method" at the end
- */
-const sortTypes = (option1, option2) => {
-  if (option1.value === 'ALL') {
-    return -1;
-  } else if (option2.value === 'ALL') {
-    return 1;
-  } else if (option1.value === null) {
-    return 1;
-  } else if (option2.value === null) {
-    return -1;
-  } else {
-    return option1.label.localeCompare(option2.label);
-  }
-};
-
 const TransactionsPaymentMethodTypeFilter = ({ onChange, value, types, ...props }) => {
   const intl = useIntl();
   const getOption = (value, idx) => ({ label: i18nPaymentMethodType(intl, value), value: value, idx });
-  const options = ['ALL', ...types].map(getOption).sort(sortTypes);
+  const options = ['ALL', ...types].map(getOption).sort(sortSelectOptions);
   const selectedTypes = value?.split(',') || [];
   const selectedOptions = !value
     ? [options[0]]

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -251,3 +251,28 @@ export const omitDeep = (obj, keys) =>
   );
 
 export const getCurrentDateInUTC = () => new Date().toISOString().split('T')[0];
+
+/**
+ * Sort options as: All, then by alphabetical order, then "No payment method" or "Other" at the end
+ */
+export const sortSelectOptions = (option1, option2) => {
+  if (option1.value === 'ALL') {
+    return -1;
+  }
+  if (option2.value === 'ALL') {
+    return 1;
+  }
+  if (option1.value === null) {
+    return 1;
+  }
+  if (option2.value === null) {
+    return -1;
+  }
+  if (option1.value === 'OTHER') {
+    return 1;
+  }
+  if (option2.value === 'OTHER') {
+    return -1;
+  }
+  return option1.label.localeCompare(option2.label);
+};


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/6436 <!-- If there's an issue associated with this pull request, add a link here -->

# Description

Alphabetize filter menu items.

Sort options as: "ALL", then by alphabetical order, then "No payment method" or "OTHER" at the end

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots
<img width="374" alt="Screenshot 2023-02-25 at 9 53 28 AM" src="https://user-images.githubusercontent.com/80162912/221338087-1e3055f4-f88c-4ed2-be1b-b474fe36d3d0.png">
<img width="259" alt="Screenshot 2023-02-25 at 9 53 49 AM" src="https://user-images.githubusercontent.com/80162912/221338091-75044f8c-96a4-4a90-84a7-8b45eb6f50fe.png">

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
