### PR TITLE
fix(authenticator): adding authenticator

### DIFF
--- a/components/two-factor-authentication/AuthenticatorSettings.tsx
+++ b/components/two-factor-authentication/AuthenticatorSettings.tsx
@@ -200,14 +200,19 @@ function AddAuthenticatorModal(props: AddAuthenticatorModalProps) {
       if (!values.twoFactorAuthenticatorCode) {
         errors.twoFactorAuthenticatorCode = intl.formatMessage(I18nMessages.REQUIRED);
       } else {
-        const verified = speakeasy.totp.verify({
-          secret: base32,
-          encoding: 'base32',
-          token: values.twoFactorAuthenticatorCode,
-          window: 2,
-        });
+        try {
+          const verified = speakeasy.totp.verify({
+            secret: base32,
+            encoding: 'base32',
+            token: values.twoFactorAuthenticatorCode,
+            window: 2,
+          });
 
-        if (!verified) {
+          if (!verified) {
+            errors.twoFactorAuthenticatorCode = intl.formatMessage(I18nMessages.INVALID_TOTP_CODE);
+          }
+        } catch (error) {
+          // Handle the error appropriately, log it, or set an error message.
           errors.twoFactorAuthenticatorCode = intl.formatMessage(I18nMessages.INVALID_TOTP_CODE);
         }
       }


### PR DESCRIPTION
…onSubmit

Validates TOTP before updating I18nMessages for better functionality.

Issue: [opencollective/opencollective#7098](https://github.com/opencollective/opencollective/issues/7098)

# Description
adding the authenticator by checking the validate first and verify the TOTP's and update I18nMessages.

**outcome**
it submits the form and adds authenticator.

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->

# Screenshots

> **Adds authenticator**

![Screenshot from 2023-11-23 18-53-03](https://github.com/opencollective/opencollective-frontend/assets/98177395/44cdf71a-8557-499a-9adb-fb666c26c655)

> **On relogin/sign in**

- working properly
![Screenshot from 2023-11-23 18-53-55](https://github.com/opencollective/opencollective-frontend/assets/98177395/f9af1831-bb89-404d-9efa-5bd1a9e34eed)

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
