### PR TITLE
Fix StyledFilters callback memoization

### DIFF
--- a/components/StyledFilters.tsx
+++ b/components/StyledFilters.tsx
@@ -103,7 +103,7 @@ export default function StyledFilters(props: StyledFiltersProps) {
         }
       }
     },
-    [selected, multiSelect],
+    [selected, multiSelect, onChange],
   );
 
   const isSelected = React.useCallback(


### PR DESCRIPTION
Fix https://opencollective.slack.com/archives/C0471HKNW7J/p1686809511012779

> navigating from https://opencollective.com/opencollective-oss-fund/expenses to "Submitted" is crashing.

Since we were not watching for `onChange` in `useCallback`, the `onChange` event was triggered with a context where `data.account` was not loaded yet, resulting in a redirection to `/expenses` rather than `/${data.accounts.slug}/expenses`.