### PR TITLE
performance: fix ssr graphql for admin panel

### DIFF
--- a/pages/admin-panel.js
+++ b/pages/admin-panel.js
@@ -1,6 +1,6 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/client';
-import { useRouter } from 'next/router';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
 import { isHostAccount } from '../lib/collective.lib';
@@ -15,10 +15,10 @@ import { ALL_SECTIONS, SECTIONS_ACCESSIBLE_TO_ACCOUNTANTS } from '../components/
 import { adminPanelQuery } from '../components/admin-panel/queries';
 import AdminPanelSideBar from '../components/admin-panel/SideBar';
 import AdminPanelTopBar from '../components/admin-panel/TopBar';
+import AuthenticatedPage from '../components/AuthenticatedPage';
 import { Flex, Grid } from '../components/Grid';
 import MessageBox from '../components/MessageBox';
 import NotificationBar from '../components/NotificationBar';
-import Page from '../components/Page';
 import SignInOrJoinFree from '../components/SignInOrJoinFree';
 import { TwoFactorAuthRequiredMessage } from '../components/TwoFactorAuthRequiredMessage';
 
@@ -97,9 +97,7 @@ const getIsAccountantOnly = (LoggedInUser, account) => {
   return LoggedInUser && !LoggedInUser.isAdminOfCollective(account) && LoggedInUser.hasRole(roles.ACCOUNTANT, account);
 };
 
-const AdminPanelPage = () => {
-  const router = useRouter();
-  const { slug, section, subpath } = router.query;
+const AdminPanelPage = ({ slug, section, subpath }) => {
   const intl = useIntl();
   const { LoggedInUser, loadingLoggedInUser } = useLoggedInUser();
   const { data, loading } = useQuery(adminPanelQuery, { context: API_V2_CONTEXT, variables: { slug } });
@@ -115,7 +113,7 @@ const AdminPanelPage = () => {
 
   return (
     <AdminPanelContext.Provider value={{ selectedSection }}>
-      <Page noRobots collective={account} title={account ? `${account.name} - ${titleBase}` : titleBase}>
+      <AuthenticatedPage noRobots collective={account} title={account ? `${account.name} - ${titleBase}` : titleBase}>
         {!blocker && (
           <AdminPanelTopBar
             isLoading={isLoading}
@@ -163,13 +161,22 @@ const AdminPanelPage = () => {
             )}
           </Grid>
         )}
-      </Page>
+      </AuthenticatedPage>
     </AdminPanelContext.Provider>
   );
 };
 
-AdminPanelPage.getInitialProps = () => {
+AdminPanelPage.propTypes = {
+  slug: PropTypes.string,
+  section: PropTypes.string,
+  subpath: PropTypes.string,
+};
+
+AdminPanelPage.getInitialProps = async ({ query: { slug, section = null, subpath = null } }) => {
   return {
+    slug,
+    section,
+    subpath,
     scripts: { googleMaps: true }, // TODO: This should be enabled only for events
   };
 };


### PR DESCRIPTION
router is not available for first ssr pass with apollo (getDataFromTree) and we need to use getInitialProps instead
