### PR TITLE
Set step path to empty if not present

### DIFF
--- a/pages/contribution-flow.js
+++ b/pages/contribution-flow.js
@@ -67,7 +67,7 @@ class NewContributionFlowPage extends React.Component {
     const queryParameters = {
       ...omit(router.query, ['verb', 'step', 'collectiveSlug']),
     };
-    addParentToURLIfMissing(router, account, `/${router.query.verb}/${router.query.step}`, queryParameters);
+    addParentToURLIfMissing(router, account, `/${router.query.verb}/${router.query.step ?? ''}`, queryParameters);
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
Reported on [slack](https://opencollective.slack.com/archives/C6JTTA4SK/p1677602589182889)

# Description

Given a project `project-a` under `collective-a`, it should be possible to visit `/project-a/donate`, the user will be redirected to `/collective-a/project-a/donate/`



