### PR TITLE
Remove `classnames` package

### DIFF
--- a/components/IncognitoUserCollective.js
+++ b/components/IncognitoUserCollective.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 import { defineMessages, injectIntl } from 'react-intl';
 
 import Footer from './navigation/Footer';
@@ -18,7 +17,6 @@ class IncognitoUserCollective extends React.Component {
 
   constructor(props) {
     super(props);
-    this.classNames = ['UserCollectivePage'];
     this.messages = defineMessages({
       'incognito.title': { id: 'UserCollective.incognito.title', defaultMessage: 'Incognito user' },
       'incognito.description': {
@@ -32,7 +30,7 @@ class IncognitoUserCollective extends React.Component {
     const { intl, collective } = this.props;
 
     return (
-      <div className={classNames('UserCollectivePage')}>
+      <div className="UserCollectivePage">
         <Header
           title={intl.formatMessage(this.messages['incognito.title'])}
           description={intl.formatMessage(this.messages['incognito.description'])}

--- a/components/MembersWithData.js
+++ b/components/MembersWithData.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from '@apollo/client/react/hoc';
-import classNames from 'classnames';
+import clsx from 'clsx';
 import { uniqBy } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
@@ -116,7 +116,7 @@ class MembersWithData extends React.Component {
             <Member
               key={member.id}
               member={member}
-              className={classNames(this.props.className, size)}
+              className={clsx(this.props.className, size)}
               collective={collective}
               viewMode={viewMode}
               LoggedInUser={LoggedInUser}

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,6 @@
         "canvas-confetti": "1.9.2",
         "carloslfu-cmdk-internal": "0.3.1",
         "class-variance-authority": "^0.7.0",
-        "classnames": "2.5.0",
         "cloudflare-ip": "0.0.7",
         "clsx": "2.1.0",
         "cookie": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "canvas-confetti": "1.9.2",
     "carloslfu-cmdk-internal": "0.3.1",
     "class-variance-authority": "^0.7.0",
-    "classnames": "2.5.0",
     "cloudflare-ip": "0.0.7",
     "clsx": "2.1.0",
     "cookie": "0.6.0",


### PR DESCRIPTION
We have since introduced `clsx`, which serves the same purpose.