### PR TITLE
MembersWithData: remove tierId parameter

### DIFF
--- a/components/MembersWithData.js
+++ b/components/MembersWithData.js
@@ -137,18 +137,9 @@ class MembersWithData extends React.Component {
 }
 
 const membersQuery = gqlV1/* GraphQL */ `
-  query Members(
-    $collectiveSlug: String!
-    $tierId: Int
-    $role: String
-    $type: String
-    $limit: Int
-    $offset: Int
-    $orderBy: String
-  ) {
+  query Members($collectiveSlug: String!, $role: String, $type: String, $limit: Int, $offset: Int, $orderBy: String) {
     allMembers(
       collectiveSlug: $collectiveSlug
-      TierId: $TierId
       role: $role
       type: $type
       limit: $limit
@@ -190,7 +181,6 @@ export const addMembersData = graphql(membersQuery, {
   options: props => ({
     variables: {
       collectiveSlug: props.collective.slug,
-      tierId: props.tier && props.tier.id,
       offset: 0,
       type: props.type,
       role: props.memberRole,


### PR DESCRIPTION
For https://opencollective.slack.com/archives/C01NGE0N9U1/p1702507447697109

Not sure how this was working before: the variable was defined as `tierId` then used as `TierID`; maybe legacy graphql versions did not care about the case? 

Anyway, the variable was not used to the simplest option is to remove it.