### PR TITLE
OrderPage: only refetch if 1st query was logged out

### DIFF
--- a/pages/order.tsx
+++ b/pages/order.tsx
@@ -12,6 +12,7 @@ import dayjs from '../lib/dayjs';
 import { API_V2_CONTEXT } from '../lib/graphql/helpers';
 import { Account, AccountWithHost } from '../lib/graphql/types/v2/graphql';
 import useLoggedInUser from '../lib/hooks/useLoggedInUser';
+import { usePrevious } from '../lib/hooks/usePrevious';
 import { i18nPaymentMethodProviderType } from '../lib/i18n/payment-method-provider-type';
 import { i18nTaxType } from '../lib/i18n/taxes';
 import { getCollectivePageCanonicalURL } from '../lib/url-helpers';
@@ -317,6 +318,7 @@ const getTransactionsToDisplay = (account, transactions) => {
 
 export default function OrderPage(props) {
   const { LoggedInUser } = useLoggedInUser();
+  const prevLoggedInUser = usePrevious(LoggedInUser);
   const [showCreatePendingOrderModal, setShowCreatePendingOrderModal] = React.useState(false);
   const queryResult = contributionPageQueryHelper.useQuery(props);
   const variables = contributionPageQueryHelper.getVariablesFromPageProps(props);
@@ -336,10 +338,10 @@ export default function OrderPage(props) {
 
   // Refetch when users logs in
   React.useEffect(() => {
-    if (LoggedInUser) {
+    if (!prevLoggedInUser && LoggedInUser) {
       queryResult.refetch();
     }
-  }, [LoggedInUser]);
+  }, [LoggedInUser, prevLoggedInUser]);
 
   if (!order || order.toAccount?.slug !== variables.collectiveSlug) {
     return <Custom404 />;


### PR DESCRIPTION
Should resolve the reliability problem mentioned in https://github.com/opencollective/opencollective/issues/6484#issuecomment-1766223578

My hypothesis is that the e2e test was failing like that:
1. Go the the contributions list
2. Open the contribution
3. _The data is loaded as authenticated since we used frontend navigation_
4. _The system triggers a refetch_
5. Test marks the expense as expired. It goes faster as the refetch, since there's only  one field fetched back
6. _Apollo updates its cache with the mutation result_
7. _Apollo updates its cache with the refetch result (which took longer), thus overriding the previous result_

Solution: only refetch if the 1st query was actually logged out.