### PR TITLE
Treeshake lodash n validator

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -16,6 +16,24 @@
     "babel-plugin-react-docgen",
     "babel-plugin-styled-components",
     [
+      "import",
+      {
+        "libraryName": "lodash",
+        "libraryDirectory": "",
+        "camel2DashComponentName": false
+      },
+      "lodash"
+    ],
+    [
+      "import",
+      {
+        "libraryName": "validator",
+        "libraryDirectory": "lib",
+        "camel2DashComponentName": false
+      },
+      "validator"
+    ],
+    [
       "babel-plugin-formatjs",
       {
         "ast": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -160,6 +160,7 @@
         "autoprefixer": "10.4.16",
         "babel-loader": "^8.2.3",
         "babel-plugin-formatjs": "^10.5.0",
+        "babel-plugin-import": "^1.13.8",
         "babel-plugin-istanbul": "^6.1.1",
         "babel-plugin-react-docgen": "^4.2.1",
         "babel-plugin-react-remove-properties": "^0.3.0",
@@ -14948,6 +14949,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-import": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/babel-plugin-import/-/babel-plugin-import-1.13.8.tgz",
+      "integrity": "sha512-36babpjra5m3gca44V6tSTomeBlPA7cHUynrE2WiQIm3rEGD9xy28MKsx5IdO45EbnpJY7Jrgd00C6Dwt/l/2Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.0.0"
       }
     },
     "node_modules/babel-plugin-istanbul": {

--- a/package.json
+++ b/package.json
@@ -220,6 +220,7 @@
     "autoprefixer": "10.4.16",
     "babel-loader": "^8.2.3",
     "babel-plugin-formatjs": "^10.5.0",
+    "babel-plugin-import": "^1.13.8",
     "babel-plugin-istanbul": "^6.1.1",
     "babel-plugin-react-docgen": "^4.2.1",
     "babel-plugin-react-remove-properties": "^0.3.0",


### PR DESCRIPTION
# Description

Small bundle reduction (50kb gziped, 13%) by moving `lodash` and `validator` to treeshakable.

gziped from
 
```
static/chunks/pages/_app-b1d3ebff2a3bd5a8.js  (350.72 KB)
./node_modules/lodash (24.13 KB)
./node_modules/validator (33.68 KB)
```

to

```
static/chunks/pages/_app-338dadb6da26f885.js (304.38 KB)
./node_modules/lodash-es (8.77 KB)
./node_modules/validator/lib (2.98 KB)
```

# Screenshots
![image](https://github.com/opencollective/opencollective-frontend/assets/5448927/0d1a5504-74a9-4395-994d-e271da42d258)

![image](https://github.com/opencollective/opencollective-frontend/assets/5448927/a8d976c6-8897-470e-9656-0d4ba316725f)

