### PR TITLE
E2E/23-event.create improve reliability

### DIFF
--- a/test/cypress/integration/23-event.create.test.js
+++ b/test/cypress/integration/23-event.create.test.js
@@ -38,7 +38,7 @@ describe('event.create.test.js', () => {
     cy.getByDataCy('confirm-btn').click();
     cy.checkToast({ type: 'SUCCESS', message: 'Ticket created.' });
 
-    cy.getByDataCy('menu-item-tickets').click();
+    // Create another ticket
     cy.getByDataCy('create-ticket').click();
     cy.get('[data-cy=name]').type('Paid ticket');
     cy.get('input[data-cy=amount]').type('15');


### PR DESCRIPTION
Should resolve one failing test from https://github.com/opencollective/opencollective/issues/6484#issuecomment-1457766677

I haven't been able to reproduce locally, but here's my assumption on failing cases:
- Cypress checks the tier creation succeded (with the toast)
- Cypress clicks on "Tickets" menu item
- Cypress clicks on "Create Ticket"
- The navigation from the menu item completes, closing the "Create Ticket" modal

The execution order was probably different when ran locally.