### PR TITLE
Fix "not subject to VAT" not being selected after being saved

### DIFF
--- a/components/edit-collective/Form.js
+++ b/components/edit-collective/Form.js
@@ -4,7 +4,7 @@ import { getApplicableTaxesForCountry, TaxType } from '@opencollective/taxes';
 import { InfoCircle } from '@styled-icons/boxicons-regular/InfoCircle';
 import { ArrowBack } from '@styled-icons/material/ArrowBack';
 import dayjs from 'dayjs';
-import { cloneDeep, find, get, set } from 'lodash';
+import { cloneDeep, find, get, isNil, set } from 'lodash';
 import { withRouter } from 'next/router';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 
@@ -565,6 +565,9 @@ class EditCollectiveForm extends React.Component {
     const taxes = getApplicableTaxesForCountry(country);
 
     if (taxes.includes(TaxType.VAT)) {
+      const vatType = get(collective, 'settings.VAT.type');
+      const vatNumber = get(collective, 'settings.VAT.number');
+
       const getVATOptions = () => {
         const options = [
           {
@@ -592,7 +595,7 @@ class EditCollectiveForm extends React.Component {
         {
           name: 'VAT',
           type: 'select',
-          defaultValue: get(collective, 'settings.VAT.type') || VAT_OPTIONS.HOST,
+          defaultValue: isNil(vatType) ? VAT_OPTIONS.HOST : vatType,
           when: () => {
             return collective.isHost || AccountTypesWithHost.includes(collective.type);
           },
@@ -602,12 +605,12 @@ class EditCollectiveForm extends React.Component {
           name: 'VAT-number',
           type: 'string',
           placeholder: 'FRXX999999999',
-          defaultValue: get(collective, 'settings.VAT.number'),
+          defaultValue: vatNumber,
           when: () => {
             const { collective } = this.state;
             if (collective.type === COLLECTIVE || collective.type === EVENT) {
               // Collectives can set a VAT number if configured
-              return get(collective, 'settings.VAT.type') === VAT_OPTIONS.OWN;
+              return vatType === VAT_OPTIONS.OWN;
             } else {
               return true;
             }


### PR DESCRIPTION
From a user:

> Every time I put "not subject to VAT", I save, everything seems to be fine. 
but the next time it's back to the way it was.

Related to https://github.com/opencollective/opencollective-frontend/pull/8509