### PR TITLE
Fix undefined slug when navigating through workspace Expense page

### DIFF
--- a/components/expenses/ExpensesPage.tsx
+++ b/components/expenses/ExpensesPage.tsx
@@ -33,7 +33,7 @@ const Expenses = props => {
   const { query, LoggedInUser, data, loading, variables, refetch, isDashboard, onlySubmittedExpenses } = props;
 
   const expensesRoute = isDashboard
-    ? `/dashboard/${data?.account?.slug}/expenses`
+    ? `/dashboard/${variables.collectiveSlug}/expenses`
     : `${getCollectivePageRoute(data?.account)}/expenses`;
 
   useEffect(() => {
@@ -241,6 +241,7 @@ Expenses.propTypes = {
     offset: PropTypes.number.isRequired,
     limit: PropTypes.number.isRequired,
     account: PropTypes.object,
+    collectiveSlug: PropTypes.string,
   }),
   data: PropTypes.shape({
     account: PropTypes.shape({


### PR DESCRIPTION
This should be safe and backward-compatible with the admin page.