### PR TITLE
Dashboard: Fix create account form

### DIFF
--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -210,7 +210,7 @@ const DashboardPage = () => {
                   </Link>
                 )}
               </MessageBox>
-              {!LoggedInUser && <SignInOrJoinFree form="signin" disableSignup />}
+              {!LoggedInUser && <SignInOrJoinFree defaultForm="signin" disableSignup />}
             </div>
           ) : !useDynamicTopBar ? (
             <div


### PR DESCRIPTION
The `form` prop on `SignInOrJoinFree` is used to control the component. Because we were forcing it, trying to click on "Yes, create account" had no effect.

![image](https://github.com/opencollective/opencollective-frontend/assets/1556356/0f7cbfab-c4cc-4c03-832c-3401165030af)
