### PR TITLE
Improve build caching on CI

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -11,6 +11,7 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version-file: 'package.json'
+        cache: 'npm'
 
     - name: Restore node_modules
       uses: actions/cache@v3
@@ -18,16 +19,6 @@ runs:
       with:
         path: node_modules
         key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}-${{ inputs.CACHE_VERSION }}
-
-    - name: Restore .npm cache
-      if: steps.node-modules.outputs.cache-hit != 'true'
-      uses: actions/cache@v3
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-npm-cache-${{ hashFiles('package-lock.json') }}-${{ inputs.CACHE_VERSION }}
-        restore-keys: |
-          ${{ runner.os }}-npm-cache-${{ hashFiles('package-lock.json') }}-${{ inputs.CACHE_VERSION }}
-          ${{ runner.os }}-npm-cache-
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,9 +102,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .next/cache
-          # Generate a new cache whenever packages or source files change.
+          # Generate a new cache whenever packages or source files change
           key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
-          # If source files changed but packages didn't, rebuild from a prior cache.
+          # If source files changed but packages didn't, rebuild from a prior cache
           restore-keys: |
             ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
             ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-nextjs-${{ hashFiles('**/package-lock.json') }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,23 +98,20 @@ jobs:
         with:
           CACHE_VERSION: ${{ secrets.CACHE_VERSION }}
 
-      - name: Restore .next cache
+      - name: Restore NextJS build cache
         uses: actions/cache@v3
         with:
           path: .next/cache
-          key: ${{ runner.os }}-next-cache-${{ github.sha }}
+          # Generate a new cache whenever packages or source files change.
+          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          # If source files changed but packages didn't, rebuild from a prior cache.
           restore-keys: |
-            ${{ runner.os }}-next-cache-${{ github.sha }}
-            ${{ runner.os }}-next-cache-
-
-      - name: Cache build
-        uses: actions/cache@v3
-        with:
-          path: .next
-          key: ${{ runner.os }}-next-build-${{ github.sha }}
+            ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+            ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
+            ${{ runner.os }}-${{ secrets.CACHE_VERSION }}-nextjs-
 
       - name: Build
-        run: npm run build
+        run: PRESERVE_NEXT_CACHE=true npm run build
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
+          cache: 'npm'
 
       # If this run was triggered by a pull request event, then checkout
       # the head of the pull request instead of the merge commit.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -86,17 +86,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
-
-      # Npm cache
-
-      - name: Restore .npm cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-npm-cache-${{ github.sha }}
-          restore-keys: |
-            - ${{ runner.os }}-npm-cache-${{ github.sha }}
-            - ${{ runner.os }}-npm-cache-
+          cache: 'npm'
 
       # Checkouts
 

--- a/scripts/build_next.sh
+++ b/scripts/build_next.sh
@@ -11,5 +11,11 @@ next build || exit 1
 
 echo "> Copying .next to dist folder"
 
-shx rm -rf .next/cache
+# We have to remove the cache to prevent issues with heroku slug size: https://github.com/opencollective/opencollective-frontend/pull/8661
+# Check env to not remove cache on CI (it's cached)
+if [ "$PRESERVE_NEXT_CACHE" != "true" ]; then
+  echo "Removing .next/cache"
+  shx rm -rf .next/cache
+fi
+
 shx cp -R .next $DIST


### PR DESCRIPTION
Inspired by https://nextjs.org/docs/pages/building-your-application/deploying/ci-build-caching, this PR changes the NextJS build folder (`.next/cache`) caching strategy on CI.

1. The build cache was not working because we always remove the `.next/cache` folder in https://github.com/opencollective/opencollective-frontend/blob/7af023a7cbe54717b768c882a11aac5f80ba6fcc/scripts/build_next.sh#L14
![image](https://github.com/opencollective/opencollective-frontend/assets/1556356/6dc7b861-8e0a-448a-a67c-69c17736ea2d)
2. By caching on the content hash rather than the commit `sha`, we will hopefully store fewer cache entries.
3. Don't cache the entire `.next` folder




[Compared to `main`](https://github.com/opencollective/opencollective-frontend/actions/runs/5130853056/jobs/9230191937), it surfaces this change can save up to 3 minutes on the build step.

It will also hopefully help with our CI cache being too large since we won't store `.next` entirely anymore, and caching on content hash rather than commit # should generate fewer entries.

![image](https://github.com/opencollective/opencollective-frontend/assets/1556356/c3afac04-d574-4ae5-98ca-33cb6d43d9d7)