### PR TITLE
Use data-testid in cypress test

### DIFF
--- a/test/cypress/integration/13-contributeFlow-stripePaymentElement.test.js
+++ b/test/cypress/integration/13-contributeFlow-stripePaymentElement.test.js
@@ -33,9 +33,9 @@ function contributeWithNewUsBankAccount({ name } = {}) {
       return iframe.contents().find('body');
     })
     .within(() => {
-      cy.contains('Agree').click();
-      cy.contains('Success').click(); // Bank account with name 'Success'
-      cy.contains('Link account').click();
+      cy.get('[data-testid="agree-button"]').click();
+      cy.get('[data-testid="success"]').click(); // Bank account with name 'Success'
+      cy.get('[data-testid="select-button"]').click();
       cy.get('[data-testid="done-button"]').click();
     });
 


### PR DESCRIPTION
Related https://github.com/opencollective/opencollective/issues/6484#issuecomment-1531051906

# Description

Use data-testid element selector to prevent failing test due to button text change


