### PR TITLE
Add back pending application banner for children accounts

### DIFF
--- a/components/collective-page/CollectiveNotificationBar.js
+++ b/components/collective-page/CollectiveNotificationBar.js
@@ -160,7 +160,7 @@ const getNotification = (intl, status, collective, host, LoggedInUser, refetch) 
       type: 'warning',
       inline: true,
     };
-  } else if (!collective.isApproved && collective.host && collective.type === CollectiveType.COLLECTIVE) {
+  } else if (!collective.isApproved && collective.host) {
     return {
       title: intl.formatMessage(messages.approvalPending),
       description: intl.formatMessage(messages.approvalPendingDescription, { host: collective.host.name }),


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/6471

See https://opencollective-frontend-oko39c19j-opencollective.vercel.app/testdsasadsad/events/testdsadas-8ed651df