### PR TITLE
Remove mislabeled column Last charge date from Contributions table

### DIFF
--- a/components/dashboard/sections/Contributions.tsx
+++ b/components/dashboard/sections/Contributions.tsx
@@ -247,20 +247,6 @@ const getColumns = ({ tab, setEditOrder, intl, isIncoming }) => {
         );
       },
     };
-    const processedAt = {
-      accessorKey: 'processedAt',
-      header: intl.formatMessage({ id: 'LastCharge', defaultMessage: 'Last Charge' }),
-      cell: ({ cell }) => {
-        const date = cell.getValue();
-        if (date) {
-          return (
-            <div className="flex items-center gap-2 truncate">
-              <DateTime value={date} dateStyle="medium" timeStyle={undefined} />
-            </div>
-          );
-        }
-      },
-    };
 
     if (tab === ContributionsTab.RECURRING) {
       const actions = {
@@ -296,20 +282,11 @@ const getColumns = ({ tab, setEditOrder, intl, isIncoming }) => {
         paymentMethod,
         amount,
         totalDonations,
-        processedAt,
         status,
         isIncoming ? null : actions,
       ]);
     } else {
-      return [
-        isIncoming ? fromAccount : toAccount,
-        orderId,
-        paymentMethod,
-        amount,
-        totalDonations,
-        processedAt,
-        status,
-      ];
+      return [isIncoming ? fromAccount : toAccount, orderId, paymentMethod, amount, totalDonations, status];
     }
   }
 };

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1981,7 +1981,6 @@
   "Label.AmountWithCurrency": "Amount ({currency})",
   "Label.NumberOfContributions": "# of Contributions",
   "Label.NumberOfExpenses": "# of Expenses",
-  "LastCharge": "Last Charge",
   "laUK3e": "Additional Information",
   "lc+Sfp": "Core member invitation declined",
   "LdgLV7": "You can provide perks or rewards for your tiers, have a set membership fee, or create categories for your contributors. Tiers can be limited to an amount or frequency (one time, monthly, yearly), or allowed to be flexibly set by contributors.",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1981,7 +1981,6 @@
   "Label.AmountWithCurrency": "Amount ({currency})",
   "Label.NumberOfContributions": "# of Contributions",
   "Label.NumberOfExpenses": "# of Expenses",
-  "LastCharge": "Last Charge",
   "laUK3e": "Additional Information",
   "lc+Sfp": "Core member invitation declined",
   "LdgLV7": "You can provide perks or rewards for your tiers, have a set membership fee, or create categories for your contributors. Tiers can be limited to an amount or frequency (one time, monthly, yearly), or allowed to be flexibly set by contributors.",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1981,7 +1981,6 @@
   "Label.AmountWithCurrency": "Amount ({currency})",
   "Label.NumberOfContributions": "# of Contributions",
   "Label.NumberOfExpenses": "# of Expenses",
-  "LastCharge": "Last Charge",
   "laUK3e": "Zusätzliche Informationen",
   "lc+Sfp": "Core member invitation declined",
   "LdgLV7": "You can provide perks or rewards for your tiers, have a set membership fee, or create categories for your contributors. Tiers can be limited to an amount or frequency (one time, monthly, yearly), or allowed to be flexibly set by contributors.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1981,7 +1981,6 @@
   "Label.AmountWithCurrency": "Amount ({currency})",
   "Label.NumberOfContributions": "# of Contributions",
   "Label.NumberOfExpenses": "# of Expenses",
-  "LastCharge": "Last Charge",
   "laUK3e": "Additional Information",
   "lc+Sfp": "Core member invitation declined",
   "LdgLV7": "You can provide perks or rewards for your tiers, have a set membership fee, or create categories for your contributors. Tiers can be limited to an amount or frequency (one time, monthly, yearly), or allowed to be flexibly set by contributors.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1981,7 +1981,6 @@
   "Label.AmountWithCurrency": "Monto ({currency})",
   "Label.NumberOfContributions": "# de Contribuciones",
   "Label.NumberOfExpenses": "# de Gastos",
-  "LastCharge": "Último cargo",
   "laUK3e": "Información adicional",
   "lc+Sfp": "Invitación a miembro principal rechazada",
   "LdgLV7": "Puedes ofrecer incentivos o recompensas para tus Categorías, tener una cuota de afiliación fija o crear niveles para tus colaboradores. Categorías pueden limitarse a una cantidad o a una frecuencia (única, mensual, anual), o permitir que sean los colaboradores quienes los establezcan de forma flexible.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1981,7 +1981,6 @@
   "Label.AmountWithCurrency": "Montant ({currency})",
   "Label.NumberOfContributions": "Nombre de contributions",
   "Label.NumberOfExpenses": "Nombre de dépenses",
-  "LastCharge": "Dernier paiement",
   "laUK3e": "Informations supplémentaires",
   "lc+Sfp": "Invitation du membre principal refusée",
   "LdgLV7": "Vous pouvez proposer des contreparties ou des récompenses pour vos paliers, fixer un montant d’adhésion, ou créer des catégories pour vos contributeurs. Les paliers peuvent avoir des limites de montant ou de fréquence (une seule fois, mensuelle, annuelle), ou permettre aux contributeurs de les définir comme ils le souhaitent.",

--- a/lang/he.json
+++ b/lang/he.json
@@ -1981,7 +1981,6 @@
   "Label.AmountWithCurrency": "סכום ({currency})",
   "Label.NumberOfContributions": "מספר תומכים",
   "Label.NumberOfExpenses": "מספר תשלומים",
-  "LastCharge": "Last Charge",
   "laUK3e": "Additional Information",
   "lc+Sfp": "Core member invitation declined",
   "LdgLV7": "You can provide perks or rewards for your tiers, have a set membership fee, or create categories for your contributors. Tiers can be limited to an amount or frequency (one time, monthly, yearly), or allowed to be flexibly set by contributors.",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1981,7 +1981,6 @@
   "Label.AmountWithCurrency": "Amount ({currency})",
   "Label.NumberOfContributions": "# of Contributions",
   "Label.NumberOfExpenses": "# of Expenses",
-  "LastCharge": "Last Charge",
   "laUK3e": "Additional Information",
   "lc+Sfp": "Core member invitation declined",
   "LdgLV7": "You can provide perks or rewards for your tiers, have a set membership fee, or create categories for your contributors. Tiers can be limited to an amount or frequency (one time, monthly, yearly), or allowed to be flexibly set by contributors.",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1981,7 +1981,6 @@
   "Label.AmountWithCurrency": "Amount ({currency})",
   "Label.NumberOfContributions": "# of Contributions",
   "Label.NumberOfExpenses": "# of Expenses",
-  "LastCharge": "Last Charge",
   "laUK3e": "Additional Information",
   "lc+Sfp": "コアメンバーへの招待を辞退しました",
   "LdgLV7": "You can provide perks or rewards for your tiers, have a set membership fee, or create categories for your contributors. Tiers can be limited to an amount or frequency (one time, monthly, yearly), or allowed to be flexibly set by contributors.",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1981,7 +1981,6 @@
   "Label.AmountWithCurrency": "Amount ({currency})",
   "Label.NumberOfContributions": "# of Contributions",
   "Label.NumberOfExpenses": "# of Expenses",
-  "LastCharge": "Last Charge",
   "laUK3e": "Additional Information",
   "lc+Sfp": "Core member invitation declined",
   "LdgLV7": "You can provide perks or rewards for your tiers, have a set membership fee, or create categories for your contributors. Tiers can be limited to an amount or frequency (one time, monthly, yearly), or allowed to be flexibly set by contributors.",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1981,7 +1981,6 @@
   "Label.AmountWithCurrency": "Amount ({currency})",
   "Label.NumberOfContributions": "# of Contributions",
   "Label.NumberOfExpenses": "# of Expenses",
-  "LastCharge": "Last Charge",
   "laUK3e": "Additional Information",
   "lc+Sfp": "Core member invitation declined",
   "LdgLV7": "You can provide perks or rewards for your tiers, have a set membership fee, or create categories for your contributors. Tiers can be limited to an amount or frequency (one time, monthly, yearly), or allowed to be flexibly set by contributors.",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -1981,7 +1981,6 @@
   "Label.AmountWithCurrency": "Kwota ({currency})",
   "Label.NumberOfContributions": "Wkładów",
   "Label.NumberOfExpenses": "# Wydatków",
-  "LastCharge": "Last Charge",
   "laUK3e": "Additional Information",
   "lc+Sfp": "Odrzucono zaproszenie dla członka głównego",
   "LdgLV7": "Możesz zapewnić korzyści lub nagrody na swoich poziomach, ustalić opłatę członkowską lub stworzyć kategorie dla swoich współpracowników. Poziomy mogą być ograniczone do określonej kwoty lub częstotliwości (jednorazowo, miesięcznie, rocznie) lub mogą być dowolnie ustalane przez wpłacających.",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1981,7 +1981,6 @@
   "Label.AmountWithCurrency": "Quantia ({currency})",
   "Label.NumberOfContributions": "# of Contributions",
   "Label.NumberOfExpenses": "# of Expenses",
-  "LastCharge": "Last Charge",
   "laUK3e": "Additional Information",
   "lc+Sfp": "Core member invitation declined",
   "LdgLV7": "You can provide perks or rewards for your tiers, have a set membership fee, or create categories for your contributors. Tiers can be limited to an amount or frequency (one time, monthly, yearly), or allowed to be flexibly set by contributors.",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1981,7 +1981,6 @@
   "Label.AmountWithCurrency": "Amount ({currency})",
   "Label.NumberOfContributions": "# of Contributions",
   "Label.NumberOfExpenses": "# of Expenses",
-  "LastCharge": "Last Charge",
   "laUK3e": "Additional Information",
   "lc+Sfp": "Core member invitation declined",
   "LdgLV7": "You can provide perks or rewards for your tiers, have a set membership fee, or create categories for your contributors. Tiers can be limited to an amount or frequency (one time, monthly, yearly), or allowed to be flexibly set by contributors.",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1981,7 +1981,6 @@
   "Label.AmountWithCurrency": "Amount ({currency})",
   "Label.NumberOfContributions": "# of Contributions",
   "Label.NumberOfExpenses": "# of Expenses",
-  "LastCharge": "Last Charge",
   "laUK3e": "Additional Information",
   "lc+Sfp": "Core member invitation declined",
   "LdgLV7": "You can provide perks or rewards for your tiers, have a set membership fee, or create categories for your contributors. Tiers can be limited to an amount or frequency (one time, monthly, yearly), or allowed to be flexibly set by contributors.",

--- a/lang/sk-SK.json
+++ b/lang/sk-SK.json
@@ -1981,7 +1981,6 @@
   "Label.AmountWithCurrency": "Amount ({currency})",
   "Label.NumberOfContributions": "# of Contributions",
   "Label.NumberOfExpenses": "# of Expenses",
-  "LastCharge": "Last Charge",
   "laUK3e": "Additional Information",
   "lc+Sfp": "Core member invitation declined",
   "LdgLV7": "You can provide perks or rewards for your tiers, have a set membership fee, or create categories for your contributors. Tiers can be limited to an amount or frequency (one time, monthly, yearly), or allowed to be flexibly set by contributors.",

--- a/lang/sv-SE.json
+++ b/lang/sv-SE.json
@@ -1981,7 +1981,6 @@
   "Label.AmountWithCurrency": "Belopp ({currency})",
   "Label.NumberOfContributions": "# av bidragsgivare",
   "Label.NumberOfExpenses": "# av utgifter",
-  "LastCharge": "Last Charge",
   "laUK3e": "Additional Information",
   "lc+Sfp": "Inbjudan till teammedlem avböjdes",
   "LdgLV7": "Du kan ge förmåner eller belöningar för dina nivåer, ha en fast medlemsavgift eller skapa kategorier för dina bidragsgivare. Nivåer kan begränsas till ett belopp eller frekvens (en gång, månadsvis, årligen) eller bestämmas fritt av dina bidragsgivare.",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -1981,7 +1981,6 @@
   "Label.AmountWithCurrency": "Сума ({currency})",
   "Label.NumberOfContributions": "# Внесків",
   "Label.NumberOfExpenses": "# Витрат",
-  "LastCharge": "Last Charge",
   "laUK3e": "Additional Information",
   "lc+Sfp": "Core member invitation declined",
   "LdgLV7": "You can provide perks or rewards for your tiers, have a set membership fee, or create categories for your contributors. Tiers can be limited to an amount or frequency (one time, monthly, yearly), or allowed to be flexibly set by contributors.",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1981,7 +1981,6 @@
   "Label.AmountWithCurrency": "总额（{currency}）",
   "Label.NumberOfContributions": "# 贡献者",
   "Label.NumberOfExpenses": "# 支出",
-  "LastCharge": "Last Charge",
   "laUK3e": "其他信息",
   "lc+Sfp": "核心成员邀请被拒绝",
   "LdgLV7": "You can provide perks or rewards for your tiers, have a set membership fee, or create categories for your contributors. Tiers can be limited to an amount or frequency (one time, monthly, yearly), or allowed to be flexibly set by contributors.",


### PR DESCRIPTION
For https://github.com/opencollective/opencollective/issues/7084

# Description

Removes a column from the contributions table labeled "Last Charge" which used `processedAt` which seems to be the first charge date.