### PR TITLE
Remove babel-plugin-lodash

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -15,7 +15,6 @@
   "plugins": [
     "babel-plugin-react-docgen",
     "babel-plugin-styled-components",
-    "lodash",
     [
       "babel-plugin-formatjs",
       {

--- a/components/accept-financial-contributions/AcceptContributionsOurselvesOrOrg.js
+++ b/components/accept-financial-contributions/AcceptContributionsOurselvesOrOrg.js
@@ -4,7 +4,7 @@ import { gql } from '@apollo/client';
 import { graphql } from '@apollo/client/react/hoc';
 import { PlusCircle } from '@styled-icons/boxicons-regular/PlusCircle';
 import { Form, Formik } from 'formik';
-import { compose, uniqBy } from 'lodash';
+import { uniqBy } from 'lodash';
 import { withRouter } from 'next/router';
 import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
@@ -13,6 +13,7 @@ import { CollectiveType } from '../../lib/constants/collectives';
 import { BANK_TRANSFER_DEFAULT_INSTRUCTIONS } from '../../lib/constants/payout-method';
 import { getErrorFromGraphqlException } from '../../lib/errors';
 import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
+import { compose } from '../../lib/utils';
 
 import Avatar from '../Avatar';
 import CollectiveNavbar from '../collective-navbar';

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,7 +147,6 @@
         "babel-loader": "^8.2.3",
         "babel-plugin-formatjs": "^10.5.0",
         "babel-plugin-istanbul": "^6.1.1",
-        "babel-plugin-lodash": "^3.3.4",
         "babel-plugin-react-docgen": "^4.2.1",
         "babel-plugin-react-remove-properties": "^0.3.0",
         "babel-plugin-styled-components": "^2.1.1",
@@ -12360,37 +12359,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/babel-plugin-lodash": {
-      "version": "3.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0-beta.49",
-        "@babel/types": "^7.0.0-beta.49",
-        "glob": "^7.1.1",
-        "lodash": "^4.17.10",
-        "require-package-name": "^2.0.1"
-      }
-    },
-    "node_modules/babel-plugin-lodash/node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -29396,11 +29364,6 @@
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/require-package-name": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/requires-port": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -206,7 +206,6 @@
     "babel-loader": "^8.2.3",
     "babel-plugin-formatjs": "^10.5.0",
     "babel-plugin-istanbul": "^6.1.1",
-    "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-react-docgen": "^4.2.1",
     "babel-plugin-react-remove-properties": "^0.3.0",
     "babel-plugin-styled-components": "^2.1.1",

--- a/pages/create-expense.js
+++ b/pages/create-expense.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { gql } from '@apollo/client';
 import { graphql } from '@apollo/client/react/hoc';
-import { compose, omit } from 'lodash';
+import { omit } from 'lodash';
 import { withRouter } from 'next/router';
 import { FormattedMessage, injectIntl } from 'react-intl';
 
@@ -15,7 +15,7 @@ import FormPersister from '../lib/form-persister';
 import { API_V2_CONTEXT } from '../lib/graphql/helpers';
 import { addParentToURLIfMissing, getCollectivePageCanonicalURL } from '../lib/url-helpers';
 import UrlQueryHelper from '../lib/UrlQueryHelper';
-import { parseToBoolean } from '../lib/utils';
+import { compose, parseToBoolean } from '../lib/utils';
 
 import CollectiveNavbar from '../components/collective-navbar';
 import { Dimensions } from '../components/collective-page/_constants';


### PR DESCRIPTION
Resolves the following warning:

> Trace: `isModuleDeclaration` has been deprecated, please migrate to `isImportOrExportDeclaration`.

Even though it increases the bundle size, running with a deprecated version of lodash sounds like a bad idea; issues (including security) get fixed regularly, and we're not benefiting from them.

## About bundle size

+15kb on average.

```diff
--- <unnamed>
+++ <unnamed>
@@ -1,89 +1,89 @@
 Route (pages)                                Size     First Load JS
-┌   /_app                                    0 B             663 kB
-├ λ /404                                     2.51 kB         790 kB
-├ λ /accept-financial-contributions          32.2 kB        1.14 MB
-├ λ /admin-panel                             6.63 kB        1.59 MB
-├ λ /api/connected-accounts/github/callback  0 B             663 kB
-├ λ /api/connected-accounts/github/oauthUrl  0 B             663 kB
-├ λ /api/docs/search                         0 B             663 kB
-├ λ /api/download-file                       0 B             663 kB
-├ λ /api/github-repositories                 0 B             663 kB
-├ λ /api/graphql/v1                          0 B             663 kB
-├ λ /api/graphql/v2                          0 B             663 kB
-├ λ /api/users/exchange-login-token          0 B             663 kB
-├ λ /api/users/exists                        0 B             663 kB
-├ λ /api/users/refresh-token                 0 B             663 kB
-├ λ /api/users/signin                        0 B             663 kB
-├ λ /api/users/two-factor-auth               0 B             663 kB
-├ λ /api/users/update-token                  0 B             663 kB
-├ λ /applications                            4.64 kB         839 kB
-├ λ /banner-iframe                           13.8 kB         689 kB
-├ λ /become-a-host                           6.78 kB         799 kB
-├ λ /become-a-sponsor                        8.04 kB         795 kB
-├ λ /button                                  1.23 kB         664 kB
-├ λ /collective-contact                      4.49 kB         1.1 MB
-├ λ /collective-page                         67.8 kB        1.27 MB
-├ λ /collectives                             10.6 kB         803 kB
-├ λ /collectives-iframe                      4.84 kB         680 kB
-├ λ /confirm-guest                           4.85 kB         792 kB
-├ λ /confirmCollectiveDeletion               3.94 kB         791 kB
-├ λ /confirmEmail                            4.18 kB         791 kB
-├ λ /confirmOrder                            5.72 kB         840 kB
-├ λ /contribute                              12.7 kB         1.1 MB
-├ λ /contribution-flow                       2.21 kB        1.13 MB
-├ λ /conversation                            10.6 kB        1.12 MB
-├ λ /conversations                           6.73 kB         1.1 MB
-├ λ /create-collective                       8.19 kB         923 kB
-├ λ /create-conversation                     8.78 kB        1.11 MB
-├ λ /create-expense                          9.32 kB        1.17 MB
-├ λ /create-fund                             12.1 kB         864 kB
-├ λ /create-project                          4.77 kB         1.1 MB
-├ λ /createEvent                             10.1 kB        1.14 MB
-├ λ /createOrganization                      25 kB           940 kB
-├ λ /createPledge                            3.1 kB          790 kB
-├ λ /createUpdate                            5.43 kB        1.11 MB
-├ λ /dashboard                               31.6 kB        1.63 MB
-├ λ /e2c                                     9.29 kB         802 kB
-├ λ /embed/contribution-flow                 3.71 kB        1.14 MB
-├ λ /expense                                 2.87 kB        1.19 MB
-├ λ /expenses                                10.4 kB        1.21 MB
-├ λ /external-redirect                       3.66 kB         824 kB
-├ λ /fiscal-hosting                          10.5 kB         803 kB
-├ λ /guest-join                              7.11 kB         794 kB
-├ λ /help-and-support                        20.6 kB         925 kB
-├ λ /home                                    18 kB           810 kB
-├ λ /how-it-works                            6.46 kB         799 kB
-├ λ /manage-contributions                    11.5 kB        1.14 MB
-├ λ /marketingPage                           70.2 kB         853 kB
-├ λ /member-invitations                      8.17 kB         842 kB
-├ λ /oauth/authorize                         6.34 kB         804 kB
-├ λ /ocf-host-application                    17.8 kB         915 kB
-├ λ /order                                   6.4 kB         1.11 MB
-├ λ /orders                                  8.33 kB        1.11 MB
-├ λ /osc-host-application                    24.7 kB         928 kB
-├ λ /pricing                                 12.5 kB         799 kB
-├ λ /redeem                                  21.2 kB         901 kB
-├ λ /redeemed                                8.91 kB         833 kB
-├ λ /reset-password                          8.49 kB         760 kB
-├ λ /reset-password-completed                2.96 kB         790 kB
-├ λ /reset-password-sent                     3.86 kB         824 kB
-├ λ /root-actions                            22.7 kB         932 kB
-├ λ /search                                  20.3 kB         830 kB
-├ λ /signin                                  4.07 kB         802 kB
-├ λ /signinLinkSent                          3.95 kB         824 kB
-├ λ /staticPage                              28.2 kB         811 kB
-├ λ /submitted-expenses                      9.17 kB        1.21 MB
-├ λ /terms-of-fiscal-sponsorship             653 B           664 kB
-├ λ /tier                                    12.6 kB        1.12 MB
-├ λ /transactions                            6.17 kB        1.11 MB
-├ λ /unsubscribeEmail                        3.67 kB         791 kB
-├ λ /update                                  5.82 kB        1.13 MB
-├ λ /updatePaymentMethod                     10.7 kB         852 kB
-├ λ /updates                                 298 B           1.1 MB
-└ λ /welcome                                 5.49 kB         840 kB
-+ First Load JS shared by all                670 kB
+┌   /_app                                    0 B             679 kB
+├ λ /404                                     2.51 kB         802 kB
+├ λ /accept-financial-contributions          31.1 kB        1.11 MB
+├ λ /admin-panel                             6.62 kB        1.57 MB
+├ λ /api/connected-accounts/github/callback  0 B             679 kB
+├ λ /api/connected-accounts/github/oauthUrl  0 B             679 kB
+├ λ /api/docs/search                         0 B             679 kB
+├ λ /api/download-file                       0 B             679 kB
+├ λ /api/github-repositories                 0 B             679 kB
+├ λ /api/graphql/v1                          0 B             679 kB
+├ λ /api/graphql/v2                          0 B             679 kB
+├ λ /api/users/exchange-login-token          0 B             679 kB
+├ λ /api/users/exists                        0 B             679 kB
+├ λ /api/users/refresh-token                 0 B             679 kB
+├ λ /api/users/signin                        0 B             679 kB
+├ λ /api/users/two-factor-auth               0 B             679 kB
+├ λ /api/users/update-token                  0 B             679 kB
+├ λ /applications                            4.53 kB         851 kB
+├ λ /banner-iframe                           10.8 kB         702 kB
+├ λ /become-a-host                           6.78 kB         812 kB
+├ λ /become-a-sponsor                        8.04 kB         808 kB
+├ λ /button                                  1.23 kB         680 kB
+├ λ /collective-contact                      4.34 kB        1.08 MB
+├ λ /collective-page                         67.3 kB        1.25 MB
+├ λ /collectives                             10.6 kB         816 kB
+├ λ /collectives-iframe                      3.12 kB         695 kB
+├ λ /confirm-guest                           4.84 kB         805 kB
+├ λ /confirmCollectiveDeletion               3.94 kB         804 kB
+├ λ /confirmEmail                            4.18 kB         804 kB
+├ λ /confirmOrder                            5.61 kB         853 kB
+├ λ /contribute                              12.5 kB        1.08 MB
+├ λ /contribution-flow                       2.2 kB         1.12 MB
+├ λ /conversation                            10.2 kB         1.1 MB
+├ λ /conversations                           6.59 kB        1.08 MB
+├ λ /create-collective                       3.83 kB         935 kB
+├ λ /create-conversation                     8.66 kB        1.09 MB
+├ λ /create-expense                          11.4 kB        1.14 MB
+├ λ /create-fund                             11.8 kB         877 kB
+├ λ /create-project                          4.76 kB        1.09 MB
+├ λ /createEvent                             6.6 kB         1.12 MB
+├ λ /createOrganization                      20.2 kB         951 kB
+├ λ /createPledge                            3.1 kB          803 kB
+├ λ /createUpdate                            5.42 kB        1.09 MB
+├ λ /dashboard                               31.5 kB        1.62 MB
+├ λ /e2c                                     9.08 kB         814 kB
+├ λ /embed/contribution-flow                 3.47 kB        1.12 MB
+├ λ /expense                                 307 B          1.17 MB
+├ λ /expenses                                10.3 kB        1.19 MB
+├ λ /external-redirect                       3.66 kB         837 kB
+├ λ /fiscal-hosting                          10.5 kB         816 kB
+├ λ /guest-join                              6.91 kB         807 kB
+├ λ /help-and-support                        18.9 kB         937 kB
+├ λ /home                                    18 kB           823 kB
+├ λ /how-it-works                            6.46 kB         812 kB
+├ λ /manage-contributions                    11.3 kB        1.12 MB
+├ λ /marketingPage                           70.2 kB         866 kB
+├ λ /member-invitations                      8.05 kB         855 kB
+├ λ /oauth/authorize                         5.9 kB          818 kB
+├ λ /ocf-host-application                    13.3 kB         927 kB
+├ λ /order                                   6.36 kB        1.09 MB
+├ λ /orders                                  7.68 kB         1.1 MB
+├ λ /osc-host-application                    20.2 kB         939 kB
+├ λ /pricing                                 12.4 kB         812 kB
+├ λ /redeem                                  17.2 kB         914 kB
+├ λ /redeemed                                8.53 kB         845 kB
+├ λ /reset-password                          8.49 kB         774 kB
+├ λ /reset-password-completed                2.96 kB         803 kB
+├ λ /reset-password-sent                     3.86 kB         837 kB
+├ λ /root-actions                            22 kB           942 kB
+├ λ /search                                  10.3 kB         843 kB
+├ λ /signin                                  3.78 kB         816 kB
+├ λ /signinLinkSent                          3.95 kB         837 kB
+├ λ /staticPage                              28.2 kB         824 kB
+├ λ /submitted-expenses                      9.14 kB        1.19 MB
+├ λ /terms-of-fiscal-sponsorship             653 B           679 kB
+├ λ /tier                                    12.6 kB         1.1 MB
+├ λ /transactions                            5.49 kB         1.1 MB
+├ λ /unsubscribeEmail                        3.67 kB         804 kB
+├ λ /update                                  5.7 kB         1.11 MB
+├ λ /updatePaymentMethod                     10.4 kB         865 kB
+├ λ /updates                                 290 B          1.09 MB
+└ λ /welcome                                 5.38 kB         852 kB
++ First Load JS shared by all                686 kB
   ├ chunks/framework-4acc41369cd80039.js     66.8 kB
   ├ chunks/main-8ab5ed92f860346b.js          39.5 kB
-  ├ chunks/pages/_app-ab9ee349f051a53f.js    554 kB
-  ├ chunks/webpack-620f690e320877af.js       2.61 kB
+  ├ chunks/pages/_app-638b0c32c2109bcd.js    570 kB
+  ├ chunks/webpack-d90827e573d78762.js       2.61 kB
   └ css/22f31e5158677ef9.css                 6.87 kB
```