### PR TITLE
Fix BudgetSection icon size

### DIFF
--- a/components/collective-page/sections/Budget/ContributionsBudget.js
+++ b/components/collective-page/sections/Budget/ContributionsBudget.js
@@ -98,16 +98,16 @@ const ContributionsBudget = ({ collective, defaultTimeInterval, ...props }) => {
             disabled={loading}
           />
           <GraphTypeButton active={graphType === GRAPH_TYPES.LIST} onClick={() => setGraphType(GRAPH_TYPES.LIST)}>
-            <FormatListBulleted />
+            <FormatListBulleted size="18px" />
           </GraphTypeButton>
           <GraphTypeButton active={graphType === GRAPH_TYPES.TIME} onClick={() => setGraphType(GRAPH_TYPES.TIME)}>
-            <Timeline />
+            <Timeline size="18px" />
           </GraphTypeButton>
           <GraphTypeButton active={graphType === GRAPH_TYPES.BAR} onClick={() => setGraphType(GRAPH_TYPES.BAR)}>
-            <BarChart />
+            <BarChart size="18px" />
           </GraphTypeButton>
           <GraphTypeButton active={graphType === GRAPH_TYPES.PIE} onClick={() => setGraphType(GRAPH_TYPES.PIE)}>
-            <PieChart />
+            <PieChart size="18px" />
           </GraphTypeButton>
         </Flex>
       </Flex>

--- a/components/collective-page/sections/Budget/ExpenseBudget.js
+++ b/components/collective-page/sections/Budget/ExpenseBudget.js
@@ -105,16 +105,16 @@ const ExpenseBudget = ({ collective, defaultTimeInterval, ...props }) => {
             disabled={loading}
           />
           <GraphTypeButton active={graphType === GRAPH_TYPES.LIST} onClick={() => setGraphType(GRAPH_TYPES.LIST)}>
-            <FormatListBulleted />
+            <FormatListBulleted size="18px" />
           </GraphTypeButton>
           <GraphTypeButton active={graphType === GRAPH_TYPES.TIME} onClick={() => setGraphType(GRAPH_TYPES.TIME)}>
-            <Timeline />
+            <Timeline size="18px" />
           </GraphTypeButton>
           <GraphTypeButton active={graphType === GRAPH_TYPES.BAR} onClick={() => setGraphType(GRAPH_TYPES.BAR)}>
-            <BarChart />
+            <BarChart size="18px" />
           </GraphTypeButton>
           <GraphTypeButton active={graphType === GRAPH_TYPES.PIE} onClick={() => setGraphType(GRAPH_TYPES.PIE)}>
-            <PieChart />
+            <PieChart size="18px" />
           </GraphTypeButton>
         </Flex>
       </Flex>


### PR DESCRIPTION
Fixes the BudgetSection graph type icon size:

<img width="352" alt="image" src="https://github.com/opencollective/opencollective-frontend/assets/2119706/dd135f17-eff8-46c7-90a6-ddd16fa6c75c">
