### PR TITLE
Correct String Overflow Error for `application_context.brand_name` in PayPal

### DIFF
--- a/components/PayWithPaypalButton.js
+++ b/components/PayWithPaypalButton.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { gql } from '@apollo/client';
 import { graphql } from '@apollo/client/react/hoc';
+import { truncate } from 'lodash';
 import { injectIntl } from 'react-intl';
 import styled, { css } from 'styled-components';
 
@@ -146,7 +147,7 @@ class PayWithPaypalButton extends Component {
           plan_id: this.props.data.paypalPlan.id,
           start_time: this.props.subscriptionStartDate,
           application_context: {
-            brand_name: `${this.props.collective.name} - Open Collective`,
+            brand_name: `${truncate(this.props.collective.name, { length: 108 })} - Open Collective`,
             locale: this.props.intl.locale,
             shipping_preference: 'NO_SHIPPING',
             user_action: 'CONTINUE',
@@ -162,7 +163,7 @@ class PayWithPaypalButton extends Component {
         return actions.order.create({
           intent: 'AUTHORIZE',
           application_context: {
-            brand_name: `${this.props.collective.name} - Open Collective`,
+            brand_name: `${truncate(this.props.collective.name, { length: 108 })} - Open Collective`,
             locale: this.props.intl.locale,
             shipping_preference: 'NO_SHIPPING',
             user_action: 'CONTINUE',


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/6563

[paypal-string-overflow.webm](https://user-images.githubusercontent.com/12435965/225465907-7daa73dd-865e-4ed0-9e4b-032b26efc420.webm)
