### PR TITLE
Iterate on accounting categories UI

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "trailingComma": "all",
   "arrowParens": "avoid",
   "printWidth": 120,
-  "plugins": ["prettier-plugin-tailwindcss"]
+  "plugins": ["prettier-plugin-tailwindcss"],
+  "tailwindFunctions": ["clsx", "cn"]
 }

--- a/components/budget/ExpenseBudgetItem.js
+++ b/components/budget/ExpenseBudgetItem.js
@@ -212,7 +212,8 @@ const ExpenseBudgetItem = ({
                     expense={expense}
                     host={host}
                     canEdit={get(expense, 'permissions.canEditAccountingCategory', false)}
-                    allowNone={false}
+                    allowNone={!isLoggedInUserExpenseHostAdmin}
+                    showCodeInSelect={isLoggedInUserExpenseHostAdmin}
                   />
                 </div>
               )}

--- a/components/dashboard/MenuLink.tsx
+++ b/components/dashboard/MenuLink.tsx
@@ -40,8 +40,8 @@ export const MenuLink = ({ section, subMenu, Icon, label, href, isBeta, classNam
   }
 
   const classNames = cn(
-    'group w-full flex gap-x-3 rounded-full py-1.5 px-3 text-sm leading-6 font-medium transition-colors',
-    isSelected ? 'bg-blue-50/50 text-blue-700' : 'text-slate-700 hover:text-blue-700 hover:bg-blue-50/50',
+    'group flex w-full gap-x-3 rounded-full px-3 py-1.5 text-sm font-medium leading-6 transition-colors',
+    isSelected ? 'bg-blue-50/50 text-blue-700' : 'text-slate-700 hover:bg-blue-50/50 hover:text-blue-700',
     className,
   );
 

--- a/components/expenses/AccountingCategoryPill.tsx
+++ b/components/expenses/AccountingCategoryPill.tsx
@@ -23,7 +23,7 @@ type AccountingCategoryPillProps = {
   allowNone?: boolean;
 };
 
-const BADGE_CLASS: ClassValue = 'rounded-lg bg-red-50 px-3 py-1 text-sm font-normal text-neutral-800';
+const BADGE_CLASS = cn('red rounded-lg bg-neutral-100 px-3 py-1  text-xs font-medium text-neutral-800');
 
 const getCategoryLabel = (category: AccountingCategory) => {
   if (!category) {
@@ -58,7 +58,7 @@ const AdminAccountingCategoryPill = ({ expense, host, allowNone }: Omit<Accounti
         }
       }}
     >
-      <Button className={cn(BADGE_CLASS, 'h-auto hover:bg-red-50 hover:opacity-90')}>
+      <Button className={cn(BADGE_CLASS, 'h-auto hover:bg-neutral-50 hover:opacity-90')}>
         <span className="mr-1">{getCategoryLabel(expense.accountingCategory)}</span>
         {loading ? <StyledSpinner size="1em" /> : <ChevronDown size="1em" />}
       </Button>

--- a/components/expenses/AccountingCategoryPill.tsx
+++ b/components/expenses/AccountingCategoryPill.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useMutation } from '@apollo/client';
-import { ClassValue } from 'clsx';
 import { ChevronDown } from 'lucide-react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -20,7 +19,10 @@ type AccountingCategoryPillProps = {
   expense: Expense;
   canEdit: boolean;
   host: Host;
+  /** Whether to allow the user to select "I don't know" */
   allowNone?: boolean;
+  /** Whether to show the category code in the select */
+  showCodeInSelect?: boolean;
 };
 
 const BADGE_CLASS = cn('red rounded-lg bg-neutral-100 px-3 py-1  text-xs font-medium text-neutral-800');
@@ -33,7 +35,12 @@ const getCategoryLabel = (category: AccountingCategory) => {
   }
 };
 
-const AdminAccountingCategoryPill = ({ expense, host, allowNone }: Omit<AccountingCategoryPillProps, 'canEdit'>) => {
+const AdminAccountingCategoryPill = ({
+  expense,
+  host,
+  allowNone,
+  showCodeInSelect,
+}: Omit<AccountingCategoryPillProps, 'canEdit'>) => {
   const intl = useIntl();
   const [editExpense, { loading }] = useMutation(editExpenseCategoryMutation, { context: API_V2_CONTEXT });
   const { toast } = useToast();
@@ -45,6 +52,7 @@ const AdminAccountingCategoryPill = ({ expense, host, allowNone }: Omit<Accounti
       selectedCategory={expense.accountingCategory}
       submitterCategory={expense.valuesByRole?.submitter?.accountingCategory}
       accountAdminCategory={expense.valuesByRole?.accountAdmin?.accountingCategory}
+      showCode={showCodeInSelect}
       onChange={async selectedCategory => {
         try {
           await editExpense({
@@ -66,10 +74,23 @@ const AdminAccountingCategoryPill = ({ expense, host, allowNone }: Omit<Accounti
   );
 };
 
-export const AccountingCategoryPill = ({ expense, host, canEdit, allowNone }: AccountingCategoryPillProps) => {
+export const AccountingCategoryPill = ({
+  expense,
+  host,
+  canEdit,
+  allowNone,
+  showCodeInSelect = false,
+}: AccountingCategoryPillProps) => {
   if (!canEdit) {
     return <div className={BADGE_CLASS}>{getCategoryLabel(expense.accountingCategory)}</div>;
   } else {
-    return <AdminAccountingCategoryPill expense={expense} host={host} allowNone={allowNone} />;
+    return (
+      <AdminAccountingCategoryPill
+        expense={expense}
+        host={host}
+        allowNone={allowNone}
+        showCodeInSelect={showCodeInSelect}
+      />
+    );
   }
 };

--- a/components/expenses/ExpenseSummary.js
+++ b/components/expenses/ExpenseSummary.js
@@ -190,7 +190,8 @@ const ExpenseSummary = ({
               host={host}
               expense={expense}
               canEdit={Boolean(expense.permissions?.canEditAccountingCategory)}
-              allowNone={!LoggedInUser?.isAdminOfCollectiveOrHost(expense.account)}
+              allowNone={!isLoggedInUserExpenseHostAdmin}
+              showCodeInSelect={isLoggedInUserExpenseHostAdmin}
             />
             <Separator orientation="vertical" className="h-[24px] w-[2px]" />
           </React.Fragment>

--- a/components/navigation/ProfileMenu.tsx
+++ b/components/navigation/ProfileMenu.tsx
@@ -60,7 +60,7 @@ const MenuItem = ({
   external?: boolean;
 }) => {
   const classes = cn(
-    'group flex justify-between items-center text-left gap-2 mx-2 rounded-md px-2 h-9 text-sm hover:bg-primary-foreground',
+    'group mx-2 flex h-9 items-center justify-between gap-2 rounded-md px-2 text-left text-sm hover:bg-primary-foreground',
     className,
   );
   const content = (


### PR DESCRIPTION
Part of https://github.com/opencollective/opencollective/issues/7028

- Added category codes for host admins (see [Slack](https://opencollective.slack.com/archives/C05QS8FEHAM/p1699549834000229?thread_ts=1699375215.418699&cid=C05QS8FEHAM))
- Made the pill greyish (see [Slack](https://opencollective.slack.com/archives/C05QS8FEHAM/p1699559160197099?thread_ts=1699375427.092319&cid=C05QS8FEHAM))

![Kooha-2023-11-10-10-32-34](https://github.com/opencollective/opencollective-frontend/assets/1556356/71706912-6abf-49e1-ae2f-7bb68676a2df)
