### PR TITLE
Redirect to /dashboard using cookie for logged in users

### DIFF
--- a/components/UserProvider.js
+++ b/components/UserProvider.js
@@ -85,6 +85,11 @@ class UserProvider extends React.Component {
     removeFromLocalStorage(LOCAL_STORAGE_KEYS.DASHBOARD_NAVIGATION_STATE);
     this.setState({ LoggedInUser: null, errorLoggedInUser: null });
     await this.props.client.clearStore();
+
+    // Refetch the LoggedInUser query to make the API clear the rootRedirect cookie
+    await this.props.client.refetchQueries({
+      include: ['LoggedInUser'],
+    });
   };
 
   login = async token => {

--- a/pages/home.js
+++ b/pages/home.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
-
+import cookie from 'cookie';
 import { getRequestIntl } from '../lib/i18n/request';
 
 // import Banner from '../components/collectives/Banner';
@@ -46,7 +46,20 @@ const HomePage = () => {
   );
 };
 
-HomePage.getInitialProps = ({ req, res }) => {
+export const getServerSideProps = async context => {
+  const cookies = cookie.parse((context.req && context.req.headers.cookie) || '');
+  console.log('cookies', cookies);
+  const redirectToDashboard = cookies.redirectToDashboard === 'true';
+
+  if (redirectToDashboard) {
+    return {
+      redirect: {
+        destination: '/dashboard',
+        permanent: false,
+      },
+    };
+  }
+  const { req, res } = context;
   if (res && req) {
     const { locale } = getRequestIntl(req);
     if (locale === 'en') {
@@ -60,8 +73,7 @@ HomePage.getInitialProps = ({ req, res }) => {
   if (req) {
     skipDataFromTree = true;
   }
-
-  return { skipDataFromTree };
+  return { props: { skipDataFromTree } };
 };
 
 export default HomePage;

--- a/pages/home.js
+++ b/pages/home.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { defineMessages, useIntl } from 'react-intl';
 import cookie from 'cookie';
+import { defineMessages, useIntl } from 'react-intl';
+
 import { getRequestIntl } from '../lib/i18n/request';
 
 // import Banner from '../components/collectives/Banner';
@@ -46,11 +47,9 @@ const HomePage = () => {
   );
 };
 
-export const getServerSideProps = async context => {
-  const cookies = cookie.parse((context.req && context.req.headers.cookie) || '');
-  console.log('cookies', cookies);
-  const redirectToDashboard = cookies.redirectToDashboard === 'true';
-
+export const getServerSideProps = async ({ req, res }) => {
+  const cookies = cookie.parse((req && req.headers.cookie) || '');
+  const redirectToDashboard = req.url === '/' && cookies.rootRedirect === 'dashboard';
   if (redirectToDashboard) {
     return {
       redirect: {
@@ -59,7 +58,7 @@ export const getServerSideProps = async context => {
       },
     };
   }
-  const { req, res } = context;
+
   if (res && req) {
     const { locale } = getRequestIntl(req);
     if (locale === 'en') {


### PR DESCRIPTION
Require https://github.com/opencollective/opencollective-api/pull/9377

# Description

We disabled the /dashboard redirect since the experience felt broken, of first loading the landing page and then doing a client side redirect.

This PR enables the root url to be redirected to '/dashboard' before it hits the client side, using a cookie set by the API when a user is authenticated.

The cookie should fall under the 'strictly necessary' category since it is required to make the app function properly (i.e. redirecting you to the dashboard when you are logged in), and thus require no cookie approval.
