### PR TITLE
fix: update back to collective page link text

### DIFF
--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -1059,7 +1059,8 @@ class ContributionFlow extends React.Component {
                       <CollectiveTitleContainer collective={collective} useLink>
                         <FormattedMessage
                           id="ContributionFlow.backToCollectivePage"
-                          defaultMessage="Back to Collective Page"
+                          defaultMessage="Back to {accountName}'s Page"
+                          values={{ accountName: collective.name }}
                         />
                       </CollectiveTitleContainer>
                     </Box>

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -677,7 +677,7 @@
   "contribution.minimumAmount": "Minimum amount: {minAmount} {currency}",
   "contribution.paymentFee": "Payment processor fee",
   "contribution.quantity": "Quantity",
-  "ContributionFlow.backToCollectivePage": "Back to Collective Page",
+  "ContributionFlow.backToCollectivePage": "Back to {accountName}'s Page",
   "ContributionFlow.Contribution": "Contribution",
   "ContributionFlow.CreateOrganizationLabel": "Contribute as an organization",
   "ContributionFlow.CreateUserLabel": "Contribute as an individual",

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -700,7 +700,7 @@
   "contribution.minimumAmount": "Minimum amount: {minAmount} {currency}",
   "contribution.paymentFee": "Payment processor fee",
   "contribution.quantity": "Quantitat",
-  "ContributionFlow.backToCollectivePage": "Back to Collective Page",
+  "ContributionFlow.backToCollectivePage": "Back to {accountName}'s Page",
   "ContributionFlow.Contribution": "Contribució",
   "ContributionFlow.CreateOrganizationLabel": "Contribute as an organization",
   "ContributionFlow.CreateUserLabel": "Contribute as an individual",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -700,7 +700,7 @@
   "contribution.minimumAmount": "Minimum amount: {minAmount} {currency}",
   "contribution.paymentFee": "Payment processor fee",
   "contribution.quantity": "Množství",
-  "ContributionFlow.backToCollectivePage": "Back to Collective Page",
+  "ContributionFlow.backToCollectivePage": "Back to {accountName}'s Page",
   "ContributionFlow.Contribution": "Příspěvek",
   "ContributionFlow.CreateOrganizationLabel": "Přispět jako organizace",
   "ContributionFlow.CreateUserLabel": "Contribute as an individual",

--- a/lang/cy-GB.json
+++ b/lang/cy-GB.json
@@ -677,7 +677,7 @@
   "contribution.minimumAmount": "Minimum amount: {minAmount} {currency}",
   "contribution.paymentFee": "Payment processor fee",
   "contribution.quantity": "Quantity",
-  "ContributionFlow.backToCollectivePage": "Back to Collective Page",
+  "ContributionFlow.backToCollectivePage": "Back to {accountName}'s Page",
   "ContributionFlow.Contribution": "Cyfraniad",
   "ContributionFlow.CreateOrganizationLabel": "Cyfrannu fel sefydliad",
   "ContributionFlow.CreateUserLabel": "Contribute as an individual",

--- a/lang/en.json
+++ b/lang/en.json
@@ -700,7 +700,7 @@
   "contribution.minimumAmount": "Minimum amount: {minAmount} {currency}",
   "contribution.paymentFee": "Payment processor fee",
   "contribution.quantity": "Quantity",
-  "ContributionFlow.backToCollectivePage": "Back to Collective Page",
+  "ContributionFlow.backToCollectivePage": "Back to {accountName}'s Page",
   "ContributionFlow.Contribution": "Contribution",
   "ContributionFlow.CreateOrganizationLabel": "Contribute as an organization",
   "ContributionFlow.CreateUserLabel": "Contribute as an individual",

--- a/lang/fa.json
+++ b/lang/fa.json
@@ -677,7 +677,7 @@
   "contribution.minimumAmount": "Minimum amount: {minAmount} {currency}",
   "contribution.paymentFee": "Payment processor fee",
   "contribution.quantity": "Quantity",
-  "ContributionFlow.backToCollectivePage": "Back to Collective Page",
+  "ContributionFlow.backToCollectivePage": "Back to {accountName}'s Page",
   "ContributionFlow.Contribution": "Contribution",
   "ContributionFlow.CreateOrganizationLabel": "Contribute as an organization",
   "ContributionFlow.CreateUserLabel": "Contribute as an individual",

--- a/lang/id-ID.json
+++ b/lang/id-ID.json
@@ -677,7 +677,7 @@
   "contribution.minimumAmount": "Minimum amount: {minAmount} {currency}",
   "contribution.paymentFee": "Payment processor fee",
   "contribution.quantity": "Quantity",
-  "ContributionFlow.backToCollectivePage": "Back to Collective Page",
+  "ContributionFlow.backToCollectivePage": "Back to {accountName}'s Page",
   "ContributionFlow.Contribution": "Contribution",
   "ContributionFlow.CreateOrganizationLabel": "Contribute as an organization",
   "ContributionFlow.CreateUserLabel": "Contribute as an individual",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -700,7 +700,7 @@
   "contribution.minimumAmount": "Minimum amount: {minAmount} {currency}",
   "contribution.paymentFee": "결제 처리 수수료",
   "contribution.quantity": "수량",
-  "ContributionFlow.backToCollectivePage": "Back to Collective Page",
+  "ContributionFlow.backToCollectivePage": "Back to {accountName}'s Page",
   "ContributionFlow.Contribution": "기부",
   "ContributionFlow.CreateOrganizationLabel": "단체로 기부",
   "ContributionFlow.CreateUserLabel": "Contribute as an individual",

--- a/lang/lt-LT.json
+++ b/lang/lt-LT.json
@@ -677,7 +677,7 @@
   "contribution.minimumAmount": "Minimum amount: {minAmount} {currency}",
   "contribution.paymentFee": "Payment processor fee",
   "contribution.quantity": "Quantity",
-  "ContributionFlow.backToCollectivePage": "Back to Collective Page",
+  "ContributionFlow.backToCollectivePage": "Back to {accountName}'s Page",
   "ContributionFlow.Contribution": "Contribution",
   "ContributionFlow.CreateOrganizationLabel": "Contribute as an organization",
   "ContributionFlow.CreateUserLabel": "Contribute as an individual",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -700,7 +700,7 @@
   "contribution.minimumAmount": "Minimum amount: {minAmount} {currency}",
   "contribution.paymentFee": "Payment processor fee",
   "contribution.quantity": "Aantal",
-  "ContributionFlow.backToCollectivePage": "Back to Collective Page",
+  "ContributionFlow.backToCollectivePage": "Back to {accountName}'s Page",
   "ContributionFlow.Contribution": "Contribution",
   "ContributionFlow.CreateOrganizationLabel": "Bijdragen als een organisatie",
   "ContributionFlow.CreateUserLabel": "Contribute as an individual",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -700,7 +700,7 @@
   "contribution.minimumAmount": "Minimum amount: {minAmount} {currency}",
   "contribution.paymentFee": "Taxa de processamento de pagamento",
   "contribution.quantity": "Quantidade",
-  "ContributionFlow.backToCollectivePage": "Back to Collective Page",
+  "ContributionFlow.backToCollectivePage": "Back to {accountName}'s Page",
   "ContributionFlow.Contribution": "Contribuição",
   "ContributionFlow.CreateOrganizationLabel": "Contribuir como uma organização",
   "ContributionFlow.CreateUserLabel": "Contribute as an individual",

--- a/lang/uz-UZ.json
+++ b/lang/uz-UZ.json
@@ -677,7 +677,7 @@
   "contribution.minimumAmount": "Minimum amount: {minAmount} {currency}",
   "contribution.paymentFee": "Payment processor fee",
   "contribution.quantity": "Quantity",
-  "ContributionFlow.backToCollectivePage": "Back to Collective Page",
+  "ContributionFlow.backToCollectivePage": "Back to {accountName}'s Page",
   "ContributionFlow.Contribution": "Contribution",
   "ContributionFlow.CreateOrganizationLabel": "Contribute as an organization",
   "ContributionFlow.CreateUserLabel": "Contribute as an individual",


### PR DESCRIPTION
Resolve  [opencollective/opencollective#6494](https://github.com/opencollective/opencollective/issues/6494)
 
# Description

 Update `Back to Collective Page` lin text to  `Back to {accountName}'s page `(e.g. `Back to Babel's page`)

# Screenshots

![Screenshot from 2023-03-01 18-16-12](https://user-images.githubusercontent.com/21278735/222144390-0d7f18ca-3632-4b2c-8fa2-368a304551ae.png)
 
