### PR TITLE
fix: overlap between TopBarProfileMenu and Dialog

### DIFF
--- a/components/TopBarProfileMenu.js
+++ b/components/TopBarProfileMenu.js
@@ -286,7 +286,7 @@ class TopBarProfileMenu extends React.Component {
         position="absolute"
         right={[0, 16]}
         top={[69, 75]}
-        zIndex={3000}
+        zIndex={999}
         data-cy="user-menu"
         css={{ overflow: 'hidden' }}
       >


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/7137

# Description

This PR fixes the overlap between two modals (the user menu and either `Preview Features` or `News and Updates`) by adjusting the `z-index` css property in `TopBarProfileMenu.js` to be lower than the one set in `Dialog.tsx`.

![image](https://github.com/opencollective/opencollective-frontend/assets/111630063/d505e273-23ac-43e3-a566-259c7a074c34)

Even though having lots of `z-index` can become problematic, I think this approach provides a better UX than closing the user menu, but if you guys prefer it that way I'm happy to update the fix accordingly!

# To think about

A long-term solution to these kinds of issues would be to standardize the `z-index` values for the entire project to make changes in this sense more predictable. Since the project uses TailwindCSS, it could even follow their pattern of having values that are multiples of 10.

Or maybe have some constants for each z-index priority number to avoid having so many arbitrary values:

![image](https://github.com/opencollective/opencollective-frontend/assets/111630063/39853056-b0d4-425c-9baf-7d0116873326)

![image](https://github.com/opencollective/opencollective-frontend/assets/111630063/2551368c-0e54-4fea-bf64-557a87574171)

# Screenshots

![image](https://github.com/opencollective/opencollective-frontend/assets/111630063/264f277f-46ed-4f6e-b167-8f3b8cb25c23)

![image](https://github.com/opencollective/opencollective-frontend/assets/111630063/ec0c73f0-071f-4005-8112-a5147bab3dfc)

