### PR TITLE
Handle KeyPress events in "Setup 2FA" modal

### DIFF
--- a/components/two-factor-authentication/AuthenticatorSettings.tsx
+++ b/components/two-factor-authentication/AuthenticatorSettings.tsx
@@ -216,6 +216,13 @@ function AddAuthenticatorModal(props: AddAuthenticatorModalProps) {
     },
   });
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      formik.handleSubmit();
+    }
+  };
+
   return (
     <StyledModal onClose={props.onClose}>
       <ModalHeader>
@@ -265,6 +272,7 @@ function AddAuthenticatorModal(props: AddAuthenticatorModalProps) {
                         minLength={6}
                         maxLength={6}
                         data-cy="add-two-factor-auth-totp-code-field"
+                        onKeyDown={handleKeyDown}
                       />
                     )}
                   </StyledInputField>


### PR DESCRIPTION
fix(authenticator): add handlekeydown event listener for enter key pressed to submit form auth

Resolve [opencollective/opencollective#7098](https://github.com/opencollective/opencollective/issues/7098)

# Description
- adds authenticator when Enter pressed
