### PR TITLE
ContributionFlow: center text in contribute button

### DIFF
--- a/components/contribution-flow/ContributionFlowButtons.js
+++ b/components/contribution-flow/ContributionFlowButtons.js
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import styled from 'styled-components';
 
 import { AnalyticsEvent } from '../../lib/analytics/events';
 import { track } from '../../lib/analytics/plausible';
@@ -12,6 +13,12 @@ import StyledButton from '../StyledButton';
 
 import { STEPS } from './constants';
 import { getTotalAmount } from './utils';
+
+const ButtonWithTextCentered = styled(StyledButton)`
+  span {
+    vertical-align: baseline;
+  }
+`;
 
 class ContributionFlowButtons extends React.Component {
   static propTypes = {
@@ -81,7 +88,7 @@ class ContributionFlowButtons extends React.Component {
             </StyledButton>
           )}
           {!paypalButtonProps || nextStep ? (
-            <StyledButton
+            <ButtonWithTextCentered
               mt={2}
               mx={[1, null, 2]}
               minWidth={!nextStep ? 185 : 145}
@@ -116,7 +123,7 @@ class ContributionFlowButtons extends React.Component {
               ) : (
                 <FormattedMessage id="contribute.submit" defaultMessage="Make contribution" />
               )}
-            </StyledButton>
+            </ButtonWithTextCentered>
           ) : (
             <Box mx={[1, null, 2]} minWidth={200} mt={2}>
               <PayWithPaypalButton {...paypalButtonProps} isSubmitting={isValidating || this.state.isLoadingNext} />


### PR DESCRIPTION
Not sure what introduced that regression.

| Before | After |
|--------|--------|
| ![localhost_3000_foundation_donate_payment_interval=oneTime amount=20 contributeAs=me paymentMethod=pm-03k0exgz-nm8yj645-5e7q5wao-9r7b4dlv (1)](https://github.com/opencollective/opencollective-frontend/assets/1556356/0af8da1e-3cf7-454d-a001-2fb4cecbfbd9) | ![localhost_3000_foundation_donate_payment_interval=oneTime amount=20 contributeAs=me paymentMethod=pm-03k0exgz-nm8yj645-5e7q5wao-9r7b4dlv](https://github.com/opencollective/opencollective-frontend/assets/1556356/ad34b137-0b96-4ecf-80ba-d1de39c51f30) | 




