### PR TITLE
Make Sure Default Query Parameters on Embed Do not Crash the Contribution Flow

### DIFF
--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -218,7 +218,7 @@ class ContributionFlow extends React.Component {
           this.props.paymentFlow === PAYMENT_FLOW.CRYPTO,
           this.props.isEmbed,
         );
-        if (!isEqual(currentUrlState, omitBy(expectedUrlState, isNil))) {
+        if (!isEqual(omitBy(currentUrlState, isNil), omitBy(expectedUrlState, isNil))) {
           const route = this.getRoute(currentStepName);
           const queryHelper = this.getQueryHelper();
           this.props.router.replace(


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/6838

Related freshdesk Issue: https://opencollective.freshdesk.com/a/tickets/216040

[embed-contribution-flow.webm](https://github.com/opencollective/opencollective-frontend/assets/12435965/12cf9fae-8a11-4eea-a5b7-c3f534c7c56f)
