### PR TITLE
ExpenseForm: Do not drop `attachedFiles` for grants

### DIFF
--- a/components/StyledDropzone.tsx
+++ b/components/StyledDropzone.tsx
@@ -95,6 +95,8 @@ const StyledDropzone = ({
   accept,
   minSize,
   maxSize,
+  onSuccess,
+  collectFilesOnly,
   name,
   error = undefined,
   value,
@@ -102,18 +104,18 @@ const StyledDropzone = ({
   kind,
   ...props
 }: StyledDropzoneProps) => {
-  const imgUploaderParams = { isMulti, mockImageGenerator, onSuccess: props.onSuccess, onReject, kind, accept };
+  const imgUploaderParams = { isMulti, mockImageGenerator, onSuccess, onReject, kind, accept };
   const { uploadFiles, isUploading, uploadProgress } = useImageUploader(imgUploaderParams);
 
   const onDrop = React.useCallback(
     (acceptedFiles: File[], fileRejections: FileRejection[]) => {
-      if (props.collectFilesOnly) {
-        props.onSuccess(acceptedFiles, fileRejections);
+      if (collectFilesOnly) {
+        onSuccess(acceptedFiles, fileRejections);
       } else {
         uploadFiles(acceptedFiles, fileRejections);
       }
     },
-    [props.collectFilesOnly, props.onSuccess, uploadFiles],
+    [collectFilesOnly, onSuccess, uploadFiles],
   );
   const dropzoneParams = { accept, minSize, maxSize, multiple: isMulti, onDrop };
   const { getRootProps, getInputProps, isDragActive } = useDropzone(dropzoneParams);

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -124,6 +124,7 @@ export const prepareExpenseForSubmit = expenseData => {
   // The collective picker still uses API V1 for when creating a new profile on the fly
   const isInvoice = expenseData.type === expenseTypes.INVOICE;
   const isGrant = expenseData.type === expenseTypes.GRANT;
+  const keepAttachedFiles = isInvoice || isGrant;
 
   // Prepare payee
   let payee;
@@ -166,7 +167,7 @@ export const prepareExpenseForSubmit = expenseData => {
     payee,
     payeeLocation,
     payoutMethod,
-    attachedFiles: isInvoice ? expenseData.attachedFiles?.map(file => pick(file, ['id', 'url', 'name'])) : [],
+    attachedFiles: keepAttachedFiles ? expenseData.attachedFiles?.map(file => pick(file, ['id', 'url', 'name'])) : [],
     tax: expenseData.taxes?.filter(tax => !tax.isDisabled).map(tax => pick(tax, ['type', 'rate', 'idNumber'])),
     items: expenseData.items.map(item => prepareExpenseItemForSubmit(item, isInvoice, isGrant)),
   };


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/6920

Also cleaned a bit the props on `StyledDropzone` to resolve some warnings.