### PR TITLE
Add draft to expense filters

### DIFF
--- a/components/expenses/filters/ExpensesStatusFilter.js
+++ b/components/expenses/filters/ExpensesStatusFilter.js
@@ -8,7 +8,7 @@ import { sortSelectOptions } from '../../../lib/utils';
 
 import { StyledSelectFilter } from '../../StyledSelectFilter';
 
-const IGNORED_EXPENSE_STATUS = [expenseStatus.DRAFT, expenseStatus.UNVERIFIED];
+const IGNORED_EXPENSE_STATUS = [expenseStatus.UNVERIFIED];
 
 const getOption = (intl, value) => ({ label: i18nExpenseStatus(intl, value), value });
 


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/6224

# Description
Add draft to expense filters.

If `ExpensesFilters` component doesn't have `ignoredExpenseStatus` props, it ignores `[expenseStatus.DRAFT, expenseStatus.UNVERIFIED]`


# Screenshots
Before: 
![image](https://user-images.githubusercontent.com/48645737/226630874-35cfe7a5-ce05-4a13-ba5f-cdf069b5dd02.png)


After: 
![image](https://user-images.githubusercontent.com/48645737/226629488-11fef83e-ae64-49bb-97ee-b41408b96b4c.png)

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
