### PR TITLE
chore(LostPixel): remove custom screenshot config

### DIFF
--- a/lostpixel.config.ts
+++ b/lostpixel.config.ts
@@ -7,14 +7,4 @@ export const config: Partial<CustomProjectConfig> = {
   },
   lostPixelProjectId: process.env.LOST_PIXEL_PROJECT_ID,
   apiKey: process.env.LOST_PIXEL_API_KEY,
-  beforeScreenshot: async page => {
-    await page.addStyleTag({
-      content: `
-        * {
-          animation-play-state: paused !important;
-          animation: none !important;
-        }
-      `,
-    });
-  },
 };


### PR DESCRIPTION
It seems that the actual fix in https://github.com/opencollective/opencollective-frontend/pull/8940 was to move `LoadingGrid` from SVG animation to CSS animation. According to https://github.com/lost-pixel/lost-pixel/issues/268#issuecomment-1578329939, CSS animations are already paused when taking screenshots.