### PR TITLE
Use `workflow_dispatch` action for Chromatic

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,13 +1,7 @@
 name: 'Chromatic'
 
 on:
-  push:
-    paths:
-      - 'components/**'
-      - '.storybook/**'
-      - 'stories/**'
-    branches-ignore:
-      - 'renovate/**'
+  workflow_dispatch:
 
 jobs:
   chromatic-deployment:


### PR DESCRIPTION
As per my comment, https://github.com/opencollective/opencollective/issues/6487#issuecomment-1449369180 maybe we can use the `workflow_dispatch`  event so that the action is run manually only when needed. Not sure if this is the best approach, but I was thinking maybe running it on each commit might be a overkill and most of them will never use it? 🤔 

cc: @Betree 