### PR TITLE
Dashboard > Contributions: set default min amount to 0

### DIFF
--- a/components/dashboard/sections/contributions/Contributions.tsx
+++ b/components/dashboard/sections/contributions/Contributions.tsx
@@ -349,7 +349,6 @@ const Contributions = ({ accountSlug, direction }: ContributionsProps) => {
       slug: accountSlug,
       filter: direction || 'OUTGOING',
       includeIncognito: true,
-      minAmount: 0,
       ...queryFilter.variables,
     },
     context: API_V2_CONTEXT,

--- a/components/dashboard/sections/contributions/Contributions.tsx
+++ b/components/dashboard/sections/contributions/Contributions.tsx
@@ -349,7 +349,7 @@ const Contributions = ({ accountSlug, direction }: ContributionsProps) => {
       slug: accountSlug,
       filter: direction || 'OUTGOING',
       includeIncognito: true,
-      minAmount: 1,
+      minAmount: 0,
       ...queryFilter.variables,
     },
     context: API_V2_CONTEXT,


### PR DESCRIPTION
As a way to provide an easy path for event organizers to see "Free tickets" in the new dashboard (see https://github.com/opencollective/opencollective/issues/7165).