### PR TITLE
Fix page inception in Transactions error handling

### DIFF
--- a/components/dashboard/sections/Transactions.tsx
+++ b/components/dashboard/sections/Transactions.tsx
@@ -6,7 +6,7 @@ import { API_V2_CONTEXT } from '../../../lib/graphql/helpers';
 import useLoggedInUser from '../../../lib/hooks/useLoggedInUser';
 
 import { transactionsPageQuery } from '../../../pages/transactions';
-import TransactionsPage, { getVariablesFromQuery } from '../../transactions/TransactionsPage';
+import TransactionsPage, { getVariablesFromQuery } from '../../transactions/TransactionsPageContent';
 import { AdminSectionProps } from '../types';
 
 const Transactions = (props: AdminSectionProps) => {

--- a/components/transactions/TransactionsPageContent.tsx
+++ b/components/transactions/TransactionsPageContent.tsx
@@ -14,11 +14,11 @@ import { addParentToURLIfMissing, getCollectivePageCanonicalURL } from '../../li
 
 import { parseAmountRange } from '../budget/filters/AmountFilter';
 import Container from '../Container';
-import ErrorPage from '../ErrorPage';
 import { Box, Flex } from '../Grid';
 import Link from '../Link';
 import Loading from '../Loading';
 import MessageBox from '../MessageBox';
+import MessageBoxGraphqlError from '../MessageBoxGraphqlError';
 import Pagination from '../Pagination';
 import SearchBar from '../SearchBar';
 import StyledButton from '../StyledButton';
@@ -176,7 +176,7 @@ const Transactions = ({
   if (!account && loading) {
     return <Loading />;
   } else if (!account) {
-    return <ErrorPage error={error} loading={loading} />;
+    return <MessageBoxGraphqlError error={error} />;
   }
 
   const transactionsAndProcessingOrders =

--- a/pages/transactions.tsx
+++ b/pages/transactions.tsx
@@ -25,7 +25,7 @@ import Footer from '../components/navigation/Footer';
 import Page from '../components/Page';
 import PageFeatureNotSupported from '../components/PageFeatureNotSupported';
 import { transactionsQueryCollectionFragment } from '../components/transactions/graphql/fragments';
-import Transactions, { getVariablesFromQuery } from '../components/transactions/TransactionsPage';
+import Transactions, { getVariablesFromQuery } from '../components/transactions/TransactionsPageContent';
 
 const processingOrderFragment = gql`
   fragment ProcessingOrderFields on Order {


### PR DESCRIPTION
`ErrorPage` renders an entire page, not just the error message. There should be a better layout for displaying errors in this transactions section (keep showing the title/filters), but this should do the job for now.

**Before**
![2023-10-13_09-35-11](https://github.com/opencollective/opencollective-frontend/assets/1556356/db9960e9-9780-4ed1-90de-728a19f6a3f8)

**After**
![2023-10-13_09-40-45](https://github.com/opencollective/opencollective-frontend/assets/1556356/a2d00f53-469f-47da-b97c-853f5842399d)

