### PR TITLE
Fix(Expense list): Show Approve button as primary for expense host admins (that are also expense account admins)

### DIFF
--- a/components/budget/ExpenseBudgetItem.js
+++ b/components/budget/ExpenseBudgetItem.js
@@ -133,8 +133,10 @@ const ExpenseBudgetItem = ({
     expense?.amountInAccountCurrency && expense.amountInAccountCurrency?.currency !== expense.currency;
 
   const isLoggedInUserExpenseHostAdmin = LoggedInUser?.isAdminOfCollective(host);
+  const isLoggedInUserExpenseAccountAdmin = LoggedInUser?.isAdminOfCollective(expense?.account);
   const isExpenseToHostCollective = expense?.account?.id === host?.id;
-  const isApproveBtnSecondary = isLoggedInUserExpenseHostAdmin && !isExpenseToHostCollective;
+  const isApproveBtnSecondary =
+    isLoggedInUserExpenseHostAdmin && !isLoggedInUserExpenseAccountAdmin && !isExpenseToHostCollective;
 
   return (
     <ExpenseContainer


### PR DESCRIPTION
We recently made the "Approve" button secondary (hiding it behind "More actions") for Expense host admins. 

This fix makes sure to display "Approve" again as primary for host admins that are also admins for the account to which the Expense has been submitted.