### PR TITLE
Fix(host applications): Fix import and use common i18n labels for custom applications

### DIFF
--- a/components/ocf-host-application/ApplicationForm.js
+++ b/components/ocf-host-application/ApplicationForm.js
@@ -16,7 +16,7 @@ import { formatCurrency } from '../../lib/currency-utils';
 import { i18nGraphqlException } from '../../lib/errors';
 import { requireFields, verifyChecked, verifyEmailPattern, verifyFieldLength } from '../../lib/form-utils';
 import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
-import { i18nOCFApplicationFormLabel } from '../../lib/i18n/custom-application-form';
+import { i18nCustomApplicationFormLabel } from '../../lib/i18n/custom-application-form';
 
 import CollectivePickerAsync from '../CollectivePickerAsync';
 import NextIllustration from '../collectives/HomeNextIllustration';
@@ -306,7 +306,7 @@ const ApplicationForm = ({
                       </Box>
                       <Box width={['256px', '234px', '324px']}>
                         <StyledInputFormikField
-                          label={i18nOCFApplicationFormLabel(intl, 'location')}
+                          label={i18nCustomApplicationFormLabel(intl, 'location')}
                           labelFontSize="13px"
                           labelColor="#4E5052"
                           labelProps={{ fontWeight: '600', lineHeight: '16px' }}
@@ -322,7 +322,7 @@ const ApplicationForm = ({
                         <Flex flexDirection={['column', 'row']}>
                           <Box mr={[null, 3]}>
                             <StyledInputFormikField
-                              label={i18nOCFApplicationFormLabel(intl, 'name')}
+                              label={i18nCustomApplicationFormLabel(intl, 'name')}
                               labelFontSize="13px"
                               labelColor="#4E5052"
                               labelProps={{ fontWeight: '600', lineHeight: '16px' }}
@@ -340,7 +340,7 @@ const ApplicationForm = ({
                           </Box>
                           <Box my={2}>
                             <StyledInputFormikField
-                              label={i18nOCFApplicationFormLabel(intl, 'email')}
+                              label={i18nCustomApplicationFormLabel(intl, 'email')}
                               labelFontSize="13px"
                               labelColor="#4E5052"
                               labelProps={{ fontWeight: '600', lineHeight: '16px' }}
@@ -368,7 +368,7 @@ const ApplicationForm = ({
                         <Flex flexDirection={['column', 'row']}>
                           <Box my={2} mr={[null, 3]}>
                             <StyledInputFormikField
-                              label={i18nOCFApplicationFormLabel(intl, 'initiativeName')}
+                              label={i18nCustomApplicationFormLabel(intl, 'initiativeName')}
                               labelFontSize="13px"
                               labelColor="#4E5052"
                               labelProps={{ fontWeight: '600', lineHeight: '16px' }}
@@ -385,7 +385,7 @@ const ApplicationForm = ({
                           </Box>
                           <Box width={['256px', '234px', '324px']} my={2}>
                             <StyledInputFormikField
-                              label={i18nOCFApplicationFormLabel(intl, 'slug')}
+                              label={i18nCustomApplicationFormLabel(intl, 'slug')}
                               helpText={<FormattedMessage defaultMessage="This can be edited later" />}
                               labelFontSize="13px"
                               labelColor="#4E5052"
@@ -424,7 +424,7 @@ const ApplicationForm = ({
                       <Flex flexDirection={['column', 'row']}>
                         <Box mr={[null, 3]}>
                           <StyledInputFormikField
-                            label={i18nOCFApplicationFormLabel(intl, 'initiativeDuration')}
+                            label={i18nCustomApplicationFormLabel(intl, 'initiativeDuration')}
                             labelFontSize="13px"
                             labelColor="#4E5052"
                             labelProps={{ fontWeight: '600', lineHeight: '16px' }}
@@ -441,7 +441,7 @@ const ApplicationForm = ({
                         </Box>
                         <Box width={['256px', '234px', '324px']} my={2}>
                           <StyledInputFormikField
-                            label={i18nOCFApplicationFormLabel(intl, 'totalAmountRaised')}
+                            label={i18nCustomApplicationFormLabel(intl, 'totalAmountRaised')}
                             labelFontSize="13px"
                             labelColor="#4E5052"
                             labelProps={{ fontWeight: '600', lineHeight: '16px' }}
@@ -473,7 +473,7 @@ const ApplicationForm = ({
                       <Flex flexDirection={['column', 'row']}>
                         <Box width={['256px', '234px', '324px']} my={2} mr={[null, 3]}>
                           <StyledInputFormikField
-                            label={i18nOCFApplicationFormLabel(intl, 'totalAmountToBeRaised')}
+                            label={i18nCustomApplicationFormLabel(intl, 'totalAmountToBeRaised')}
                             labelFontSize="13px"
                             labelColor="#4E5052"
                             labelProps={{ fontWeight: '600', lineHeight: '16px' }}
@@ -498,7 +498,7 @@ const ApplicationForm = ({
                         </Box>
                         <Box width={['256px', '234px', '324px']} my={2}>
                           <StyledInputFormikField
-                            label={i18nOCFApplicationFormLabel(intl, 'expectedFundingPartner')}
+                            label={i18nCustomApplicationFormLabel(intl, 'expectedFundingPartner')}
                             labelFontSize="13px"
                             labelColor="#4E5052"
                             labelProps={{ fontWeight: '600', lineHeight: '16px' }}
@@ -519,7 +519,7 @@ const ApplicationForm = ({
                       </Flex>
                       <Box width={['256px', '484px', '663px']} my={2}>
                         <StyledInputFormikField
-                          label={i18nOCFApplicationFormLabel(intl, 'initiativeDescription')}
+                          label={i18nCustomApplicationFormLabel(intl, 'initiativeDescription')}
                           labelFontSize="13px"
                           labelColor="#4E5052"
                           labelProps={{ fontWeight: '600', lineHeight: '16px' }}
@@ -544,7 +544,7 @@ const ApplicationForm = ({
                       </Box>
                       <Box width={['256px', '484px', '663px']} my={2}>
                         <StyledInputFormikField
-                          label={i18nOCFApplicationFormLabel(intl, 'missionImpactExplanation')}
+                          label={i18nCustomApplicationFormLabel(intl, 'missionImpactExplanation')}
                           labelFontSize="13px"
                           labelColor="#4E5052"
                           labelProps={{ fontWeight: '600', lineHeight: '16px' }}
@@ -670,7 +670,7 @@ const ApplicationForm = ({
                       </Box>
                       <Box width={['256px', '484px', '663px']} my={2}>
                         <StyledInputFormikField
-                          label={i18nOCFApplicationFormLabel(intl, 'websiteAndSocialLinks')}
+                          label={i18nCustomApplicationFormLabel(intl, 'websiteAndSocialLinks')}
                           labelFontSize="13px"
                           labelColor="#4E5052"
                           labelProps={{ fontWeight: '600', lineHeight: '16px' }}

--- a/components/osc-host-application/ApplicationForm.js
+++ b/components/osc-host-application/ApplicationForm.js
@@ -5,7 +5,7 @@ import { ArrowLeft2 } from '@styled-icons/icomoon/ArrowLeft2';
 import { ArrowRight2 } from '@styled-icons/icomoon/ArrowRight2';
 import { Form, Formik } from 'formik';
 import { withRouter } from 'next/router';
-import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import spdxLicenses from 'spdx-license-list';
 
 import { suggestSlug } from '../../lib/collective.lib';
@@ -19,6 +19,7 @@ import {
   verifyURLPattern,
 } from '../../lib/form-utils';
 import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
+import { i18nLabels } from '../../lib/i18n/custom-application-form';
 
 import CollectivePickerAsync from '../CollectivePickerAsync';
 import NextIllustration from '../collectives/HomeNextIllustration';
@@ -98,108 +99,6 @@ const applyToHostMutation = gql`
     }
   }
 `;
-
-const messages = defineMessages({
-  nameLabel: { id: 'createCollective.form.nameLabel', defaultMessage: 'Collective name' },
-  suggestedLabel: { id: 'createCollective.form.suggestedLabel', defaultMessage: 'Suggested' },
-  descriptionLabel: {
-    id: 'createCollective.form.descriptionLabel',
-    defaultMessage: 'What does your Collective do?',
-  },
-  tagsLabel: { id: 'Tags', defaultMessage: 'Tags' },
-  descriptionHint: {
-    id: 'createCollective.form.descriptionHint',
-    defaultMessage: 'Write a short description (150 characters max)',
-  },
-  descriptionPlaceholder: {
-    id: 'create.collective.placeholder',
-    defaultMessage: 'Making the world a better place',
-  },
-  errorSlugHyphen: {
-    id: 'createCollective.form.error.slug.hyphen',
-    defaultMessage: 'Collective handle cannot start or end with a hyphen',
-  },
-  name: {
-    id: 'OCFHostApplication.name.label',
-    defaultMessage: 'Your Name',
-  },
-  email: {
-    id: 'Form.yourEmail',
-    defaultMessage: 'Your email address',
-  },
-  slug: {
-    id: 'createCollective.form.slugLabel',
-    defaultMessage: 'Set your profile URL',
-  },
-  repositoryUrl: {
-    id: 'HostApplication.form.RepositoryUrlLabel',
-    defaultMessage: 'Your Repository or Organization',
-  },
-  repositoryLicense: {
-    id: 'HostApplication.form.license',
-    defaultMessage: 'License',
-  },
-  tellUsMoreLabel: {
-    id: 'HostApplication.form.tellUsMoreLabel',
-    defaultMessage: "Tell us a little about your project, what you're working on and what you need from us.",
-  },
-  tellUsMorePlaceholder: {
-    id: 'HostApplication.form.tellUsMorePlaceHolder',
-    defaultMessage: 'Please include all the info you think is valuable of your Collective',
-  },
-  tellUsMoreHelpText: {
-    id: 'HostApplication.form.tellUsMoreHelpText',
-    defaultMessage: 'We want to know more about you and how we can help you.',
-  },
-  linksToPreviousEvents: {
-    id: 'HostApplication.form.linksToPreviousEvents',
-    defaultMessage: 'Links to previous events (if any)',
-  },
-  linksToPreviousEventsPlaceholder: {
-    id: 'HostApplication.form.linksToPreviousEventsPlaceholder',
-    defaultMessage: 'Enter URL of previous events.',
-  },
-  linksToPreviousEventsHelpText: {
-    id: 'HostApplication.form.linksToPreviousEventsHelpText',
-    defaultMessage:
-      'YouTube, Discord, Disqus, Meetup, Eventbrite events etc are all welcome. We just want to understand your community presence.',
-  },
-  amountOfMembers: {
-    id: 'HostApplication.form.amountOfMembers',
-    defaultMessage: 'How many members do you have?',
-  },
-  extraLicenseInfo: {
-    id: 'HostApplication.form.extraLicenseInfo',
-    defaultMessage: 'Extra information about your license(s)',
-  },
-  extraLicenseInfoHelpText: {
-    id: 'HostApplication.form.extraLicenseInfoHelpText',
-    defaultMessage: 'If your license is unrecognized or have more than one license, add information here',
-  },
-  publicInformation: {
-    id: 'HostApplication.form.publicInformation',
-    defaultMessage:
-      'This information is public. Please do not add any personal information such as names or addresses in this field.',
-  },
-  aboutYourCommunityTitle: {
-    id: 'HostApplication.form.aboutYourCommunity',
-    defaultMessage: 'About your Community {optional}',
-  },
-  aboutYourCommunitySubtitle: {
-    id: 'HostApplication.form.aboutYourCommunity.subtitle',
-    defaultMessage:
-      'If applicable, please share information about your community and your events so we can properly consider your application.',
-  },
-  aboutYourCodeTitle: {
-    id: 'HostApplication.form.code',
-    defaultMessage: 'About your Code {optional}',
-  },
-  aboutYourCodeSubtitle: {
-    id: 'HostApplication.form.code.subtitle',
-    defaultMessage:
-      "If a codebase is central to your community's work please share information about your code and license so we can properly consider your application.",
-  },
-});
 
 const useApplicationMutation = canApplyWithCollective =>
   useMutation(canApplyWithCollective ? applyToHostMutation : createCollectiveMutation, {
@@ -401,7 +300,7 @@ const ApplicationForm = ({
                         <Grid gridTemplateColumns={['1fr', 'repeat(2, minmax(0, 1fr))']} gridGap={3} py={2}>
                           <Box>
                             <StyledInputFormikField
-                              label={intl.formatMessage(messages.name)}
+                              label={intl.formatMessage(i18nLabels.name)}
                               labelFontSize="16px"
                               labelProps={{ fontWeight: '600' }}
                               disabled={!!LoggedInUser}
@@ -417,7 +316,7 @@ const ApplicationForm = ({
                           </Box>
                           <Box>
                             <StyledInputFormikField
-                              label={intl.formatMessage(messages.email)}
+                              label={intl.formatMessage(i18nLabels.email)}
                               labelFontSize="16px"
                               labelProps={{ fontWeight: '600' }}
                               disabled={!!LoggedInUser}
@@ -444,7 +343,7 @@ const ApplicationForm = ({
                           <Grid gridTemplateColumns={['1fr', 'repeat(2, minmax(0, 1fr))']} gridGap={3} mb={3}>
                             <Box>
                               <StyledInputFormikField
-                                label={intl.formatMessage(messages.nameLabel)}
+                                label={intl.formatMessage(i18nLabels.nameLabel)}
                                 labelFontSize="16px"
                                 labelProps={{ fontWeight: '600' }}
                                 name="collective.name"
@@ -459,7 +358,7 @@ const ApplicationForm = ({
                             </Box>
                             <Box>
                               <StyledInputFormikField
-                                label={intl.formatMessage(messages.slug)}
+                                label={intl.formatMessage(i18nLabels.slug)}
                                 helpText={<FormattedMessage defaultMessage="This can be edited later" />}
                                 labelFontSize="16px"
                                 labelProps={{ fontWeight: '600' }}
@@ -492,7 +391,7 @@ const ApplicationForm = ({
                               htmlFor="description"
                               labelFontSize="16px"
                               labelProps={{ fontWeight: '600' }}
-                              label={intl.formatMessage(messages.descriptionLabel)}
+                              label={intl.formatMessage(i18nLabels.descriptionLabel)}
                               required
                               data-cy="ccf-form-description"
                             >
@@ -504,12 +403,12 @@ const ApplicationForm = ({
                                   maxLength={150}
                                   showCount
                                   fontSize="14px"
-                                  placeholder={intl.formatMessage(messages.descriptionPlaceholder)}
+                                  placeholder={intl.formatMessage(i18nLabels.descriptionPlaceholder)}
                                 />
                               )}
                             </StyledInputFormikField>
                             <P fontSize="13px" lineHeight="20px" color="black.600" mt="6px">
-                              {intl.formatMessage(messages.descriptionHint)}
+                              {intl.formatMessage(i18nLabels.descriptionHint)}
                             </P>
                           </Box>
                           <Box>
@@ -518,7 +417,7 @@ const ApplicationForm = ({
                               htmlFor="tags"
                               labelFontSize="16px"
                               labelProps={{ fontWeight: '600' }}
-                              label={intl.formatMessage(messages.tagsLabel)}
+                              label={intl.formatMessage(i18nLabels.tagsLabel)}
                               data-cy="ccf-form-tags"
                             >
                               {({ field }) => (
@@ -582,7 +481,7 @@ const ApplicationForm = ({
                       </StyledInputFormikField>
 
                       <CollapseSection
-                        title={intl.formatMessage(messages.aboutYourCodeTitle, {
+                        title={intl.formatMessage(i18nLabels.aboutYourCodeTitle, {
                           optional:
                             values.applicationData.typeOfProject === 'COMMUNITY' ? (
                               <Span fontWeight={400} color="black.700">
@@ -593,12 +492,12 @@ const ApplicationForm = ({
                         isExpanded={codeSectionExpanded}
                         toggleExpanded={() => setCodeSectionExpanded(!codeSectionExpanded)}
                         imageSrc="/static/images/night-sky.png"
-                        subtitle={intl.formatMessage(messages.aboutYourCodeSubtitle)}
+                        subtitle={intl.formatMessage(i18nLabels.aboutYourCodeSubtitle)}
                       >
                         <Grid gridTemplateColumns={['1fr', 'repeat(2, minmax(0, 1fr))']} gridGap={3} pt={2}>
                           <Box>
                             <StyledInputFormikField
-                              label={intl.formatMessage(messages.repositoryUrl)}
+                              label={intl.formatMessage(i18nLabels.repositoryUrl)}
                               labelFontSize="16px"
                               labelProps={{ fontWeight: '600' }}
                               name="applicationData.repositoryUrl"
@@ -623,7 +522,7 @@ const ApplicationForm = ({
                           </Box>
 
                           <StyledInputFormikField
-                            label={intl.formatMessage(messages.repositoryLicense)}
+                            label={intl.formatMessage(i18nLabels.repositoryLicense)}
                             labelFontSize="16px"
                             labelProps={{ fontWeight: '600' }}
                             name="applicationData.licenseSpdxId"
@@ -651,25 +550,25 @@ const ApplicationForm = ({
                             htmlFor="extraLicenseInformation"
                             labelFontSize="16px"
                             labelProps={{ fontWeight: '600' }}
-                            label={intl.formatMessage(messages.extraLicenseInfo)}
+                            label={intl.formatMessage(i18nLabels.extraLicenseInfo)}
                           >
                             {({ field }) => (
                               <StyledTextarea
                                 {...field}
                                 rows={4}
                                 fontSize="14px"
-                                placeholder={intl.formatMessage(messages.extraLicenseInfoHelpText)}
+                                placeholder={intl.formatMessage(i18nLabels.extraLicenseInfoHelpText)}
                               />
                             )}
                           </StyledInputFormikField>
                           <P fontSize="13px" lineHeight="20px" color="black.700" mt={2}>
-                            <FormattedMessage {...messages.extraLicenseInfoHelpText} />
+                            <FormattedMessage {...i18nLabels.extraLicenseInfoHelpText} />
                           </P>
                         </Box>
                       </CollapseSection>
 
                       <CollapseSection
-                        title={intl.formatMessage(messages.aboutYourCommunityTitle, {
+                        title={intl.formatMessage(i18nLabels.aboutYourCommunityTitle, {
                           optional:
                             values.applicationData.typeOfProject === 'CODE' ? (
                               <Span fontWeight={400} color="black.700">
@@ -680,12 +579,12 @@ const ApplicationForm = ({
                         isExpanded={communitySectionExpanded}
                         toggleExpanded={() => setCommunitySectionExpanded(!communitySectionExpanded)}
                         imageSrc="/static/images/community.png"
-                        subtitle={intl.formatMessage(messages.aboutYourCommunitySubtitle)}
+                        subtitle={intl.formatMessage(i18nLabels.aboutYourCommunitySubtitle)}
                       >
                         <Grid gridTemplateColumns={['1fr', 'repeat(2, minmax(0, 1fr))']} gridGap={3} pt={2}>
                           <Box>
                             <StyledInputFormikField
-                              label={intl.formatMessage(messages.amountOfMembers)}
+                              label={intl.formatMessage(i18nLabels.amountOfMembers)}
                               labelFontSize="16px"
                               labelProps={{ fontWeight: '600' }}
                               name="applicationData.amountOfMembers"
@@ -709,19 +608,19 @@ const ApplicationForm = ({
                             htmlFor="previousEvents"
                             labelFontSize="16px"
                             labelProps={{ fontWeight: '600' }}
-                            label={intl.formatMessage(messages.linksToPreviousEvents)}
+                            label={intl.formatMessage(i18nLabels.linksToPreviousEvents)}
                           >
                             {({ field }) => (
                               <StyledTextarea
                                 {...field}
                                 rows={4}
                                 fontSize="14px"
-                                placeholder={intl.formatMessage(messages.linksToPreviousEventsPlaceholder)}
+                                placeholder={intl.formatMessage(i18nLabels.linksToPreviousEventsPlaceholder)}
                               />
                             )}
                           </StyledInputFormikField>
                           <P fontSize="13px" lineHeight="20px" color="black.700" mt={2}>
-                            <FormattedMessage {...messages.linksToPreviousEventsHelpText} />
+                            <FormattedMessage {...i18nLabels.linksToPreviousEventsHelpText} />
                           </P>
                         </Box>
                       </CollapseSection>
@@ -808,7 +707,7 @@ const ApplicationForm = ({
                           required={true}
                           labelFontSize="16px"
                           labelProps={{ fontWeight: '600' }}
-                          label={intl.formatMessage(messages.tellUsMoreLabel)}
+                          label={intl.formatMessage(i18nLabels.tellUsMoreLabel)}
                           data-cy="ccf-form-message"
                         >
                           {({ field }) => (
@@ -816,12 +715,12 @@ const ApplicationForm = ({
                               {...field}
                               rows={6}
                               fontSize="14px"
-                              placeholder={intl.formatMessage(messages.tellUsMorePlaceholder)}
+                              placeholder={intl.formatMessage(i18nLabels.tellUsMorePlaceholder)}
                             />
                           )}
                         </StyledInputFormikField>
                         <P fontSize="13px" lineHeight="20px" color="black.700" mt={2}>
-                          <FormattedMessage {...messages.tellUsMoreHelpText} />
+                          <FormattedMessage {...i18nLabels.tellUsMoreHelpText} />
                         </P>
                       </Box>
 

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1769,7 +1769,6 @@
   "HostApplication.form.mainInfo": "Main info",
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
-  "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
   "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1769,7 +1769,6 @@
   "HostApplication.form.mainInfo": "Main info",
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
-  "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
   "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1769,7 +1769,6 @@
   "HostApplication.form.mainInfo": "Main info",
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
-  "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
   "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1769,7 +1769,6 @@
   "HostApplication.form.mainInfo": "Main info",
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
-  "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
   "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1769,7 +1769,6 @@
   "HostApplication.form.mainInfo": "Información principal",
   "HostApplication.form.publicInformation": "Esta información es pública. Por favor, no añadas ninguna información personal, como nombres o direcciones, en esta casilla.",
   "HostApplication.form.readFaqs": "Consulta nuestras preguntas frecuentes",
-  "HostApplication.form.RepositoryUrlLabel": "Tu Repositorio u Organización",
   "HostApplication.form.subheading": "¡Presenta tu Colectivo! Por favor, incluye todo el contexto posible para que podamos darte el mejor servicio posible. ¿Dudas? {faqLink}",
   "HostApplication.form.team": "Tu equipo",
   "HostApplication.form.tellUsMoreHelpText": "Queremos saber más sobre ti y cómo podemos ayudarte.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1769,7 +1769,6 @@
   "HostApplication.form.mainInfo": "Infos principales",
   "HostApplication.form.publicInformation": "Ce champ est public. N'ajoutez pas d'informations personnelles telles que des noms ou des adresses dans ce champ.",
   "HostApplication.form.readFaqs": "Lisez notre FAQ",
-  "HostApplication.form.RepositoryUrlLabel": "Votre dépôt ou votre organisation",
   "HostApplication.form.subheading": "Présentez votre Collectif, veuillez inclure autant de contexte que possible afin que nous puissions vous offrir le meilleur service qui soit ! Vous avez des doutes ? {faqLink}",
   "HostApplication.form.team": "Votre équipe",
   "HostApplication.form.tellUsMoreHelpText": "Nous voulons en savoir plus sur vous et sur la façon dont nous pouvons vous aider.",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1769,7 +1769,6 @@
   "HostApplication.form.mainInfo": "Main info",
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
-  "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
   "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1769,7 +1769,6 @@
   "HostApplication.form.mainInfo": "Main info",
   "HostApplication.form.publicInformation": "この情報は公開されます。氏名、住所など個人情報は記入しないでください。",
   "HostApplication.form.readFaqs": "Read our FAQs",
-  "HostApplication.form.RepositoryUrlLabel": "リポジトリまたは組織",
   "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1769,7 +1769,6 @@
   "HostApplication.form.mainInfo": "Main info",
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
-  "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
   "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1769,7 +1769,6 @@
   "HostApplication.form.mainInfo": "Main info",
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
-  "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
   "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -1769,7 +1769,6 @@
   "HostApplication.form.mainInfo": "Główne informacje",
   "HostApplication.form.publicInformation": "Ta informacja jest publiczna. Prosimy nie dodawać w tym polu żadnych danych osobowych, takich jak nazwisk czy też adresów.",
   "HostApplication.form.readFaqs": "Przeczytaj nasze FAQ",
-  "HostApplication.form.RepositoryUrlLabel": "Twoje Repozytorium lub organizacja",
   "HostApplication.form.subheading": "Przedstaw swój zbiórkę. Prosimy zawrzeć jak najwięcej szczegółów, abyśmy mogli zapewnić Ci jak najlepszą obsługę! Masz jakieś pytania? {faqLink}",
   "HostApplication.form.team": "Twój zespół",
   "HostApplication.form.tellUsMoreHelpText": "Chcemy wiedzieć więcej o tobie oraz jak możemy ci pomóc.",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1769,7 +1769,6 @@
   "HostApplication.form.mainInfo": "Main info",
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
-  "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
   "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1769,7 +1769,6 @@
   "HostApplication.form.mainInfo": "Main info",
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
-  "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
   "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1769,7 +1769,6 @@
   "HostApplication.form.mainInfo": "Main info",
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Читайте наши ЧЗВ",
-  "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
   "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",

--- a/lang/sk-SK.json
+++ b/lang/sk-SK.json
@@ -1769,7 +1769,6 @@
   "HostApplication.form.mainInfo": "Main info",
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
-  "HostApplication.form.RepositoryUrlLabel": "Your Repository or Organization",
   "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Your team",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",

--- a/lang/sv-SE.json
+++ b/lang/sv-SE.json
@@ -1769,7 +1769,6 @@
   "HostApplication.form.mainInfo": "Huvudinformation",
   "HostApplication.form.publicInformation": "Denna information är offentlig. Lägg inte till någon personlig information som namn eller adresser i detta fält.",
   "HostApplication.form.readFaqs": "Vanliga frågor",
-  "HostApplication.form.RepositoryUrlLabel": "Ditt repo eller organisation",
   "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Ditt team",
   "HostApplication.form.tellUsMoreHelpText": "Vi vill veta mer om dig och hur vi kan hjälpa dig.",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -1769,7 +1769,6 @@
   "HostApplication.form.mainInfo": "Основні відомості",
   "HostApplication.form.publicInformation": "This information is public. Please do not add any personal information such as names or addresses in this field.",
   "HostApplication.form.readFaqs": "Read our FAQs",
-  "HostApplication.form.RepositoryUrlLabel": "Ваш репозиторій або організація",
   "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "Ваша команда",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1769,7 +1769,6 @@
   "HostApplication.form.mainInfo": "主要信息",
   "HostApplication.form.publicInformation": "此信息是公开的。请不要添加任何个人信息，如此字段中的姓名或地址。",
   "HostApplication.form.readFaqs": "阅读我们的常见问题",
-  "HostApplication.form.RepositoryUrlLabel": "你的仓库或组织",
   "HostApplication.form.subheading": "Introduce your Collective, please include as much context as possible so we can give you the best service we can! Have doubts? {faqLink}",
   "HostApplication.form.team": "你的团队",
   "HostApplication.form.tellUsMoreHelpText": "We want to know more about you and how we can help you.",

--- a/lib/i18n/custom-application-form.js
+++ b/lib/i18n/custom-application-form.js
@@ -1,6 +1,6 @@
 import { defineMessages } from 'react-intl';
 
-const i18nLabels = defineMessages({
+export const i18nLabels = defineMessages({
   location: {
     id: 'OCFHostApplication.location.label',
     defaultMessage: 'Your Location',
@@ -52,6 +52,89 @@ const i18nLabels = defineMessages({
   repositoryUrl: {
     id: 'HostApplication.repositoryUrl.label',
     defaultMessage: 'Repository URL',
+  },
+  nameLabel: { id: 'createCollective.form.nameLabel', defaultMessage: 'Collective name' },
+  suggestedLabel: { id: 'createCollective.form.suggestedLabel', defaultMessage: 'Suggested' },
+  descriptionLabel: {
+    id: 'createCollective.form.descriptionLabel',
+    defaultMessage: 'What does your Collective do?',
+  },
+  tagsLabel: { id: 'Tags', defaultMessage: 'Tags' },
+  descriptionHint: {
+    id: 'createCollective.form.descriptionHint',
+    defaultMessage: 'Write a short description (150 characters max)',
+  },
+  descriptionPlaceholder: {
+    id: 'create.collective.placeholder',
+    defaultMessage: 'Making the world a better place',
+  },
+  errorSlugHyphen: {
+    id: 'createCollective.form.error.slug.hyphen',
+    defaultMessage: 'Collective handle cannot start or end with a hyphen',
+  },
+  repositoryLicense: {
+    id: 'HostApplication.form.license',
+    defaultMessage: 'License',
+  },
+  tellUsMoreLabel: {
+    id: 'HostApplication.form.tellUsMoreLabel',
+    defaultMessage: "Tell us a little about your project, what you're working on and what you need from us.",
+  },
+  tellUsMorePlaceholder: {
+    id: 'HostApplication.form.tellUsMorePlaceHolder',
+    defaultMessage: 'Please include all the info you think is valuable of your Collective',
+  },
+  tellUsMoreHelpText: {
+    id: 'HostApplication.form.tellUsMoreHelpText',
+    defaultMessage: 'We want to know more about you and how we can help you.',
+  },
+  linksToPreviousEvents: {
+    id: 'HostApplication.form.linksToPreviousEvents',
+    defaultMessage: 'Links to previous events (if any)',
+  },
+  linksToPreviousEventsPlaceholder: {
+    id: 'HostApplication.form.linksToPreviousEventsPlaceholder',
+    defaultMessage: 'Enter URL of previous events.',
+  },
+  linksToPreviousEventsHelpText: {
+    id: 'HostApplication.form.linksToPreviousEventsHelpText',
+    defaultMessage:
+      'YouTube, Discord, Disqus, Meetup, Eventbrite events etc are all welcome. We just want to understand your community presence.',
+  },
+  amountOfMembers: {
+    id: 'HostApplication.form.amountOfMembers',
+    defaultMessage: 'How many members do you have?',
+  },
+  extraLicenseInfo: {
+    id: 'HostApplication.form.extraLicenseInfo',
+    defaultMessage: 'Extra information about your license(s)',
+  },
+  extraLicenseInfoHelpText: {
+    id: 'HostApplication.form.extraLicenseInfoHelpText',
+    defaultMessage: 'If your license is unrecognized or have more than one license, add information here',
+  },
+  publicInformation: {
+    id: 'HostApplication.form.publicInformation',
+    defaultMessage:
+      'This information is public. Please do not add any personal information such as names or addresses in this field.',
+  },
+  aboutYourCommunityTitle: {
+    id: 'HostApplication.form.aboutYourCommunity',
+    defaultMessage: 'About your Community {optional}',
+  },
+  aboutYourCommunitySubtitle: {
+    id: 'HostApplication.form.aboutYourCommunity.subtitle',
+    defaultMessage:
+      'If applicable, please share information about your community and your events so we can properly consider your application.',
+  },
+  aboutYourCodeTitle: {
+    id: 'HostApplication.form.code',
+    defaultMessage: 'About your Code {optional}',
+  },
+  aboutYourCodeSubtitle: {
+    id: 'HostApplication.form.code.subtitle',
+    defaultMessage:
+      "If a codebase is central to your community's work please share information about your code and license so we can properly consider your application.",
   },
 });
 


### PR DESCRIPTION
### Description
Fixes a faulty import and makes sure to use the same i18n labels object everywhere for custom host applications, to get the labels right both in the two custom forms and in the common drawer when displaying that data.