### PR TITLE
feat: add support for yt-short embeds

### DIFF
--- a/components/RichTextEditor.tsx
+++ b/components/RichTextEditor.tsx
@@ -414,7 +414,7 @@ export default class RichTextEditor extends React.Component<RichTextEditorProps,
   parseServiceLink = videoLink => {
     const regexps = {
       youtube: new RegExp(
-        '(?:https?://)?(?:www\\.)?youtu(?:\\.be/|be\\.com/\\S*(?:watch|embed)(?:(?:(?=/[^&\\s?]+(?!\\S))/)|(?:\\S*v=|v/)))([^&\\s?]+)',
+        '(?:https?://)?(?:www\\.)?youtu(?:\\.be/|be\\.com/\\S*(?:watch|embed|shorts)(?:(?:(?=/[^&\\s?]+(?!\\S))/)|(?:\\S*v=|v/)))([^&\\s?]+)',
         'i',
       ),
       anchorFm: /^(http|https)?:\/\/(www\.)?anchor\.fm\/([^/]+)(\/embed)?(\/episodes\/)?([^/]+)?\/?$/, // TODO: moved to https://podcasters.spotify.com


### PR DESCRIPTION
Fixes https://github.com/opencollective/opencollective/issues/6939

# Description

Adds shorts in regex so that the video Id can be extracted from shorts too.
<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots / Working Demo

https://github.com/opencollective/opencollective-frontend/assets/64399555/c78d3f78-85d8-4c00-a22b-f2316a1f1980

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
