### PR TITLE
Workspace: make sure Sidebar menu is regenerated when viewport changes

### DIFF
--- a/components/dashboard/SideBar.js
+++ b/components/dashboard/SideBar.js
@@ -80,7 +80,7 @@ const AdminPanelSideBar = ({
         )}
       </Box>
     ),
-    [collective, isLoading],
+    [collective, isLoading, viewport],
   );
 
   return (


### PR DESCRIPTION
This sometimes can cause the sidebar drawer to not automatically close when navigating to another page.