### PR TITLE
Add comments count to expenses for Host admins

### DIFF
--- a/components/budget/ExpenseBudgetItem.js
+++ b/components/budget/ExpenseBudgetItem.js
@@ -28,6 +28,7 @@ import ProcessExpenseButtons, {
 } from '../expenses/ProcessExpenseButtons';
 import FormattedMoneyAmount from '../FormattedMoneyAmount';
 import { Box, Flex } from '../Grid';
+import CommentIcon from '../icons/CommentIcon';
 import Link from '../Link';
 import LinkCollective from '../LinkCollective';
 import LoadingPlaceholder from '../LoadingPlaceholder';
@@ -197,6 +198,14 @@ const ExpenseBudgetItem = ({
                         ),
                       }}
                     />
+                    {Boolean(expense?.comments.totalCount) && (
+                      <React.Fragment>
+                        {' • '}
+                        {expense?.comments.totalCount}
+                        &nbsp;
+                        <CommentIcon size={14} color="#4D4F51" />
+                      </React.Fragment>
+                    )}
                   </React.Fragment>
                 )}
               </P>
@@ -361,6 +370,9 @@ ExpenseBudgetItem.propTypes = {
   expense: PropTypes.shape({
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     legacyId: PropTypes.number,
+    comments: PropTypes.shape({
+      totalCount: PropTypes.number,
+    }),
     type: PropTypes.string.isRequired,
     description: PropTypes.string.isRequired,
     status: PropTypes.string.isRequired,

--- a/components/expenses/graphql/fragments.ts
+++ b/components/expenses/graphql/fragments.ts
@@ -434,6 +434,9 @@ export const expensesListFieldsFragment = gql`
     createdAt
     tags
     amount
+    comments {
+      totalCount
+    }
     amountInAccountCurrency: amountV2(currencySource: ACCOUNT) {
       valueInCents
       currency


### PR DESCRIPTION
Resolve: https://github.com/opencollective/opencollective/issues/5803


# Description

This Pr add count of comments on an expense overview for host admins

# Screenshots
<img width="998" alt="Screenshot 2023-03-14 at 8 14 37 PM" src="https://user-images.githubusercontent.com/29824008/225113054-c611ff10-9449-4b2f-93d8-710f21d5c256.png">


