### PR TITLE
Improve 2FA Input for backup codes

### DIFF
--- a/components/two-factor-authentication/TwoFactorAuthenticationModal.tsx
+++ b/components/two-factor-authentication/TwoFactorAuthenticationModal.tsx
@@ -290,9 +290,9 @@ function RecoveryCodeOptions(props: { value: string; onChange: (string) => void;
         name="2fa-code-input"
         type="text"
         mt={3}
+        placeholder="ABCDEFGHIJKLM123"
         minHeight={50}
         fontSize="20px"
-        inputMode="numeric"
         value={props.value}
         onChange={e => props.onChange(e.target.value)}
         disabled={props.disabled}


### PR DESCRIPTION
- Do not use `inputMode="numeric"`, since backup codes are alphanum
- Add a placeholder, to help clarify that we're not expecting a 6 digits code in there