### PR TITLE
language switcher is breaking the display on mobile resolutions

### DIFF
--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -27,7 +27,7 @@ export function LanguageSwitcher() {
   const languageOptions = React.useMemo(generateLanguageOptions, []);
   const defaultLanguage = languageOptions.find(language => language.value === intl.locale) || languageOptions[0];
   return (
-    <div className="relative">
+    <div className="relative max-w-[50%]">
       <Select onValueChange={value => localeContext.setLocale(value)} defaultValue={defaultLanguage.value}>
         <Tooltip>
           <label className="sr-only" htmlFor="language-options">


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/7139

# Description

When selecting an option with a large text in the language switcher box, the OpenCollective logo next to it is compressed or even breaks the resolution, as is the case when selecting 'Brazilian Portuguese - Português brasileiro'.

# Screenshots
- Before:
![image](https://github.com/opencollective/opencollective-frontend/assets/102393263/03b0f90a-a1c4-4937-a016-ffdbe35c3372)

- After:
![image](https://github.com/opencollective/opencollective-frontend/assets/102393263/7d4c820a-eff3-4eb9-aa05-34d54dc364ff)

