### PR TITLE
Move Captcha into StepProfileGuest

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -220,7 +220,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: screenshots
-          path: test/cypress/screenshots
+          path: opencollective-frontend/test/cypress/screenshots
         if: ${{ failure() }}
 
       - name: Report Coverage

--- a/components/contribution-flow/StepProfileGuestForm.js
+++ b/components/contribution-flow/StepProfileGuestForm.js
@@ -4,6 +4,7 @@ import { set } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import { isEmail } from 'validator';
 
+import Captcha, { isCaptchaEnabled } from '../Captcha';
 import Container from '../Container';
 import { Flex } from '../Grid';
 import I18nFormatters, { getI18nLink } from '../I18nFormatters';
@@ -129,6 +130,11 @@ const StepProfileGuestForm = ({ stepDetails, onChange, data, isEmbed, onSignInCl
           />
         )}
       </StyledInputField>
+      {isCaptchaEnabled() && (
+        <Flex mt="18px" justifyContent="center">
+          <Captcha onVerify={result => dispatchChange('captcha', result)} />
+        </Flex>
+      )}
       {contributionRequiresAddress(stepDetails, tier) && (
         <React.Fragment>
           <Flex alignItems="center" my="14px">

--- a/components/contribution-flow/StepProfileGuestForm.js
+++ b/components/contribution-flow/StepProfileGuestForm.js
@@ -32,6 +32,10 @@ export const validateGuestProfile = (stepProfile, stepDetails, tier) => {
     }
   }
 
+  if (isCaptchaEnabled() && !stepProfile.captcha) {
+    return false;
+  }
+
   if (!stepProfile.email || !isEmail(stepProfile.email)) {
     return false;
   } else {

--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -542,6 +542,11 @@ class ContributionFlow extends React.Component {
     if (!stepProfile) {
       return action === 'prev';
     } else if (stepProfile.isGuest) {
+      if (isCaptchaEnabled() && !stepProfile.captcha) {
+        this.setState({ error: this.props.intl.formatMessage({ defaultMessage: 'Captcha is required.' }) });
+        window.scrollTo(0, 0);
+        return false;
+      }
       return validateGuestProfile(stepProfile, stepDetails, this.props.tier);
     }
 

--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -4,7 +4,7 @@ import { gql } from '@apollo/client';
 import { graphql } from '@apollo/client/react/hoc';
 import { getApplicableTaxes } from '@opencollective/taxes';
 import { CardElement } from '@stripe/react-stripe-js';
-import { get, intersection, isEmpty, isEqual, isNil, omitBy, pick, set } from 'lodash';
+import { get, intersection, isEmpty, isEqual, isNil, omitBy, pick } from 'lodash';
 import memoizeOne from 'memoize-one';
 import { withRouter } from 'next/router';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
@@ -29,10 +29,10 @@ import { followOrderRedirectUrl, getCollectivePageRoute } from '../../lib/url-he
 import { reportValidityHTML5 } from '../../lib/utils';
 
 import { isValidExternalRedirect } from '../../pages/external-redirect';
-import Captcha, { isCaptchaEnabled } from '../Captcha';
+import { isCaptchaEnabled } from '../Captcha';
 import Container from '../Container';
 import ContributeFAQ from '../faqs/ContributeFAQ';
-import { Box, Flex, Grid } from '../Grid';
+import { Box, Grid } from '../Grid';
 import Loading from '../Loading';
 import MessageBox from '../MessageBox';
 import Steps from '../Steps';
@@ -142,7 +142,6 @@ class ContributionFlow extends React.Component {
     super(props);
     this.mainContainerRef = React.createRef();
     this.formRef = React.createRef();
-    this.captchaRef = React.createRef();
 
     const { collective, tier, LoggedInUser } = props;
     const queryParams = this.getQueryParams();
@@ -365,10 +364,6 @@ class ContributionFlow extends React.Component {
 
   handleError = message => {
     this.setState({ isSubmitting: false, error: message });
-    if (isCaptchaEnabled() && !this.props.LoggedInUser) {
-      this.setState({ stepProfile: set(this.state.stepProfile, 'captcha', null) });
-      this.captchaRef?.current?.resetCaptcha();
-    }
   };
 
   handleStripeError = async (order, stripeError, email, guestToken) => {
@@ -851,7 +846,6 @@ class ContributionFlow extends React.Component {
     const { error, isSubmitted, isSubmitting, stepDetails, stepSummary, stepProfile, stepPayment } = this.state;
     const isLoading = isSubmitted || isSubmitting;
     const pastEvent = collective.type === CollectiveType.EVENT && isPastEvent(collective);
-    const shouldDisplayCaptcha = isCaptchaEnabled() && !LoggedInUser && stepPayment?.key === NEW_CREDIT_CARD_KEY;
     const queryParams = this.getQueryParams();
     const currency = tier?.amount.currency || collective.currency;
     const currentStepName = this.getCurrentStepName();
@@ -962,14 +956,6 @@ class ContributionFlow extends React.Component {
                     hideCreditCardPostalCode={queryParams.hideCreditCardPostalCode}
                     contributeProfiles={this.getContributeProfiles(LoggedInUser, collective, tier)}
                   />
-                  {!nextStep && shouldDisplayCaptcha && (
-                    <Flex mt={40} justifyContent="center">
-                      <Captcha
-                        ref={this.captchaRef}
-                        onVerify={result => this.setState({ stepProfile: set(stepProfile, 'captcha', result) })}
-                      />
-                    </Flex>
-                  )}
                   <Box mt={40}>
                     <ContributionFlowButtons
                       goNext={goNext}

--- a/test/cypress/integration/13-contributionFlow.contribute.test.js
+++ b/test/cypress/integration/13-contributionFlow.contribute.test.js
@@ -89,6 +89,9 @@ describe('Contribution Flow: Order', () => {
       // Country required since we're contributing > $500
       cy.getByDataCy('country-select').click();
       cy.contains('[data-cy="select-option"]', 'Algeria').click();
+      cy.get('input[data-cy="address-address1"]').type('Street Name, 123');
+      cy.get('input[data-cy="address-postalCode"]').type('123');
+      cy.get('input[data-cy="address-city"]').type('Citycitycity');
       cy.get('button[data-cy="cf-next-step"]').click();
 
       // ---- Step 3: Payment ----


### PR DESCRIPTION
This should help with the broken UX when a guest user is donating to a host using Stripe's payment method form. In the current implementation, the user needs to fail the Captcha test when creating the payment intent and then check the Captcha in order to render the form. In this implementation, the captcha is checked at the previous step and used to generate the form or to submit the createOrder request using the legacy credit card form.

![image](https://github.com/opencollective/opencollective-frontend/assets/2119706/82d8ba14-a141-4e38-9376-229d05c7889c)
