### PR TITLE
Fixed link to examples of "open source" collectives

### DIFF
--- a/components/create-collective/CollectiveCategoryPicker.js
+++ b/components/create-collective/CollectiveCategoryPicker.js
@@ -78,7 +78,7 @@ const CollectiveCategoryPicker = () => {
                 {formatMessage(messages.opensource)}
               </StyledButton>
             </Link>
-            <ExamplesLink href="/search?tag=opensource" openInNewTab>
+            <ExamplesLink href="/search?tag=open+source" openInNewTab>
               <FormattedMessage id="createCollective.examples" defaultMessage="See examples" />
             </ExamplesLink>
           </Flex>


### PR DESCRIPTION
# Description

There is only one collective with the "[opensource](https://opencollective.com/search?tag=opensource)" tag, whereas there are over 200 with the tag "[open source](https://opencollective.com/search?tag=open+source)".

Note that the link to "[community](https://opencollective.com/search?tag=community)" tag does not appear to be working either (not showing any selected tag, but maybe this tag has a special meaning).

# Screenshot

![image](https://user-images.githubusercontent.com/531764/224706984-d345124d-3d60-4d03-892e-1778fbdef94d.png)
