### PR TITLE
Redirect root to /dashboard in middleware

### DIFF
--- a/components/UserProvider.js
+++ b/components/UserProvider.js
@@ -7,6 +7,7 @@ import Router, { withRouter } from 'next/router';
 import { injectIntl } from 'react-intl';
 
 import { createError, ERROR, formatErrorMessage } from '../lib/errors';
+import { loggedInUserQuery } from '../lib/graphql/v1/queries';
 import withLoggedInUser from '../lib/hooks/withLoggedInUser';
 import { getFromLocalStorage, LOCAL_STORAGE_KEYS, removeFromLocalStorage } from '../lib/local-storage';
 import UserClass from '../lib/LoggedInUser';
@@ -90,12 +91,9 @@ class UserProvider extends React.Component {
     // By default, we refetch all queries to make sure we don't display stale data
     if (!skipQueryRefetch) {
       await this.props.client.reFetchObservableQueries();
-    }
-    // Otherwise we refetch only the LoggedInUser query to make the API clear the rootRedirect cookie
-    else {
-      await this.props.client.refetchQueries({
-        include: ['LoggedInUser'],
-      });
+    } else {
+      // Send any request to API to clear rootRedirectDashboard cookie
+      await this.props.client.query({ query: loggedInUserQuery, fetchPolicy: 'network-only' });
     }
 
     if (redirect) {

--- a/env.js
+++ b/env.js
@@ -20,6 +20,7 @@ debug.enable(process.env.DEBUG);
 const defaults = {
   PORT: 3000,
   NODE_ENV: 'development',
+  HOSTNAME: 'localhost',
   API_KEY: '09u624Pc9F47zoGLlkg1TBSbOl2ydSAq',
   API_URL: 'https://api-staging.opencollective.com',
   IMAGES_URL: 'https://images-staging.opencollective.com',

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,16 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  // Note: only need to check presence rootRedirectDashboard cookie, not its value
+  const redirectToDashboard = req.cookies.get('rootRedirectDashboard');
+
+  if (redirectToDashboard) {
+    return NextResponse.redirect(new URL('/dashboard', req.url));
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: '/',
+};

--- a/next.config.js
+++ b/next.config.js
@@ -11,7 +11,7 @@ const { REWRITES } = require('./rewrites');
 
 const nextConfig = {
   eslint: { ignoreDuringBuilds: true },
-  useFileSystemPublicRoutes: process.env.IS_VERCEL === 'true' || process.env.API_PROXY !== 'true',
+  useFileSystemPublicRoutes: true,
   productionBrowserSourceMaps: true,
   typescript: {
     ignoreBuildErrors: true,

--- a/pages/home.js
+++ b/pages/home.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import cookie from 'cookie';
 import { defineMessages, useIntl } from 'react-intl';
 
 import { getRequestIntl } from '../lib/i18n/request';
@@ -48,17 +47,6 @@ const HomePage = () => {
 };
 
 export const getServerSideProps = async ({ req, res }) => {
-  const cookies = cookie.parse((req && req.headers.cookie) || '');
-  const redirectToDashboard = req.url === '/' && cookies.rootRedirect === 'dashboard';
-  if (redirectToDashboard) {
-    return {
-      redirect: {
-        destination: '/dashboard',
-        permanent: false,
-      },
-    };
-  }
-
   if (res && req) {
     const { locale } = getRequestIntl(req);
     if (locale === 'en') {

--- a/server/index.js
+++ b/server/index.js
@@ -21,10 +21,9 @@ const app = express();
 app.set('trust proxy', ['loopback', 'linklocal', 'uniquelocal'].concat(cloudflareIps));
 
 const dev = process.env.NODE_ENV === 'development';
-
-const nextApp = next({ dev });
-
 const port = process.env.PORT;
+const hostname = process.env.HOSTNAME;
+const nextApp = next({ dev, hostname, port });
 
 const workers = process.env.WEB_CONCURRENCY || 1;
 


### PR DESCRIPTION
Requires https://github.com/opencollective/opencollective-api/pull/9667

Redirection to `/dashboard` in middleware.ts instead of in getServerSideProps, as this will be a faster redirection, without having to load any code associated with the home page.

`middleware.ts` requires `useFileSystemPublicRoutes: true`, so we should be aware that some routes not previously rendering will now try to render something (but mostly displaying "Unexpected Error" instead of "Page not found")