### PR TITLE
Ignore SWC in Vercel functions

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -19,6 +19,11 @@ const nextConfig = {
   images: {
     disableStaticImages: true,
   },
+  experimental: {
+    outputFileTracingExcludes: {
+      '*': ['node_modules/@swc/core-linux-x64-gnu', 'node_modules/@swc/core-linux-x64-musl'],
+    },
+  },
   webpack: (config, { webpack, buildId }) => {
     config.plugins.push(
       // Ignore __tests__


### PR DESCRIPTION
As suggested in https://github.com/orgs/vercel/discussions/103#discussioncomment-5427097

To solve the issue:

> The Serverless Function "404" is 51.8mb which exceeds the maximum size limit of 50mb. Learn More: https://vercel.link/serverless-function-size