### PR TITLE
Expense drawer follow-up fixes

### DIFF
--- a/components/budget/ExpenseBudgetItem.js
+++ b/components/budget/ExpenseBudgetItem.js
@@ -175,7 +175,8 @@ const ExpenseBudgetItem = ({
                   underlineOnHover
                   {...(useDrawer
                     ? {
-                        as: 'button',
+                        as: Link,
+                        href: `${getCollectivePageRoute(expense.account)}/expenses/${expense.legacyId}`,
                         onClick: expandExpense,
                       }
                     : {

--- a/components/expenses/Expense.tsx
+++ b/components/expenses/Expense.tsx
@@ -111,7 +111,6 @@ function Expense(props) {
     isRefetchingDataForUser,
     legacyExpenseId,
   } = props;
-
   const { LoggedInUser, loadingLoggedInUser } = useLoggedInUser();
   const intl = useIntl();
   const router = useRouter();
@@ -726,7 +725,7 @@ Expense.propTypes = {
   legacyExpenseId: PropTypes.number,
   draftKey: PropTypes.string,
   edit: PropTypes.string,
-  client: PropTypes.object.isRequired,
+  client: PropTypes.object,
   data: PropTypes.object.isRequired,
   loading: PropTypes.bool,
   error: PropTypes.any,
@@ -735,7 +734,7 @@ Expense.propTypes = {
   startPolling: PropTypes.func,
   stopPolling: PropTypes.func,
   isRefetchingDataForUser: PropTypes.bool,
-  drawerActionsContainer: PropTypes.element,
+  drawerActionsContainer: PropTypes.object,
 
   expensesTags: PropTypes.arrayOf(
     PropTypes.shape({

--- a/components/expenses/ExpenseAttachedFiles.js
+++ b/components/expenses/ExpenseAttachedFiles.js
@@ -37,7 +37,7 @@ const ExpenseAttachedFiles = ({ files, onRemove, showInvoice, collective, expens
           </ExpenseInvoiceDownloadHelper>
         </Box>
       )}
-      {files.map((file, idx) => (
+      {files?.map((file, idx) => (
         <Box key={file.id || file.url} mr={3} mb={3}>
           <UploadedFilePreview
             size={88}
@@ -70,7 +70,7 @@ ExpenseAttachedFiles.propTypes = {
       id: PropTypes.string,
       url: PropTypes.string.isRequired,
     }).isRequired,
-  ).isRequired,
+  ),
   /** If provided, a link to remove the file will be displayed */
   onRemove: PropTypes.func,
 };

--- a/components/expenses/ExpenseDrawer.tsx
+++ b/components/expenses/ExpenseDrawer.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { useLazyQuery } from '@apollo/client';
+import { useApolloClient, useLazyQuery } from '@apollo/client';
 import MUIDrawer from '@mui/material/Drawer';
 import { XMark } from '@styled-icons/heroicons-outline/XMark';
 import { themeGet } from '@styled-system/theme-get';
 import styled from 'styled-components';
-import { useApolloClient } from '@apollo/client';
 
 import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
 import { useTwoFactorAuthenticationPrompt } from '../../lib/two-factor-authentication/TwoFactorAuthenticationContext';

--- a/components/expenses/ExpenseDrawer.tsx
+++ b/components/expenses/ExpenseDrawer.tsx
@@ -5,6 +5,7 @@ import MUIDrawer from '@mui/material/Drawer';
 import { XMark } from '@styled-icons/heroicons-outline/XMark';
 import { themeGet } from '@styled-system/theme-get';
 import styled from 'styled-components';
+import { useApolloClient } from '@apollo/client';
 
 import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
 import { useTwoFactorAuthenticationPrompt } from '../../lib/two-factor-authentication/TwoFactorAuthenticationContext';
@@ -49,8 +50,8 @@ const CloseDrawerButton = styled(StyledRoundButton)`
 export default function ExpenseDrawer({ open, handleClose, expense }) {
   const drawerActionsRef = React.useRef(null);
   const [drawerActionsContainer, setDrawerActionsContainer] = useState(null);
-
-  const [getExpense, { data, loading, error, startPolling, stopPolling, refetch, fetchMore, client }] = useLazyQuery(
+  const client = useApolloClient();
+  const [getExpense, { data, loading, error, startPolling, stopPolling, refetch, fetchMore }] = useLazyQuery(
     expensePageQuery,
     {
       variables: getVariableFromProps({ legacyExpenseId: expense?.legacyId }),

--- a/components/expenses/ExpenseDrawer.tsx
+++ b/components/expenses/ExpenseDrawer.tsx
@@ -84,7 +84,8 @@ export default function ExpenseDrawer({ open, handleClose, expense }) {
             <Box px={[3, '24px']}>
               <Expense
                 data={{ ...data, expense: { ...expense, ...data?.expense } }}
-                loading={loading}
+                // Making sure to initially set loading to true before the query is called
+                loading={loading || (!data && !error)}
                 error={error}
                 refetch={refetch}
                 client={client}

--- a/components/expenses/ExpenseDrawer.tsx
+++ b/components/expenses/ExpenseDrawer.tsx
@@ -7,6 +7,7 @@ import { themeGet } from '@styled-system/theme-get';
 import styled from 'styled-components';
 
 import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
+import { useTwoFactorAuthenticationPrompt } from '../../lib/two-factor-authentication/TwoFactorAuthenticationContext';
 
 import { getVariableFromProps } from '../../pages/expense';
 import Container from '../Container';
@@ -57,6 +58,9 @@ export default function ExpenseDrawer({ open, handleClose, expense }) {
     },
   );
 
+  const twoFactorPrompt = useTwoFactorAuthenticationPrompt();
+  const disableEnforceFocus = Boolean(twoFactorPrompt?.isOpen);
+
   useEffect(() => {
     if (open) {
       getExpense();
@@ -69,7 +73,7 @@ export default function ExpenseDrawer({ open, handleClose, expense }) {
   }, [open]);
 
   return (
-    <MUIDrawer anchor="right" open={open} onClose={handleClose}>
+    <MUIDrawer anchor="right" open={open} onClose={handleClose} disableEnforceFocus={disableEnforceFocus}>
       <DrawerContainer>
         <Flex flex={1} flexDirection="column" overflowY="scroll">
           <Container position="relative" py={'24px'}>

--- a/components/expenses/ExpenseSummary.js
+++ b/components/expenses/ExpenseSummary.js
@@ -442,7 +442,7 @@ ExpenseSummary.propTypes = {
           type: PropTypes.string,
           rate: PropTypes.number,
         }).isRequired,
-      ).isRequired,
+      ),
     }),
     permissions: PropTypes.shape({
       canSeeInvoiceInfo: PropTypes.bool,

--- a/components/expenses/ExpenseSummary.js
+++ b/components/expenses/ExpenseSummary.js
@@ -382,7 +382,7 @@ ExpenseSummary.propTypes = {
       id: PropTypes.string.isRequired,
       host: PropTypes.shape({
         id: PropTypes.string.isRequired,
-      }).isRequired,
+      }),
     }).isRequired,
     items: PropTypes.arrayOf(
       PropTypes.shape({
@@ -392,13 +392,13 @@ ExpenseSummary.propTypes = {
         amount: PropTypes.number.isRequired,
         url: PropTypes.string,
       }).isRequired,
-    ).isRequired,
+    ),
     taxes: PropTypes.arrayOf(
       PropTypes.shape({
         type: PropTypes.string,
         rate: PropTypes.number,
       }).isRequired,
-    ).isRequired,
+    ),
     payee: PropTypes.shape({
       id: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,

--- a/components/expenses/ExpensesList.js
+++ b/components/expenses/ExpensesList.js
@@ -106,7 +106,8 @@ const ExpensesList = ({
                 onProcess={onProcess}
                 suggestedTags={suggestedTags}
                 selected={selectedId === expense.id}
-                expandExpense={() => {
+                expandExpense={e => {
+                  e.preventDefault();
                   setExpenseInDrawer(expense);
                   setSelectedId(expense.id);
                 }}

--- a/components/expenses/MarkExpenseAsIncompleteModal.js
+++ b/components/expenses/MarkExpenseAsIncompleteModal.js
@@ -52,7 +52,7 @@ const MarkExpenseAsIncompleteModal = ({ expense, onClose }) => {
   };
 
   return (
-    <StyledModal role="alertdialog" width="432px" onClose={onClose}>
+    <StyledModal role="alertdialog" width="432px" onClose={onClose} trapFocus>
       <ModalHeader>
         <FormattedMessage defaultMessage="Mark as incomplete" />
       </ModalHeader>

--- a/components/expenses/ProcessExpenseButtons.js
+++ b/components/expenses/ProcessExpenseButtons.js
@@ -57,7 +57,8 @@ export const hasProcessButtons = permissions => {
     permissions.canPay ||
     permissions.canMarkAsUnpaid ||
     permissions.canMarkAsSpam ||
-    permissions.canDelete
+    permissions.canDelete ||
+    permissions.canUnschedulePayment
   );
 };
 

--- a/components/expenses/SecurityChecksModal.js
+++ b/components/expenses/SecurityChecksModal.js
@@ -119,7 +119,7 @@ const SecurityChecksModal = ({ expense, onClose, onConfirm, ...modalProps }) => 
   const [scope, setScope] = React.useState();
 
   return (
-    <StyledModal onClose={onClose} width="680px" data-cy="security-check-modal" {...modalProps}>
+    <StyledModal trapFocus onClose={onClose} width="680px" data-cy="security-check-modal" {...modalProps}>
       <ModalHeader onClose={onClose}>
         <Box>
           <H1 color="black.900" fontSize="20px" lineHeight="28px">

--- a/lib/LoggedInUser.js
+++ b/lib/LoggedInUser.js
@@ -181,7 +181,8 @@ LoggedInUser.prototype.hasEarlyAccess = function (feature) {
   const featureActivated = Boolean(earlyAccess[feature]);
 
   switch (feature) {
-    case 'dashboard': {
+    case 'dashboard':
+    case 'expense-drawer': {
       return (
         featureActivated ||
         (this.hasRole([ROLES.ADMIN, ROLES.MEMBER], { slug: 'opencollective' }) && earlyAccess[feature] !== false)


### PR DESCRIPTION
Fixes some issues following up from #8855 and enabling the early access again for `opencollective` members/admins
- Disables enforced focus in ExpenseDrawer when TwoFactorAuth modal is open (not automatically handled since the TwoFactorAuthModal is outside the ExpenseDrawer) - this caused the loop crashing the browser with the drawer and modal trying to capture focus from each other.
- Enable trapFocus in MarkExpensesAsIncompleteModal and SecurityChecksModal (to take over focus from the drawer)
- Include `canUnschedulePayment` in `hasProcessButtons` helper to display the "Unschedule payment" button in the drawer
- Making sure to initialize `isLoading` as true for Expense in drawer to prevent crashing on undefined vars in sub-components
- Prop type fixes