### PR TITLE
Revert "ExpenseFilters: always show charge receipts filter"

### DIFF
--- a/components/expenses/ExpensesFilters.js
+++ b/components/expenses/ExpensesFilters.js
@@ -45,6 +45,7 @@ const ExpensesFilters = ({
   showOrderFilter = true,
   wrap = true,
   displayOnHoldPseudoStatus = false,
+  showChargeHasReceiptFilter = false,
   ...props
 }) => {
   const intl = useIntl();
@@ -139,17 +140,19 @@ const ExpensesFilters = ({
           <ExpensesOrder {...getFilterProps('orderBy')} />
         </FilterContainer>
       )}
-      <FilterContainer>
-        <FilterLabel htmlFor="expenses-charge-has-receipts">
-          <FormattedMessage id="expenses.chargeHasReceiptsFilter" defaultMessage="Charge Receipts" />
-        </FilterLabel>
-        <StyledSelectFilter
-          inputId="expenses-charge-has-receipts"
-          onChange={newValue => props.onChargeHasReceiptFilterChange(newValue.value)}
-          value={chargeHasReceiptFilterValue}
-          options={chargeHasReceiptFilterOptions}
-        />
-      </FilterContainer>
+      {showChargeHasReceiptFilter && (
+        <FilterContainer>
+          <FilterLabel htmlFor="expenses-charge-has-receipts">
+            <FormattedMessage id="expenses.chargeHasReceiptsFilter" defaultMessage="Charge Receipts" />
+          </FilterLabel>
+          <StyledSelectFilter
+            inputId="expenses-charge-has-receipts"
+            onChange={newValue => props.onChargeHasReceiptFilterChange(newValue.value)}
+            value={chargeHasReceiptFilterValue}
+            options={chargeHasReceiptFilterOptions}
+          />
+        </FilterContainer>
+      )}
     </Flex>
   );
 };

--- a/components/host-dashboard/HostDashboardExpenses.js
+++ b/components/host-dashboard/HostDashboardExpenses.js
@@ -382,6 +382,7 @@ const HostDashboardExpenses = ({ accountSlug: hostSlug, isDashboard }) => {
             filters={query}
             explicitAllForStatus
             displayOnHoldPseudoStatus
+            showChargeHasReceiptFilter
             chargeHasReceiptFilter={queryFilter.values.chargeHasReceipts}
             onChargeHasReceiptFilterChange={queryFilter.setChargeHasReceipts}
             onChange={queryParams =>


### PR DESCRIPTION
Reverts opencollective/opencollective-frontend#9623

Since this has been implemented with a different pattern (using `useQueryFilter`), the function is not plug-and-play like the other filters and requires some additional code in order to work. Reverting to go back to it later.