### PR TITLE
Remove DOMParser polyfill for Node

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -37,12 +37,6 @@ import GlobalToasts from '../components/GlobalToasts';
 import NewsAndUpdatesProvider from '../components/NewsAndUpdatesProvider';
 import ToastProvider from '../components/ToastProvider';
 
-// Use JSDOM on server-side so that react-intl can render rich messages
-// See https://github.com/formatjs/react-intl/blob/c736c2e6c6096b1d5ad1fb6be85fa374891d0a6c/docs/Getting-Started.md#domparser
-if (!process.browser) {
-  global.DOMParser = new (require('jsdom').JSDOM)().window.DOMParser;
-}
-
 // This is optional but highly recommended
 // since it prevents memory leak
 const cache = createIntlCache();


### PR DESCRIPTION
Remove DOMParser polyfill for Node since [react-intl is no longer depending on this since v4](https://github.com/formatjs/formatjs/releases/tag/v4.0.0).