### PR TITLE
Split app external dependencies into appCommon chunk

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -27,7 +27,7 @@ const nextConfig = {
       '/_document': ['./.next/language-manifest.json'],
     },
   },
-  webpack: (config, { webpack, buildId }) => {
+  webpack: (config, { webpack, isServer, dev, buildId }) => {
     config.resolve.alias['@sentry/replay'] = false;
 
     config.plugins.push(
@@ -172,6 +172,19 @@ const nextConfig = {
       include: /node_modules/,
       type: 'javascript/auto',
     });
+
+    if (!isServer && !dev) {
+      config.optimization.splitChunks.cacheGroups.appCommon = {
+        name: 'appCommon',
+        chunks(chunk) {
+          return chunk.name === 'pages/_app';
+        },
+        test(module) {
+          return /node_modules[/\\]/.test(module.nameForCondition() || '');
+        },
+        enforce: true,
+      };
+    }
 
     return config;
   },


### PR DESCRIPTION
# Description

Reduces the _app chunk from 350kb to 50kb.... by moving 300kb dependencies to another chunk...
There is no size reduction in this PR, this simply takes external dependencies from the _app chunk to a new chunk named `appCommon`. 

The optimization comes from the fact that this new chunk (which was the majority of _app) can be cached longer by clients as it will preserve the same contenthash for the same external dependency included.

The three builds below were made with vercel using the exact same source code, note that the _app chunk content hash changes everytime. I am not sure why that happens, I am guessing that it might be code generated by nextjs during the build process.  

Note that the rest of common dependencies remain stable, this mean that clients loading a new build now only download 50kb instead of 350kb.

> + First Load JS shared by all                483 kB
>   **├ chunks/appCommon-c2700cedc457748e.js     308 kB**
>   ├ chunks/framework-4acc41369cd80039.js     66.8 kB
>   ├ chunks/main-8ab5ed92f860346b.js          39.5 kB
>   **├ chunks/pages/_app-86194ef49374da8b.js    48.9 kB**
>   ├ chunks/webpack-4e75b41cda1786e8.js       3.46 kB
>   ├ css/2ce0e5748a9a8631.css                 10.5 kB
>   └ css/993df85a8fb78300.css                 5.95 kB


> + First Load JS shared by all                483 kB
>   **├ chunks/appCommon-c2700cedc457748e.js     308 kB**
>   ├ chunks/framework-4acc41369cd80039.js     66.8 kB
>   ├ chunks/main-8ab5ed92f860346b.js          39.5 kB
>   **├ chunks/pages/_app-fc25a06c49c83d0b.js    48.9 kB**
>   ├ chunks/webpack-4e75b41cda1786e8.js       3.46 kB
>   ├ css/2ce0e5748a9a8631.css                 10.5 kB
>   └ css/993df85a8fb78300.css                 5.95 kB
  

> + First Load JS shared by all                483 kB
>   **├ chunks/appCommon-c2700cedc457748e.js     308 kB**
>   ├ chunks/framework-4acc41369cd80039.js     66.8 kB
>   ├ chunks/main-8ab5ed92f860346b.js          39.5 kB
>   **├ chunks/pages/_app-7c40b639392b2e3e.js    48.9 kB**
>   ├ chunks/webpack-4e75b41cda1786e8.js       3.46 kB
>   ├ css/2ce0e5748a9a8631.css                 10.5 kB
>   └ css/993df85a8fb78300.css                 5.95 kB
