### PR TITLE
Fix: expense.comments can be null after collective leaves host

### DIFF
--- a/components/budget/ExpenseBudgetItem.js
+++ b/components/budget/ExpenseBudgetItem.js
@@ -198,7 +198,7 @@ const ExpenseBudgetItem = ({
                         ),
                       }}
                     />
-                    {Boolean(expense?.comments.totalCount) && (
+                    {Boolean(expense?.comments?.totalCount) && (
                       <React.Fragment>
                         {' • '}
                         {expense?.comments.totalCount}


### PR DESCRIPTION
This bug can break the expense dashboard of a fiscal host.