### PR TITLE
Modify root redirect to only check for existence of cookie

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,21 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  const rootRedirect = req.cookies.get('rootRedirect');
+  const host = req.headers.get('host');
+  const pathname = req.nextUrl.pathname;
+
+  const redirectToDashboard = rootRedirect?.value === 'dashboard';
+
+  console.log('in next.js middleware');
+  console.log({ host: host, reqUrl: req.url, pathname, rootRedirect });
+
+  if (redirectToDashboard) {
+    return NextResponse.redirect(new URL('/dashboard', req.url));
+  }
+}
+
+export const config = {
+  matcher: '/',
+};

--- a/next.config.js
+++ b/next.config.js
@@ -277,13 +277,15 @@ const nextConfig = {
   },
 };
 
-let exportedConfig = withSentryConfig({
-  ...nextConfig,
-  sentry: {
-    disableServerWebpackPlugin: true,
-    disableClientWebpackPlugin: true,
-  },
-});
+let exportedConfig = ['production'].includes(process.env.OC_ENV)
+  ? withSentryConfig({
+      ...nextConfig,
+      sentry: {
+        disableServerWebpackPlugin: true,
+        disableClientWebpackPlugin: true,
+      },
+    })
+  : nextConfig;
 
 if (process.env.ANALYZE) {
   // eslint-disable-next-line node/no-unpublished-require

--- a/package-lock.json
+++ b/package-lock.json
@@ -29848,6 +29848,23 @@
       "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
       "optional": true
     },
+    "node_modules/nanoid": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "dev": true,
@@ -31605,23 +31622,6 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "license": "MIT"
-    },
-    "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
     },
     "node_modules/posthog-node": {
       "version": "2.2.3",

--- a/pages/home.js
+++ b/pages/home.js
@@ -48,21 +48,20 @@ const HomePage = () => {
 };
 
 export const getServerSideProps = async ({ req, res }) => {
-  const cookies = cookie.parse((req && req.headers.cookie) || '');
-  const redirectToDashboard = req.url === '/' && cookies.rootRedirect === 'dashboard';
-  if (redirectToDashboard) {
-    return {
-      redirect: {
-        destination: '/dashboard',
-        permanent: false,
-      },
-    };
-  }
-
+  // const redirectToDashboard = req.url === '/' && typeof cookies.rootRedirect !== 'undefined';
+  // if (redirectToDashboard) {
+  //   return {
+  //     redirect: {
+  //       destination: '/dashboard',
+  //       permanent: false,
+  //     },
+  //   };
+  // }
   if (res && req) {
     const { locale } = getRequestIntl(req);
     if (locale === 'en') {
       res.setHeader('Cache-Control', 'public, s-maxage=3600');
+      res.setHeader('Vary', 'Cookie');
     }
   }
 

--- a/server/index.js
+++ b/server/index.js
@@ -22,7 +22,7 @@ app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal'].concat(cloudflar
 
 const dev = process.env.NODE_ENV === 'development';
 
-const nextApp = next({ dev });
+const nextApp = next({ dev, hostname: 'localhost', port: 3000 });
 const nextRequestHandler = nextApp.getRequestHandler();
 
 const port = process.env.PORT;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,8 @@
     "scripts",
     "server",
     "stories",
-    "test"
+    "test",
+    "middleware.ts"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
# Description

The root redirect cookie does not seem to get the value set by the API (https://github.com/opencollective/opencollective-api/blob/main/server/middleware/authentication.js#L155).

However, we should only need the existence of the cookie to determine that the user has activated the early access Dashboard feature. 