### PR TITLE
AccountingCategoryPill: prevent usage if there's no host

### DIFF
--- a/components/expenses/AccountingCategoryPill.tsx
+++ b/components/expenses/AccountingCategoryPill.tsx
@@ -87,7 +87,7 @@ export const AccountingCategoryPill = ({
   allowNone,
   showCodeInSelect = false,
 }: AccountingCategoryPillProps) => {
-  if (!canEdit) {
+  if (!canEdit || !host) {
     return <div className={BADGE_CLASS}>{getCategoryLabel(expense.accountingCategory)}</div>;
   } else {
     return (


### PR DESCRIPTION
Hotfix to work around a synchronization issue with dashboard queries.