### PR TITLE
Update PrivateInfoIcon with new icon and tooltip

### DIFF
--- a/components/InputField.js
+++ b/components/InputField.js
@@ -23,7 +23,7 @@ import TimezonePicker from './TimezonePicker';
 
 const Label = ({ label, isPrivate }) => (
   <label className="text-sm font-bold">
-    {label}&nbsp;{isPrivate && <PrivateInfoIcon tooltipProps={{ containerVerticalAlign: 'text-bottom' }} />}
+    {label}&nbsp;{isPrivate && <PrivateInfoIcon />}
   </label>
 );
 

--- a/components/StyledInputField.js
+++ b/components/StyledInputField.js
@@ -12,7 +12,7 @@ import { P, Span } from './Text';
 const PrivateIconWithSpace = () => (
   <React.Fragment>
     &nbsp;
-    <PrivateInfoIcon tooltipProps={{ containerVerticalAlign: 'text-top' }} />
+    <PrivateInfoIcon />
   </React.Fragment>
 );
 

--- a/components/UploadedFilePreview.js
+++ b/components/UploadedFilePreview.js
@@ -85,13 +85,6 @@ const FileName = styled(P)`
   text-overflow: ellipsis;
 `;
 
-const PrivateIconContainer = styled.div`
-  text-align: center;
-  svg {
-    max-height: 32px;
-  }
-`;
-
 const formatFileSize = sizeInBytes => {
   if (sizeInBytes < 1024) {
     return `${sizeInBytes} bytes`;
@@ -133,7 +126,7 @@ const UploadedFilePreview = ({
     content = <StyledSpinner size="50%" />;
   } else if (isPrivate) {
     content = (
-      <PrivateInfoIcon color="#dcdee0" size="60%" tooltipProps={{ childrenContainer: PrivateIconContainer }}>
+      <PrivateInfoIcon size="60%" className="mx-auto text-slate-200">
         <FormattedMessage id="Attachment.Private" defaultMessage="This attachment is private" />
       </PrivateInfoIcon>
     );

--- a/components/attached-files/AttachedFilesForm.tsx
+++ b/components/attached-files/AttachedFilesForm.tsx
@@ -54,7 +54,7 @@ const AttachedFilesForm = ({
             }}
           />
           &nbsp;
-          <PrivateInfoIcon color="#969BA3" size={12} />
+          <PrivateInfoIcon className="text-muted-foreground" size={12} />
         </Span>
         <StyledHr flex="1" borderColor="black.300" mx={2} />
         {isMulti && files?.length > 0 && (

--- a/components/contribution-flow/StepProfileGuestForm.js
+++ b/components/contribution-flow/StepProfileGuestForm.js
@@ -146,7 +146,7 @@ const StepProfileGuestForm = ({ stepDetails, onChange, data, isEmbed, onSignInCl
               <FormattedMessage id="collective.address.label" defaultMessage="Address" />
             </P>
             <Span mr={2} lineHeight="0">
-              <PrivateInfoIcon size="14px" tooltipProps={{ containerLineHeight: '0' }} />
+              <PrivateInfoIcon className="text-muted-foreground" />
             </Span>
             <StyledHr my="18px" borderColor="black.300" width="100%" />
           </Flex>

--- a/components/contribution-flow/StepProfileLoggedInForm.js
+++ b/components/contribution-flow/StepProfileLoggedInForm.js
@@ -100,7 +100,7 @@ const StepProfileLoggedInForm = ({ profiles, onChange, collective, tier, data, s
               <FormattedMessage id="collective.address.label" defaultMessage="Address" />
             </P>
             <Span mr={2} lineHeight="0">
-              <PrivateInfoIcon size="14px" tooltipProps={{ containerLineHeight: '0' }} />
+              <PrivateInfoIcon />
             </Span>
             <StyledHr my="18px" borderColor="black.300" width="100%" />
           </Flex>

--- a/components/expenses/Expense.tsx
+++ b/components/expenses/Expense.tsx
@@ -94,7 +94,7 @@ const PrivateNoteLabel = () => {
     <Span fontSize="12px" color="black.700" fontWeight="bold">
       <FormattedMessage id="Expense.PrivateNote" defaultMessage="Private note" />
       &nbsp;&nbsp;
-      <PrivateInfoIcon color="#969BA3" />
+      <PrivateInfoIcon size={12} className="text-muted-foreground" />
     </Span>
   );
 };

--- a/components/expenses/ExpenseAttachedFilesForm.tsx
+++ b/components/expenses/ExpenseAttachedFilesForm.tsx
@@ -54,7 +54,7 @@ const ExpenseAttachedFilesForm = ({
             }}
           />
           &nbsp;
-          <PrivateInfoIcon color="#969BA3" size={12} />
+          <PrivateInfoIcon className="text-muted-foreground" />
         </Span>
         <StyledHr flex="1" borderColor="black.300" mx={2} />
         {files?.length > 0 && (

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -617,7 +617,7 @@ const ExpenseFormBody = ({
                   {formatMessage(msg.stepPayee)}
                 </Span>
                 <Box ml={2}>
-                  <PrivateInfoIcon size={12} color="#969BA3" tooltipProps={{ display: 'flex' }} />
+                  <PrivateInfoIcon size={12} className="text-muted-foreground" />
                 </Box>
                 <StyledHr flex="1" borderColor="black.300" mx={2} />
               </Flex>

--- a/components/expenses/ExpenseItemForm.js
+++ b/components/expenses/ExpenseItemForm.js
@@ -121,7 +121,7 @@ const AttachmentLabel = () => (
   <Span fontSize="13px" whiteSpace="nowrap">
     <FormattedMessage id="Expense.Attachment" defaultMessage="Attachment" />
     &nbsp;&nbsp;
-    <PrivateInfoIcon color="#969BA3" />
+    <PrivateInfoIcon />
   </Span>
 );
 

--- a/components/expenses/ExpenseNotesForm.js
+++ b/components/expenses/ExpenseNotesForm.js
@@ -20,7 +20,7 @@ const PrivateNoteLabel = () => {
     <Span color="black.700">
       <FormattedMessage id="ExpenseSummary.addNotesLabel" defaultMessage="Add notes" />
       &nbsp;&nbsp;
-      <PrivateInfoIcon color="#969BA3" />
+      <PrivateInfoIcon />
     </Span>
   );
 };

--- a/components/expenses/ExpenseSummaryAdditionalInformation.js
+++ b/components/expenses/ExpenseSummaryAdditionalInformation.js
@@ -287,7 +287,7 @@ const ExpenseSummaryAdditionalInformation = ({
               <Container fontSize="11px" fontWeight="500" mb={2}>
                 <FormattedMessage id="ExpenseForm.InvoiceInfo" defaultMessage="Additional invoice information" />
                 &nbsp;&nbsp;
-                <PrivateInfoIcon color="#969BA3" />
+                <PrivateInfoIcon />
               </Container>
               <P fontSize="11px" lineHeight="16px" whiteSpace="pre-wrap">
                 {expense.invoiceInfo}

--- a/components/expenses/PayoutMethodData.js
+++ b/components/expenses/PayoutMethodData.js
@@ -67,7 +67,7 @@ const PayoutMethodData = ({ payoutMethod, showLabel, isLoading }) => {
             <Container fontSize="14px" fontWeight="700" mb={2}>
               <FormattedMessage id="User.EmailAddress" defaultMessage="Email address" />
               &nbsp;&nbsp;
-              <PrivateInfoIcon color="#969BA3" />
+              <PrivateInfoIcon />
             </Container>
           )}
           <Container fontSize="14px" color="black.700">
@@ -82,7 +82,7 @@ const PayoutMethodData = ({ payoutMethod, showLabel, isLoading }) => {
             <Container fontSize="14px" fontWeight="700" mb={2}>
               <FormattedMessage id="Details" defaultMessage="Details" />
               &nbsp;&nbsp;
-              <PrivateInfoIcon color="#969BA3" />
+              <PrivateInfoIcon />
             </Container>
           )}
           <Container fontSize="14px" color="black.700">
@@ -97,7 +97,7 @@ const PayoutMethodData = ({ payoutMethod, showLabel, isLoading }) => {
             <Container fontSize="14px" fontWeight="700" mb={2}>
               <FormattedMessage id="Details" defaultMessage="Details" />
               &nbsp;&nbsp;
-              <PrivateInfoIcon color="#969BA3" />
+              <PrivateInfoIcon />
             </Container>
           )}
           {payoutMethod.data ? (

--- a/components/icons/PrivateInfoIcon.tsx
+++ b/components/icons/PrivateInfoIcon.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
-import { Lock } from '@styled-icons/material/Lock';
+import { Lock } from 'lucide-react';
 import { useIntl } from 'react-intl';
 
-import StyledTooltip from '../StyledTooltip';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/Tooltip';
 
 type PrivateInfoIconProps = {
   children?: React.ReactNode;
   size?: string | number;
-  tooltipProps?: any;
-  withoutTooltip?: boolean;
   color?: string;
+  className?: string;
 };
 
 /**
@@ -17,27 +16,20 @@ type PrivateInfoIconProps = {
  */
 const PrivateInfoIcon = ({
   children = undefined,
-  size = '0.9em',
-  tooltipProps = undefined,
-  withoutTooltip = undefined,
-  color = '#75777A',
+  size = 14,
+  className = undefined,
   ...props
 }: PrivateInfoIconProps) => {
   const { formatMessage } = useIntl();
-  const icon = <Lock size={size} color={color} {...props} />;
-
-  if (withoutTooltip) {
-    return icon;
-  }
+  const icon = <Lock size={size} className={className} {...props} />;
 
   return (
-    <StyledTooltip
-      childrenContainer="span"
-      content={() => children || formatMessage({ id: 'Tooltip.PrivateInfo', defaultMessage: 'This info is private' })}
-      {...tooltipProps}
-    >
-      {icon}
-    </StyledTooltip>
+    <Tooltip>
+      <TooltipTrigger className="cursor-help align-middle">{icon}</TooltipTrigger>
+      <TooltipContent className="font-normal">
+        {children || formatMessage({ id: 'Tooltip.PrivateInfo', defaultMessage: 'This info is private' })}
+      </TooltipContent>
+    </Tooltip>
   );
 };
 

--- a/components/transactions/TransactionItem.js
+++ b/components/transactions/TransactionItem.js
@@ -239,14 +239,12 @@ const TransactionItem = ({ displayActions, collective, transaction, onMutationSu
                   </Span>
                 </ItemTitleWrapper>
                 {isOwnUserProfile && transaction.fromAccount?.isIncognito && (
-                  <Span ml={1} css={{ verticalAlign: 'text-bottom' }}>
-                    <PrivateInfoIcon color="#969BA3">
-                      <FormattedMessage
-                        id="PrivateTransaction"
-                        defaultMessage="This incognito transaction is only visible to you"
-                      />
-                    </PrivateInfoIcon>
-                  </Span>
+                  <PrivateInfoIcon className="ml-1 align-bottom text-muted-foreground">
+                    <FormattedMessage
+                      id="PrivateTransaction"
+                      defaultMessage="This incognito transaction is only visible to you"
+                    />
+                  </PrivateInfoIcon>
                 )}
               </Container>
               <P mt="4px" fontSize="12px" lineHeight="20px" color="black.700" data-cy="transaction-details">

--- a/pages/order.tsx
+++ b/pages/order.tsx
@@ -687,14 +687,7 @@ export default function OrderPage(props) {
                 <Span fontSize="12px" color="black.700" fontWeight="bold">
                   <FormattedMessage id="Expense.PrivateNote" defaultMessage="Private note" />
                   &nbsp;&nbsp;
-                  <PrivateInfoIcon
-                    color="#969BA3"
-                    size={undefined}
-                    tooltipProps={undefined}
-                    withoutTooltip={undefined}
-                    // eslint-disable-next-line react/no-children-prop
-                    children={undefined}
-                  />
+                  <PrivateInfoIcon className="text-muted-foreground" size={12} />
                 </Span>
                 <HTMLContent color="black.700" mt={1} fontSize="13px" content={order.memo} />
               </Box>


### PR DESCRIPTION
# Description

Updates the PrivateInfoIcon to use Lock icon from Lucide icons and new tooltip.

# Screenshots

<img width="186" alt="Screenshot 2023-12-06 at 12 49 21" src="https://github.com/opencollective/opencollective-frontend/assets/1552194/87ea2a40-4229-4fdd-aed5-89b6006357e9">
