### PR TITLE
ExpenseForm: limit OCR prefill starter to root only

### DIFF
--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -557,7 +557,7 @@ const ExpenseFormBody = ({
           supportedExpenseTypes={supportedExpenseTypes}
         />
       )}
-      {!values.type && !hideOCRPrefillStater && hasOCRFeature && (
+      {Boolean(!values.type && !hideOCRPrefillStater && LoggedInUser?.isRoot) && (
         <ExpenseOCRPrefillStarter
           collective={collective}
           form={formik}


### PR DESCRIPTION
This is an experimental feature