### PR TITLE
Changed the link of Open Company component

### DIFF
--- a/components/collectives/sections/LearnMore.js
+++ b/components/collectives/sections/LearnMore.js
@@ -95,7 +95,7 @@ const learningChannels = [
   {
     id: 'openCompany',
     name: 'Open Company',
-    link: 'https://drive.opencollective.com',
+    link: 'https://opencollective.com/opencollective',
     desktopItemOrder: 6,
   },
 ];


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/7194

# Description

I updated the link of Open Compony component to https://opencollective.com/opencollective as suggested.

# Screenshots
![Screenshot 2024-01-08 135409](https://github.com/opencollective/opencollective-frontend/assets/67920373/0072fca5-d1fa-4466-a73c-0f4dc2bfacf5)

