### PR TITLE
PayExpenseModal: Improve validations

### DIFF
--- a/components/expenses/PayExpenseModal.js
+++ b/components/expenses/PayExpenseModal.js
@@ -189,6 +189,7 @@ const getInitialValues = (expense, host, payoutMethodType) => {
     ...DEFAULT_VALUES,
     ...getPayoutOptionValue(payoutMethodType, true, host),
     feesPayer: expense.feesPayer || DEFAULT_VALUES.feesPayer,
+    totalAmountPaidInHostCurrency: expense.currency === host.currency ? expense.amount : null,
   };
 };
 
@@ -284,7 +285,7 @@ const PayExpenseModal = ({ onClose, onSubmit, expense, collective, host, error, 
                 ...formik.values,
                 ...getPayoutOptionValue(payoutMethodType, item === 'AUTO', host),
                 paymentProcessorFeeInHostCurrency: null,
-                totalAmountPaidInHostCurrency: null,
+                totalAmountPaidInHostCurrency: expense.currency === host.currency ? expense.amount : null,
                 feesPayer: !getCanCustomizeFeesPayer(expense, collective, hasManualPayment, null, LoggedInUser.isRoot)
                   ? DEFAULT_VALUES.feesPayer // Reset fees payer if can't customize
                   : formik.values.feesPayer,
@@ -331,7 +332,7 @@ const PayExpenseModal = ({ onClose, onSubmit, expense, collective, host, error, 
                   data-cy="total-amount-paid"
                   placeholder="0.00"
                   maxWidth="100%"
-                  min={0}
+                  min={1}
                   onChange={value => formik.setFieldValue('totalAmountPaidInHostCurrency', value)}
                 />
               )}
@@ -360,7 +361,7 @@ const PayExpenseModal = ({ onClose, onSubmit, expense, collective, host, error, 
                   placeholder="0.00"
                   maxWidth="100%"
                   min={0}
-                  max={100000000}
+                  max={formik.values.totalAmountPaidInHostCurrency || 100000000}
                   onChange={value => formik.setFieldValue('paymentProcessorFeeInHostCurrency', value)}
                 />
               )}


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/6744

- Pre-fill amount
- Prevent entering a payment processor fee bigger than the total amount 
![image](https://github.com/opencollective/opencollective-frontend/assets/1556356/c0a74410-0f38-41fa-9ec0-1ec5ea2c4f07)
- Prevent entering `0` as total amount 
![image](https://github.com/opencollective/opencollective-frontend/assets/1556356/5661f6ad-5d4c-4da2-8545-66e8990f56f9)
