### PR TITLE
Correct Range to Include Current Year in Tax Form Modal

### DIFF
--- a/components/expenses/TaxFormLinkModal.js
+++ b/components/expenses/TaxFormLinkModal.js
@@ -29,7 +29,7 @@ const setTaxFormMutation = gql`
 `;
 
 const arrayOfYears = () => {
-  return range(2018, new Date().getFullYear());
+  return range(2018, new Date().getFullYear() + 1);
 };
 
 const TaxFormLinkModal = ({ account, year, onClose, expenseData }) => {


### PR DESCRIPTION
Seems that we are not including the current year in the tax form modal due to using `_lodash.range(start, end)` as `range` goes upto `end` but not inclusive of end. I've corrected that by adding one to the `end` value. 