### PR TITLE
Fix expense submitted toast & survey

### DIFF
--- a/components/ui/useToast.tsx
+++ b/components/ui/useToast.tsx
@@ -6,7 +6,7 @@ import type { ToastActionElement, ToastProps } from './Toast';
 const TOAST_LIMIT = 3;
 const TOAST_REMOVE_DELAY_IN_MS = 1000000;
 
-type ToasterToast = Omit<ToastProps, 'title'> & {
+type ToasterToast = Omit<ToastProps, 'title' | 'description'> & {
   id: string;
   title?: string | React.ReactNode;
   message?: string | React.ReactNode;

--- a/pages/create-expense.js
+++ b/pages/create-expense.js
@@ -273,8 +273,9 @@ class CreateExpensePage extends React.Component {
         `${parentCollectiveSlugRoute}${collectiveTypeRoute}${collectiveSlug}/expenses/${legacyExpenseId}`,
       );
       toast({
+        variant: 'success',
         title: <FormattedMessage id="Expense.Submitted" defaultMessage="Expense submitted" />,
-        description: this.props.LoggedInUser ? (
+        message: this.props.LoggedInUser ? (
           <Survey hasParentTitle surveyKey={SURVEY_KEY.EXPENSE_SUBMITTED} />
         ) : (
           <FormattedMessage id="Expense.SuccessPage" defaultMessage="You can edit or review updates on this page." />
@@ -285,7 +286,7 @@ class CreateExpensePage extends React.Component {
     } catch (e) {
       toast({
         variant: 'error',
-        description: i18nGraphqlException(this.props.intl, e),
+        message: i18nGraphqlException(this.props.intl, e),
       });
       this.setState({ isSubmitting: false });
     }


### PR DESCRIPTION
The toast after an expense was submitted had the wrong proptype for message, causing the Survey to not be displayed.

Also updating the type of the Toast so that typescript will warn when trying to use 'description' instead of 'message'.