### PR TITLE
feat: add user invalid pseudo class

### DIFF
--- a/components/StyledInput.tsx
+++ b/components/StyledInput.tsx
@@ -88,6 +88,10 @@ const StyledInput = styled.input`
   &[type='date'] {
     font-family: inherit;
   }
+
+  &:user-invalid {
+    border-color: ${themeGet('colors.red.500')} !important;
+  }
 `;
 
 StyledInput.propTypes = {


### PR DESCRIPTION
Resolves ... https://github.com/opencollective/opencollective/issues/5473

## ⚠️ Note

This currently doesn't make the input scroll into view nor it adds a message saying this "email is invalid". It only adds a border for now. Needs input (no pun intended :P)

# Description
Adds user-invalid to show error border in firefox mobile
<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots
<img width="50%" src="https://github.com/opencollective/opencollective-frontend/assets/64399555/a9be0f2c-cec4-4d83-a0a3-49c6519be7d7">


<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
