### PR TITLE
Workspace: Fix instant loading of the root url for both dashboard and landing page

### DIFF
--- a/components/dashboard/AccountSwitcher.tsx
+++ b/components/dashboard/AccountSwitcher.tsx
@@ -6,7 +6,6 @@ import { ChevronUpDown } from '@styled-icons/heroicons-outline/ChevronUpDown';
 import { css } from '@styled-system/css';
 import { flatten, groupBy, uniqBy } from 'lodash';
 import memoizeOne from 'memoize-one';
-import { useRouter } from 'next/router';
 import { useIntl } from 'react-intl';
 import styled from 'styled-components';
 
@@ -170,13 +169,9 @@ MenuEntry.propTypes = {
   activeSlug: PropTypes.string,
 };
 
-const AccountSwitcher = () => {
+const AccountSwitcher = ({ activeSlug }) => {
   const { LoggedInUser } = useLoggedInUser();
   const intl = useIntl();
-  const router = useRouter();
-  const { slug } = router.query;
-  const activeSlug = Array.isArray(slug) ? slug[0] : slug;
-
   const loggedInUserCollective = LoggedInUser?.collective;
 
   const groupedAccounts = getGroupedAdministratedAccounts(LoggedInUser);

--- a/components/dashboard/SideBar.js
+++ b/components/dashboard/SideBar.js
@@ -20,12 +20,20 @@ const Sticky = styled.div`
   top: 0;
 `;
 
-const AdminPanelSideBar = ({ collective, isAccountantOnly, isLoading, selectedSection, onRoute, ...props }) => {
+const AdminPanelSideBar = ({
+  activeSlug,
+  collective,
+  isAccountantOnly,
+  isLoading,
+  selectedSection,
+  onRoute,
+  ...props
+}) => {
   return (
     <SidebarContainer {...props}>
       <Sticky>
         <MenuContainer>
-          <AccountSwitcher collective={collective} isLoading={isLoading} />
+          <AccountSwitcher activeSlug={activeSlug} isLoading={isLoading} />
           {isLoading ? (
             <Box py={3}>
               {[...Array(5).keys()].map(i => (
@@ -59,6 +67,7 @@ AdminPanelSideBar.propTypes = {
   }),
   isAccountantOnly: PropTypes.bool,
   onRoute: PropTypes.func,
+  activeSlug: PropTypes.string,
 };
 
 export default AdminPanelSideBar;

--- a/components/dashboard/index.js
+++ b/components/dashboard/index.js
@@ -3,24 +3,24 @@ import { useQuery } from '@apollo/client';
 import { useRouter } from 'next/router';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
-import { isHostAccount } from '../lib/collective.lib';
-import roles from '../lib/constants/roles';
-import { API_V2_CONTEXT } from '../lib/graphql/helpers';
-import useLoggedInUser from '../lib/hooks/useLoggedInUser';
-import { require2FAForAdmins } from '../lib/policies';
+import { isHostAccount } from '../../lib/collective.lib';
+import roles from '../../lib/constants/roles';
+import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
+import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
+import { require2FAForAdmins } from '../../lib/policies';
 
-import { ALL_SECTIONS, SECTIONS_ACCESSIBLE_TO_ACCOUNTANTS } from '../components/dashboard/constants';
-import { DashboardContext } from '../components/dashboard/DashboardContext';
-import AdminPanelSection from '../components/dashboard/DashboardSection';
-import { adminPanelQuery } from '../components/dashboard/queries';
-import AdminPanelSideBar from '../components/dashboard/SideBar';
-import AdminPanelTopBar from '../components/dashboard/TopBar';
-import { Box, Flex } from '../components/Grid';
-import MessageBox from '../components/MessageBox';
-import NotificationBar from '../components/NotificationBar';
-import Page from '../components/Page';
-import SignInOrJoinFree from '../components/SignInOrJoinFree';
-import { TwoFactorAuthRequiredMessage } from '../components/TwoFactorAuthRequiredMessage';
+import { ALL_SECTIONS, SECTIONS_ACCESSIBLE_TO_ACCOUNTANTS } from '../dashboard/constants';
+import { DashboardContext } from '../dashboard/DashboardContext';
+import AdminPanelSection from '../dashboard/DashboardSection';
+import { adminPanelQuery } from '../dashboard/queries';
+import AdminPanelSideBar from '../dashboard/SideBar';
+import AdminPanelTopBar from '../dashboard/TopBar';
+import { Box, Flex } from '../Grid';
+import MessageBox from '../MessageBox';
+import NotificationBar from '../NotificationBar';
+import Page from '../Page';
+import SignInOrJoinFree from '../SignInOrJoinFree';
+import { TwoFactorAuthRequiredMessage } from '../TwoFactorAuthRequiredMessage';
 
 const messages = defineMessages({
   collectiveIsArchived: {
@@ -104,18 +104,15 @@ const DashboardPage = () => {
   const router = useRouter();
   const { slug, section, subpath } = router.query;
   const { LoggedInUser, loadingLoggedInUser } = useLoggedInUser();
-
+  const activeSlug = slug || LoggedInUser?.getLastDashboardSlug();
   // Redirect to the dashboard of the logged in user if no slug is provided
   useEffect(() => {
-    if (!slug && LoggedInUser) {
-      router.replace(`/dashboard/${LoggedInUser.getLastDashboardSlug()}`);
-    }
     if (slug) {
       LoggedInUser?.saveLastDashboardSlug(slug);
     }
   }, [slug, LoggedInUser]);
 
-  const { data, loading } = useQuery(adminPanelQuery, { context: API_V2_CONTEXT, variables: { slug } });
+  const { data, loading } = useQuery(adminPanelQuery, { context: API_V2_CONTEXT, variables: { slug: activeSlug } });
   const account = data?.account;
   const notification = getNotification(intl, account);
   const selectedSection = section || getDefaultSectionForAccount(account, LoggedInUser);
@@ -131,7 +128,7 @@ const DashboardPage = () => {
           <AdminPanelTopBar
             isLoading={isLoading}
             collective={data?.account}
-            collectiveSlug={slug}
+            collectiveSlug={activeSlug}
             selectedSection={selectedSection}
             display={['flex', null, 'none']}
           />
@@ -155,6 +152,7 @@ const DashboardPage = () => {
             <AdminPanelSideBar
               isLoading={isLoading}
               collective={account}
+              activeSlug={activeSlug}
               selectedSection={selectedSection}
               display={['none', 'none', 'block']}
               isAccountantOnly={getIsAccountantOnly(LoggedInUser, account)}
@@ -177,12 +175,6 @@ const DashboardPage = () => {
       </Page>
     </DashboardContext.Provider>
   );
-};
-
-DashboardPage.getInitialProps = () => {
-  return {
-    scripts: { googleMaps: true }, // TODO: This should be enabled only for events
-  };
 };
 
 export default DashboardPage;

--- a/rewrites.js
+++ b/rewrites.js
@@ -128,11 +128,11 @@ exports.REWRITES = [
   },
   {
     source: '/dashboard',
-    destination: '/dashboard',
+    destination: '/home',
   },
   {
     source: '/dashboard/:slug/:section?/:subpath*',
-    destination: '/dashboard',
+    destination: '/home',
   },
   {
     source: '/:parentCollectiveSlug?/:collectiveType(events|projects)?/:slug/admin/:section?/:subpath*',


### PR DESCRIPTION
# Description

- The intended behavior when going to the root is to end up in the dashboard if you are logged in, currently we achieve this with a redirect, but that creates a bit of a yanky experience.
- This PR uses the same Next.js page for landing page and dashboard to prevent that and get a more direct experience.
- The trade-off to consider is that the landing page grows a bit in size.
- Perhaps a solution to that is to refactor the dashboard page to not contain all the dashboard pages (either as other pages or dynamically import sections)

## To do
- [ ] check impact on page size
- [ ] consider ways to reduce size of dashboard
- [ ] other approaches?