### PR TITLE
fix: error when logout from settings

### DIFF
--- a/components/UserProvider.js
+++ b/components/UserProvider.js
@@ -72,8 +72,8 @@ class UserProvider extends React.Component {
 
   logout = async () => {
     removeFromLocalStorage(LOCAL_STORAGE_KEYS.ACCESS_TOKEN);
-    await this.props.client.resetStore();
     this.setState({ LoggedInUser: null, errorLoggedInUser: null });
+    await this.props.client.resetStore();
   };
 
   login = async (token, options = {}) => {


### PR DESCRIPTION
Resolve  [opencollective#6531](https://github.com/opencollective/opencollective/issues/6531)

# Description

 fixes the error when logging out from the settings page after selecting some of the  menu links
(Payment Receipts", "For developers", "Activity log", "Team", "Virtual Cards")

 # Screenshot

![opencollectivelogout](https://user-images.githubusercontent.com/21278735/224491570-86006427-0e6c-41c2-9b9c-ff371b7c5c1a.gif)
