### PR TITLE
Get Correct Number of Admins for Child Collective When Showing the Freeze Banner

### DIFF
--- a/components/collective-page/CollectiveNotificationBar.js
+++ b/components/collective-page/CollectiveNotificationBar.js
@@ -98,9 +98,9 @@ const messages = defineMessages({
 });
 
 const getNotification = (intl, status, collective, host, LoggedInUser, refetch) => {
-  const numberOfAdmins = [CollectiveType.EVENT, CollectiveType.PROJECT].includes(collective.type)
-    ? collective?.parentCollective?.coreContributors?.filter(c => c.isAdmin)?.length
-    : collective?.admins?.length;
+  const numberOfAdmins = collective.parentCollective
+    ? collective.parentCollective.coreContributors?.filter(c => c.isAdmin)?.length + collective.admins.length
+    : collective.admins.length;
   if (status === 'collectiveCreated') {
     switch (collective.type) {
       case CollectiveType.ORGANIZATION:

--- a/components/collective-page/CollectiveNotificationBar.js
+++ b/components/collective-page/CollectiveNotificationBar.js
@@ -98,6 +98,9 @@ const messages = defineMessages({
 });
 
 const getNotification = (intl, status, collective, host, LoggedInUser, refetch) => {
+  const numberOfAdmins = [CollectiveType.EVENT, CollectiveType.PROJECT].includes(collective.type)
+    ? collective?.parentCollective?.coreContributors?.filter(c => c.isAdmin)?.length
+    : collective?.admins?.length;
   if (status === 'collectiveCreated') {
     switch (collective.type) {
       case CollectiveType.ORGANIZATION:
@@ -170,7 +173,7 @@ const getNotification = (intl, status, collective, host, LoggedInUser, refetch) 
     LoggedInUser?.isAdminOfCollectiveOrHost(collective) &&
     collective.isApproved &&
     host?.policies?.COLLECTIVE_MINIMUM_ADMINS?.freeze &&
-    host?.policies?.COLLECTIVE_MINIMUM_ADMINS?.numberOfAdmins > collective?.admins?.length &&
+    host?.policies?.COLLECTIVE_MINIMUM_ADMINS?.numberOfAdmins > numberOfAdmins &&
     collective?.features?.RECEIVE_FINANCIAL_CONTRIBUTIONS === 'DISABLED'
   ) {
     return {


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/6598

[no-freeze-banner.webm](https://user-images.githubusercontent.com/12435965/227112221-f40c9663-4230-4546-ac4a-b2fc349cf816.webm)
