### PR TITLE
Fix running custom server locally

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,7 +1,5 @@
 require('../env');
 
-const path = require('path');
-
 const next = require('next');
 const express = require('express');
 const helmet = require('helmet');
@@ -24,7 +22,7 @@ app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal'].concat(cloudflar
 
 const dev = process.env.NODE_ENV === 'development';
 
-const nextApp = next({ dev, dir: path.dirname(__dirname) });
+const nextApp = next({ dev });
 
 const port = process.env.PORT;
 


### PR DESCRIPTION
Fixes an issue when trying to run the custom server locally:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/zQq4TRpYwmRLp4NBVpwm/5bd6e52d-b51d-45d4-b759-0be24a26fa68/image.png)

# Description

Removes the `dir` property when creating the Next app in the custom server. This property is optional and presumably needed when Next.js is placed in another directory than the root.

# Todo 

- [ ] Verify it works also on staging.