### PR TITLE
ExpenseFilters: always show charge receipts filter

### DIFF
--- a/components/expenses/ExpensesFilters.js
+++ b/components/expenses/ExpensesFilters.js
@@ -45,7 +45,6 @@ const ExpensesFilters = ({
   showOrderFilter = true,
   wrap = true,
   displayOnHoldPseudoStatus = false,
-  showChargeHasReceiptFilter = false,
   ...props
 }) => {
   const intl = useIntl();
@@ -140,19 +139,17 @@ const ExpensesFilters = ({
           <ExpensesOrder {...getFilterProps('orderBy')} />
         </FilterContainer>
       )}
-      {showChargeHasReceiptFilter && (
-        <FilterContainer>
-          <FilterLabel htmlFor="expenses-charge-has-receipts">
-            <FormattedMessage id="expenses.chargeHasReceiptsFilter" defaultMessage="Charge Receipts" />
-          </FilterLabel>
-          <StyledSelectFilter
-            inputId="expenses-charge-has-receipts"
-            onChange={newValue => props.onChargeHasReceiptFilterChange(newValue.value)}
-            value={chargeHasReceiptFilterValue}
-            options={chargeHasReceiptFilterOptions}
-          />
-        </FilterContainer>
-      )}
+      <FilterContainer>
+        <FilterLabel htmlFor="expenses-charge-has-receipts">
+          <FormattedMessage id="expenses.chargeHasReceiptsFilter" defaultMessage="Charge Receipts" />
+        </FilterLabel>
+        <StyledSelectFilter
+          inputId="expenses-charge-has-receipts"
+          onChange={newValue => props.onChargeHasReceiptFilterChange(newValue.value)}
+          value={chargeHasReceiptFilterValue}
+          options={chargeHasReceiptFilterOptions}
+        />
+      </FilterContainer>
     </Flex>
   );
 };

--- a/components/host-dashboard/HostDashboardExpenses.js
+++ b/components/host-dashboard/HostDashboardExpenses.js
@@ -382,7 +382,6 @@ const HostDashboardExpenses = ({ accountSlug: hostSlug, isDashboard }) => {
             filters={query}
             explicitAllForStatus
             displayOnHoldPseudoStatus
-            showChargeHasReceiptFilter
             chargeHasReceiptFilter={queryFilter.values.chargeHasReceipts}
             onChargeHasReceiptFilterChange={queryFilter.setChargeHasReceipts}
             onChange={queryParams =>


### PR DESCRIPTION
Follow-up on https://github.com/opencollective/opencollective-frontend/pull/8991
To resolve https://github.com/opencollective/opencollective/issues/6816

When going to Dashboard > Expenses for an individual profile (aka. Submitted expenses), there was no filter to see the ones with a pending receipt; while it's one of the most helpful places to display it as it lets you edit all your expenses that are waiting for your action in a single batch.

I remember someone looking for this in Slack, but I can't find the original conversation.