### PR TITLE
Fix: dashboard routing

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -160,11 +160,11 @@ const nextConfig = {
         permanent: false,
       },
       // Legacy host dashboard (/host/dashboard)
-      // {
-      //   source: '/:slug/dashboard/:section*',
-      //   destination: '/:slug/admin/:section*',
-      //   permanent: false,
-      // },
+      {
+        source: '/:slug/dashboard/:section*',
+        destination: '/:slug/admin/:section*',
+        permanent: false,
+      },
       // Legacy subscriptions
       {
         source: '/subscriptions',

--- a/pages/applications.js
+++ b/pages/applications.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
+import { getDashboardRoute } from '../lib/url-helpers';
+
 import AuthenticatedPage from '../components/AuthenticatedPage';
 import { Flex } from '../components/Grid';
 import MessageBox from '../components/MessageBox';
@@ -25,7 +27,7 @@ class Apps extends React.Component {
             <StyledLink
               href={
                 LoggedInUser.hasEarlyAccess('dashboard')
-                  ? `/dashboard/for-developers/${LoggedInUser.collective.slug}`
+                  ? getDashboardRoute(LoggedInUser.collective, 'for-developrs')
                   : `/${LoggedInUser.collective.slug}/admin/for-developers`
               }
             >


### PR DESCRIPTION
Two smaller routing fixes, follow up on https://github.com/opencollective/opencollective-frontend/pull/8751

- Broken link to dashboard on /pages/applications.js
- Adding back legacy host dashboard route (it initially conflicted with the new workspace route, but not since putting `/dashboard` first)