### PR TITLE
Top bar/account switcher fixes

### DIFF
--- a/components/dashboard/preview/AccountSwitcher.tsx
+++ b/components/dashboard/preview/AccountSwitcher.tsx
@@ -236,7 +236,6 @@ const getGroupedAdministratedAccounts = memoizeOne(loggedInUser => {
     [CollectiveType.COLLECTIVE]: [],
     ...groupBy(activeAccounts, a => a.type),
   };
-  // if (archivedAccounts?.length > 0) {
   //   groupedAccounts.archived = archivedAccounts;
   // }
   return { groupedAccounts, archivedAccounts };

--- a/components/dashboard/preview/AccountSwitcher.tsx
+++ b/components/dashboard/preview/AccountSwitcher.tsx
@@ -251,9 +251,7 @@ const getGroupedChildAccounts = memoizeOne(accounts => {
     [CollectiveType.EVENT]: [],
     ...groupBy(activeAccounts, a => a.type),
   };
-  // if (archivedAccounts?.length > 0) {
-  //   groupedAccounts.archived = archivedAccounts;
-  // }
+
   return { groupedAccounts, archivedAccounts };
 });
 
@@ -264,7 +262,6 @@ export default function AccountSwitcher({ activeSlug, defaultSlug, setDefaultSlu
   const { viewport } = useWindowResize();
   const isMobile = [VIEWPORTS.XSMALL, VIEWPORTS.SMALL].includes(viewport);
 
-  // const [open, setOpen] = React.useState(false);
   const loggedInUserCollective = LoggedInUser?.collective;
   const { groupedAccounts, archivedAccounts } = getGroupedAdministratedAccounts(LoggedInUser);
   const rootAccounts = flatten(Object.values({ ...groupedAccounts, archived: archivedAccounts }));

--- a/components/ui/Command.tsx
+++ b/components/ui/Command.tsx
@@ -69,7 +69,8 @@ const CommandList = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.List
     ref={ref}
-    className={cn('max-h-[300px] overflow-y-auto overflow-x-hidden', className)}
+    className={cn('max-h-[300px] overflow-y-auto overflow-x-hidden [&::-webkit-scrollbar]:hidden', className)}
+    cmdk-list-wrapper=""
     {...props}
   />
 ));

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -143,7 +143,7 @@ const DashboardPage = () => {
   // Keep track of last visited workspace account and sections
   React.useEffect(() => {
     if (activeSlug && activeSlug !== lastWorkspaceVisit.slug) {
-      if (!useDynamicTopBar) {
+      if (LoggedInUser && !useDynamicTopBar) {
         // this is instead configured as "default" account in NewAccountSwitcher
         setLastWorkspaceVisit({ slug: activeSlug });
       }

--- a/pages/transactions.tsx
+++ b/pages/transactions.tsx
@@ -143,6 +143,7 @@ export const transactionsPageQuery = gql`
         parent {
           id
           slug
+          name
         }
       }
       ... on AccountWithHost {


### PR DESCRIPTION
Some fixes for the Top bar preview feature

- AccountSwitcher
  - adding a max height (calculated from available height)
  - putting organisations before collectives
  - fixing the "Save as default" feature (by making sure to not save the last workspace visit when using the dynamic top bar preview feature)
- When viewing a child collective in Dashboard, the parent account is a link back to that account rather than another triggger for the AccountSwitcher, to enable going back more easily.
- Fix display of parent account in breadcrumb on child collectives Transaction page


https://github.com/opencollective/opencollective-frontend/assets/1552194/bd83a2ea-b1d4-40b2-910c-34ad06a6693b


