### PR TITLE
Add redirect to and from old/new dashboard

### DIFF
--- a/pages/admin-panel.js
+++ b/pages/admin-panel.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/client';
+import { useRouter } from 'next/router';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 
 import { isHostAccount } from '../lib/collective.lib';
@@ -8,6 +9,7 @@ import roles from '../lib/constants/roles';
 import { API_V2_CONTEXT } from '../lib/graphql/helpers';
 import useLoggedInUser from '../lib/hooks/useLoggedInUser';
 import { require2FAForAdmins } from '../lib/policies';
+import { PREVIEW_FEATURE_KEYS } from '../lib/preview-features';
 
 import { AdminPanelContext } from '../components/admin-panel/AdminPanelContext';
 import AdminPanelSection from '../components/admin-panel/AdminPanelSection';
@@ -95,8 +97,16 @@ function getBlocker(LoggedInUser, account, section) {
 
 const AdminPanelPage = ({ slug, section, subpath }) => {
   const intl = useIntl();
+  const router = useRouter();
   const { LoggedInUser, loadingLoggedInUser } = useLoggedInUser();
   const { data, loading } = useQuery(adminPanelQuery, { context: API_V2_CONTEXT, variables: { slug } });
+
+  // Redirect to the new dashboard if the user has the feature flag enabled
+  React.useEffect(() => {
+    if (LoggedInUser && LoggedInUser.hasPreviewFeatureEnabled(PREVIEW_FEATURE_KEYS.DASHBOARD)) {
+      router.push(`/workspace/${slug}`);
+    }
+  }, [LoggedInUser]);
 
   const account = data?.account;
   const notification = getNotification(intl, account);

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -8,6 +8,7 @@ import roles from '../lib/constants/roles';
 import { API_V2_CONTEXT } from '../lib/graphql/helpers';
 import useLoggedInUser from '../lib/hooks/useLoggedInUser';
 import { require2FAForAdmins } from '../lib/policies';
+import { PREVIEW_FEATURE_KEYS } from '../lib/preview-features';
 
 import { ALL_SECTIONS, SECTIONS_ACCESSIBLE_TO_ACCOUNTANTS } from '../components/dashboard/constants';
 import { DashboardContext } from '../components/dashboard/DashboardContext';
@@ -102,12 +103,19 @@ const DashboardPage = () => {
   const { LoggedInUser, loadingLoggedInUser } = useLoggedInUser();
   const activeSlug = slug || LoggedInUser?.getLastDashboardSlug();
 
-  // Redirect to the dashboard of the logged in user if no slug is provided
+  // Save current slug as last visited dashboard slug
   useEffect(() => {
     if (slug) {
       LoggedInUser?.saveLastDashboardSlug(slug);
     }
   }, [slug, LoggedInUser]);
+
+  // Redirect to home if user doesn't have access to new dashboard
+  useEffect(() => {
+    if (LoggedInUser && !LoggedInUser.hasPreviewFeatureEnabled(PREVIEW_FEATURE_KEYS.DASHBOARD)) {
+      router.push(`/`);
+    }
+  }, [LoggedInUser]);
 
   const { data, loading } = useQuery(adminPanelQuery, {
     context: API_V2_CONTEXT,


### PR DESCRIPTION
When turning on/off the new workspace preview features, a lot of users get lost not seeing the new changes because the route stays the same (if they are on the old dashboard). It's also true the other way, if you are on the workspace route and turn off the feature you still saw the same page.

This PR introduces a redirect to/from the new and old dashboard depending on the preview features' enabled status.
