### PR TITLE
fix(component): fixed the fixed-width issue in StyledButton component

### DIFF
--- a/components/StyledButton.tsx
+++ b/components/StyledButton.tsx
@@ -57,6 +57,7 @@ const StyledButtonContent = styled.button<StyledButtonProps>`
   border-radius: 100px;
   letter-spacing: -0.4px;
   font-weight: 500;
+  min-width: max-content;
 
   &:disabled {
     cursor: not-allowed;


### PR DESCRIPTION
fix #6709

# Description

Added `min-width` to `StyledButton` component to fix [this](https://github.com/opencollective/opencollective/issues/6709) issue

# Screenshots

Example 1:

Before
![image](https://github.com/opencollective/opencollective-frontend/assets/69810789/a919aca8-79d0-4508-a757-2f9c1aa154c5)


After Change
![image](https://github.com/opencollective/opencollective-frontend/assets/69810789/f1cbbfe9-6fb2-4450-857b-8224075214b4)


Example 2:

Before
![image](https://github.com/opencollective/opencollective-frontend/assets/69810789/a4511c58-8000-457f-b065-f6ab4831028c)


After Change
![image](https://github.com/opencollective/opencollective-frontend/assets/69810789/aa258a34-4403-4e22-a175-f63945a6874a)

Kindly please review it. @Betree 

Thank you :grin: 
