### PR TITLE
Fix missing accounting category in the expense drawer

### DIFF
--- a/components/expenses/Expense.tsx
+++ b/components/expenses/Expense.tsx
@@ -609,6 +609,7 @@ function Expense(props) {
           ) : (
             <ExpenseForm
               collective={collective}
+              host={host}
               loading={loading || loadingLoggedInUser || isRefetchingDataForUser}
               expense={editedExpense || expense}
               originalExpense={expense}

--- a/components/expenses/ExpenseSummary.js
+++ b/components/expenses/ExpenseSummary.js
@@ -184,7 +184,7 @@ const ExpenseSummary = ({
         </Flex>
       </Flex>
       <div className="flex gap-2 align-middle">
-        {Boolean(expense?.accountingCategory || userMustSetAccountingCategory(LoggedInUser, collective)) && (
+        {Boolean(expense?.accountingCategory || userMustSetAccountingCategory(LoggedInUser, collective, host)) && (
           <React.Fragment>
             <AccountingCategoryPill
               host={host}

--- a/components/expenses/lib/accounting-categories.ts
+++ b/components/expenses/lib/accounting-categories.ts
@@ -2,8 +2,12 @@ import { LoggedInUser } from '../../../lib/custom_typings/LoggedInUser';
 import { AccountWithHost } from '../../../lib/graphql/types/v2/graphql';
 import { getPolicy } from '../../../lib/policies';
 
-export const userMustSetAccountingCategory = (user: LoggedInUser | null, collective: AccountWithHost | null) => {
-  const policy = getPolicy<'EXPENSE_CATEGORIZATION'>(collective?.host, 'EXPENSE_CATEGORIZATION');
+export const userMustSetAccountingCategory = (
+  user: LoggedInUser | null,
+  collective: AccountWithHost | null,
+  host = collective?.host,
+) => {
+  const policy = getPolicy<'EXPENSE_CATEGORIZATION'>(host, 'EXPENSE_CATEGORIZATION');
   if (policy) {
     if (policy.requiredForExpenseSubmitters) {
       return true;

--- a/pages/create-expense.js
+++ b/pages/create-expense.js
@@ -392,6 +392,7 @@ class CreateExpensePage extends React.Component {
                         {step !== STEPS.SUMMARY ? (
                           <ExpenseForm
                             collective={collective}
+                            host={host}
                             loading={loadingLoggedInUser}
                             loggedInAccount={loggedInAccount}
                             onSubmit={this.onFormSubmit}


### PR DESCRIPTION
Because we fetch the host differently in the Host workspace (at the root level rather than `expense.account.host`), we need to pass the `host` separately. 

This resolves the issue [reported on Slack](https://opencollective.slack.com/archives/C05QS8FEHAM/p1699479932219769?thread_ts=1699466435.813669&cid=C05QS8FEHAM) regarding accounting categories, but could likely fix other discrepancies that may have occurred between the expense page and the drawer.