### PR TITLE
Fix(PDF Viewer): Add support for non-latin characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ scripts/publish-components/.tmp
 
 # pdfjs worker - copied from node_modules by webpack (see next.config.js)
 public/static/scripts/pdf.worker.min.js
+
+# pdfjs character maps - copied from node_modules by webpack (see next.config.js)
+public/static/cmaps

--- a/components/PDFViewer.tsx
+++ b/components/PDFViewer.tsx
@@ -16,6 +16,11 @@ const DocumentContainer = styled.div`
   }
 `;
 
+const options = {
+  cMapUrl: `/static/cmaps/`,
+  cMapPacked: true,
+};
+
 const PDFViewer = ({ pdfUrl, contentWrapperRef }) => {
   const [numPages, setNumPages] = useState(null);
   const [wrapperWidth, setWrapperWidth] = useState(0);
@@ -50,6 +55,7 @@ const PDFViewer = ({ pdfUrl, contentWrapperRef }) => {
         onLoadSuccess={({ numPages }) => {
           setNumPages(numPages);
         }}
+        options={options}
         error={
           <Span color="white.full" fontSize={'16px'}>
             <FormattedMessage defaultMessage="Failed to load PDF file." id="PDFViewer.error" />

--- a/next.config.js
+++ b/next.config.js
@@ -70,6 +70,18 @@ const nextConfig = {
       );
     }
 
+    // Copying cMaps to get non-latin characters to work in PDFs (https://github.com/wojtekmaj/react-pdf#support-for-non-latin-characters)
+    config.plugins.push(
+      new CopyPlugin({
+        patterns: [
+          {
+            from: path.join(path.dirname(require.resolve('pdfjs-dist/package.json')), 'cmaps'),
+            to: path.join(__dirname, 'public/static/cmaps'),
+          },
+        ],
+      }),
+    );
+
     // Copy pdfjs worker to public folder (used by PDFViewer component)
     // (Workaround for working with react-pdf and CommonJS - if moving to ESM this can be removed)
     // TODO(ESM): Move this to standard ESM

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "react-intl": "6.4.4",
         "react-is": "18.2.0",
         "react-password-strength-bar": "0.4.1",
-        "react-pdf": "7.1.3",
+        "react-pdf": "7.3.3",
         "react-popper": "2.3.0",
         "react-scrollchor": "7.0.2",
         "react-select": "5.7.4",
@@ -25296,8 +25296,9 @@
       "license": "ISC"
     },
     "node_modules/make-event-props": {
-      "version": "1.5.0",
-      "license": "MIT",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/make-event-props/-/make-event-props-1.6.1.tgz",
+      "integrity": "sha512-JhvWq/iz1BvlmnPvLJjXv+xnMPJZuychrDC68V+yCGQJn5chcA8rLGKo5EP1XwIKVrigSXKLmbeXAGkf36wdCQ==",
       "funding": {
         "url": "https://github.com/wojtekmaj/make-event-props?sponsor=1"
       }
@@ -29115,13 +29116,13 @@
       }
     },
     "node_modules/react-pdf": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-7.1.3.tgz",
-      "integrity": "sha512-6llkAHFVj24QhheAfB8FMKAlIDTuF2HUK7ULgLNDahJT2WYNvYc41hbHCSZ0DqI0jUtUxEkroq40iQuy0S+o8A==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-7.3.3.tgz",
+      "integrity": "sha512-d7WAxcsjOogJfJ+I+zX/mdip3VjR1yq/yDa4hax4XbQVjbbbup6rqs4c8MGx0MLSnzob17TKp1t4CsNbDZ6GeQ==",
       "dependencies": {
         "clsx": "^2.0.0",
         "make-cancellable-promise": "^1.3.1",
-        "make-event-props": "^1.5.0",
+        "make-event-props": "^1.6.0",
         "merge-refs": "^1.2.1",
         "pdfjs-dist": "3.6.172",
         "prop-types": "^15.6.2",
@@ -29132,8 +29133,14 @@
         "url": "https://github.com/wojtekmaj/react-pdf?sponsor=1"
       },
       "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-pdf/node_modules/clsx": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "react-intl": "6.4.4",
     "react-is": "18.2.0",
     "react-password-strength-bar": "0.4.1",
-    "react-pdf": "7.1.3",
+    "react-pdf": "7.3.3",
     "react-popper": "2.3.0",
     "react-scrollchor": "7.0.2",
     "react-select": "5.7.4",


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/6822

# Description

Adding back support for non-latin characters, making sure to initialize the react pdf options object outside the React component, [as mentioned here](https://github.com/wojtekmaj/react-pdf/issues/1533). 

This seems to have fixed the crashing and errors, also verified that a document with non latin characters displayed correctly.