### PR TITLE
E2E Fix: Logout Before Executing Contribution Flow Test

### DIFF
--- a/test/cypress/integration/13-contributeFlow-stripePaymentElement.test.js
+++ b/test/cypress/integration/13-contributeFlow-stripePaymentElement.test.js
@@ -186,6 +186,8 @@ describe('Contribute Flow: Stripe Payment Element', () => {
     });
 
     it('Guest', () => {
+      cy.logout();
+
       const email = `${randomSlug()}@guest.com`;
       cy.get('@collective').then(col => {
         cy.visit(`/${col.slug}/donate`);


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/6484