### PR TITLE
Use inviteMembers in CreateOrg mutation to add admins

### DIFF
--- a/lib/graphql/schemaV2.graphql
+++ b/lib/graphql/schemaV2.graphql
@@ -12859,6 +12859,11 @@ type Mutation {
     Information about the organization to create (name, slug, description, website, ...)
     """
     organization: OrganizationCreateInput!
+
+    """
+    List of members to invite on Organization creation.
+    """
+    inviteMembers: [InviteMemberInput]
   ): Organization
 
   """

--- a/lib/graphql/types/v2/graphql.ts
+++ b/lib/graphql/types/v2/graphql.ts
@@ -5637,6 +5637,7 @@ export type MutationCreateOrderArgs = {
 
 /** This is the root mutation */
 export type MutationCreateOrganizationArgs = {
+  inviteMembers?: InputMaybe<Array<InputMaybe<InviteMemberInput>>>;
   organization: OrganizationCreateInput;
 };
 


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-api/pull/8602

# Description

Moves the setting of admins to be included in the CreateOrganizationMutation, instead of as a side effect in the frontend when the CreateOrganizationMutation responds successfully.

Fixes an issue in the #8326, where the refetchLoggedInUser wasn't reliably resolving before trying to update admins for the newly created organization.
