### PR TITLE
Remove "px" for Image `width` and `height` Attributes and Make them Consistent

### DIFF
--- a/components/navigation/ProfileMenu.tsx
+++ b/components/navigation/ProfileMenu.tsx
@@ -179,7 +179,7 @@ const ProfileMenu = () => {
       <Box>
         <HorziontalSeparator style={{ margin: '24px 0' }} />
         <Link href="/home">
-          <Image src="/static/images/opencollectivelogo-footer-n.svg" alt="Open Collective" width="122" height="24" />
+          <Image src="/static/images/opencollectivelogo-footer-n.svg" alt="Open Collective" width={122} height={24} />
         </Link>
         <FooterLinks mt="16px" gap="32px">
           <Link href="/home">

--- a/components/navigation/TopBar.tsx
+++ b/components/navigation/TopBar.tsx
@@ -251,7 +251,7 @@ const TopBar = ({ menuItems, showProfileAndChangelogMenu, account, navTitle, loa
           <Box flexShrink={0}>
             <Link href={ocLogoRoute}>
               <Flex alignItems="center" gridGap={2}>
-                <Image width="32" height="32" src="/static/images/opencollective-icon.png" alt="Open Collective" />
+                <Image width={32} height={32} src="/static/images/opencollective-icon.png" alt="Open Collective" />
                 {onHomeRoute && (
                   <Hide xs sm md display="flex" alignItems="center">
                     <Image height={20} width={120} src="/static/images/logotype.svg" alt="Open Collective" />

--- a/components/oauth/OAuthApplicationsList.js
+++ b/components/oauth/OAuthApplicationsList.js
@@ -85,7 +85,7 @@ const OAuthApplicationsList = ({ account, onApplicationCreated, offset = 0 }) =>
           <StyledCard p="24px">
             <Flex>
               <Flex flex="0 0 64px" height="64px" justifyContent="center" alignItems="center">
-                <Image src="/static/icons/apps.png" width="52px" height="52px" alt="" />
+                <Image src="/static/icons/apps.png" width={52} height={52} alt="" />
               </Flex>
               <Flex flexDirection="column" ml={3}>
                 <P fontSize="14px" fontWeight="700" lineHeight="20px" mb="12px">

--- a/components/personal-token/PersonalTokensList.js
+++ b/components/personal-token/PersonalTokensList.js
@@ -88,7 +88,7 @@ const PersonalTokensList = ({ account, onPersonalTokenCreated, offset = 0 }) => 
           <StyledCard p="24px">
             <Flex>
               <Flex flex="0 0 64px" height="64px" justifyContent="center" alignItems="center">
-                <Image src="/static/icons/apps.png" width="52px" height="52px" alt="" />
+                <Image src="/static/icons/apps.png" width={52} height={52} alt="" />
               </Flex>
               <Flex flexDirection="column" ml={3}>
                 <P fontSize="14px" fontWeight="700" lineHeight="20px" mb="12px">

--- a/pages/reset-password-completed.js
+++ b/pages/reset-password-completed.js
@@ -13,7 +13,7 @@ const ResetPasswordCompleted = ({ LoggedInUser, loadingLoggedInUser }) => {
   return (
     <Page noRobots showFooter={false}>
       <Container pt={[4, 5]} pb={6} px={3} textAlign="center" data-cy="reset-password-success-page">
-        <Image src="/static/images/sign-in-illustration.png" width="624" height="372" />
+        <Image src="/static/images/sign-in-illustration.png" width={624} height={372} />
         <P fontSize="32px" lineHeight="40px" color="black.900" fontWeight={700}>
           <FormattedMessage defaultMessage="Your password was updated." />
         </P>

--- a/pages/reset-password-sent.js
+++ b/pages/reset-password-sent.js
@@ -33,7 +33,7 @@ class ResetPasswordSent extends Component {
     return (
       <Page noRobots showFooter={false}>
         <Container pt={[4, 5]} pb={6} px={3} textAlign="center">
-          <Image src="/static/images/sign-in-illustration.png" width="624" height="372" />
+          <Image src="/static/images/sign-in-illustration.png" width={624} height={372} />
           <P fontSize="32px" lineHeight="40px" color="black.900" fontWeight={700}>
             <FormattedMessage defaultMessage="Your reset password email is on its way." />
           </P>

--- a/pages/signinLinkSent.js
+++ b/pages/signinLinkSent.js
@@ -33,7 +33,7 @@ class SignInLinkSent extends Component {
     return (
       <Page title="Login Link Sent" noRobots showFooter={false}>
         <Container pt={[4, 5]} pb={6} px={3} textAlign="center">
-          <Image src="/static/images/sign-in-illustration.png" width="624" height="372" />
+          <Image src="/static/images/sign-in-illustration.png" width={624} height={372} />
           <P fontSize="32px" lineHeight="40px" fontWeight={700} color="black.900">
             <FormattedMessage id="SignIn.LinkSent" defaultMessage="Your magic link is on its way!" />
           </P>

--- a/pages/welcome.js
+++ b/pages/welcome.js
@@ -53,7 +53,7 @@ const Welcome = () => {
           mt={['100px', 0]}
         >
           <Box mt="-64px">
-            <Image src="/static/images/sample-avatar.png" height="128px" width="128px" />
+            <Image src="/static/images/sample-avatar.png" height={128} width={128} />
           </Box>
           <Flex fontSize="24px" fontWeight="700" color="black.900" lineHeight="32px" pt="40px" pb="40px">
             {LoggedInUser?.collective?.name}
@@ -70,7 +70,7 @@ const Welcome = () => {
                   </Flex>
                 </Box>
                 <Box pl="39px">
-                  <Image src="/static/images/right-arrow.png" alt="Right Arrow" width="22px" height="20px" />
+                  <Image src="/static/images/right-arrow.png" alt="Right Arrow" width={22} height={20} />
                 </Box>
               </Flex>
             </WelcomeOptionContainer>
@@ -87,7 +87,7 @@ const Welcome = () => {
                   </Flex>
                 </Box>
                 <Box pl="39px">
-                  <Image src="/static/images/right-arrow.png" alt="Right Arrow" width="22px" height="20px" />
+                  <Image src="/static/images/right-arrow.png" alt="Right Arrow" width={22} height={20} />
                 </Box>
               </Flex>
             </WelcomeOptionContainer>
@@ -104,7 +104,7 @@ const Welcome = () => {
                   </Flex>
                 </Box>
                 <Box pl="39px">
-                  <Image src="/static/images/right-arrow.png" alt="Right Arrow" width="22px" height="20px" />
+                  <Image src="/static/images/right-arrow.png" alt="Right Arrow" width={22} height={20} />
                 </Box>
               </Flex>
             </WelcomeOptionContainer>


### PR DESCRIPTION
It seems that when we use "px" for `width` and `height` attributes in `Image` components we get, 

```
Error: Image with src "/static/images/sample-avatar.png" has invalid "width" property. Expected a numeric value in pixels but received "128px".
```

This PR fixes that. 