### PR TITLE
Increase wait for order status

### DIFF
--- a/test/cypress/integration/13-contributeFlow-stripePaymentElement.test.js
+++ b/test/cypress/integration/13-contributeFlow-stripePaymentElement.test.js
@@ -56,7 +56,7 @@ function waitOrderStatus(status = 'PAID') {
       }
     },
     {
-      maxAttempts: 10,
+      maxAttempts: 30,
       wait: 6000,
     },
   );


### PR DESCRIPTION
Stripe e2e tests are flaky when the order status is not transitioned to PAID in the current timeout. Increasing timeout to see if it helps.
