### PR TITLE
ProfilePage: Fix Social link margins

### DIFF
--- a/components/collective-page/hero/Hero.js
+++ b/components/collective-page/hero/Hero.js
@@ -264,12 +264,12 @@ const Hero = ({ collective, host, isAdmin, onPrimaryColorChange }) => {
                   )}
                 </Flex>
               )}
-              <Flex alignItems="center" flexWrap="wrap" fontSize="14px">
-                <Flex mb={2} mt={-2} flexWrap="wrap">
+              <Flex alignItems="center" flexWrap="wrap" fontSize="14px" gap="16px" mt={2}>
+                <Flex gap="16px" flexWrap="wrap">
                   {collective.canContact && (
                     <ContactCollectiveBtn collective={collective} LoggedInUser={LoggedInUser}>
                       {btnProps => (
-                        <StyledRoundButton mt={2} {...btnProps} size={32} mr={3} title="Contact" aria-label="Contact">
+                        <StyledRoundButton {...btnProps} size={32} title="Contact" aria-label="Contact">
                           <Mail size={12} />
                         </StyledRoundButton>
                       )}
@@ -282,7 +282,7 @@ const Hero = ({ collective, host, isAdmin, onPrimaryColorChange }) => {
                       href={twitterProfileUrl(collective.twitterHandle)}
                       openInNewTabNoFollowRelMe
                     >
-                      <StyledRoundButton size={32} mt={2} mr={3} title="Twitter" aria-label="Twitter link">
+                      <StyledRoundButton size={32} title="Twitter" aria-label="Twitter link">
                         <Twitter size={12} />
                       </StyledRoundButton>
                     </StyledLink>
@@ -291,8 +291,6 @@ const Hero = ({ collective, host, isAdmin, onPrimaryColorChange }) => {
                     <StyledLink data-cy="collectiveWebsite" href={collective.website} openInNewTabNoFollowRelMe>
                       <StyledRoundButton
                         size={32}
-                        mr={3}
-                        mt={2}
                         title={intl.formatMessage(Translations.website)}
                         aria-label="Website link"
                       >
@@ -302,7 +300,7 @@ const Hero = ({ collective, host, isAdmin, onPrimaryColorChange }) => {
                   )}
                   {!hasSocialLinks && collective.repositoryUrl && (
                     <StyledLink data-cy="repositoryUrl" href={collective.repositoryUrl} openInNewTabNoFollowRelMe>
-                      <StyledButton mt={2} buttonSize="tiny" color="black.700" height={32} mr={3}>
+                      <StyledButton buttonSize="tiny" color="black.700" height={32}>
                         <CodeRepositoryIcon size={12} repositoryUrl={collective.repositoryUrl} />
                         <Span ml={2}>
                           <FormattedMessage defaultMessage="Code repository" />
@@ -385,12 +383,11 @@ const Hero = ({ collective, host, isAdmin, onPrimaryColorChange }) => {
                             color="black.700"
                             textDecoration="none"
                             fontSize="12px"
-                            mr={2}
                           >
                             <FormattedMessage id="host.tos" defaultMessage="Terms of fiscal hosting" />
                           </StyledLink>
                         )}
-                        <Container ml={2} mr={3} color="black.700" fontSize="12px">
+                        <Container color="black.700" fontSize="12px">
                           <FormattedMessage
                             id="Hero.HostFee"
                             defaultMessage="Host fee: {fee}"
@@ -406,7 +403,7 @@ const Hero = ({ collective, host, isAdmin, onPrimaryColorChange }) => {
                       </Fragment>
                     )}
                     {collective.platformFeePercent > 0 && (
-                      <Container ml={2} mr={3} color="black.700" fontSize="12px">
+                      <Container color="black.700" fontSize="12px">
                         <FormattedMessage
                           id="Hero.PlatformFee"
                           defaultMessage="Platform fee: {fee}"

--- a/components/collective-page/hero/HeroSocialLinks.tsx
+++ b/components/collective-page/hero/HeroSocialLinks.tsx
@@ -64,7 +64,7 @@ export default function HeroSocialLinks({ socialLinks, relMe }: HeroSocialLinksP
         openInNewTabNoFollow={!relMe}
         openInNewTabNoFollowRelMe={!!relMe}
       >
-        <StyledRoundButton size={32} mt={2} mr={3}>
+        <StyledRoundButton size={32}>
           <Icon size={12} />
         </StyledRoundButton>
       </StyledLink>


### PR DESCRIPTION
Rewrote how the social links margins work to be consistent and remove the existing negative margin.

Before:
<img width="647" alt="Screenshot 2023-09-25 at 14 17 34" src="https://github.com/opencollective/opencollective-frontend/assets/2119706/c931703d-0d93-49ca-b272-50339934f4e0">


After:
https://github.com/opencollective/opencollective-frontend/assets/2119706/c17dcdfa-98d5-4107-90bf-678fd6c86707

