### PR TITLE
Invoice statements

### DIFF
--- a/components/expenses/ExpenseFormItems.js
+++ b/components/expenses/ExpenseFormItems.js
@@ -161,6 +161,7 @@ class ExpenseFormItems extends React.PureComponent {
     const { values, errors, setFieldValue } = this.props.form;
     const requireFile = attachmentRequiresFile(values.type);
     const isGrant = values.type === expenseTypes.GRANT;
+    const isInvoice = values.type === expenseTypes.INVOICE;
     const isCreditCardCharge = values.type === expenseTypes.CHARGE;
     const items = values.items || [];
     const hasItems = items.length > 0;
@@ -213,6 +214,7 @@ class ExpenseFormItems extends React.PureComponent {
             hasMultiCurrency={!index && availableCurrencies?.length > 1} // Only display currency picker for the first item
             availableCurrencies={availableCurrencies}
             onCurrencyChange={async value => await this.onCurrencyChange(value)}
+            isInvoice={isInvoice}
             isLastItem={index === items.length - 1}
           />
         ))}

--- a/components/expenses/ExpenseItemForm.js
+++ b/components/expenses/ExpenseItemForm.js
@@ -30,6 +30,10 @@ export const msg = defineMessages({
     id: 'Fields.description',
     defaultMessage: 'Description',
   },
+  invoiceDescriptionLabel: {
+    id: 'Fields.InvoiceDescription',
+    defaultMessage: 'Specify item or activity and timeframe, e.g. "Volunteer Training, April 2023"',
+  },
   amountLabel: {
     id: 'Fields.amount',
     defaultMessage: 'Amount',
@@ -125,6 +129,7 @@ const ExpenseItemForm = ({
   hasMultiCurrency,
   availableCurrencies,
   onCurrencyChange,
+  isInvoice,
   isLastItem,
 }) => {
   const intl = useIntl();
@@ -176,7 +181,7 @@ const ExpenseItemForm = ({
             name={getFieldName('description')}
             error={getError('description')}
             htmlFor={`${attachmentKey}-description`}
-            label={formatMessage(msg.descriptionLabel)}
+            label={formatMessage(isInvoice ? msg.invoiceDescriptionLabel : msg.descriptionLabel)}
             labelFontSize="13px"
             required={!isOptional}
           >
@@ -311,6 +316,8 @@ ExpenseItemForm.propTypes = {
   onCurrencyChange: PropTypes.func.isRequired,
   /** For multi-currency expenses */
   availableCurrencies: PropTypes.arrayOf(PropTypes.string),
+  /** Is it an invoice */
+  isInvoice: PropTypes.bool,
   /** the attachment data */
   attachment: PropTypes.shape({
     id: PropTypes.string,


### PR DESCRIPTION
# Description

Over 15% of all incomplete cases are due to insufficient invoice statements, based on a sample of 30% of incomplete cases from January to May on OSC, OCF and OCE.

<img width="833" alt="Screenshot 2023-06-29 at 17 09 29" src="https://github.com/opencollective/opencollective-frontend/assets/7785081/6eef2076-c8b4-4a3c-9ddc-60d4d9a2e799">

<img width="856" alt="Screenshot 2023-06-29 at 17 10 42" src="https://github.com/opencollective/opencollective-frontend/assets/7785081/7ce66651-9fa1-4801-bd7e-f23dcd34096f">

Usually, these cases are resolved after host admins ask expense submitters to elaborate with a canned response - [see example](https://opencollective.com/pixelfed/expenses/139367).

If we can improve on this with a small low-cost change to give the users more instructions, that would be a low cost high reward improvement. 

This PR is only an update of the label for the invoice item on the submission form, changing it from "Description" to:

`Specify item or activity and timeframe, e.g. "Volunteer Training, April 2023"`

To only change the label for invoices and not receipts, this PR also introduces some additional small changes. 

# Screenshots

Old
<img width="714" alt="Screenshot 2023-06-29 at 17 13 39" src="https://github.com/opencollective/opencollective-frontend/assets/7785081/8690dbb3-d8d2-4ea7-95c3-7eb68a173b74">

New
<img width="703" alt="Screenshot 2023-06-29 at 17 13 04" src="https://github.com/opencollective/opencollective-frontend/assets/7785081/e31a66ca-0fd0-4b08-ac72-005d2a385344">

