### PR TITLE
Truncate ExpenseTag in Budget Visualization section

### DIFF
--- a/components/collective-page/sections/Budget/ExpenseBudget.js
+++ b/components/collective-page/sections/Budget/ExpenseBudget.js
@@ -34,6 +34,12 @@ import {
   TagMarker,
 } from './common';
 
+const makeLabel = (intl, label) => {
+  return label === 'OTHERS_COMBINED'
+    ? intl.formatMessage({ id: 'Tags.OthersCombined', defaultMessage: 'Others Combined' })
+    : label;
+};
+
 export const budgetSectionExpenseQuery = gql`
   query BudgetSectionExpenseQuery($slug: String!, $from: DateTime, $to: DateTime) {
     account(slug: $slug) {
@@ -65,6 +71,7 @@ export const budgetSectionExpenseQuery = gql`
     }
   }
 `;
+
 const ExpenseBudget = ({ collective, defaultTimeInterval, ...props }) => {
   const [tmpDateInterval, setTmpDateInterval] = React.useState(defaultTimeInterval);
   const [graphType, setGraphType] = React.useState(GRAPH_TYPES.LIST);
@@ -155,10 +162,10 @@ const ExpenseBudget = ({ collective, defaultTimeInterval, ...props }) => {
                 />,
               ]}
               rows={data?.account?.stats.expensesTags.map((expenseTag, i) =>
-                makeBudgetTableRow(expenseTag.id + expenseTag.count, [
+                makeBudgetTableRow(expenseTag.label + expenseTag.count, [
                   <React.Fragment key={expenseTag.label}>
                     <TagMarker color={COLORS[i % COLORS.length]} />
-                    {expenseTag.label}
+                    {makeLabel(intl, expenseTag.label)}
                   </React.Fragment>,
                   expenseTag.count,
                   formatCurrency(expenseTag.amount.valueInCents, expenseTag.amount.currency),
@@ -206,7 +213,9 @@ const ExpenseBudget = ({ collective, defaultTimeInterval, ...props }) => {
                 width="100%"
                 height="300px"
                 options={{
-                  labels: data?.account?.stats.expensesTags.map(expenseTag => capitalize(expenseTag.label)),
+                  labels: data?.account?.stats.expensesTags.map(expenseTag =>
+                    capitalize(makeLabel(intl, expenseTag.label)),
+                  ),
                   colors: COLORS,
                   chart: {
                     id: 'chart-budget-expenses-pie',

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -2695,6 +2695,7 @@
   "Tags.MEDIA": "Media",
   "Tags.OPEN_SOURCE": "Codi obert",
   "Tags.ORGANIZATION": "Organització",
+  "Tags.OthersCombined": "Others Combined",
   "Tags.POLITICS": "Política",
   "Tags.TECH_MEETUP": "Tech meetup",
   "Tags.US_NONPROFIT": "US nonprofit",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -2695,6 +2695,7 @@
   "Tags.MEDIA": "Média",
   "Tags.OPEN_SOURCE": "Open source",
   "Tags.ORGANIZATION": "Organizace",
+  "Tags.OthersCombined": "Others Combined",
   "Tags.POLITICS": "Politika",
   "Tags.TECH_MEETUP": "Tech meetup",
   "Tags.US_NONPROFIT": "Americká nezisková",

--- a/lang/de.json
+++ b/lang/de.json
@@ -2695,6 +2695,7 @@
   "Tags.MEDIA": "Media",
   "Tags.OPEN_SOURCE": "Quelloffen",
   "Tags.ORGANIZATION": "Organization",
+  "Tags.OthersCombined": "Others Combined",
   "Tags.POLITICS": "Politik",
   "Tags.TECH_MEETUP": "Tech meetup",
   "Tags.US_NONPROFIT": "US nonprofit",

--- a/lang/en.json
+++ b/lang/en.json
@@ -2695,6 +2695,7 @@
   "Tags.MEDIA": "Media",
   "Tags.OPEN_SOURCE": "Open source",
   "Tags.ORGANIZATION": "Organization",
+  "Tags.OthersCombined": "Others Combined",
   "Tags.POLITICS": "Politics",
   "Tags.TECH_MEETUP": "Tech meetup",
   "Tags.US_NONPROFIT": "US nonprofit",

--- a/lang/es.json
+++ b/lang/es.json
@@ -2695,6 +2695,7 @@
   "Tags.MEDIA": "Medios",
   "Tags.OPEN_SOURCE": "Código abierto",
   "Tags.ORGANIZATION": "Organización",
+  "Tags.OthersCombined": "Others Combined",
   "Tags.POLITICS": "Politicas",
   "Tags.TECH_MEETUP": "Reunión de tecnología",
   "Tags.US_NONPROFIT": "EEUU sin ánimo de lucro",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2695,6 +2695,7 @@
   "Tags.MEDIA": "Média",
   "Tags.OPEN_SOURCE": "Open source",
   "Tags.ORGANIZATION": "Organisation",
+  "Tags.OthersCombined": "Others Combined",
   "Tags.POLITICS": "Politique",
   "Tags.TECH_MEETUP": "Meetup Tech",
   "Tags.US_NONPROFIT": "Association à but non lucratif américaine",

--- a/lang/it.json
+++ b/lang/it.json
@@ -2695,6 +2695,7 @@
   "Tags.MEDIA": "Media",
   "Tags.OPEN_SOURCE": "Open source",
   "Tags.ORGANIZATION": "Organization",
+  "Tags.OthersCombined": "Others Combined",
   "Tags.POLITICS": "Politics",
   "Tags.TECH_MEETUP": "Tech meetup",
   "Tags.US_NONPROFIT": "US nonprofit",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -2695,6 +2695,7 @@
   "Tags.MEDIA": "Media",
   "Tags.OPEN_SOURCE": "オープンソース",
   "Tags.ORGANIZATION": "Organization",
+  "Tags.OthersCombined": "Others Combined",
   "Tags.POLITICS": "Politics",
   "Tags.TECH_MEETUP": "Tech meetup",
   "Tags.US_NONPROFIT": "US nonprofit",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -2695,6 +2695,7 @@
   "Tags.MEDIA": "미디어",
   "Tags.OPEN_SOURCE": "오픈 소스",
   "Tags.ORGANIZATION": "조직",
+  "Tags.OthersCombined": "Others Combined",
   "Tags.POLITICS": "정치",
   "Tags.TECH_MEETUP": "Tech meetup",
   "Tags.US_NONPROFIT": "미국 비영리",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -2695,6 +2695,7 @@
   "Tags.MEDIA": "Media",
   "Tags.OPEN_SOURCE": "Open source",
   "Tags.ORGANIZATION": "Organization",
+  "Tags.OthersCombined": "Others Combined",
   "Tags.POLITICS": "Politics",
   "Tags.TECH_MEETUP": "Tech meetup",
   "Tags.US_NONPROFIT": "US nonprofit",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -2695,6 +2695,7 @@
   "Tags.MEDIA": "Media",
   "Tags.OPEN_SOURCE": "Open source",
   "Tags.ORGANIZATION": "Organizacja",
+  "Tags.OthersCombined": "Others Combined",
   "Tags.POLITICS": "Polityka",
   "Tags.TECH_MEETUP": "Spotkanie techniczne",
   "Tags.US_NONPROFIT": "Amerykańska organizacja non-profit",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -2695,6 +2695,7 @@
   "Tags.MEDIA": "Mídia",
   "Tags.OPEN_SOURCE": "Código aberto",
   "Tags.ORGANIZATION": "Organização",
+  "Tags.OthersCombined": "Others Combined",
   "Tags.POLITICS": "Política",
   "Tags.TECH_MEETUP": "Encontro técnico",
   "Tags.US_NONPROFIT": "Organização sem fins lucrativos dos EUA",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -2695,6 +2695,7 @@
   "Tags.MEDIA": "Mídia",
   "Tags.OPEN_SOURCE": "Código aberto",
   "Tags.ORGANIZATION": "Organização",
+  "Tags.OthersCombined": "Others Combined",
   "Tags.POLITICS": "Política",
   "Tags.TECH_MEETUP": "Encontro tecnológico",
   "Tags.US_NONPROFIT": "ONG americana",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -2695,6 +2695,7 @@
   "Tags.MEDIA": "Media",
   "Tags.OPEN_SOURCE": "Исходный код",
   "Tags.ORGANIZATION": "Организация",
+  "Tags.OthersCombined": "Others Combined",
   "Tags.POLITICS": "Политика",
   "Tags.TECH_MEETUP": "Tech meetup",
   "Tags.US_NONPROFIT": "Некоммерческая организация США",

--- a/lang/sk-SK.json
+++ b/lang/sk-SK.json
@@ -2695,6 +2695,7 @@
   "Tags.MEDIA": "Médiá",
   "Tags.OPEN_SOURCE": "Otvorený zdrojový kód",
   "Tags.ORGANIZATION": "Organizácia",
+  "Tags.OthersCombined": "Others Combined",
   "Tags.POLITICS": "Politika",
   "Tags.TECH_MEETUP": "Technické stretnutie",
   "Tags.US_NONPROFIT": "Nezisková organizácia v USA",

--- a/lang/sv-SE.json
+++ b/lang/sv-SE.json
@@ -2695,6 +2695,7 @@
   "Tags.MEDIA": "Media",
   "Tags.OPEN_SOURCE": "Öppen källkod",
   "Tags.ORGANIZATION": "Organisation",
+  "Tags.OthersCombined": "Others Combined",
   "Tags.POLITICS": "Politik",
   "Tags.TECH_MEETUP": "Teknikmeetup",
   "Tags.US_NONPROFIT": "Amerikansk ideell förening",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -2695,6 +2695,7 @@
   "Tags.MEDIA": "Медіа",
   "Tags.OPEN_SOURCE": "Open Source",
   "Tags.ORGANIZATION": "Організація",
+  "Tags.OthersCombined": "Others Combined",
   "Tags.POLITICS": "Політика",
   "Tags.TECH_MEETUP": "Tech meetup",
   "Tags.US_NONPROFIT": "Неприбуткова організація США",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -2695,6 +2695,7 @@
   "Tags.MEDIA": "媒体",
   "Tags.OPEN_SOURCE": "开源",
   "Tags.ORGANIZATION": "组织",
+  "Tags.OthersCombined": "Others Combined",
   "Tags.POLITICS": "政策",
   "Tags.TECH_MEETUP": "技术会议",
   "Tags.US_NONPROFIT": "美国非营利",


### PR DESCRIPTION
Requires https://github.com/opencollective/opencollective-api/pull/8976

I tried to truncate this in the SQL query but that would make it considerably more complex. In order to just fix the Collective page, I decided to implement the aggregation in JS.

![Screenshot from 2023-05-29 13-56-05](https://github.com/opencollective/opencollective-frontend/assets/2119706/1b8f0c28-b192-40fe-b2ad-de639d2dbca9)
