### PR TITLE
Disable expense drawer earlyAccess for `opencollective` members

### DIFF
--- a/lib/LoggedInUser.js
+++ b/lib/LoggedInUser.js
@@ -181,8 +181,7 @@ LoggedInUser.prototype.hasEarlyAccess = function (feature) {
   const featureActivated = Boolean(earlyAccess[feature]);
 
   switch (feature) {
-    case 'dashboard':
-    case 'expense-drawer': {
+    case 'dashboard': {
       return (
         featureActivated ||
         (this.hasRole([ROLES.ADMIN, ROLES.MEMBER], { slug: 'opencollective' }) && earlyAccess[feature] !== false)


### PR DESCRIPTION
Disabling the expense drawer for members and admins of `opencollective` org due to unresolved issues