### PR TITLE
Collective Page: restore legacy loading state

### DIFF
--- a/components/collective-page/BudgetStats.js
+++ b/components/collective-page/BudgetStats.js
@@ -234,9 +234,9 @@ BudgetStats.propTypes = {
 
   /** Stats */
   stats: PropTypes.shape({
-    balance: AmountPropTypeShape.isRequired,
-    consolidatedBalance: AmountPropTypeShape.isRequired,
-    yearlyBudget: AmountPropTypeShape.isRequired,
+    balance: AmountPropTypeShape,
+    consolidatedBalance: AmountPropTypeShape,
+    yearlyBudget: AmountPropTypeShape,
     activeRecurringContributions: PropTypes.object,
     totalAmountReceived: AmountPropTypeShape,
     totalAmountRaised: AmountPropTypeShape,

--- a/pages/collective-page.js
+++ b/pages/collective-page.js
@@ -91,7 +91,7 @@ class CollectivePage extends React.Component {
     data: PropTypes.shape({
       loading: PropTypes.bool,
       error: PropTypes.any,
-      account: PropTypes.object,
+      previousData: PropTypes.object,
       Collective: PropTypes.shape({
         name: PropTypes.string,
         type: PropTypes.string.isRequired,
@@ -145,23 +145,21 @@ class CollectivePage extends React.Component {
     const { slug, data, LoggedInUser, status, step, mode, action } = this.props;
     const { showOnboardingModal } = this.state;
 
-    const loading = data.loading && !data.Collective;
-
+    const collective = data?.Collective || data?.previousData?.Collective;
+    const loading = data.loading && !collective;
     if (!loading) {
       if (!data || data.error) {
         return <ErrorPage data={data} />;
-      } else if (!data.Collective) {
+      } else if (!collective) {
         return <ErrorPage error={generateNotFoundError(slug)} log={false} />;
-      } else if (data.Collective.isPledged && !data.Collective.isActive) {
-        return <PledgedCollectivePage collective={data.Collective} />;
-      } else if (data.Collective.isIncognito) {
-        return <IncognitoUserCollective collective={data.Collective} />;
-      } else if (data.Collective.isGuest) {
-        return <GuestUserProfile account={data.Collective} />;
+      } else if (collective.isPledged && !collective.isActive) {
+        return <PledgedCollectivePage collective={collective} />;
+      } else if (collective.isIncognito) {
+        return <IncognitoUserCollective collective={collective} />;
+      } else if (collective.isGuest) {
+        return <GuestUserProfile account={collective} />;
       }
     }
-
-    const collective = data && data.Collective;
 
     // Don't allow /collective/apply
     if (action === 'apply' && !collective?.isHost) {


### PR DESCRIPTION
In previous versions of Apollo, when re-fetching (i.e after a route change), `data` contained a reference to fetched items until fresher entries replaced them. In its current version, Apollo unsets previously fetched data while loading, and makes it available through `data.previousData`.

This PR restores the legacy behavior of not showing a loading spinner while navigating from one profile to the other.