### PR TITLE
Fix expense query ID param for drawer

### DIFF
--- a/components/expenses/ExpenseDrawer.tsx
+++ b/components/expenses/ExpenseDrawer.tsx
@@ -26,7 +26,7 @@ export default function ExpenseDrawer({ openExpenseLegacyId, handleClose, initia
 
   useEffect(() => {
     if (openExpenseLegacyId) {
-      getExpense({ variables: getVariableFromProps({ legacyExpenseId: openExpenseLegacyId }) });
+      getExpense({ variables: getVariableFromProps({ ExpenseId: openExpenseLegacyId }) });
     }
   }, [openExpenseLegacyId]);
 


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/6952

We have two `getVariableFromProps`; this duplication is likely to have caused this confusion.