### PR TITLE
HostDashboard: improve refetch strategy for scheduled expenses

### DIFF
--- a/components/ConfirmationModal.js
+++ b/components/ConfirmationModal.js
@@ -41,18 +41,18 @@ export const CONFIRMATION_MODAL_TERMINATE = { __CONFIRMATION_MODAL_TERMINATE: tr
  * confirmation purpose.
  */
 const ConfirmationModal = ({
-  header,
-  body,
-  children,
+  header = undefined,
+  body = undefined,
+  children = undefined,
   onClose,
-  type,
-  isDanger,
-  isSuccess,
-  cancelLabel,
-  continueLabel,
-  cancelHandler,
+  type = 'confirm',
+  isDanger = undefined,
+  isSuccess = undefined,
+  cancelLabel = undefined,
+  continueLabel = undefined,
+  cancelHandler = onClose,
   continueHandler,
-  disableSubmit,
+  disableSubmit = undefined,
   ...props
 }) => {
   const [submitting, setSubmitting] = React.useState(false);
@@ -69,7 +69,7 @@ const ConfirmationModal = ({
             my={1}
             autoFocus
             minWidth={140}
-            onClick={cancelHandler || onClose}
+            onClick={cancelHandler}
             disabled={submitting}
             data-cy="confirmation-modal-cancel"
           >

--- a/components/MessageBox.tsx
+++ b/components/MessageBox.tsx
@@ -113,7 +113,7 @@ const MessageBox = ({ type = 'white', withIcon = false, isLoading, children, ...
           </Box>
         )}
 
-        <Box width="100%">{children}</Box>
+        <Box flex={1}>{children}</Box>
       </Flex>
     </Message>
   );

--- a/components/MessageBox.tsx
+++ b/components/MessageBox.tsx
@@ -113,7 +113,7 @@ const MessageBox = ({ type = 'white', withIcon = false, isLoading, children, ...
           </Box>
         )}
 
-        <Box>{children}</Box>
+        <Box width="100%">{children}</Box>
       </Flex>
     </Message>
   );

--- a/components/expenses/ExpensesPage.tsx
+++ b/components/expenses/ExpensesPage.tsx
@@ -139,7 +139,7 @@ const Expenses = props => {
         )}
       </Box>
       {isSelfHosted && LoggedInUser?.isHostAdmin(data?.account) && data.scheduledExpenses?.totalCount > 0 && (
-        <ScheduledExpensesBanner host={data.account} />
+        <ScheduledExpensesBanner hostSlug={data.account.slug} />
       )}
       <Flex justifyContent="space-between" flexWrap="wrap" gridGap={[0, 3, 5]}>
         <Box flex="1 1 500px" minWidth={300} mb={5} mt={['16px', '46px']}>

--- a/components/expenses/ProcessExpenseButtons.js
+++ b/components/expenses/ProcessExpenseButtons.js
@@ -12,6 +12,7 @@ import PERMISSION_CODES, { ReasonMessage } from '../../lib/constants/permissions
 import { i18nGraphqlException } from '../../lib/errors';
 import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
 
+import { getScheduledExpensesQueryVariables, scheduledExpensesQuery } from '../host-dashboard/ScheduledExpensesBanner';
 import Link from '../Link';
 import StyledButton from '../StyledButton';
 import StyledTooltip from '../StyledTooltip';
@@ -150,7 +151,16 @@ const ProcessExpenseButtons = ({
 
     try {
       const variables = { id: expense.id, legacyId: expense.legacyId, action, paymentParams };
-      await processExpense({ variables });
+      const refetchQueries = [];
+      if (action === 'SCHEDULE_FOR_PAYMENT' || action === 'UNSCHEDULE_PAYMENT') {
+        refetchQueries.push({
+          query: scheduledExpensesQuery,
+          context: API_V2_CONTEXT,
+          variables: getScheduledExpensesQueryVariables(host.slug),
+        });
+      }
+
+      await processExpense({ variables, refetchQueries });
       return true;
     } catch (e) {
       // Display a toast with light variant since we're in a modal

--- a/components/expenses/filters/ExpensesStatusFilter.js
+++ b/components/expenses/filters/ExpensesStatusFilter.js
@@ -41,7 +41,7 @@ const ExpenseStatusFilter = ({ value, onChange, ignoredExpenseStatus = IGNORED_E
 
 ExpenseStatusFilter.propTypes = {
   onChange: PropTypes.func.isRequired,
-  value: PropTypes.oneOf([...Object.values(expenseStatus), 'READY_TO_PAY']),
+  value: PropTypes.oneOf([...Object.values(expenseStatus), 'ALL', 'READY_TO_PAY']),
   ignoredExpenseStatus: PropTypes.arrayOf(PropTypes.oneOf(Object.values(expenseStatus))),
 };
 

--- a/components/host-dashboard/HostDashboardExpenses.js
+++ b/components/host-dashboard/HostDashboardExpenses.js
@@ -230,32 +230,30 @@ const HostDashboardExpenses = ({ hostSlug }) => {
           <HostInfoCard host={data.host} />
         )}
       </Box>
-      {!expenses.loading && data?.host && (
-        <ScheduledExpensesBanner
-          host={data.host}
-          expenses={paginatedExpenses.nodes}
-          onSubmit={() => {
-            expenses.refetch();
-          }}
-          secondButton={
-            !(query.status === 'SCHEDULED_FOR_PAYMENT' && query.payout === 'BANK_ACCOUNT') ? (
-              <StyledButton
-                buttonSize="tiny"
-                buttonStyle="successSecondary"
-                mr={1}
-                onClick={() => {
-                  router.push({
-                    pathname: pageRoute,
-                    query: getQueryParams({ status: 'SCHEDULED_FOR_PAYMENT', payout: 'BANK_ACCOUNT', offset: null }),
-                  });
-                }}
-              >
-                <FormattedMessage id="expenses.list" defaultMessage="List Expenses" />
-              </StyledButton>
-            ) : null
-          }
-        />
-      )}
+      <ScheduledExpensesBanner
+        hostSlug={hostSlug}
+        expenses={paginatedExpenses.nodes}
+        onSubmit={() => {
+          expenses.refetch();
+        }}
+        secondButton={
+          !(query.status === 'SCHEDULED_FOR_PAYMENT' && query.payout === 'BANK_ACCOUNT') ? (
+            <StyledButton
+              buttonSize="tiny"
+              buttonStyle="successSecondary"
+              mr={1}
+              onClick={() => {
+                router.push({
+                  pathname: pageRoute,
+                  query: getQueryParams({ status: 'SCHEDULED_FOR_PAYMENT', payout: 'BANK_ACCOUNT', offset: null }),
+                });
+              }}
+            >
+              <FormattedMessage id="expenses.list" defaultMessage="List Expenses" />
+            </StyledButton>
+          ) : null
+        }
+      />
       <Box mb={34}>
         {data?.host ? (
           <ExpensesFilters


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/6686
Reverts the changes from https://github.com/opencollective/opencollective-frontend/pull/6572

Previous strategy: each time `data.expenses` change, refetch information about pending expenses. This was triggering unnecessary requests, e.g. when navigating with pagination or approving expenses.

New strategy: Only refetch scheduled expenses banner when scheduling or unscheduling expenses.