### PR TITLE
Deactivate files viewer focus trap on outside click

### DIFF
--- a/components/FilesViewerModal.tsx
+++ b/components/FilesViewerModal.tsx
@@ -242,7 +242,7 @@ export default function FilesViewerModal({ onClose, parentTitle, files, openFile
     <React.Fragment>
       <GlobalModalStyle />
 
-      <FocusTrap focusTrapOptions={{ allowOutsideClick: true }}>
+      <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }}>
         <Wrapper
           tabIndex={0}
           onKeyDown={event => {


### PR DESCRIPTION
Resolves https://opencollective.slack.com/archives/GFH4N961L/p1700080033306429

Issue: Focus trap of file viewer prevents focusing the comment input of the expense drawer.
Fix: Set option to deactivate focus trap if clicked outside.