### PR TITLE
Fix flaky draft expense e2e test

### DIFF
--- a/components/expenses/Expense.tsx
+++ b/components/expenses/Expense.tsx
@@ -133,6 +133,7 @@ function Expense(props) {
         editedExpense: data?.expense,
         isPollingEnabled: false,
       }));
+      return;
     }
 
     handlePolling();
@@ -278,7 +279,7 @@ function Expense(props) {
           draftKey: data?.expense?.status === ExpenseStatus.DRAFT ? draftKey : null,
         },
       });
-      if (data?.expense?.type === expenseTypes.CHARGE) {
+      if (data?.expense?.type === expenseTypes.CHARGE || data?.expense?.status === ExpenseStatus.DRAFT) {
         await refetch();
       }
       const createdUser = editedExpense?.payee;

--- a/pages/expense.tsx
+++ b/pages/expense.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useLazyQuery } from '@apollo/client';
 import dayjs from 'dayjs';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, omit } from 'lodash';
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 import { useRouter } from 'next/router';
 import { defineMessages, useIntl } from 'react-intl';
@@ -67,7 +67,7 @@ export const getServerSideProps: GetServerSideProps<ExpensePageProps> = async ct
 
   return {
     props: {
-      ...query,
+      ...omit(query, 'key'),
       legacyExpenseId: parseInt(query.ExpenseId as string),
       draftKey: query.key || null,
       data,


### PR DESCRIPTION
Related https://github.com/opencollective/opencollective/issues/6484#issuecomment-1708155338

# Description

Polling when editing the draft expense refreshes the form while is edited.
