### PR TITLE
Fix(FilesViewer): make pdfjs worker available through custom server

### DIFF
--- a/server/routes.js
+++ b/server/routes.js
@@ -160,5 +160,8 @@ module.exports = (expressApp, nextApp) => {
     );
   });
 
+  // TODO(ESM): Can be removed when moving to ESM bundling this file in another way (for react-pdf)
+  app.use('/pdf.worker.min.js', express.static(path.join(__dirname, '../public/pdf.worker.min.js')));
+
   return nextApp.getRequestHandler();
 };


### PR DESCRIPTION
Follow up from #8899.

The pdfjs worker was not served on the staging frontend server, this should ensure that it is.
