### PR TITLE
Fix typo in ApplicationForm subheading

### DIFF
--- a/components/osc-host-application/ApplicationForm.js
+++ b/components/osc-host-application/ApplicationForm.js
@@ -320,7 +320,7 @@ const ApplicationForm = ({
             <P fontSize="16px" lineHeight="24px" fontWeight="500" color="black.700">
               <FormattedMessage
                 id="HostApplication.form.subheading"
-                defaultMessage="Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}"
+                defaultMessage="Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}"
                 values={{
                   faqLink: (
                     <StyledLink href="https://docs.oscollective.org/faq/general" openInNewTab color="purple.500">

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -1733,7 +1733,7 @@
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
   "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
-  "HostApplication.form.subheading": "Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
+  "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",
   "HostApplication.form.tellUsMoreLabel": "Tell us a little about your project, what you're working on and what you need from us.",

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1731,7 +1731,7 @@
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
   "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
-  "HostApplication.form.subheading": "Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
+  "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",
   "HostApplication.form.tellUsMoreLabel": "Tell us a little about your project, what you're working on and what you need from us.",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1731,7 +1731,7 @@
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
   "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
-  "HostApplication.form.subheading": "Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
+  "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",
   "HostApplication.form.tellUsMoreLabel": "Tell us a little about your project, what you're working on and what you need from us.",

--- a/lang/cy-GB.json
+++ b/lang/cy-GB.json
@@ -1733,7 +1733,7 @@
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
   "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
-  "HostApplication.form.subheading": "Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
+  "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",
   "HostApplication.form.tellUsMoreLabel": "Tell us a little about your project, what you're working on and what you need from us.",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1731,7 +1731,7 @@
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
   "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
-  "HostApplication.form.subheading": "Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
+  "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",
   "HostApplication.form.tellUsMoreLabel": "Tell us a little about your project, what you're working on and what you need from us.",

--- a/lang/el-GR.json
+++ b/lang/el-GR.json
@@ -1733,7 +1733,7 @@
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
   "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
-  "HostApplication.form.subheading": "Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
+  "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",
   "HostApplication.form.tellUsMoreLabel": "Tell us a little about your project, what you're working on and what you need from us.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1731,7 +1731,7 @@
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
   "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
-  "HostApplication.form.subheading": "Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
+  "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",
   "HostApplication.form.tellUsMoreLabel": "Tell us a little about your project, what you're working on and what you need from us.",

--- a/lang/fa.json
+++ b/lang/fa.json
@@ -1733,7 +1733,7 @@
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
   "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
-  "HostApplication.form.subheading": "Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
+  "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",
   "HostApplication.form.tellUsMoreLabel": "Tell us a little about your project, what you're working on and what you need from us.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1731,7 +1731,7 @@
   "HostApplication.form.publicInformation": "Ce champ est public. N'ajoutez pas d'informations personnelles telles que des noms ou des adresses dans ce champ.",
   "HostApplication.form.readFaqs": "Lisez notre FAQ",
   "HostApplication.form.RepositoryUrlLabel": "Votre dépôt ou votre organisation",
-  "HostApplication.form.subheading": "Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
+  "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Votre équipe",
   "HostApplication.form.tellUsMoreHelpText": "Nous voulons en savoir plus sur vous et sur la façon dont nous pouvons vous aider.",
   "HostApplication.form.tellUsMoreLabel": "Tell us a little about your project, what you're working on and what you need from us.",

--- a/lang/id-ID.json
+++ b/lang/id-ID.json
@@ -1733,7 +1733,7 @@
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
   "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
-  "HostApplication.form.subheading": "Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
+  "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",
   "HostApplication.form.tellUsMoreLabel": "Tell us a little about your project, what you're working on and what you need from us.",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1731,7 +1731,7 @@
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
   "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
-  "HostApplication.form.subheading": "Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
+  "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",
   "HostApplication.form.tellUsMoreLabel": "Tell us a little about your project, what you're working on and what you need from us.",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1731,7 +1731,7 @@
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
   "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
-  "HostApplication.form.subheading": "Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
+  "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",
   "HostApplication.form.tellUsMoreLabel": "Tell us a little about your project, what you're working on and what you need from us.",

--- a/lang/lt-LT.json
+++ b/lang/lt-LT.json
@@ -1733,7 +1733,7 @@
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
   "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
-  "HostApplication.form.subheading": "Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
+  "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",
   "HostApplication.form.tellUsMoreLabel": "Tell us a little about your project, what you're working on and what you need from us.",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1731,7 +1731,7 @@
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
   "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
-  "HostApplication.form.subheading": "Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
+  "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",
   "HostApplication.form.tellUsMoreLabel": "Tell us a little about your project, what you're working on and what you need from us.",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1731,7 +1731,7 @@
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
   "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
-  "HostApplication.form.subheading": "Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
+  "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",
   "HostApplication.form.tellUsMoreLabel": "Tell us a little about your project, what you're working on and what you need from us.",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1731,7 +1731,7 @@
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
   "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
-  "HostApplication.form.subheading": "Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
+  "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",
   "HostApplication.form.tellUsMoreLabel": "Tell us a little about your project, what you're working on and what you need from us.",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1731,7 +1731,7 @@
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Читайте наши ЧЗВ",
   "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
-  "HostApplication.form.subheading": "Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
+  "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",
   "HostApplication.form.tellUsMoreLabel": "Tell us a little about your project, what you're working on and what you need from us.",

--- a/lang/sk-SK.json
+++ b/lang/sk-SK.json
@@ -1731,7 +1731,7 @@
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
   "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
-  "HostApplication.form.subheading": "Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
+  "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",
   "HostApplication.form.tellUsMoreLabel": "Tell us a little about your project, what you're working on and what you need from us.",

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -1733,7 +1733,7 @@
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
   "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
-  "HostApplication.form.subheading": "Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
+  "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",
   "HostApplication.form.tellUsMoreLabel": "Tell us a little about your project, what you're working on and what you need from us.",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -1731,7 +1731,7 @@
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
   "HostApplication.form.RepositoryUrlLabel": "Ваш репозиторій або організація",
-  "HostApplication.form.subheading": "Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
+  "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Ваша команда",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",
   "HostApplication.form.tellUsMoreLabel": "Tell us a little about your project, what you're working on and what you need from us.",

--- a/lang/uz-UZ.json
+++ b/lang/uz-UZ.json
@@ -1733,7 +1733,7 @@
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
   "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
-  "HostApplication.form.subheading": "Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
+  "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",
   "HostApplication.form.tellUsMoreLabel": "Tell us a little about your project, what you're working on and what you need from us.",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1731,7 +1731,7 @@
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
   "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
-  "HostApplication.form.subheading": "Introduce your Collective, please incude as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
+  "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",
   "HostApplication.form.tellUsMoreLabel": "Tell us a little about your project, what you're working on and what you need from us.",


### PR DESCRIPTION
# Description

Fixes a typo in the Open Source Collective application form, `incude` -> `include`. Also makes the same change across all  locale files that had a match for `incude`.

I did this with code search-and-replace so am not 100% sure this is all that’s needed.