### PR TITLE
Fix error message when invite expense fails

### DIFF
--- a/pages/create-expense.js
+++ b/pages/create-expense.js
@@ -241,7 +241,7 @@ class CreateExpensePage extends React.Component {
     } catch (e) {
       toast({
         variant: 'error',
-        description: i18nGraphqlException(this.props.intl, e),
+        message: i18nGraphqlException(this.props.intl, e),
       });
     }
   };


### PR DESCRIPTION
In https://github.com/opencollective/opencollective-frontend/pull/9415, we haven't updated this prop according to the new API.