### PR TITLE
ExpenseForm: skip summary step for PROCESSING charges

### DIFF
--- a/components/expenses/Expense.tsx
+++ b/components/expenses/Expense.tsx
@@ -200,7 +200,7 @@ function Expense(props) {
   const isDraft = expense?.status === expenseStatus.DRAFT;
   const showTaxFormMsg = includes(expense?.requiredLegalDocuments, 'US_TAX_FORM');
   const isMissingReceipt =
-    expense?.status === expenseStatus.PAID &&
+    [expenseStatus.PAID, expenseStatus.PROCESSING].includes(expense?.status) &&
     expense?.type === expenseTypes.CHARGE &&
     expense?.permissions?.canEdit &&
     expense?.items?.every(item => !item.url);


### PR DESCRIPTION
Follow-up on https://github.com/opencollective/opencollective-api/pull/5222
Resolve the issue reported in https://opencollective.slack.com/archives/C6JTTA4SK/p1688669303322959

Demo of the issue:

https://github.com/opencollective/opencollective-frontend/assets/1556356/b4337b83-4a9c-45c1-98c8-8c8c11e130f3

