### PR TITLE
Fix Logout method to clearStore without refetching queries

### DIFF
--- a/components/UserProvider.js
+++ b/components/UserProvider.js
@@ -84,7 +84,7 @@ class UserProvider extends React.Component {
     removeFromLocalStorage(LOCAL_STORAGE_KEYS.LAST_DASHBOARD_SLUG);
     removeFromLocalStorage(LOCAL_STORAGE_KEYS.DASHBOARD_NAVIGATION_STATE);
     this.setState({ LoggedInUser: null, errorLoggedInUser: null });
-    await this.props.client.resetStore();
+    await this.props.client.clearStore();
   };
 
   login = async token => {


### PR DESCRIPTION
From Apollo docs https://www.apollographql.com/docs/react/caching/advanced-topics/#resetting-the-cache
> To reset the cache without refetching active queries, use client.clearStore() instead of client.resetStore().

This is important for us because the refetch function of resetStore can cause components to redraw before the LoggedInUser is set to null, which in turn will cause any rendered component that queries for private data to fail.