### PR TITLE
ExpenseForm: prevent double submit

### DIFF
--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -501,7 +501,8 @@ const ExpenseFormBody = ({
         disabled={!stepTwoCompleted || !formik.isValid}
         loading={formik.isSubmitting}
         onClick={() => {
-          if (formRef.current) {
+          // When used inside the drawer, the submit button is rendered outside the form (with a portal). The form must be manually submitted.
+          if (drawerActionsContainer && formRef.current) {
             formRef.current.requestSubmit();
           }
         }}


### PR DESCRIPTION
Resolve https://opencollective.slack.com/archives/GFH4N961L/p1685688920513489

The `submit` button being inside the form, there is normally no need to manually trigger the submit.