### PR TITLE
Fix Virtual cards not showing in admin panel

### DIFF
--- a/components/edit-collective/Form.js
+++ b/components/edit-collective/Form.js
@@ -551,7 +551,7 @@ class EditCollectiveForm extends React.Component {
         return <HostVirtualCardsSettings collective={collective} />;
 
       case ALL_SECTIONS.VIRTUAL_CARDS:
-        return <VirtualCards collective={collective} />;
+        return <VirtualCards collective={collective} accountSlug={collective.slug} />;
 
       default:
         return null;


### PR DESCRIPTION
Fixes bug introduced in https://github.com/opencollective/opencollective-frontend/pull/9459 that caused the Virtual Cards page in the Collective/Event/Project admin panel to not display any virtual cards.