### PR TITLE
Fix views/tabs in Host Expenses

### DIFF
--- a/components/StyledTabs.tsx
+++ b/components/StyledTabs.tsx
@@ -60,7 +60,7 @@ const Tabs = ({ tabs, selectedId, onChange, ...props }: TabsProps & Parameters<t
               )}
             >
               {tab.label}{' '}
-              {typeof tab.count !== 'undefined' && (
+              {tab.count > 0 && (
                 <span
                   className={cn(
                     'ml-3 hidden rounded-full px-2.5 py-0.5 text-xs font-medium md:inline-block',


### PR DESCRIPTION
# Description

- Fix to simplify setting of views (no need to use memoization since the views are now using it's separate metaData query not affected by the main query updating).
- Includes a count for all tabs/views
- Instead of showing `0` for views that have zero count, the count label is hidden, making it easier to see when there are things in a tab  or not.