### PR TITLE
Add support for webp images in Trix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,7 +109,7 @@
         "styled-components": "5.3.10",
         "styled-system": "5.1.5",
         "throng": "5.0.0",
-        "trix": "2.0.4",
+        "trix": "2.0.5",
         "uuid": "9.0.0",
         "validator": "13.9.0",
         "winston": "3.8.2"
@@ -41308,9 +41308,9 @@
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "node_modules/trix": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/trix/-/trix-2.0.4.tgz",
-      "integrity": "sha512-WOMKqwCVti0i3RVaDrMnrEZWs6XMpFoCfUvFCZNd15KndAy6MsYQscizxEpFiCLUlo+rXMkueK0ldRDo5xpVJA=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/trix/-/trix-2.0.5.tgz",
+      "integrity": "sha512-OiCbDf17F7JahEwhyL1MvK9DxAAT1vkaW5sn+zpwfemZAcc4RfQB4ku18/1mKP58LRwBhjcy+6TBho7ciXz52Q=="
     },
     "node_modules/trough": {
       "version": "1.0.5",
@@ -75285,9 +75285,9 @@
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "trix": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/trix/-/trix-2.0.4.tgz",
-      "integrity": "sha512-WOMKqwCVti0i3RVaDrMnrEZWs6XMpFoCfUvFCZNd15KndAy6MsYQscizxEpFiCLUlo+rXMkueK0ldRDo5xpVJA=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/trix/-/trix-2.0.5.tgz",
+      "integrity": "sha512-OiCbDf17F7JahEwhyL1MvK9DxAAT1vkaW5sn+zpwfemZAcc4RfQB4ku18/1mKP58LRwBhjcy+6TBho7ciXz52Q=="
     },
     "trough": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "styled-components": "5.3.10",
     "styled-system": "5.1.5",
     "throng": "5.0.0",
-    "trix": "2.0.4",
+    "trix": "2.0.5",
     "uuid": "9.0.0",
     "validator": "13.9.0",
     "winston": "3.8.2"


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/6716
Require https://github.com/opencollective/opencollective-api/pull/8897

# Description
-  Update the trix package to support the ability to preview a .webp image.

# Screenshots

https://www.loom.com/share/aa82863f39a446eda01671817f76697f
