### PR TITLE
e2e: logout after creating collective in test

### DIFF
--- a/test/cypress/integration/13-contributeFlow-stripePaymentElement.test.js
+++ b/test/cypress/integration/13-contributeFlow-stripePaymentElement.test.js
@@ -103,6 +103,7 @@ describe('Contribute Flow: Stripe Payment Element', () => {
       });
 
       cy.createCollectiveV2({ host: { slug: 'e2e-host' } }).as('collective');
+      cy.logout();
     });
 
     it('Guest', () => {
@@ -183,11 +184,10 @@ describe('Contribute Flow: Stripe Payment Element', () => {
       });
 
       cy.createCollectiveV2({ host: { slug: 'e2e-host' } }).as('collective');
+      cy.logout();
     });
 
     it('Guest', () => {
-      cy.logout();
-
       const email = `${randomSlug()}@guest.com`;
       cy.get('@collective').then(col => {
         cy.visit(`/${col.slug}/donate`);
@@ -241,6 +241,7 @@ describe('Contribute Flow: Stripe Payment Element', () => {
       });
 
       cy.createCollectiveV2({ host: { slug: 'e2e-eur-host' } }).as('collective');
+      cy.logout();
     });
 
     it('Guest', () => {
@@ -300,6 +301,7 @@ describe('Contribute Flow: Stripe Payment Element', () => {
       });
 
       cy.createCollectiveV2({ host: { slug: 'e2e-eur-host' } }).as('collective');
+      cy.logout();
     });
 
     it('Guest', () => {


### PR DESCRIPTION
Follow up from https://github.com/opencollective/opencollective-frontend/pull/8671

`createCollectiveV2` logs you in as an user, tests were intented to use a different user.