### PR TITLE
Move "Active as Host" to the "Advanced" section

### DIFF
--- a/components/admin-panel/Menu.js
+++ b/components/admin-panel/Menu.js
@@ -43,7 +43,6 @@ const OrganizationSettingsMenuLinks = ({ collective, isAccountantOnly }) => {
           <MenuLink collective={collective} section={COLLECTIVE_SECTIONS.ACTIVITY_LOG} />
           <MenuLink collective={collective} section={FISCAL_HOST_SECTIONS.SECURITY} />
           <MenuLink collective={collective} section={ALL_SECTIONS.ADVANCED} />
-          {!isHostAccount(collective) && <MenuLink collective={collective} section={ALL_SECTIONS.FISCAL_HOSTING} />}
         </React.Fragment>
       )}
     </React.Fragment>

--- a/components/dashboard/Menu.tsx
+++ b/components/dashboard/Menu.tsx
@@ -40,7 +40,6 @@ const Menu = ({ isAccountantOnly, onRoute }) => {
   const router = useRouter();
   const { account } = React.useContext(DashboardContext);
   const isHost = isHostAccount(account);
-  const isUserHost = account.isHost === true && isType(account, USER); // for legacy compatibility for users who are hosts
   const isIndividual = isIndividualAccount(account);
 
   React.useEffect(() => {
@@ -126,7 +125,7 @@ const Menu = ({ isAccountantOnly, onRoute }) => {
             ) : isType(account, COLLECTIVE) ? (
               <FormattedMessage id="CollectiveDashboard" defaultMessage="Collective Dashboard" />
             ) : (
-              <FormattedMessage id="Workspace" defaultMessage="Workspace" />
+              <FormattedMessage id="Dashboard" defaultMessage="Dashboard" />
             )}
           </MenuSectionHeader>
         )}
@@ -142,7 +141,7 @@ const Menu = ({ isAccountantOnly, onRoute }) => {
         <MenuLink section={COLLECTIVE_SECTIONS.TRANSACTIONS} Icon={Transfer} />
         <MenuLink
           Icon={Settings}
-          if={!isHost || isUserHost}
+          if={!isType(account, ORGANIZATION)}
           section="SETTINGS"
           goToSection={COLLECTIVE_SECTIONS.INFO}
           renderSubMenu={({ parentSection }) => (
@@ -248,10 +247,11 @@ const Menu = ({ isAccountantOnly, onRoute }) => {
         >
           <FormattedMessage id="Settings" defaultMessage="Settings" />
         </MenuLink>
-        {/* org settings for hosts */}
+
+        {/* org settings */}
         <MenuLink
           Icon={Settings}
-          if={isType(account, ORGANIZATION) && isHost}
+          if={isType(account, ORGANIZATION)}
           section="ORG_SETTINGS"
           goToSection={isAccountantOnly ? ALL_SECTIONS.PAYMENT_RECEIPTS : ABOUT_ORG_SECTIONS.INFO}
           renderSubMenu={({ parentSection }) => (
@@ -275,15 +275,16 @@ const Menu = ({ isAccountantOnly, onRoute }) => {
                   <MenuLink parentSection={parentSection} section={COLLECTIVE_SECTIONS.ACTIVITY_LOG} />
                   <MenuLink parentSection={parentSection} section={FISCAL_HOST_SECTIONS.SECURITY} />
                   <MenuLink parentSection={parentSection} section={ALL_SECTIONS.ADVANCED} />
-                  {!isHostAccount(account) && (
-                    <MenuLink parentSection={parentSection} section={ALL_SECTIONS.FISCAL_HOSTING} />
-                  )}
                 </React.Fragment>
               )}
             </React.Fragment>
           )}
         >
-          <FormattedMessage id="AdminPanel.OrganizationSettings" defaultMessage="Organization Settings" />
+          {isHost ? (
+            <FormattedMessage id="AdminPanel.OrganizationSettings" defaultMessage="Organization Settings" />
+          ) : (
+            <FormattedMessage id="Settings" defaultMessage="Settings" />
+          )}
         </MenuLink>
       </MenuGroup>
     </div>

--- a/components/edit-collective/Form.js
+++ b/components/edit-collective/Form.js
@@ -498,6 +498,7 @@ class EditCollectiveForm extends React.Component {
         return (
           <Box>
             {collective.type === USER && <EditUserEmailForm />}
+            {collective.type === ORGANIZATION && <FiscalHosting collective={collective} LoggedInUser={LoggedInUser} />}
             {[COLLECTIVE, FUND, PROJECT, EVENT].includes(collective.type) && (
               <EmptyBalance collective={collective} LoggedInUser={LoggedInUser} />
             )}
@@ -509,7 +510,7 @@ class EditCollectiveForm extends React.Component {
       // Fiscal Hosts
 
       case ALL_SECTIONS.FISCAL_HOSTING:
-        return <FiscalHosting collective={collective} LoggedInUser={LoggedInUser} />;
+        return null;
 
       case ALL_SECTIONS.RECEIVING_MONEY:
         return <ReceivingMoney collective={collective} />;

--- a/components/edit-collective/sections/FiscalHosting.js
+++ b/components/edit-collective/sections/FiscalHosting.js
@@ -20,6 +20,8 @@ const activateCollectiveAsHostMutation = gqlV1/* GraphQL */ `
     activateCollectiveAsHost(id: $id) {
       id
       currency
+      isActive
+      isDeletable
       isHost
       plan {
         id
@@ -34,6 +36,8 @@ const deactivateCollectiveAsHostMutation = gqlV1/* GraphQL */ `
     deactivateCollectiveAsHost(id: $id) {
       id
       currency
+      isActive
+      isDeletable
       isHost
       plan {
         id
@@ -179,7 +183,11 @@ const FiscalHosting = ({ collective }) => {
   useKeyboardShortcut({ callback: handlePrimaryBtnClick, keyMatch: ENTER_KEY });
 
   return (
-    <Container display="flex" flexDirection="column" width={1} alignItems="flex-start">
+    <Container display="flex" flexDirection="column" width={1} alignItems="flex-start" mb={50}>
+      <SettingsSectionTitle>
+        <FormattedMessage id="editCollective.fiscalHosting" defaultMessage="Fiscal Hosting" />
+      </SettingsSectionTitle>
+
       {!isHostAccount && (
         <P>
           <FormattedMessage
@@ -189,12 +197,6 @@ const FiscalHosting = ({ collective }) => {
             }
           />
         </P>
-      )}
-
-      {isHostAccount && (
-        <SettingsSectionTitle>
-          <FormattedMessage id="host.deactivate" defaultMessage="Deactivate as Host" />
-        </SettingsSectionTitle>
       )}
 
       {isHostAccount && (


### PR DESCRIPTION
From JF:

> I've created an org but I don't see anything in the settings to change it to fiscal host. 
> Maybe the redesign of the dashboard menu forgot to put this option back?