### PR TITLE
Fix  empty dropdown on approved expenses

### DIFF
--- a/components/expenses/AdminExpenseStatusTag.js
+++ b/components/expenses/AdminExpenseStatusTag.js
@@ -27,6 +27,7 @@ const ExpenseStatusTag = styled(StyledTag)`
   line-height: 16px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
+  cursor: ${props => (props?.hideProcessExpenseButtons ? 'auto' : 'pointer')};
 `;
 
 const PopupContainer = styled(`div`)`
@@ -81,11 +82,12 @@ const AdminExpenseStatusTag = ({ expense, host, collective, ...props }) => {
   const [showPopup, setShowPopup] = React.useState(false);
   const [isClosable, setClosable] = React.useState(true);
   const [showMarkAsIncompleteModal, setMarkAsIncompleteModal] = React.useState(false);
-  const hideProcessExpenseButtons = expense?.status === expenseStatus.APPROVED;
+  const hideProcessExpenseButtons =
+    expense?.status === expenseStatus.APPROVED && !expense?.permissions?.canMarkAsIncomplete;
   const buttonProps = { px: 2, py: 2, isBorderless: true, width: '100%', textAlign: 'left' };
 
   const onClick = () => {
-    if (hideProcessExpenseButtons && !expense?.permissions?.canMarkAsIncomplete) {
+    if (hideProcessExpenseButtons) {
       return;
     }
     setShowPopup(true);
@@ -118,10 +120,11 @@ const AdminExpenseStatusTag = ({ expense, host, collective, ...props }) => {
                 type={getExpenseStatusMsgType(expense.status)}
                 data-cy="admin-expense-status-msg"
                 {...props}
+                hideProcessExpenseButtons={hideProcessExpenseButtons}
               >
                 <Flex>
                   {i18nExpenseStatus(intl, expense.status)}
-                  {(!hideProcessExpenseButtons || expense?.permissions?.canMarkAsIncomplete) && <ChevronDownIcon />}
+                  {!hideProcessExpenseButtons && <ChevronDownIcon />}
                 </Flex>
               </ExpenseStatusTag>
             </Box>

--- a/components/expenses/AdminExpenseStatusTag.js
+++ b/components/expenses/AdminExpenseStatusTag.js
@@ -85,6 +85,9 @@ const AdminExpenseStatusTag = ({ expense, host, collective, ...props }) => {
   const buttonProps = { px: 2, py: 2, isBorderless: true, width: '100%', textAlign: 'left' };
 
   const onClick = () => {
+    if (hideProcessExpenseButtons && !expense?.permissions?.canMarkAsIncomplete) {
+      return;
+    }
     setShowPopup(true);
   };
 
@@ -118,7 +121,7 @@ const AdminExpenseStatusTag = ({ expense, host, collective, ...props }) => {
               >
                 <Flex>
                   {i18nExpenseStatus(intl, expense.status)}
-                  <ChevronDownIcon />
+                  {(!hideProcessExpenseButtons || expense?.permissions?.canMarkAsIncomplete) && <ChevronDownIcon />}
                 </Flex>
               </ExpenseStatusTag>
             </Box>

--- a/components/expenses/AdminExpenseStatusTag.js
+++ b/components/expenses/AdminExpenseStatusTag.js
@@ -18,7 +18,7 @@ import StyledTag from '../StyledTag';
 
 import ConfirmProcessExpenseModal from './ConfirmProcessExpenseModal';
 import { getExpenseStatusMsgType } from './ExpenseStatusTag';
-import ProcessExpenseButtons, { ButtonLabel } from './ProcessExpenseButtons';
+import ProcessExpenseButtons, { ButtonLabel, hasProcessButtons } from './ProcessExpenseButtons';
 
 const ExpenseStatusTag = styled(StyledTag)`
   cursor: pointer;
@@ -27,7 +27,6 @@ const ExpenseStatusTag = styled(StyledTag)`
   line-height: 16px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  cursor: ${props => (props?.hideProcessExpenseButtons ? 'auto' : 'pointer')};
 `;
 
 const PopupContainer = styled(`div`)`
@@ -83,13 +82,10 @@ const AdminExpenseStatusTag = ({ expense, host, collective, ...props }) => {
   const [isClosable, setClosable] = React.useState(true);
   const [showMarkAsIncompleteModal, setMarkAsIncompleteModal] = React.useState(false);
   const hideProcessExpenseButtons =
-    expense?.status === expenseStatus.APPROVED && !expense?.permissions?.canMarkAsIncomplete;
+    expense?.status === expenseStatus.APPROVED && !hasProcessButtons(expense?.permissions);
   const buttonProps = { px: 2, py: 2, isBorderless: true, width: '100%', textAlign: 'left' };
 
   const onClick = () => {
-    if (hideProcessExpenseButtons) {
-      return;
-    }
     setShowPopup(true);
   };
 
@@ -120,11 +116,10 @@ const AdminExpenseStatusTag = ({ expense, host, collective, ...props }) => {
                 type={getExpenseStatusMsgType(expense.status)}
                 data-cy="admin-expense-status-msg"
                 {...props}
-                hideProcessExpenseButtons={hideProcessExpenseButtons}
               >
                 <Flex>
                   {i18nExpenseStatus(intl, expense.status)}
-                  {!hideProcessExpenseButtons && <ChevronDownIcon />}
+                  <ChevronDownIcon />
                 </Flex>
               </ExpenseStatusTag>
             </Box>


### PR DESCRIPTION
Resolve  [opencollective/opencollective#6517](https://github.com/opencollective/opencollective/issues/6517)
 

# Description

Remove empty actions dropdown on approved expenses
 
# Screenshots
![image](https://user-images.githubusercontent.com/21278735/223455470-14c3f54b-4437-45ee-b13d-b68aea19ef3f.png)
