### PR TITLE
Add advanced logout parameter support

### DIFF
--- a/components/navigation/ProfileMenu.tsx
+++ b/components/navigation/ProfileMenu.tsx
@@ -19,7 +19,7 @@ import { useRouter } from 'next/router';
 import { FormattedMessage } from 'react-intl';
 
 import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
-import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
+import useLoggedInUser, { UserContextProps } from '../../lib/hooks/useLoggedInUser';
 import { useWindowResize, VIEWPORTS } from '../../lib/hooks/useWindowResize';
 import { cn } from '../../lib/utils';
 
@@ -95,7 +95,7 @@ const MenuItem = ({
   );
 };
 
-const ProfileMenu = () => {
+const ProfileMenu = ({ logoutParameters }: { logoutParameters?: Parameters<UserContextProps['logout']>[0] }) => {
   const router = useRouter();
   const { LoggedInUser, logout } = useLoggedInUser();
   const [isMenuOpen, setMenuOpen] = React.useState(false);
@@ -107,6 +107,8 @@ const ProfileMenu = () => {
     variables: { memberAccount: { slug: LoggedInUser?.collective?.slug } },
     skip: !LoggedInUser,
     context: API_V2_CONTEXT,
+    // We ignore errors here because the logout action can trigger refetch before LoggedInUser is set to null and we don't really care if this query fails
+    errorPolicy: 'ignore',
   });
 
   React.useEffect(() => {
@@ -196,7 +198,7 @@ const ProfileMenu = () => {
 
             <Separator className="my-1" />
 
-            <MenuItem Icon={LogOut} onClick={() => logout()}>
+            <MenuItem Icon={LogOut} onClick={() => logout(logoutParameters)}>
               <FormattedMessage id="menu.logout" defaultMessage="Log out" />
             </MenuItem>
           </div>

--- a/components/navigation/TopBar.tsx
+++ b/components/navigation/TopBar.tsx
@@ -198,7 +198,9 @@ const TopBar = ({ account }: TopBarProps) => {
             <div className="hidden sm:block">
               <ChangelogTrigger />
             </div>
-            <ProfileMenu />
+            <ProfileMenu
+              logoutParameters={{ skipQueryRefetch: onDashboardRoute, redirect: onDashboardRoute ? '/' : undefined }}
+            />
           </Flex>
         </div>
       </div>

--- a/lib/hooks/useLoggedInUser.ts
+++ b/lib/hooks/useLoggedInUser.ts
@@ -4,12 +4,12 @@ import { UserContext } from '../../components/UserProvider';
 
 import type { LoggedInUser as LoggedInUserType } from '../custom_typings/LoggedInUser';
 
-type UserContextProps = {
+export type UserContextProps = {
   errorLoggedInUser?: Error;
   loadingLoggedInUser: boolean;
   LoggedInUser: LoggedInUserType | null;
   login: () => void;
-  logout: () => void;
+  logout: (arg?: { redirect?: string; skipQueryRefetch?: boolean }) => void;
   refetchLoggedInUser: () => void;
 };
 


### PR DESCRIPTION
Add optional parameters to log out so we can provide better control of Apollo's refetch side-effects. I'm also updating the TopBar component to skip refetch when logging out from the Dashboard page, so we don't end up causing any unnecessary errors.