### PR TITLE
debt: remove unused fields from the legacyCollectiveQuery

### DIFF
--- a/lib/graphql/queries.js
+++ b/lib/graphql/queries.js
@@ -418,69 +418,6 @@ export const legacyCollectiveQuery = gqlV1/* GraphQL */ `
       currency
       settings
       createdAt
-      stats {
-        id
-        balance
-        yearlyBudget
-        backers {
-          id
-          all
-          users
-          organizations
-          collectives
-        }
-        collectives {
-          id
-          hosted
-          memberOf
-        }
-        transactions {
-          id
-          all
-        }
-        expenses {
-          id
-          all
-        }
-        updates
-        events
-        totalAmountSpent
-        totalAmountReceived
-      }
-      tiers {
-        id
-        slug
-        type
-        name
-        description
-        useStandalonePage
-        button
-        amount
-        amountType
-        minimumAmount
-        presets
-        interval
-        currency
-        maxQuantity
-        stats {
-          id
-          totalOrders
-          totalActiveDistinctOrders
-          availableQuantity
-        }
-        orders(limit: 30, isActive: true) {
-          id
-          fromCollective {
-            id
-            slug
-            type
-            name
-            imageUrl
-            website
-            isIncognito
-          }
-        }
-      }
       isHost
       hostFeePercent
       canApply
@@ -497,78 +434,8 @@ export const legacyCollectiveQuery = gqlV1/* GraphQL */ `
           CONTACT_FORM
         }
       }
-      members {
-        id
-        role
-        createdAt
-        since
-        description
-        member {
-          id
-          description
-          name
-          slug
-          type
-          imageUrl
-          backgroundImage
-          isIncognito
-          company
-        }
-      }
       ... on User {
         isIncognito
-        memberOf(limit: 60) {
-          id
-          role
-          createdAt
-          stats {
-            id
-            totalDonations
-          }
-          collective {
-            id
-            name
-            currency
-            slug
-            path
-            type
-            imageUrl
-            backgroundImage
-            description
-            longDescription
-            parentCollective {
-              id
-              slug
-            }
-          }
-        }
-      }
-      ... on Organization {
-        memberOf(limit: 60) {
-          id
-          role
-          createdAt
-          stats {
-            id
-            totalDonations
-          }
-          collective {
-            id
-            name
-            currency
-            slug
-            path
-            type
-            imageUrl
-            backgroundImage
-            description
-            longDescription
-            parentCollective {
-              id
-              slug
-            }
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
Only used in createEvent. Spotted this when investigating the members related crash.
