### PR TITLE
Small query improvements on Vendors

### DIFF
--- a/components/vendors/queries.ts
+++ b/components/vendors/queries.ts
@@ -49,11 +49,11 @@ export const vendorFieldFragment = gql`
       data
     }
 
-    orders {
+    orders(filter: OUTGOING, limit: 1) {
       totalCount
     }
 
-    expenses(status: PAID, direction: SUBMITTED) {
+    expenses(status: PAID, direction: SUBMITTED, limit: 1) {
       totalCount
     }
   }


### PR DESCRIPTION
A tiny follow-up on https://github.com/opencollective/opencollective-frontend/pull/9639#discussion_r1400759518

Note that we still have a N+1 on each of these fields, as they're not backed by loaders. It could be interesting to explore something on `server/graphql/v2/object/AccountStats.js`.