### PR TITLE
Dashboard: fix loading state for metadata

### DIFF
--- a/components/dashboard/sections/expenses/ReceivedExpenses.tsx
+++ b/components/dashboard/sections/expenses/ReceivedExpenses.tsx
@@ -77,7 +77,7 @@ const ROUTE_PARAMS = ['slug', 'section', 'subpath'];
 const ReceivedExpenses = ({ accountSlug }: DashboardSectionProps) => {
   const router = useRouter();
 
-  const { data: metadata } = useQuery(accountExpensesMetadataQuery, {
+  const { data: metadata, loading: loadingMetaData } = useQuery(accountExpensesMetadataQuery, {
     variables: { accountSlug },
     context: API_V2_CONTEXT,
   });
@@ -127,7 +127,7 @@ const ReceivedExpenses = ({ accountSlug }: DashboardSectionProps) => {
       ) : (
         <React.Fragment>
           <ExpensesList
-            isLoading={loading}
+            isLoading={loading || loadingMetaData}
             collective={metadata?.account}
             host={metadata?.account?.isHost ? metadata?.account : metadata?.account?.host}
             expenses={data?.expenses?.nodes}


### PR DESCRIPTION
Fixes a synchronization issue with dashboard queries that was triggering a crash on the expenses list because of an undefined `host`.