### PR TITLE
Fix some tailwind-related style regressions on lists

### DIFF
--- a/components/e2c/InvestingInTheCommonsSection.js
+++ b/components/e2c/InvestingInTheCommonsSection.js
@@ -15,6 +15,7 @@ const ListItem = styled.li`
 
 const ListWrapper = styled.ul`
   padding-left: 20px;
+  list-style: disc;
 `;
 
 const InvestingInTheCommons = () => {

--- a/components/host-dashboard/AddFundsModal.js
+++ b/components/host-dashboard/AddFundsModal.js
@@ -726,12 +726,12 @@ const AddFundsModal = ({ collective, ...props }) => {
                 <Form>
                   <ModalBody data-cy="funds-added">
                     <Container>
-                      <h3>
+                      <h3 className="mt-4 text-xl  text-black">
                         <FormattedMessage id="AddFundsModal.FundsAdded" defaultMessage="Funds Added ✅" />
                       </h3>
-                      <Container pb={2}>
+                      <Container pb={2} mt={3}>
                         <FormattedMessage id="AddFundsModal.YouAdded" defaultMessage="You added:" />
-                        <ul>
+                        <ul className="mt-2 list-inside list-disc pl-3">
                           <li>
                             <strong>{`${fundDetails.fundAmount / 100} ${currency}`}</strong>
                           </li>
@@ -816,7 +816,7 @@ const AddFundsModal = ({ collective, ...props }) => {
                           )}
                         </ul>
                       </Container>
-                      <Container pb={2}>
+                      <Container pb={2} mt={2}>
                         <FormattedMessage id="AddFundsModal.NeedHelp" defaultMessage="Need Help?" />{' '}
                         <StyledLink href="/support" buttonStyle="standard" buttonSize="tiny">
                           <FormattedMessage id="error.contactSupport" defaultMessage="Contact support" />

--- a/components/root-actions/AccountSettings.js
+++ b/components/root-actions/AccountSettings.js
@@ -110,7 +110,7 @@ const AccountSettings = () => {
               <Container pt={4}>
                 <MessageBox type="error">
                   <div>Some instructions on what to look when disabling 2FA for a user;</div>
-                  <ul>
+                  <ul className="list-disc">
                     <li>
                       If user has Twitter, GitHub or any other social accounts linked we can ask for a proof to be added
                       to them.

--- a/components/updates/UpdateAudienceBreakdown.js
+++ b/components/updates/UpdateAudienceBreakdown.js
@@ -50,7 +50,7 @@ const UpdateAudienceBreakdown = ({ audienceStats, isLoading }) => {
       />
       {hasOnlyTotal ? '.' : ':'}
       {!hasOnlyTotal && (
-        <ul>
+        <ul className="list-inside list-disc">
           {Object.entries(stats).map(([key, count]) => (
             <li key={key}>{intl.formatMessage(translatedTypes[key], { count })}</li>
           ))}

--- a/pages/search.js
+++ b/pages/search.js
@@ -445,7 +445,7 @@ class SearchPage extends React.Component {
             </AllCardsContainer>
 
             {accounts?.nodes?.length === 0 && (
-              <Flex py={3} width={1} justifyContent="center" flexDirection="column" alignItems="center">
+              <Flex py={3} mt={4} width={1} justifyContent="center" flexDirection="column" alignItems="center">
                 <H1 fontSize="32px" lineHeight="40px" color="black.700" fontWeight={500}>
                   <FormattedMessage defaultMessage="No results match your search" />
                 </H1>
@@ -457,7 +457,7 @@ class SearchPage extends React.Component {
                     <FormattedMessage defaultMessage="Try refining your search, here are some tips:" />
                   </Container>
                   <Container fontSize="15px" lineHeight="22px">
-                    <ul>
+                    <ul className="list-inside list-disc">
                       <li>
                         <FormattedMessage defaultMessage="Make sure your spelling is correct" />
                       </li>
@@ -481,7 +481,7 @@ class SearchPage extends React.Component {
                       </li>
                     </ul>
                   </Container>
-                  <Container fontSize="18px" lineHeight="26px" pt={16}>
+                  <Container fontSize="18px" lineHeight="26px" pt={16} mt={4} textAlign="center">
                     <FormattedMessage
                       defaultMessage="Still no luck? Contact <SupportLink>support</SupportLink> or find us in <SlackLink>Slack</SlackLink>"
                       values={{


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/6958
Related to https://github.com/opencollective/opencollective/issues/7192

Mostly addressing lists that were rendered unstyled by default (need to add `className="list-*"`)