### PR TITLE
PeriodFilter: fix general UX + refactor

### DIFF
--- a/components/PeriodFilterPresetsSelect.js
+++ b/components/PeriodFilterPresetsSelect.js
@@ -68,7 +68,15 @@ export const getSelectedPeriodOptionFromInterval = ({ from, to }) => {
 
 const periodSelectThemeBuilder = theme => ({ ...theme, spacing: { ...theme.spacing, controlHeight: 28 } });
 
-const PeriodFilterPresetsSelect = ({ onChange, interval, inputId, formatDateFn }) => {
+const PeriodFilterPresetsSelect = ({
+  onChange,
+  interval,
+  inputId,
+  formatDateFn = stripTime,
+  SelectComponent = StyledSelectFilter,
+  styles = PERIOD_FILTER_SELECT_STYLES,
+  ...selectProps
+}) => {
   const intl = useIntl();
   const selectedOption = React.useMemo(() => getSelectedPeriodOptionFromInterval(interval), [interval]);
   const options = React.useMemo(() => {
@@ -79,12 +87,13 @@ const PeriodFilterPresetsSelect = ({ onChange, interval, inputId, formatDateFn }
   }, [intl]);
 
   return (
-    <StyledSelectFilter
+    <SelectComponent
+      {...selectProps}
       inputId={inputId}
       value={selectedOption}
       options={options}
       selectTheme={periodSelectThemeBuilder}
-      styles={PERIOD_FILTER_SELECT_STYLES}
+      styles={styles}
       onChange={({ value }) => {
         if (value === 'custom') {
           return interval;
@@ -105,10 +114,9 @@ PeriodFilterPresetsSelect.propTypes = {
     to: PropTypes.string,
   }).isRequired,
   formatDateFn: PropTypes.func,
-};
-
-PeriodFilterPresetsSelect.defaultProps = {
-  formatDateFn: stripTime,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  SelectComponent: PropTypes.elementType.isRequired,
+  styles: PropTypes.object,
 };
 
 export default PeriodFilterPresetsSelect;

--- a/components/expenses/ExpenseStatusTag.js
+++ b/components/expenses/ExpenseStatusTag.js
@@ -58,7 +58,7 @@ const BaseTag = ({ status, ...props }) => {
 };
 
 BaseTag.propTypes = {
-  status: PropTypes.oneOf(Object.values(ExpenseStatus)),
+  status: PropTypes.oneOf([...Object.values(ExpenseStatus), 'COMPLETED']),
 };
 
 /**

--- a/lib/date-utils.js
+++ b/lib/date-utils.js
@@ -141,10 +141,3 @@ export const convertDateToApiUtc = (date, timezone) => {
 export const convertDateFromApiUtc = (date, timezone) => {
   return dayjs(date).tz(timezone).format('YYYY-MM-DD HH:mm:ss');
 };
-
-/**
- * Check if the date is valid while editing
- */
-export const isValidDate = date => {
-  return date && !date.startsWith('0');
-};


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/5162

A follow-up on https://github.com/opencollective/opencollective-frontend/pull/8736/files#diff-6023aad1ed480e0431173b9cdbe3ab33d7804e90c93dbcc2d8588709c8fa3becR136 that broke the fix implemented in https://github.com/opencollective/opencollective-frontend/pull/7449 by forcing the component whenever the passed value changed, likely to update after the preset value changes.

A few simplifications have been made:
1. Add customization options (`SelectComponent`, `styles`) to `PeriodFilterPresetsSelect` rather than re-creating it. The component has some logic with date formatting that was not implemented in the copy that was made.
2. Centralize state management in parent (`PeriodFilter` or `ExportTransactionsCSVModal`)