### PR TITLE
Collective Page: do not double-count BACKER/ADMIN

### DIFF
--- a/components/collective-page/sections/Contributors.js
+++ b/components/collective-page/sections/Contributors.js
@@ -121,7 +121,9 @@ export default class SectionContributors extends React.PureComponent {
               id="CollectivePage.OurContributors"
               defaultMessage="Our contributors {count}"
               values={{
-                count: <Span color="black.600">{stats.backers.all + coreContributors.length}</Span>,
+                count: (
+                  <Span color="black.600">{stats.backers.all + coreContributors.filter(c => !c.isBacker).length}</Span>
+                ),
               }}
             />
           </H3>


### PR DESCRIPTION
Reported for https://opencollective.com/omstallning

We were double-counting members with both the "ADMIN" and "BACKER" roles.