### PR TITLE
Improve conditions to display accounting categories

### DIFF
--- a/components/budget/ExpenseBudgetItem.js
+++ b/components/budget/ExpenseBudgetItem.js
@@ -14,6 +14,7 @@ import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
 import { AmountPropTypeShape } from '../../lib/prop-types';
 import { toPx } from '../../lib/theme/helpers';
 import { getCollectivePageRoute, getDashboardRoute } from '../../lib/url-helpers';
+import { shouldDisplayExpenseCategoryPill } from '../expenses/lib/accounting-categories';
 
 import AmountWithExchangeRateInfo from '../AmountWithExchangeRateInfo';
 import AutosizeText from '../AutosizeText';
@@ -202,20 +203,19 @@ const ExpenseBudgetItem = ({
                 </StyledLink>
               </StyledTooltip>
 
-              {isAdminView &&
-                (expense.accountingCategory || LoggedInUser.hasPreviewFeatureEnabled('EXPENSE_CATEGORIZATION')) && (
-                  <div className="flex items-center gap-1">
-                    <span className="text-sm font-normal text-neutral-700">
-                      <FormattedMessage id="expense.accountingCategory" defaultMessage="Category" />
-                    </span>
-                    <AccountingCategoryPill
-                      expense={expense}
-                      host={host}
-                      canEdit={get(expense, 'permissions.canEditAccountingCategory', false)}
-                      allowNone={false}
-                    />
-                  </div>
-                )}
+              {shouldDisplayExpenseCategoryPill(LoggedInUser, expense, expense.account, host) && (
+                <div className="flex items-center gap-1">
+                  <span className="text-sm font-normal text-neutral-700">
+                    <FormattedMessage id="expense.accountingCategory" defaultMessage="Category" />
+                  </span>
+                  <AccountingCategoryPill
+                    expense={expense}
+                    host={host}
+                    canEdit={get(expense, 'permissions.canEditAccountingCategory', false)}
+                    allowNone={false}
+                  />
+                </div>
+              )}
 
               <P mt="5px" fontSize="12px" color="black.700">
                 {isAdminView ? (

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -193,7 +193,7 @@ export const prepareExpenseForSubmit = expenseData => {
 /**
  * Validate the expense
  */
-const validateExpense = (intl, expense, collective, LoggedInUser) => {
+const validateExpense = (intl, expense, collective, host, LoggedInUser) => {
   const isCardCharge = expense.type === expenseTypes.CHARGE;
   if (expense.payee?.isInvite) {
     return expense.payee.id
@@ -237,7 +237,7 @@ const validateExpense = (intl, expense, collective, LoggedInUser) => {
     Object.assign(errors, requireFields(expense, ['payeeLocation.country', 'payeeLocation.address']));
   }
 
-  if (userMustSetAccountingCategory(LoggedInUser, collective)) {
+  if (userMustSetAccountingCategory(LoggedInUser, collective, host)) {
     Object.assign(errors, requireFields(expense, ['accountingCategory'], { allowNull: true }));
   }
 
@@ -953,7 +953,7 @@ const ExpenseForm = ({
   const { LoggedInUser } = useLoggedInUser();
   const supportedExpenseTypes = React.useMemo(() => getSupportedExpenseTypes(collective), [collective]);
   const initialValues = { ...getDefaultExpense(collective, supportedExpenseTypes), ...expense };
-  const validate = expenseData => validateExpense(intl, expenseData, collective, LoggedInUser);
+  const validate = expenseData => validateExpense(intl, expenseData, collective, host, LoggedInUser);
   if (isDraft) {
     initialValues.items = expense.draft.items?.map(newExpenseItem) || [];
     initialValues.taxes = expense.draft.taxes;

--- a/components/expenses/ExpenseSummary.js
+++ b/components/expenses/ExpenseSummary.js
@@ -12,7 +12,7 @@ import { PayoutMethodType } from '../../lib/constants/payout-method';
 import { ExpenseStatus } from '../../lib/graphql/types/v2/graphql';
 import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
 import { AmountPropTypeShape } from '../../lib/prop-types';
-import { userMustSetAccountingCategory } from './lib/accounting-categories';
+import { shouldDisplayExpenseCategoryPill } from './lib/accounting-categories';
 import { expenseTypeSupportsAttachments } from './lib/attachments';
 import { expenseItemsMustHaveFiles } from './lib/items';
 
@@ -184,7 +184,7 @@ const ExpenseSummary = ({
         </Flex>
       </Flex>
       <div className="flex gap-2 align-middle">
-        {Boolean(expense?.accountingCategory || userMustSetAccountingCategory(LoggedInUser, collective, host)) && (
+        {shouldDisplayExpenseCategoryPill(LoggedInUser, expense, collective, host) && (
           <React.Fragment>
             <AccountingCategoryPill
               host={host}

--- a/components/expenses/ProcessExpenseButtons.js
+++ b/components/expenses/ProcessExpenseButtons.js
@@ -197,7 +197,7 @@ const ProcessExpenseButtons = ({
           <PermissionButton
             {...getButtonProps('APPROVE')}
             onClick={() => {
-              if (collectiveAdminsMustConfirmAccountingCategory(collective)) {
+              if (collectiveAdminsMustConfirmAccountingCategory(collective, host)) {
                 setShowApproveExpenseModal(true);
               } else {
                 triggerAction('APPROVE');


### PR DESCRIPTION
Followup on https://github.com/opencollective/opencollective-frontend/pull/9586

Standardize the conditions to display the accounting category pill under a common `shouldDisplayExpenseCategoryPill` helper. The conditions are:
- Either there is an accounting category set on the expense
- Or the host has some accounting categories defined **AND**...
  - The user is required to set an accounting category (by the host's policy) 
  - Or the user has the `EXPENSE_CATEGORIZATION` feature enabled 