### PR TITLE
Auto-select expense type when there's only one possible

### DIFF
--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -97,22 +97,27 @@ export const msg = defineMessages({
   },
 });
 
-const getDefaultExpense = collective => ({
-  description: '',
-  longDescription: '',
-  items: [],
-  attachedFiles: [],
-  payee: null,
-  payoutMethod: undefined,
-  privateMessage: '',
-  invoiceInfo: '',
-  currency: collective.currency,
-  taxes: null,
-  payeeLocation: {
-    address: '',
-    country: null,
-  },
-});
+const getDefaultExpense = (collective, supportedExpenseTypes) => {
+  const isSingleSupportedExpenseType = supportedExpenseTypes.length === 1;
+
+  return {
+    description: '',
+    longDescription: '',
+    items: [],
+    attachedFiles: [],
+    payee: null,
+    payoutMethod: undefined,
+    privateMessage: '',
+    invoiceInfo: '',
+    currency: collective.currency,
+    taxes: null,
+    type: isSingleSupportedExpenseType ? supportedExpenseTypes[0] : undefined,
+    payeeLocation: {
+      address: '',
+      country: null,
+    },
+  };
+};
 
 const CREATE_PAYEE_PROFILE_FIELDS = ['name', 'email', 'legalName', 'organization', 'newsletterOptIn'];
 
@@ -462,6 +467,7 @@ const ExpenseFormBody = ({
         editingExpense={editingExpense}
         resetDefaultStep={() => setStep(EXPENSE_FORM_STEPS.PAYEE)}
         formPersister={formPersister}
+        supportedExpenseTypes={supportedExpenseTypes}
         getDefaultExpense={getDefaultExpense}
         onInvite={isInvite => {
           setOnBehalf(isInvite);
@@ -533,7 +539,7 @@ const ExpenseFormBody = ({
               onCancel();
             } else {
               setStep(EXPENSE_FORM_STEPS.PAYEE);
-              resetForm({ values: getDefaultExpense(collective) });
+              resetForm({ values: getDefaultExpense(collective, supportedExpenseTypes) });
               if (formPersister) {
                 formPersister.clearValues();
                 window.scrollTo(0, 0);
@@ -835,12 +841,7 @@ const ExpenseForm = ({
   const [hasValidate, setValidate] = React.useState(validateOnChange && !isDraft);
   const intl = useIntl();
   const supportedExpenseTypes = React.useMemo(() => getSupportedExpenseTypes(collective), [collective]);
-  const isSingleSupportedExpenseType = supportedExpenseTypes.length === 1;
-  const initialValues = {
-    ...getDefaultExpense(collective),
-    type: !isDraft && isSingleSupportedExpenseType ? supportedExpenseTypes[0] : undefined,
-    ...expense,
-  };
+  const initialValues = { ...getDefaultExpense(collective, supportedExpenseTypes), ...expense };
   const validate = expenseData => validateExpense(intl, expenseData);
   if (isDraft) {
     initialValues.items = expense.draft.items?.map(newExpenseItem) || [];

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -266,6 +266,7 @@ const ExpenseFormBody = ({
   isDraft,
   defaultStep,
   drawerActionsContainer,
+  supportedExpenseTypes,
 }) => {
   const intl = useIntl();
   const { formatMessage } = intl;
@@ -277,7 +278,6 @@ const ExpenseFormBody = ({
   const isReceipt = values.type === expenseTypes.RECEIPT;
   const isGrant = values.type === expenseTypes.GRANT;
   const isCreditCardCharge = values.type === expenseTypes.CHARGE;
-  const supportedExpenseTypes = React.useMemo(() => getSupportedExpenseTypes(collective), [collective]);
   const isRecurring = expense && expense.recurringExpense !== null;
   const stepOneCompleted =
     values.payoutMethod &&
@@ -808,6 +808,7 @@ ExpenseFormBody.propTypes = {
     ),
   }),
   drawerActionsContainer: PropTypes.object,
+  supportedExpenseTypes: PropTypes.arrayOf(PropTypes.string),
 };
 
 /**
@@ -833,7 +834,13 @@ const ExpenseForm = ({
   const isDraft = expense?.status === expenseStatus.DRAFT;
   const [hasValidate, setValidate] = React.useState(validateOnChange && !isDraft);
   const intl = useIntl();
-  const initialValues = { ...getDefaultExpense(collective), ...expense };
+  const supportedExpenseTypes = React.useMemo(() => getSupportedExpenseTypes(collective), [collective]);
+  const isSingleSupportedExpenseType = supportedExpenseTypes.length === 1;
+  const initialValues = {
+    ...getDefaultExpense(collective),
+    type: !isDraft && isSingleSupportedExpenseType ? supportedExpenseTypes[0] : undefined,
+    ...expense,
+  };
   const validate = expenseData => validateExpense(intl, expenseData);
   if (isDraft) {
     initialValues.items = expense.draft.items?.map(newExpenseItem) || [];
@@ -876,6 +883,7 @@ const ExpenseForm = ({
           isDraft={isDraft}
           defaultStep={defaultStep}
           drawerActionsContainer={drawerActionsContainer}
+          supportedExpenseTypes={supportedExpenseTypes}
         />
       )}
     </Formik>

--- a/components/expenses/ExpenseFormPayeeStep.js
+++ b/components/expenses/ExpenseFormPayeeStep.js
@@ -226,6 +226,7 @@ const ExpenseFormPayeeStep = ({
   editingExpense,
   resetDefaultStep,
   formPersister,
+  supportedExpenseTypes,
   getDefaultExpense,
   drawerActionsContainer,
 }) => {
@@ -364,7 +365,7 @@ const ExpenseFormPayeeStep = ({
               onCancel();
             } else {
               resetDefaultStep();
-              formik.resetForm({ values: getDefaultExpense(collective) });
+              formik.resetForm({ values: getDefaultExpense(collective, supportedExpenseTypes) });
               if (formPersister) {
                 formPersister.clearValues();
                 window.scrollTo(0, 0);
@@ -563,6 +564,7 @@ ExpenseFormPayeeStep.propTypes = {
   editingExpense: PropTypes.bool,
   resetDefaultStep: PropTypes.func,
   formPersister: PropTypes.object,
+  supportedExpenseTypes: PropTypes.arrayOf(PropTypes.string),
   getDefaultExpense: PropTypes.func,
   payoutProfiles: PropTypes.array,
   onCancel: PropTypes.func,


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/5931

# Description

# Screenshots

Before:
![before](https://github.com/opencollective/opencollective-frontend/assets/48645737/ab00d3e9-99f9-496f-9b81-96055e14d01d)

After:
![after](https://github.com/opencollective/opencollective-frontend/assets/48645737/2c1f349f-87f0-4880-81a5-174bb04143ef)

