### PR TITLE
Improve performances for contributors counts

### DIFF
--- a/components/StyledMembershipCard.js
+++ b/components/StyledMembershipCard.js
@@ -56,15 +56,15 @@ const StyledMembershipCard = ({ membership, intl, ...props }) => {
             </P>
           ) : (
             <P mt={3} fontSize="12px" lineHeight="18px">
-              {account.backers?.totalCount > 0 && (
+              {account.stats?.contributorsCount > 0 && (
                 <FormattedMessage
                   id="StyledMembershipCard.backers.all"
                   defaultMessage="{count, plural, one {{prettyCount} contributor} other {{prettyCount} contributors}}"
                   values={{
-                    count: account.backers.totalCount,
+                    count: account.stats.contributorsCount,
                     prettyCount: (
                       <Span fontWeight="bold" fontSize="16px">
-                        {account.backers.totalCount}
+                        {account.stats.contributorsCount}
                       </Span>
                     ),
                   }}
@@ -87,8 +87,8 @@ StyledMembershipCard.propTypes = {
       isHost: PropTypes.bool,
       isIncognito: PropTypes.bool,
       name: PropTypes.string,
-      backers: PropTypes.shape({
-        totalCount: PropTypes.number,
+      stats: PropTypes.shape({
+        contributorsCount: PropTypes.number,
       }),
     }),
     description: PropTypes.string,

--- a/components/collective-page/sections/Contributions.js
+++ b/components/collective-page/sections/Contributions.js
@@ -262,9 +262,9 @@ const contributionsSectionQuery = gql`
                 backgroundImageUrl(height: 200)
               }
             }
-            # limit: 1 as current best practice to avoid the API fetching entries it doesn't need
-            backers: members(role: [BACKER], limit: 1) {
-              totalCount
+            stats {
+              id
+              contributorsCount
             }
           }
         }

--- a/components/contribution-flow/ContributorCardWithTier.js
+++ b/components/contribution-flow/ContributorCardWithTier.js
@@ -51,7 +51,7 @@ const ContributorCardWithTier = ({ contribution, ...props }) => {
               values={{
                 contributors: (
                   <span style={{ color: 'black.900' }}>
-                    <b>{collective.contributors?.totalCount || 1}</b>
+                    <b>{collective.stats?.contributorsCount || 1}</b>
                   </span>
                 ),
               }}

--- a/components/contribution-flow/graphql/fragments.js
+++ b/components/contribution-flow/graphql/fragments.js
@@ -165,11 +165,9 @@ export const orderSuccessFragment = gql`
       socialLinks {
         type
       }
-      ... on AccountWithContributions {
-        # limit: 1 as current best practice to avoid the API fetching entries it doesn't need
-        contributors(limit: 1, roles: [BACKER, ATTENDEE]) {
-          totalCount
-        }
+      stats {
+        id
+        contributorsCount
       }
       ... on AccountWithParent {
         parent {

--- a/components/root-actions/BanAccountsWithSearch.js
+++ b/components/root-actions/BanAccountsWithSearch.js
@@ -25,7 +25,7 @@ import { banAccountsMutation } from './BanAccounts';
 import BanAccountsSummary from './BanAccountsSummary';
 
 export const searchQuery = gql`
-  query SearchPage($term: String!, $offset: Int) {
+  query BanAccountSearch($term: String!, $offset: Int) {
     accounts(
       searchTerm: $term
       limit: 30
@@ -75,12 +75,6 @@ export const searchQuery = gql`
             slug
             backgroundImageUrl
           }
-        }
-        backers: members(role: BACKER) {
-          totalCount
-        }
-        memberOf(role: BACKER) {
-          totalCount
         }
       }
       limit

--- a/components/search-page/SearchCollectiveCard.js
+++ b/components/search-page/SearchCollectiveCard.js
@@ -57,16 +57,16 @@ const SearchCollectiveCard = ({ collective, ...props }) => {
           ) : (
             <React.Fragment>
               <P fontSize="12px" lineHeight="18px">
-                {collective.backers.totalCount > 0 && (
+                {collective.stats?.contributorsCount > 0 && (
                   <Box pb="6px">
                     <Span fontSize="14px" fontWeight={700} color="black.900">
-                      {collective.backers.totalCount}
+                      {collective.stats.contributorsCount}
                     </Span>
                     {` `}
                     <Span fontSize="12px" fontWeight={400} color="black.700">
                       <FormattedMessage
                         defaultMessage="Financial {count, plural, one {Contributor} other {Contributors}}"
-                        values={{ count: collective.backers.totalCount }}
+                        values={{ count: collective.stats.contributorsCount }}
                       />
                     </Span>
                   </Box>
@@ -134,6 +134,7 @@ SearchCollectiveCard.propTypes = {
     description: PropTypes.string,
     isHost: PropTypes.bool,
     stats: PropTypes.shape({
+      contributorsCount: PropTypes.number,
       totalAmountReceived: PropTypes.shape({
         valueInCents: PropTypes.number,
         currency: PropTypes.string,
@@ -146,9 +147,6 @@ SearchCollectiveCard.propTypes = {
     host: PropTypes.shape({
       totalHostedCollectives: PropTypes.number,
       hostFeePercent: PropTypes.number,
-    }),
-    backers: PropTypes.shape({
-      totalCount: PropTypes.number,
     }),
   }).isRequired,
 };

--- a/pages/search.js
+++ b/pages/search.js
@@ -581,6 +581,7 @@ export const searchPageQuery = gql`
         currency
         stats {
           id
+          contributorsCount
           totalAmountReceived(useCache: true) {
             currency
             valueInCents
@@ -607,9 +608,6 @@ export const searchPageQuery = gql`
               country
             }
           }
-        }
-        backers: members(role: BACKER) {
-          totalCount
         }
       }
       limit


### PR DESCRIPTION
On the search page, we were fetching the count through `account.members.totalCount`. Since the field is not backed by a loader, we were:
- Running 20 SQL queries to count the members each time the page was loaded, which surely had a noticeable impact on the root page (https://opencollective.com/search) since it showcases large profiles (OC Inc, OSC, OCF, ...etc).
- Fetching and loading in RAM 5 x 100 members and their collectives (without using them)

Also applied similar fixes in:
- The "Contributions" section of the collective page (should have some impact)
- The "Order success" page (should not have a meaningful impact)