### PR TITLE
Fix GraphQL cross-version id bug when submitting Expense as Vendor

### DIFF
--- a/components/expenses/ExpenseFormPayeeStep.js
+++ b/components/expenses/ExpenseFormPayeeStep.js
@@ -228,7 +228,7 @@ const collectivePickerSearchQuery = gqlV1/* GraphQL */ `
         isArchived
         isHost
         payoutMethods {
-          id
+          legacyId: id
           type
           name
           data


### PR DESCRIPTION
Reported by https://opencollective.freshdesk.com/a/tickets/302999
Requires https://github.com/opencollective/opencollective-api/pull/9587