### PR TITLE
Include Guest Users in Recurring Contribution and Activity Log Root Actions

### DIFF
--- a/components/root-actions/RecurringContributions.js
+++ b/components/root-actions/RecurringContributions.js
@@ -21,7 +21,12 @@ const RecurringContributions = () => {
     <Box my={4}>
       <StyledInputField htmlFor="recurring-contributions-account" label="Account" flex="1 1">
         {({ id }) => (
-          <CollectivePickerAsync inputId={id} onChange={({ value }) => setAccount(value)} collective={account} />
+          <CollectivePickerAsync
+            inputId={id}
+            onChange={({ value }) => setAccount(value)}
+            collective={account}
+            skipGuests={false}
+          />
         )}
       </StyledInputField>
       {loading ? (

--- a/components/root-actions/RootActivityLog.js
+++ b/components/root-actions/RootActivityLog.js
@@ -11,7 +11,12 @@ const RootActivityLog = () => {
     <Box my={4}>
       <StyledInputField htmlFor="activity-log-account" label="Account" flex="1 1">
         {({ id }) => (
-          <CollectivePickerAsync inputId={id} onChange={({ value }) => setAccount(value)} collective={account} />
+          <CollectivePickerAsync
+            inputId={id}
+            onChange={({ value }) => setAccount(value)}
+            collective={account}
+            skipGuests={false}
+          />
         )}
       </StyledInputField>
       {account && <ActivityLog accountSlug={account.slug} />}


### PR DESCRIPTION
We don't seem to be including guest users in recurring contributions and activity log root actions so when support tries to find a user by their guest slug it fails as seen here; https://opencollective.freshdesk.com/a/tickets/270503