### PR TITLE
Fix StyledModal's FocusTrap interference with StyledSelect

### DIFF
--- a/components/StyledModal.tsx
+++ b/components/StyledModal.tsx
@@ -210,10 +210,9 @@ ModalFooter.defaultProps = {
 };
 
 const DefaultTrapContainer = props => {
-  return <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }} {...props} />;
+  return <FocusTrap focusTrapOptions={{ allowOutsideClick: true }} {...props} />;
 };
 
-export const ModalReferenceContext = React.createContext(null);
 /**
  * Modal component. Will pass down additional props to `ModalWrapper`, which is
  * a styled `Container`.
@@ -258,14 +257,12 @@ const StyledModal = ({
         <Wrapper>
           <TrapContainer>
             <Modal ref={modalRef} {...props}>
-              <ModalReferenceContext.Provider value={modalRef}>
-                {React.Children.map(children, child => {
-                  if (child?.type?.displayName === 'Header') {
-                    return React.cloneElement(child, { onClose: closeHandler });
-                  }
-                  return child;
-                })}
-              </ModalReferenceContext.Provider>
+              {React.Children.map(children, child => {
+                if (child?.type?.displayName === 'Header') {
+                  return React.cloneElement(child, { onClose: closeHandler });
+                }
+                return child;
+              })}
             </Modal>
           </TrapContainer>
         </Wrapper>
@@ -280,14 +277,12 @@ const StyledModal = ({
         <Wrapper zindex={props.zindex}>
           <TrapContainer>
             <Modal ref={modalRef} {...props}>
-              <ModalReferenceContext.Provider value={modalRef}>
-                {React.Children.map(children, child => {
-                  if (child?.type?.displayName === 'Header') {
-                    return React.cloneElement(child, { onClose: closeHandler });
-                  }
-                  return child;
-                })}
-              </ModalReferenceContext.Provider>
+              {React.Children.map(children, child => {
+                if (child?.type?.displayName === 'Header') {
+                  return React.cloneElement(child, { onClose: closeHandler });
+                }
+                return child;
+              })}
             </Modal>
           </TrapContainer>
           <ModalOverlay

--- a/components/StyledSelect.tsx
+++ b/components/StyledSelect.tsx
@@ -17,7 +17,6 @@ import Container from './Container';
 import { Flex } from './Grid';
 import SearchIcon from './SearchIcon';
 import StyledHr from './StyledHr';
-import { ModalReferenceContext } from './StyledModal';
 import StyledTag from './StyledTag';
 import { P } from './Text';
 
@@ -190,13 +189,10 @@ export const makeStyledSelect = SelectComponent => styled(SelectComponent).attrs
     options,
   }) => {
     isSearchable = isSearchable ?? options?.length > 8;
-    // If a StyledSelect is rendered within a modal, make sure we use the modal as the portal target
-    const modalRef = React.useContext(ModalReferenceContext);
-
     return {
       isSearchable,
       menuPortalTarget:
-        menuPortalTarget === null || typeof document === 'undefined' ? undefined : modalRef?.current || document.body,
+        menuPortalTarget || (menuPortalTarget === null || typeof document === 'undefined' ? undefined : document.body),
       isDisabled: disabled || isDisabled,
       placeholder: placeholder || intl.formatMessage(Messages.placeholder),
       loadingMessage: () => intl.formatMessage(Messages.loading),


### PR DESCRIPTION
Reverts https://github.com/opencollective/opencollective-frontend/pull/8613
Resolve https://github.com/opencollective/opencollective/issues/6545
Resolve https://github.com/opencollective/opencollective/issues/6512

While https://github.com/opencollective/opencollective-frontend/pull/8613 successfully resolved https://github.com/opencollective/opencollective/issues/5599, it changed the rendering strategy from rendering in the root node to rendering in the opened modal, which caused a series of rendering issue because the position could then be broken by a parent component using `position: absolute`.

In this PR, I'm using the `clickOutsideDeactivates` focus-trap option, which resolves the display issues while seemingly not re-introducing https://github.com/opencollective/opencollective/issues/5599.

## Other approaches

- In https://github.com/opencollective/opencollective-frontend/compare/main...fix/react-select-bug-1 I tried to keep the implemented ModalContext solution and hack things by making sure none of the parents in the modal were using `position: absolute`. I quickly realized this solution would be tough to maintain and enforce on the long-term.
- In https://github.com/opencollective/opencollective-frontend/compare/main...fix/react-select-bug-2, I tried to take advantage of the `containerElements` option to notify focus-trap about the existence of nested portals. Results were cleaner, but the app would crash whenever there were no focusable elements in the portal (which happens with react-select). Plus, it increased a lot the complexity.

## Long-term solution

In the long-term, I think we'll need to think about a better system for multi-layer interfaces (aka. a tooltip above a modal, or a modal that opens a modal, etc). Something that correctly handles focus, z-indez, and layout at each level.