### PR TITLE
Expense Form: add id on draft items

### DIFF
--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -29,7 +29,7 @@ import StyledTextarea from '../StyledTextarea';
 import { P, Span } from '../Text';
 
 import ExpenseAttachedFilesForm from './ExpenseAttachedFilesForm';
-import ExpenseFormItems, { addNewExpenseItem } from './ExpenseFormItems';
+import ExpenseFormItems, { addNewExpenseItem, newExpenseItem } from './ExpenseFormItems';
 import ExpenseFormPayeeInviteNewStep, { validateExpenseFormPayeeInviteNewStep } from './ExpenseFormPayeeInviteNewStep';
 import ExpenseFormPayeeSignUpStep from './ExpenseFormPayeeSignUpStep';
 import ExpenseFormPayeeStep from './ExpenseFormPayeeStep';
@@ -820,7 +820,7 @@ const ExpenseForm = ({
   const initialValues = { ...getDefaultExpense(collective), ...expense };
   const validate = expenseData => validateExpense(intl, expenseData);
   if (isDraft) {
-    initialValues.items = expense.draft.items;
+    initialValues.items = expense.draft.items?.map(newExpenseItem) || [];
     initialValues.taxes = expense.draft.taxes;
     initialValues.attachedFiles = expense.draft.attachedFiles;
     initialValues.payoutMethod = expense.draft.payoutMethod;

--- a/components/expenses/ExpenseFormItems.js
+++ b/components/expenses/ExpenseFormItems.js
@@ -24,7 +24,7 @@ import ExpenseAmountBreakdown from './ExpenseAmountBreakdown';
 import ExpenseItemForm from './ExpenseItemForm';
 
 /** Init a new expense item with default attributes */
-const newExpenseItem = attrs => ({
+export const newExpenseItem = attrs => ({
   id: uuid(), // we generate it here to properly key lists, but it won't be submitted to API
   incurredAt: toIsoDateStr(new Date()),
   description: '',


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/6634

We were missing `id` on expense items, which resulted in two issues:
- https://github.com/opencollective/opencollective/issues/6634
- Random layout issues (because React was not able to use the `key`)