### PR TITLE
Add loading state for 'Withdraw application'

### DIFF
--- a/components/edit-collective/sections/Host.js
+++ b/components/edit-collective/sections/Host.js
@@ -76,7 +76,7 @@ class Host extends React.Component {
 
   async changeHost(newHost = { id: null }) {
     const { collective } = this.props;
-    this.setState({ showModal: false });
+
     if (newHost.id === get(collective, 'host.id')) {
       return;
     }
@@ -91,7 +91,7 @@ class Host extends React.Component {
         this.updateSelectedOption('noHost');
       }
     } finally {
-      this.setState({ isSubmitting: false });
+      this.setState({ isSubmitting: false, showModal: false });
     }
   }
 
@@ -325,7 +325,12 @@ class Host extends React.Component {
                   >
                     <FormattedMessage id="actions.cancel" defaultMessage={'Cancel'} />
                   </StyledButton>
-                  <StyledButton buttonStyle="primary" onClick={() => this.changeHost()} data-cy="continue">
+                  <StyledButton
+                    buttonStyle="primary"
+                    loading={this.state.isSubmitting}
+                    onClick={() => this.changeHost()}
+                    data-cy="continue"
+                  >
                     {/** TODO(i18n): This should be internationalized */}
                     {action}
                   </StyledButton>


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/6289

# Description
Added loading state for 'Withdraw application'

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots

After:
![after-new](https://user-images.githubusercontent.com/48645737/231503864-d75aff33-521f-47cc-9019-a2d7ee7d19d4.gif)

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
