### PR TITLE
Fix(Expenses): Fix crashing of deleted expenses

### DIFF
--- a/components/expenses/Expense.tsx
+++ b/components/expenses/Expense.tsx
@@ -525,7 +525,7 @@ function Expense(props) {
           <ExpenseSummary
             expense={status === PAGE_STATUS.EDIT_SUMMARY ? editedExpense : expense}
             host={host}
-            isLoading={loading}
+            isLoading={loading || !expense}
             isEditing={status === PAGE_STATUS.EDIT_SUMMARY}
             isLoadingLoggedInUser={loadingLoggedInUser || isRefetchingDataForUser}
             collective={collective}


### PR DESCRIPTION
If trying to open a deleted expense - I should be shown "Not found" instead of a crash.

Restoring the previous behaviour of setting the `isLoading` prop passed to ExpenseSummary to true if expense is nil (this is on top of using the loading prop from the query itself to also set `isLoading` - to enable showing loading indicators if there is some data from the expense list while still loading more data).