### PR TITLE
Fix E2E 3D secure test

### DIFF
--- a/test/cypress/integration/12-contributionFlow.donate.test.js
+++ b/test/cypress/integration/12-contributionFlow.donate.test.js
@@ -147,23 +147,23 @@ describe('Contribution Flow: Donate', () => {
     cy.get('button[data-cy="cf-next-step"]').click();
     cy.checkStepsProgress({ enabled: ['details', 'profile', 'payment'] });
     cy.wait(3000); // Wait for stripe to be loaded
-    cy.fillStripeInput({ card: CreditCards.CARD_3D_SECURE });
+    cy.fillStripeInput({ card: CreditCards.CARD_3D_SECURE_2 });
     cy.contains('button', 'Contribute $42').click();
     cy.wait(8000); // Wait for order to be submitted and popup to appear
 
     // Rejecting the validation should produce an error
-    cy.complete3dSecure(false);
+    cy.complete3dSecure(false, { version: 2 });
     cy.contains('We are unable to authenticate your payment method.');
 
     // Refill stripe input to avoid using the same token twice
-    cy.fillStripeInput({ card: CreditCards.CARD_3D_SECURE });
+    cy.fillStripeInput({ card: CreditCards.CARD_3D_SECURE_2 });
 
     // Re-trigger the popup
     cy.contains('button', 'Contribute $42').click();
 
     // Approving the validation should create the order
     cy.wait(8000); // Wait for order to be submitted and popup to appear
-    cy.complete3dSecure(true);
+    cy.complete3dSecure(true, { version: 2 });
     cy.getByDataCy('order-success', { timeout: 20000 });
     cy.contains('You are now supporting APEX.');
   });

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -339,36 +339,36 @@ Cypress.Commands.add('fillStripeInput', fillStripeInput);
  *
  * @param {boolean} approve: Set to false to reject
  */
-Cypress.Commands.add('complete3dSecure', (approve = true) => {
+Cypress.Commands.add('complete3dSecure', (approve = true, { version = 1 } = {}) => {
   const iframeSelector = 'iframe[name^="__privateStripeFrame"]';
   const targetBtn = approve ? '#test-source-authorize-3ds' : '#test-source-fail-3ds';
 
   cy.get(iframeSelector)
     .should($stripeFrame => {
       const frameContent = $stripeFrame.contents();
-      const challengeFrame = frameContent.find('body iframe#challengeFrame');
-      expect(challengeFrame).to.exist;
 
-      const acsFrame = challengeFrame.contents().find('iframe[name="acsFrame"]');
-      expect(acsFrame).to.exist;
+      let buttonsFrame = frameContent.find('body iframe#challengeFrame');
+      expect(buttonsFrame).to.exist;
 
-      const frameBody = acsFrame.contents().find('body');
-      expect(frameBody).to.exist;
+      // With 3DSecure v2, the buttons are stored directly in the iframe. With v1, there is an extra iframe.
+      if (version === 1) {
+        const acsFrame = buttonsFrame.contents().find('iframe[name="acsFrame"]');
+        expect(acsFrame).to.exist;
+        buttonsFrame = acsFrame;
+      }
 
-      expect(frameBody.find(targetBtn)).to.exist;
+      const challengeFrameBody = buttonsFrame.contents().find('body');
+      expect(challengeFrameBody).to.exist;
+      expect(challengeFrameBody.find(targetBtn)).to.exist;
     })
     .then($iframe => {
-      const btn = cy.wrap(
-        $iframe
-          .contents()
-          .find('body iframe#challengeFrame')
-          .contents()
-          .find('iframe[name="acsFrame"]')
-          .contents()
-          .find('body')
-          .find(targetBtn),
-      );
+      const $challengeFrameContent = $iframe.contents().find('body iframe#challengeFrame').contents();
+      let $btnContainer = $challengeFrameContent;
+      if (version === 1) {
+        $btnContainer = $btnContainer.find('iframe[name="acsFrame"]').contents();
+      }
 
+      const btn = cy.wrap($btnContainer.find('body').find(targetBtn));
       btn.click();
     });
 });

--- a/test/stripe-helpers.js
+++ b/test/stripe-helpers.js
@@ -10,7 +10,6 @@ export const generateValidCard = code => ({
 export const CreditCards = {
   CARD_DEFAULT: generateValidCard('4242424242424242'),
   CARD_DECLINED: generateValidCard('4000000000000002'),
-  CARD_3D_SECURE: generateValidCard('4000000000003063'),
   CARD_3D_SECURE_2: generateValidCard('4000000000003220'),
   CARD_3D_SECURE_DECLINED: generateValidCard('4000008400001629'),
   CARD_3D_SECURE_ALWAYS_AUTHENTICATE: generateValidCard('4000002760003184'),


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/6484

Stripe apparently deprecated 3D secure V1 cards, so we have to update the test to 3D secure V2.