### PR TITLE
Redirect stripe webhook stdout on e2e test

### DIFF
--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -5,7 +5,7 @@ npx maildev@2.0.5 &
 MAILDEV_PID=$!
 
 echo "> Starting stripe webhook listener"
-stripe --api-key $STRIPE_WEBHOOK_KEY listen --forward-connect-to localhost:3060/webhooks/stripe &
+stripe --api-key $STRIPE_WEBHOOK_KEY listen --forward-connect-to localhost:3060/webhooks/stripe > /dev/null &
 STRIPE_WEBHOOK_PID=$!
 
 echo "> Starting api server"


### PR DESCRIPTION
Redirects stripe webhook listener stdout to prevent floding the e2e tests.