### PR TITLE
NavBar: incorrect "actions" select on 640px

### DIFF
--- a/components/collective-navbar/ActionsMenu.js
+++ b/components/collective-navbar/ActionsMenu.js
@@ -51,7 +51,7 @@ const MenuItem = styled('li')`
     letter-spacing: -0.4px;
     outline: none;
 
-    @media (max-width: 40em) {
+    @media (max-width: 39.938em) {
       font-size: 14px;
     }
 
@@ -120,7 +120,7 @@ const ActionsDropdown = styled(Dropdown)`
     }
   }
 
-  @media (max-width: 40em) {
+  @media (max-width: 39.938em) {
     ${DropdownArrow} {
       display: none !important;
     }
@@ -144,7 +144,7 @@ const ActionsDropdown = styled(Dropdown)`
   ${props =>
     props.$isHiddenOnNonMobile &&
     css`
-      @media screen and (min-width: 40em) {
+      @media screen and (min-width: 39.938em) {
         display: none;
       }
     `}
@@ -160,14 +160,14 @@ const StyledActionButton = styled(ActionButton).attrs({ isSecondary: true })`
     margin-right: 4px;
   }
 
-  @media (max-width: 40em) {
+  @media (max-width: 39.938em) {
     cursor: none;
     pointer-events: none;
   }
 `;
 
 const StyledChevronDown = styled(ChevronDown)`
-  @media (max-width: 40em) {
+  @media (max-width: 39.938em) {
     display: none;
   }
 `;


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/7057

# Description

The action component was transitioning to the mobile layout 1px earlier than expected.
We are using `@media (max-width: 40em)`, 40em is equal 640px, the change must be in 639px (`@media (max-width: 39.938em)`).

# Screenshots

![image](https://github.com/opencollective/opencollective-frontend/assets/102393263/bbc2050d-fa39-4017-9a20-e0b970b0567b)
