### PR TITLE
fix(style regressions): Dialog overflow + rich text editor outline issue

### DIFF
--- a/components/NewsAndUpdatesModal.js
+++ b/components/NewsAndUpdatesModal.js
@@ -7,6 +7,7 @@ import { FormattedDate, FormattedMessage } from 'react-intl';
 import { API_V2_CONTEXT } from '../lib/graphql/helpers';
 
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from './ui/Dialog';
+import { Separator } from './ui/Separator';
 import HTMLContent from './HTMLContent';
 import Image from './Image';
 import Link from './Link';
@@ -42,7 +43,7 @@ const newsAndUpdatesQuery = gql`
 const renderStyledCarousel = (data, loading, error, onClose) => {
   if (loading === false && data) {
     return (
-      <StyledCarousel contentPosition="left" className="-mx-6">
+      <StyledCarousel contentPosition="left">
         {data.account.updates.nodes.map(update => (
           <div key={update.id} className="px-3">
             <span className="text-sm text-muted-foreground">
@@ -119,8 +120,8 @@ const NewsAndUpdatesModal = ({ open, setOpen }) => {
   const onClose = () => setOpen(false);
   return (
     <Dialog open={open} onOpenChange={open => setOpen(open)}>
-      <DialogContent className="max-w-xl">
-        <DialogHeader>
+      <DialogContent className="p-0">
+        <DialogHeader className="px-6 pt-6">
           <div className="flex items-start justify-between gap-2">
             <div>
               <DialogTitle className="mb-1.5">
@@ -140,10 +141,12 @@ const NewsAndUpdatesModal = ({ open, setOpen }) => {
             />
           </div>
         </DialogHeader>
-        <hr className="-mx-6 my-1" />
-        <Query query={newsAndUpdatesQuery} variables={{ limit: 5 }} context={API_V2_CONTEXT}>
-          {({ data, loading, error }) => renderStyledCarousel(data, loading, error, onClose)}
-        </Query>
+        <Separator className="my-3" />
+        <div className="px-0 pb-6">
+          <Query query={newsAndUpdatesQuery} variables={{ limit: 5 }} context={API_V2_CONTEXT}>
+            {({ data, loading, error }) => renderStyledCarousel(data, loading, error, onClose)}
+          </Query>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/components/RichTextEditor.tsx
+++ b/components/RichTextEditor.tsx
@@ -674,6 +674,7 @@ export default class RichTextEditor extends React.Component<RichTextEditorProps,
         error={error}
         data-cy={this.props['data-cy']}
         ref={this.mainContainerRef}
+        className="focus-within:border-ring"
       >
         {this.state.error && (
           <MessageBox type="error" mb="36px" withIcon>
@@ -683,7 +684,7 @@ export default class RichTextEditor extends React.Component<RichTextEditorProps,
 
         <input id={this.state.id} value={this.state.value} type="hidden" name={inputName} />
         <HTMLContent fontSize={fontSize}>
-          <Container position="relative">
+          <div className="relative focus-visible:[&>_trix-editor]:outline-none">
             {React.createElement('trix-editor', {
               ref: this.editorRef,
               input: this.state.id,
@@ -698,7 +699,7 @@ export default class RichTextEditor extends React.Component<RichTextEditorProps,
                 </StyledTag>
               )}
             </Container>
-          </Container>
+          </div>
         </HTMLContent>
       </TrixEditorContainer>
     );

--- a/components/ui/Dialog.tsx
+++ b/components/ui/Dialog.tsx
@@ -20,7 +20,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-[3000] grid max-h-screen place-items-stretch overflow-y-auto bg-foreground/25 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 sm:place-items-center sm:px-6 sm:py-12',
+      'fixed inset-0 z-[3000] flex max-h-screen flex-col items-center overflow-y-auto bg-foreground/25 px-0 py-0 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 sm:px-6 sm:py-20',
       className,
     )}
     {...props}
@@ -39,7 +39,7 @@ const DialogContent = React.forwardRef<
       <DialogPrimitive.Content
         ref={ref}
         className={cn(
-          'relative z-50 grid w-full max-w-lg gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg md:w-full',
+          'relative z-50 w-full grow gap-4 bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out  data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:max-w-lg sm:grow-0 sm:rounded-lg',
           className,
         )}
         {...props}


### PR DESCRIPTION
For https://github.com/opencollective/opencollective/issues/6958
- Fix for Dialog overflow issue in Firefox.
- Fix for rich text editor outline on inner input in Firefox, but also adding a new 1px outline to the surrounding text area, similar to InputFields:
<img width="756" alt="image" src="https://github.com/opencollective/opencollective-frontend/assets/1552194/51e526e7-8015-4be7-8331-cf96d2de76de">
