### PR TITLE
Add Host Fields to Account in Transactions Page

### DIFF
--- a/pages/transactions.js
+++ b/pages/transactions.js
@@ -67,6 +67,12 @@ export const transactionsPageQuery = gql`
           slug
         }
       }
+      ... on AccountWithHost {
+        host {
+          id
+          slug
+        }
+      }
       processingOrders: orders(filter: OUTGOING, includeIncognito: true, status: [PENDING, PROCESSING]) {
         totalCount
         nodes {


### PR DESCRIPTION
Related to https://opencollective.slack.com/archives/C0429NTTABF/p1681163207750909

We don't seem to have have the `account.host` added in this graphql query which results in always returning, `LoggedInUser.prototype.isHostAdmin` to return `false`. 