### PR TITLE
PayExpenseModal: fix effective rate value

### DIFF
--- a/components/expenses/PayExpenseModal.js
+++ b/components/expenses/PayExpenseModal.js
@@ -18,7 +18,6 @@ import { i18nTaxType } from '../../lib/i18n/taxes';
 import { AmountPropTypeShape } from '../../lib/prop-types';
 import { getAmountWithoutTaxes, getTaxAmount } from './lib/utils';
 
-import Container from '../Container';
 import FormattedMoneyAmount from '../FormattedMoneyAmount';
 import { Box, Flex } from '../Grid';
 import LoadingPlaceholder from '../LoadingPlaceholder';
@@ -205,7 +204,8 @@ const calculateAmounts = ({ formik, expense, quote, host, feesPayer }) => {
       valueInCents: formik.values.paymentProcessorFeeInHostCurrency,
       currency: host.currency,
     };
-    const effectiveRate = expense.currency !== host.currency && totalAmount.valueInCents / expense.amount;
+    const grossAmount = totalAmount.valueInCents - (paymentProcessorFee.valueInCents || 0);
+    const effectiveRate = expense.currency !== host.currency && grossAmount / expense.amount;
     return { paymentProcessorFee, totalAmount, effectiveRate };
   } else if (quote) {
     const effectiveRate = expense.currency !== host.currency && quote.sourceAmount.valueInCents / expense.amount;
@@ -481,9 +481,9 @@ const PayExpenseModal = ({ onClose, onSubmit, expense, collective, host, error, 
               <Label color="black.600" fontWeight="500">
                 <FormattedMessage id="EffectiveRate" defaultMessage="Effective rate" />
               </Label>
-              <Flex>
-                <Container color="black.600">~ {round(amounts.effectiveRate, 5)}</Container>
-              </Flex>
+              <P fontSize="13px" color="black.600" whiteSpace="nowrap">
+                ~ {expense.currency} 1 = {amounts.totalAmount?.currency} {round(amounts.effectiveRate, 5)}
+              </P>
             </AmountLine>
           ) : null}
         </Box>


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/7129
The issue was actually reported in the [original PR's feedback](https://github.com/opencollective/opencollective-frontend/pull/8478#discussion_r1058878481).

Also improved a bit the UI:

![image](https://github.com/opencollective/opencollective-frontend/assets/1556356/443fff76-6ad0-41e5-b5eb-184f28823cbc)
