### PR TITLE
Fix crashing Expense page

### DIFF
--- a/components/expenses/Expense.tsx
+++ b/components/expenses/Expense.tsx
@@ -677,7 +677,7 @@ function Expense(props) {
           <Box mb={3} pt={3}>
             {loading ? (
               <LoadingPlaceholder width="100%" height="44px" />
-            ) : (
+            ) : expense ? (
               <Thread
                 collective={collective}
                 hasMore={expense.comments?.totalCount > threadItems.length}
@@ -686,7 +686,7 @@ function Expense(props) {
                 onCommentDeleted={onCommentDeleted}
                 loading={loading}
               />
-            )}
+            ) : null}
           </Box>
 
           {expense?.permissions.canComment && (

--- a/components/expenses/ExpensePayeeDetails.js
+++ b/components/expenses/ExpensePayeeDetails.js
@@ -110,9 +110,15 @@ const ExpensePayeeDetails = ({ expense, host, isLoading, borderless, isLoadingLo
   const isPaid = expense?.status === expenseStatus.PAID;
   const displayedHost = expense?.host ?? host;
 
-  return isLoading ? (
-    <LoadingPlaceholder height={150} mt={3} />
-  ) : (
+  if (isLoading) {
+    <LoadingPlaceholder height={150} mt={3} />;
+  }
+
+  if (!payee) {
+    return null;
+  }
+
+  return (
     <Flex
       flexDirection={['column', 'row']}
       alignItems={['stretch', 'flex-start']}


### PR DESCRIPTION
Resolves issue reported in Slack of `expense` being null in some cases:

![image](https://user-images.githubusercontent.com/1552194/236782411-90a87f55-e068-48ff-960d-57a62cfb7434.png)
