### PR TITLE
Make Sure User is Able to Click on the TOS Within Checkbox Label 

### DIFF
--- a/components/create-collective/CreateCollectiveForm.js
+++ b/components/create-collective/CreateCollectiveForm.js
@@ -419,7 +419,7 @@ class CreateCollectiveForm extends React.Component {
                                   defaultMessage="I agree with the {toslink} of Open Collective."
                                   values={{
                                     toslink: (
-                                      <StyledLink href="/tos" openInNewTab>
+                                      <StyledLink href="/tos" openInNewTab onClick={e => e.stopPropagation()}>
                                         <FormattedMessage id="tos" defaultMessage="terms of service" />
                                       </StyledLink>
                                     ),

--- a/pages/expense.js
+++ b/pages/expense.js
@@ -626,12 +626,12 @@ class ExpensePage extends React.Component {
                                 defaultMessage="I agree with the {toslink} and {privacylink} of Open Collective."
                                 values={{
                                   toslink: (
-                                    <StyledLink href="/tos" openInNewTab>
+                                    <StyledLink href="/tos" openInNewTab onClick={e => e.stopPropagation()}>
                                       <FormattedMessage id="tos" defaultMessage="terms of service" />
                                     </StyledLink>
                                   ),
                                   privacylink: (
-                                    <StyledLink href="/privacypolicy" openInNewTab>
+                                    <StyledLink href="/privacypolicy" openInNewTab onClick={e => e.stopPropagation()}>
                                       <FormattedMessage id="privacypolicy" defaultMessage="privacy policy" />
                                     </StyledLink>
                                   ),


### PR DESCRIPTION
Related to the discussion; https://opencollective.slack.com/archives/C6JTTA4SK/p1678301875094419

We need to add the `stopPropagation` method whenever we have links within a clickable label. 

[click.webm](https://user-images.githubusercontent.com/12435965/223824979-8e46b455-faae-4274-ac64-dfc15079736c.webm)

