### PR TITLE
Fix description length validation in Host Application form

### DIFF
--- a/components/ocf-host-application/ApplicationForm.js
+++ b/components/ocf-host-application/ApplicationForm.js
@@ -144,11 +144,11 @@ const ApplicationForm = ({
       'applicationData.websiteAndSocialLinks',
     ]);
 
-    verifyEmailPattern(errors, values, 'user.email');
-
-    // verifyFieldLength(intl, errors, values, 'collective.name', 1, 50);
-    // verifyFieldLength(intl, errors, values, 'collective.slug', 1, 30);
-    verifyFieldLength(intl, errors, values, 'collective.description', 1, 250);
+    // User is not inputting a Collective or User if there is already a Collective that they apply with
+    if (!canApplyWithCollective) {
+      verifyEmailPattern(errors, values, 'user.email');
+      verifyFieldLength(intl, errors, values, 'collective.description', 1, 255);
+    }
     verifyFieldLength(intl, errors, values, 'applicationData.missionImpactExplanation', 1, 250);
 
     verifyChecked(errors, values, 'termsOfServiceOC');

--- a/components/osc-host-application/ApplicationForm.js
+++ b/components/osc-host-application/ApplicationForm.js
@@ -140,8 +140,11 @@ const ApplicationForm = ({
       'applicationData.typeOfProject',
     ]);
 
-    verifyEmailPattern(errors, values, 'user.email');
-    verifyFieldLength(intl, errors, values, 'collective.description', 1, 150);
+    // User is not inputting a Collective or User if there is already a Collective that they apply with
+    if (!canApplyWithCollective) {
+      verifyEmailPattern(errors, values, 'user.email');
+      verifyFieldLength(intl, errors, values, 'collective.description', 1, 255);
+    }
     verifyURLPattern(errors, values, 'applicationData.repositoryUrl');
     verifyChecked(errors, values, 'termsOfServiceOC');
 


### PR DESCRIPTION
# Description

Fixes a bug reported on Slack. If you were applying with an existing Collective that had a description longer than 155 characters the form did not validate, but because the form is lacking description field input when you apply with an existing Collective, the error message did not show.

This fix adjusts the length validation in the form to be the same as the backend allows (max 255 characters), but also makes sure to not validate the length when applying with an existing Collective.

