### PR TITLE
Define plausible contribution flow events

### DIFF
--- a/components/contribution-flow/ContributionFlowButtons.js
+++ b/components/contribution-flow/ContributionFlowButtons.js
@@ -2,6 +2,9 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
+import { AnalyticsEvent } from '../../lib/analytics/events';
+import { track } from '../../lib/analytics/plausible';
+
 import Currency from '../Currency';
 import { Box, Flex } from '../Grid';
 import PayWithPaypalButton from '../PayWithPaypalButton';
@@ -14,6 +17,7 @@ class ContributionFlowButtons extends React.Component {
   static propTypes = {
     goNext: PropTypes.func,
     goBack: PropTypes.func,
+    step: PropTypes.shape({ name: PropTypes.string }),
     prevStep: PropTypes.shape({ name: PropTypes.string }),
     nextStep: PropTypes.shape({ name: PropTypes.string }),
     isValidating: PropTypes.bool,
@@ -35,6 +39,10 @@ class ContributionFlowButtons extends React.Component {
         await this.props.goNext();
         this.setState({ isLoadingNext: false });
       });
+    }
+
+    if (this.props.step.name === 'details') {
+      track(AnalyticsEvent.CONTRIBUTION_DETAILS_STEP_COMPLETED);
     }
   };
 

--- a/components/contribution-flow/ContributionFlowSuccess.js
+++ b/components/contribution-flow/ContributionFlowSuccess.js
@@ -11,6 +11,8 @@ import { withRouter } from 'next/router';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import styled from 'styled-components';
 
+import { AnalyticsEvent } from '../../lib/analytics/events';
+import { track } from '../../lib/analytics/plausible';
 import { ORDER_STATUS } from '../../lib/constants/order-status';
 import { formatCurrency } from '../../lib/currency-utils';
 import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
@@ -130,6 +132,10 @@ class ContributionFlowSuccess extends React.Component {
     isEmbed: PropTypes.bool,
     data: PropTypes.object,
   };
+
+  componentDidMount() {
+    track(AnalyticsEvent.CONTRIBUTION_SUCCESS);
+  }
 
   componentDidUpdate() {
     const {

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -4,6 +4,9 @@ import { isEmpty, isNil } from 'lodash';
 import { withRouter } from 'next/router';
 import { FormattedMessage, useIntl } from 'react-intl';
 
+import { AnalyticsEvent } from '../../lib/analytics/events';
+import { track } from '../../lib/analytics/plausible';
+import { AnalyticsProperty } from '../../lib/analytics/properties';
 import { canContributeRecurring, hostIsTaxDeductibleInTheUs } from '../../lib/collective.lib';
 import INTERVALS from '../../lib/constants/intervals';
 import { AmountTypes, TierTypes } from '../../lib/constants/tiers-types';
@@ -64,6 +67,14 @@ const StepDetails = ({ onChange, data, collective, tier, showPlatformTip, router
       dispatchChange('interval', INTERVALS.oneTime);
     }
   }, [selectedInterval, isFixedInterval, supportsRecurring]);
+
+  React.useEffect(() => {
+    track(AnalyticsEvent.CONTRIBUTION_STARTED, {
+      props: {
+        [AnalyticsProperty.CONTRIBUTION_STEP]: 'details',
+      },
+    });
+  }, []);
 
   return (
     <Box width={1}>

--- a/components/contribution-flow/StepPayment.js
+++ b/components/contribution-flow/StepPayment.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { AnalyticsEvent } from '../../lib/analytics/events';
+import { track } from '../../lib/analytics/plausible';
 import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
 import { require2FAForAdmins } from '../../lib/policies';
 
@@ -23,6 +25,10 @@ const StepPayment = ({
   disabledPaymentMethodTypes,
 }) => {
   const { LoggedInUser } = useLoggedInUser();
+
+  React.useEffect(() => {
+    track(AnalyticsEvent.CONTRIBUTION_PAYMENT_STEP);
+  }, []);
 
   if (require2FAForAdmins(stepProfile) && !LoggedInUser?.hasTwoFactorAuth) {
     return <TwoFactorAuthRequiredMessage borderWidth={0} noTitle />;

--- a/env.js
+++ b/env.js
@@ -34,6 +34,7 @@ const defaults = {
   CAPTCHA_ENABLED: false,
   CAPTCHA_PROVIDER: 'HCAPTCHA',
   CLIENT_ANALYTICS_ENABLED: false,
+  CLIENT_ANALYTICS_DOMAIN: 'localhost',
   TW_API_COLLECTIVE_SLUG: 'opencollective-host',
   OC_APPLICATION: 'frontend',
   OC_ENV: process.env.NODE_ENV || 'development',

--- a/lib/analytics/events.ts
+++ b/lib/analytics/events.ts
@@ -1,0 +1,8 @@
+export const enum AnalyticsEvent {
+  CONTRIBUTION_STARTED = 'Contribution Started',
+  CONTRIBUTION_DETAILS_STEP_COMPLETED = 'Contribution Details Step Completed',
+  CONTRIBUTION_PAYMENT_STEP = 'Contribution Payment Step',
+  CONTRIBUTION_SUBMITTED = 'Contribution Submitted',
+  CONTRIBUTION_SUCCESS = 'Contribution Success',
+  CONTRIBUTION_ERROR = 'Contribution Error',
+}

--- a/lib/analytics/plausible.ts
+++ b/lib/analytics/plausible.ts
@@ -1,0 +1,23 @@
+import { AnalyticsEvent } from './events';
+import { AnalyticsProperty } from './properties';
+
+declare global {
+  interface Window {
+    plausible: (
+      event: string,
+      options: {
+        props: Record<string, string | boolean | number>;
+      },
+    ) => void;
+  }
+}
+
+type TrackOptions = {
+  props: Record<AnalyticsProperty, string | number | boolean>;
+};
+
+export function track(event: AnalyticsEvent, options?: TrackOptions) {
+  if (window.plausible) {
+    window.plausible(event, options);
+  }
+}

--- a/lib/analytics/properties.ts
+++ b/lib/analytics/properties.ts
@@ -1,0 +1,5 @@
+export const enum AnalyticsProperty {
+  CONTRIBUTION_STEP = 'contributionStep',
+  CONTRIBUTION_HAS_PLATFORM_TIP = 'contributionHasPlatformTip',
+  CONTRIBUTION_PLATFORM_TIP_PERCENTAGE = 'contributionPlatformTipPercentage',
+}

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -22,6 +22,11 @@ export default class IntlDocument extends Document {
 
     const clientAnalytics = {
       enabled: parseToBoolean(process.env.CLIENT_ANALYTICS_ENABLED),
+      domain: process.env.CLIENT_ANALYTICS_DOMAIN,
+      scriptSrc:
+        'development' === process.env.OC_ENV
+          ? 'https://plausible.io/js/script.tagged-events.local.js'
+          : 'https://plausible.io/js/script.tagged-events.js',
     };
 
     // On server-side, add a CSP header
@@ -99,9 +104,9 @@ export default class IntlDocument extends Document {
             <script
               nonce={this.props.cspNonce}
               defer
-              data-domain="opencollective.com"
-              src="https://plausible.io/js/script.js"
-            />
+              data-domain={this.props.clientAnalytics.domain}
+              src={this.props.clientAnalytics.scriptSrc}
+            ></script>
           )}
         </body>
       </Html>


### PR DESCRIPTION

# Description

Track events in the contribution funnel so they can be measured in plausible.

Requires the env variable `CLIENT_ANALYTICS_DOMAIN` to be set before deployment.

# Screenshots

![image](https://github.com/opencollective/opencollective-frontend/assets/5448927/53d08eb6-d30a-463f-a645-8884d0286564)
![image](https://github.com/opencollective/opencollective-frontend/assets/5448927/835cc912-fdf4-492c-b97e-30b19529c622)

