### PR TITLE
fix: improve standalone contribute page

### DIFF
--- a/pages/contribute.js
+++ b/pages/contribute.js
@@ -183,7 +183,7 @@ class TiersPage extends React.Component {
           props: {
             collective: collective,
             event: event,
-            hideContributors: showAll ? !hasContributors : hasEventContributors,
+            hideContributors: showAll ? !hasContributors : !hasEventContributors,
           },
         });
       });

--- a/pages/contribute.js
+++ b/pages/contribute.js
@@ -71,9 +71,26 @@ class TiersPage extends React.Component {
     return contributors.filter(c => c.isBacker && (c.tiersIds.length === 0 || c.tiersIds[0] === null));
   });
 
-  hasContributors = memoizeOne((contributors, events) => {
-    const hasFinancial = contributors.find(c => c.isBacker);
-    return hasFinancial || events.find(event => event.contributors.length > 0);
+  hasContributors = memoizeOne((collective, verb) => {
+    const hasFinancial = collective.contributors.some(c => c.isBacker);
+    const hasEventContributors = collective.events?.some(event => event.contributors.length > 0);
+    const hasProjectContributors = collective.projects?.some(project => project.contributors.length > 0);
+    const hasConnectedCollectiveContributors = collective.connectedCollectives?.some(
+      connectedCollective => connectedCollective.collective.contributors.length > 0,
+    );
+
+    switch (verb) {
+      case 'events':
+        return hasEventContributors;
+      case 'projects':
+        return hasProjectContributors;
+      case 'connected-collectives':
+        return hasConnectedCollectiveContributors;
+      case 'tiers':
+        return hasFinancial;
+      default:
+        return hasFinancial || hasEventContributors || hasProjectContributors;
+    }
   });
 
   getPageMetadata(collective) {
@@ -98,9 +115,7 @@ class TiersPage extends React.Component {
 
     const waysToContribute = [];
     const canContribute = collective.isActive && collective.host;
-    const hasContributors = this.hasContributors(collective.contributors, collective.events);
-    const hasEventContributors = this.hasContributors([], collective.events);
-    const hasProjectContributors = this.hasContributors([], collective.projects);
+    const hasContributors = this.hasContributors(collective, verb);
     const showAll = verb === 'contribute';
 
     // Financial contributions
@@ -168,7 +183,7 @@ class TiersPage extends React.Component {
             collective: collective,
             project: project,
             disableCTA: !project.isActive,
-            hideContributors: showAll ? !hasContributors : !hasProjectContributors,
+            hideContributors: !hasContributors,
           },
         });
       });
@@ -183,7 +198,7 @@ class TiersPage extends React.Component {
           props: {
             collective: collective,
             event: event,
-            hideContributors: showAll ? !hasContributors : !hasEventContributors,
+            hideContributors: !hasContributors,
           },
         });
       });

--- a/pages/contribute.js
+++ b/pages/contribute.js
@@ -99,6 +99,8 @@ class TiersPage extends React.Component {
     const waysToContribute = [];
     const canContribute = collective.isActive && collective.host;
     const hasContributors = this.hasContributors(collective.contributors, collective.events);
+    const hasEventContributors = this.hasContributors([], collective.events);
+    const hasProjectContributors = this.hasContributors([], collective.projects);
     const showAll = verb === 'contribute';
 
     // Financial contributions
@@ -166,7 +168,7 @@ class TiersPage extends React.Component {
             collective: collective,
             project: project,
             disableCTA: !project.isActive,
-            hideContributors: !hasContributors,
+            hideContributors: showAll ? !hasContributors : !hasProjectContributors,
           },
         });
       });
@@ -181,7 +183,7 @@ class TiersPage extends React.Component {
           props: {
             collective: collective,
             event: event,
-            hideContributors: !hasContributors,
+            hideContributors: showAll ? !hasContributors : hasEventContributors,
           },
         });
       });


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/6526


# Description

"Be the first one to contribute" should not be displayed when there are no contributors at all.
<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots

<details>
<summary>   /events  </summary>
<img width="1229" alt="Screenshot 2023-03-08 at 2 48 13 PM" src="https://user-images.githubusercontent.com/46647141/223673260-a7d7f53f-45c9-434a-8ff9-6ce2527caaf9.png">


</details>


<details>
<summary>   /projects </summary>

<img width="1242" alt="Screenshot 2023-03-08 at 2 47 12 PM" src="https://user-images.githubusercontent.com/46647141/223673340-41f81060-4fc6-4c9d-ac8f-ad0066831504.png">

</details>

<details>
<summary>   /tiers </summary>

<img width="1242" alt="Screenshot 2023-03-08 at 2 48 52 PM" src="https://user-images.githubusercontent.com/46647141/223673548-fc86b290-0c14-4c7a-9115-23838b9b2f37.png">


</details>

<details>
<summary>   /contribute </summary>

<img width="668" alt="Screenshot 2023-03-08 at 2 49 52 PM" src="https://user-images.githubusercontent.com/46647141/223673424-6799cffe-c69f-4d87-ab13-8077cfcf035b.png">


</details>