### PR TITLE
Custom Host Fee for pending contributions

### DIFF
--- a/components/edit-collective/Form.js
+++ b/components/edit-collective/Form.js
@@ -216,6 +216,14 @@ class EditCollectiveForm extends React.Component {
         id: 'newPricing.tab.hostFeeChargeExample',
         defaultMessage: `If your Host fee is 10% and your Collectives bring in $1,000, your Platform fee will be $15. If you host fee is 0%, your Platform fee will be 0.`,
       },
+      'settings.hostFeePercentPendingContributions.label': {
+        id: 'collective.hostFeePercentPendingContributions.title',
+        defaultMessage: 'Host fee for Pending Contributions',
+      },
+      'settings.hostFeePercentPendingContributions.description': {
+        id: 'collective.hostFeePercentPendingContributions.description',
+        defaultMessage: 'Default host fee set when creating pending contributions.',
+      },
       'location.label': {
         id: 'SectionLocation.Title',
         defaultMessage: 'Location',
@@ -777,6 +785,18 @@ class EditCollectiveForm extends React.Component {
           post: '%',
           defaultValue: get(this.state.collective, 'hostFeePercent'),
           when: () => collective.isHost && (collective.type === ORGANIZATION || collective.hostFeePercent !== 0),
+        },
+        {
+          name: 'settings.hostFeePercentPendingContributions',
+          type: 'number',
+          className: 'horizontal',
+          step: '0.01',
+          post: '%',
+          defaultValue: get(this.state.collective, 'settings.hostFeePercentPendingContributions'),
+          placeholder: get(this.state.collective, 'hostFeePercent'),
+          when: () =>
+            collective.isHost &&
+            (collective.type === ORGANIZATION || collective.settings.hostFeePercentPendingContributions !== 0),
         },
         {
           name: 'tos',

--- a/components/host-dashboard/CreatePendingOrderModal.tsx
+++ b/components/host-dashboard/CreatePendingOrderModal.tsx
@@ -841,7 +841,7 @@ const CreatePendingContributionModal = ({ hostSlug, edit, ...props }: CreatePend
         paymentMethod: edit.pendingContributionData?.paymentMethod,
         tax: edit.tax && omit(edit.tax, ['id']),
       }
-    : { hostFeePercent: host?.hostFeePercent || 0 };
+    : { hostFeePercent: host?.settings?.hostFeePercentPendingContributions || host?.hostFeePercent || 0 };
 
   return (
     <CreatePendingContributionModalContainer {...props} trapFocus onClose={handleClose}>

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -592,6 +592,8 @@
   "collective.hostAccount.modal.description": "A Fiscal Host is a legal entity (company or individual) who holds Collective funds in their bank account, and can generate invoices and receipts for Financial Contributors.{br}Think of a Fiscal Host as an umbrella organization for its Collectives.",
   "collective.hostFeePercent.description": "Fee on financial contributions to Collectives you fiscally host.",
   "collective.hostFeePercent.warning": "Open Collective will charge 15% of your Host Fee revenue as its Platform Fee.",
+  "collective.hostFeePercentPendingContributions.description": "Default host fee set when creating pending contributions.",
+  "collective.hostFeePercentPendingContributions.title": "Host fee for Pending Contributions",
   "collective.image.label": "Avatar",
   "collective.isArchived": "{name} has been archived.",
   "collective.isArchived.description": "{name} has been archived and is no longer active.",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -592,6 +592,8 @@
   "collective.hostAccount.modal.description": "A Fiscal Host is a legal entity (company or individual) who holds Collective funds in their bank account, and can generate invoices and receipts for Financial Contributors.{br}Think of a Fiscal Host as an umbrella organization for its Collectives.",
   "collective.hostFeePercent.description": "Fee on financial contributions to Collectives you fiscally host.",
   "collective.hostFeePercent.warning": "Open Collective will charge 15% of your Host Fee revenue as its Platform Fee.",
+  "collective.hostFeePercentPendingContributions.description": "Default host fee set when creating pending contributions.",
+  "collective.hostFeePercentPendingContributions.title": "Host fee for Pending Contributions",
   "collective.image.label": "Avatar",
   "collective.isArchived": "{name} has been archived.",
   "collective.isArchived.description": "{name} has been archived and is no longer active.",

--- a/lang/de.json
+++ b/lang/de.json
@@ -592,6 +592,8 @@
   "collective.hostAccount.modal.description": "Ein Fiscal Host ist eine juristische Person (Unternehmen oder Einzelperson), die Kollektivgelder auf ihrem Bankkonto hält und Rechnungen und Quittungen für Finanzbeitragszahler erstellen kann.{br}Stellen Sie sich einen Fiscal Host als Dachorganisation für seine Kollektive vor.",
   "collective.hostFeePercent.description": "Gebühr für finanzielle Beiträge an Kollektive, die Sie steuerlich beherbergen.",
   "collective.hostFeePercent.warning": "Open Collective berechnet 15 % Ihrer Einnahmen aus Hostgebühren als Plattformgebühr.",
+  "collective.hostFeePercentPendingContributions.description": "Default host fee set when creating pending contributions.",
+  "collective.hostFeePercentPendingContributions.title": "Host fee for Pending Contributions",
   "collective.image.label": "Avatar",
   "collective.isArchived": "{name} wurde archiviert.",
   "collective.isArchived.description": "{name} wurde archiviert und ist nicht mehr aktiv.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -592,6 +592,8 @@
   "collective.hostAccount.modal.description": "A Fiscal Host is a legal entity (company or individual) who holds Collective funds in their bank account, and can generate invoices and receipts for Financial Contributors.{br}Think of a Fiscal Host as an umbrella organization for its Collectives.",
   "collective.hostFeePercent.description": "Fee on financial contributions to Collectives you fiscally host.",
   "collective.hostFeePercent.warning": "Open Collective will charge 15% of your Host Fee revenue as its Platform Fee.",
+  "collective.hostFeePercentPendingContributions.description": "Default host fee set when creating pending contributions.",
+  "collective.hostFeePercentPendingContributions.title": "Host fee for Pending Contributions",
   "collective.image.label": "Avatar",
   "collective.isArchived": "{name} has been archived.",
   "collective.isArchived.description": "{name} has been archived and is no longer active.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -592,6 +592,8 @@
   "collective.hostAccount.modal.description": "Un Anfitrión Fiscal es una entidad legal (empresa o individual) que posee fondos colectivos en su cuenta bancaria, y puede generar facturas y recibos para los colaboradores financieros.{br}Piense en un anfitrión fiscal como una organización paraguas para sus Colectivos.",
   "collective.hostFeePercent.description": "La comisión de las contribuciones financieras a los colectivos que usted patrocina fiscalmente.",
   "collective.hostFeePercent.warning": "Open Collective cobrará el 15% de los ingresos de tu Cuota de Anfitrión como su tarifa de Plataforma.",
+  "collective.hostFeePercentPendingContributions.description": "Default host fee set when creating pending contributions.",
+  "collective.hostFeePercentPendingContributions.title": "Host fee for Pending Contributions",
   "collective.image.label": "Avatar",
   "collective.isArchived": "{name} ha sido archivado.",
   "collective.isArchived.description": "{name} ha sido archivado y ya no está activo.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -592,6 +592,8 @@
   "collective.hostAccount.modal.description": "Un hôte fiscal est une entité juridique (entreprise ou individu) qui détient des fonds collectifs dans son compte bancaire et peut générer des factures et des reçus pour les contributeurs financiers.{br} Pensez à un hôte fiscal comme une organisation faîtière pour ses collectifs.",
   "collective.hostFeePercent.description": "Frais sur les contributions financières aux collectifs que vous hébergez fiscalement.",
   "collective.hostFeePercent.warning": "Open Collective facturera 15% des revenus de votre hôte en tant que frais de plate-forme.",
+  "collective.hostFeePercentPendingContributions.description": "Default host fee set when creating pending contributions.",
+  "collective.hostFeePercentPendingContributions.title": "Host fee for Pending Contributions",
   "collective.image.label": "Avatar",
   "collective.isArchived": "{name} a été archivé.",
   "collective.isArchived.description": "{name} a été archivé et n'est plus actif.",

--- a/lang/he.json
+++ b/lang/he.json
@@ -592,6 +592,8 @@
   "collective.hostAccount.modal.description": "ארגון מארח זה ישות חוקית (עמותה, למשל) שמנהלת את כספי הקבוצה בחשבון הבנק שלה, יכולה ליצור דרישות תשלום וקבלות לתורמים.{br} אפשר להתייחס לארגון מארח כארגון-גג לקבוצות.",
   "collective.hostFeePercent.description": "תקורה או עמלה על הכנסות כספיות לקבוצות שהארגון שלך מארח.",
   "collective.hostFeePercent.warning": "OpenCollective גובה 15% מעמלות הארגון / התקורה, עבור השימוש בפלטפורמה.",
+  "collective.hostFeePercentPendingContributions.description": "Default host fee set when creating pending contributions.",
+  "collective.hostFeePercentPendingContributions.title": "Host fee for Pending Contributions",
   "collective.image.label": "תמונת משתמש",
   "collective.isArchived": "העברת את {name} לארכיון.",
   "collective.isArchived.description": "{name} עבר לארכיון ואינו פעיל יותר.",

--- a/lang/it.json
+++ b/lang/it.json
@@ -592,6 +592,8 @@
   "collective.hostAccount.modal.description": "Un gestore fiscale, o Host, è un soggetto (una persona giuridica o un individuo) che detiene i fondi di un Collettivo sul suo conto bancario, e può generare fatture e ricevute per i Collaboratori Finanziari.{br}Puoi pensare ad un Host come ad una società ombrello per Collettivi.",
   "collective.hostFeePercent.description": "Fee on financial contributions to Collectives you fiscally host.",
   "collective.hostFeePercent.warning": "Open Collective will charge 15% of your Host Fee revenue as its Platform Fee.",
+  "collective.hostFeePercentPendingContributions.description": "Default host fee set when creating pending contributions.",
+  "collective.hostFeePercentPendingContributions.title": "Host fee for Pending Contributions",
   "collective.image.label": "Avatar",
   "collective.isArchived": "{name} è stato archiviato.",
   "collective.isArchived.description": "{name} è stato archiviato, e non è più attivo.",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -592,6 +592,8 @@
   "collective.hostAccount.modal.description": "A Fiscal Host is a legal entity (company or individual) who holds Collective funds in their bank account, and can generate invoices and receipts for Financial Contributors.{br}Think of a Fiscal Host as an umbrella organization for its Collectives.",
   "collective.hostFeePercent.description": "Fee on financial contributions to Collectives you fiscally host.",
   "collective.hostFeePercent.warning": "Open Collective will charge 15% of your Host Fee revenue as its Platform Fee.",
+  "collective.hostFeePercentPendingContributions.description": "Default host fee set when creating pending contributions.",
+  "collective.hostFeePercentPendingContributions.title": "Host fee for Pending Contributions",
   "collective.image.label": "アバター",
   "collective.isArchived": "{name} はアーカイブされています。",
   "collective.isArchived.description": "{name} has been archived and is no longer active.",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -592,6 +592,8 @@
   "collective.hostAccount.modal.description": "A Fiscal Host is a legal entity (company or individual) who holds Collective funds in their bank account, and can generate invoices and receipts for Financial Contributors.{br}Think of a Fiscal Host as an umbrella organization for its Collectives.",
   "collective.hostFeePercent.description": "Fee on financial contributions to Collectives you fiscally host.",
   "collective.hostFeePercent.warning": "Open Collective will charge 15% of your Host Fee revenue as its Platform Fee.",
+  "collective.hostFeePercentPendingContributions.description": "Default host fee set when creating pending contributions.",
+  "collective.hostFeePercentPendingContributions.title": "Host fee for Pending Contributions",
   "collective.image.label": "아바타",
   "collective.isArchived": "{name}이 아카이브 되었습니다.",
   "collective.isArchived.description": "{name} has been archived and is no longer active.",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -592,6 +592,8 @@
   "collective.hostAccount.modal.description": "A Fiscal Host is a legal entity (company or individual) who holds Collective funds in their bank account, and can generate invoices and receipts for Financial Contributors.{br}Think of a Fiscal Host as an umbrella organization for its Collectives.",
   "collective.hostFeePercent.description": "Fee on financial contributions to Collectives you fiscally host.",
   "collective.hostFeePercent.warning": "Open Collective will charge 15% of your Host Fee revenue as its Platform Fee.",
+  "collective.hostFeePercentPendingContributions.description": "Default host fee set when creating pending contributions.",
+  "collective.hostFeePercentPendingContributions.title": "Host fee for Pending Contributions",
   "collective.image.label": "Profielfoto",
   "collective.isArchived": "{name} is gearchiveerd.",
   "collective.isArchived.description": "{name} has been archived and is no longer active.",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -592,6 +592,8 @@
   "collective.hostAccount.modal.description": "Gospodarz podatkowy to legalna jednostka (firma lub osoba fizyczna), która posiada środki na swoim koncie bankowym i może generować faktury lub rachunki dla osób wnoszących wkład finansowy.{br}Pomyśl o gospodarzu podatkowym jako organizacja nadrzędnej dla swoich wspólników.",
   "collective.hostFeePercent.description": "Opłata od wkładów finansowych na rzecz Zbiórek, których jest się gospodarzem finansowym.",
   "collective.hostFeePercent.warning": "Otwarty Collective będzie pobierać 15% przychodów z opłat za gospodarstwo jako opłatę platformową.",
+  "collective.hostFeePercentPendingContributions.description": "Default host fee set when creating pending contributions.",
+  "collective.hostFeePercentPendingContributions.title": "Host fee for Pending Contributions",
   "collective.image.label": "Awatar",
   "collective.isArchived": "{name} został zarchiwizowany.",
   "collective.isArchived.description": "{name} został zarchiwizowany i nie jest już aktywny.",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -592,6 +592,8 @@
   "collective.hostAccount.modal.description": "Um administrador fiscal é uma entidade jurídica (empresa ou indivíduo) que detém fundos de Coletivos em sua conta bancária e pode gerar faturas e recibos para contribuidores financeiros.{br}Pense em um administrador fiscal como uma organização guarda-chuva para seus Coletivos.",
   "collective.hostFeePercent.description": "Taxa sobre contribuições financeiras para Coletivos que você hospeda fiscalmente.",
   "collective.hostFeePercent.warning": "O Coletivo Aberto irá cobrar 15% da sua receita de Taxa de Administração como sua Taxa de Plataforma.",
+  "collective.hostFeePercentPendingContributions.description": "Default host fee set when creating pending contributions.",
+  "collective.hostFeePercentPendingContributions.title": "Host fee for Pending Contributions",
   "collective.image.label": "Foto de Perfil",
   "collective.isArchived": "{name} foi arquivado.",
   "collective.isArchived.description": "{name} foi arquivado e não está mais ativo.",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -592,6 +592,8 @@
   "collective.hostAccount.modal.description": "Um Anfitrião Fiscal é uma entidade jurídica (empresa ou indivíduo) que detém fundos das Coletividades na sua conta bancária, e pode gerar faturas e recibos de Contribuidores Financeiros.{br}Pense num Anfitrião Fiscal como uma organização guarda-chuva para as suas Coletividades.",
   "collective.hostFeePercent.description": "Comissão sobre as contribuições financeiras para as Coletividades que fiscalmente hospeda.",
   "collective.hostFeePercent.warning": "Open Collective will charge 15% of your Host Fee revenue as its Platform Fee.",
+  "collective.hostFeePercentPendingContributions.description": "Default host fee set when creating pending contributions.",
+  "collective.hostFeePercentPendingContributions.title": "Host fee for Pending Contributions",
   "collective.image.label": "Imagem de Perfil",
   "collective.isArchived": "{name} foi arquivado.",
   "collective.isArchived.description": "{name} has been archived and is no longer active.",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -592,6 +592,8 @@
   "collective.hostAccount.modal.description": "A Fiscal Host is a legal entity (company or individual) who holds Collective funds in their bank account, and can generate invoices and receipts for Financial Contributors.{br}Think of a Fiscal Host as an umbrella organization for its Collectives.",
   "collective.hostFeePercent.description": "Fee on financial contributions to Collectives you fiscally host.",
   "collective.hostFeePercent.warning": "Open Collective will charge 15% of your Host Fee revenue as its Platform Fee.",
+  "collective.hostFeePercentPendingContributions.description": "Default host fee set when creating pending contributions.",
+  "collective.hostFeePercentPendingContributions.title": "Host fee for Pending Contributions",
   "collective.image.label": "Аватар",
   "collective.isArchived": "{name} был помещён в архив.",
   "collective.isArchived.description": "{name} в архиве и более не активен.",

--- a/lang/sk-SK.json
+++ b/lang/sk-SK.json
@@ -592,6 +592,8 @@
   "collective.hostAccount.modal.description": "Fiškálny hostiteľ je právnická osoba (spoločnosť alebo jednotlivec), ktorá má na svojom bankovom účte prostriedky kolektívu a môže vytvárať faktúry a potvrdenia pre finančných prispievateľov.{br}Predstavte si fiškálneho hostiteľa ako zastrešujúcu organizáciu pre svoje kolektívy.",
   "collective.hostFeePercent.description": "Poplatok za finančné príspevky kolektívom, ktorým poskytujete fiškálne zázemie.",
   "collective.hostFeePercent.warning": "Open Collective si účtuje 15 % z vášho Poplatku Hostiteľa ako Poplatok Platformy.",
+  "collective.hostFeePercentPendingContributions.description": "Default host fee set when creating pending contributions.",
+  "collective.hostFeePercentPendingContributions.title": "Host fee for Pending Contributions",
   "collective.image.label": "Avatar",
   "collective.isArchived": "{name} bolo archivované.",
   "collective.isArchived.description": "{name} bolo archivované a už nie je aktívne.",

--- a/lang/sv-SE.json
+++ b/lang/sv-SE.json
@@ -592,6 +592,8 @@
   "collective.hostAccount.modal.description": "En finansiell värd är en juridisk person (företag eller privatperson) som innehar kollektivets pengar på sitt bankkonto, och skapar fakturor och kvitton.{br}En värd är som en paraplyorganisation för sina kollektiv.",
   "collective.hostFeePercent.description": "Avgift för ekonomiska bidrag till kollektiv du är värd för.",
   "collective.hostFeePercent.warning": "Open Collective debiterar 15% av intäkterna från ditt värdskap som plattformsavgift.",
+  "collective.hostFeePercentPendingContributions.description": "Default host fee set when creating pending contributions.",
+  "collective.hostFeePercentPendingContributions.title": "Host fee for Pending Contributions",
   "collective.image.label": "Profilbild",
   "collective.isArchived": "{name} har arkiverats.",
   "collective.isArchived.description": "{name} har arkiverats och är inte längre aktiv.",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -592,6 +592,8 @@
   "collective.hostAccount.modal.description": "Фіскальний агент — це юридична особа (компанія або індивідуальна), яка зберігає кошти колективів на своєму банківському рахунку й може генерувати рахунки-фактури та квитанції для фінансових помічників.{br}Ви можете вважати фіскальний агент організацією-парасолькою для його колективів.",
   "collective.hostFeePercent.description": "Комісія з фінансових внесків колективам, для яких ви фіскальний вузол.",
   "collective.hostFeePercent.warning": "Open Collective стягує 15% від вашого доходу як хосту в якості плати за платформу.",
+  "collective.hostFeePercentPendingContributions.description": "Default host fee set when creating pending contributions.",
+  "collective.hostFeePercentPendingContributions.title": "Host fee for Pending Contributions",
   "collective.image.label": "Аватар",
   "collective.isArchived": "{name} архівовано.",
   "collective.isArchived.description": "{name} заархівовано й він більше не активний.",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -592,6 +592,8 @@
   "collective.hostAccount.modal.description": "财务托管方是在其银行账户中持有集体资金的合法实体（公司或个人）。并且能够为财务贡献者提供发票和收据。{br}你可以把财政托管方想象成为针对集体的伞式组织。",
   "collective.hostFeePercent.description": "财务贡献者给集体的财务托管的费用",
   "collective.hostFeePercent.warning": "Open Collective 将收取你15%的主机费用作为平台费用。",
+  "collective.hostFeePercentPendingContributions.description": "Default host fee set when creating pending contributions.",
+  "collective.hostFeePercentPendingContributions.title": "Host fee for Pending Contributions",
   "collective.image.label": "头像",
   "collective.isArchived": "{name} 已存档。",
   "collective.isArchived.description": "{name} 已被归档且不再活跃。",


### PR DESCRIPTION
A small prototype requested by the foundation, can later be used to cover all manual contributions.