### PR TITLE
Changes to resolve the scrolling issue in Contributors grid

### DIFF
--- a/components/ContributorsGrid.js
+++ b/components/ContributorsGrid.js
@@ -135,6 +135,7 @@ const ContributorsGrid = ({
   currency,
   LoggedInUser,
   collectiveId,
+  gridRef,
 }) => {
   const maxNbRows = maxNbRowsForViewports[viewport];
   const [nbCols, nbRows] = getItemsRepartition(contributors.length, width, maxNbRows);
@@ -159,6 +160,7 @@ const ContributorsGrid = ({
         const idx = getContributorIdx(columnIndex, rowIndex, nbRows, nbCols, hasScroll);
         return idx < contributors.length ? contributors[idx].id : `empty-${idx}`;
       }}
+      ref={gridRef}
     >
       {({ columnIndex, rowIndex, style }) => {
         const idx = getContributorIdx(columnIndex, rowIndex, nbRows, nbCols, hasScroll);
@@ -221,6 +223,9 @@ ContributorsGrid.propTypes = {
 
   /** Collective id */
   collectiveId: PropTypes.number,
+
+  /* Reference to the FixedSizedGrid */
+  gridRef: PropTypes.oneOfType([PropTypes.func, PropTypes.shape({ current: PropTypes.any })]),
 };
 
 ContributorsGrid.defaultProps = {

--- a/components/collective-page/sections/Contributors.js
+++ b/components/collective-page/sections/Contributors.js
@@ -15,6 +15,9 @@ import SectionTitle from '../SectionTitle';
 
 import ContributorsGridBackgroundSVG from '../../../public/static/images/collective-page/ContributorsGridBackground.svg';
 
+/* reference to the FixedSizedGrid element */
+const contributorsGridRef = React.createRef();
+
 /** Main contributors container with the bubbles background */
 const MainContainer = styled(Container)`
   background:
@@ -66,6 +69,12 @@ export default class SectionContributors extends React.PureComponent {
 
   setFilter = filter => {
     this.setState({ filter });
+
+    // whenever the filter is changed, scroll is set to poin to the initial item
+    contributorsGridRef.current.scrollToItem({
+      columnIndex: 0,
+      rowIndex: 0,
+    });
   };
 
   // Memoize filtering functions as they can get expensive if there are a lot of contributors
@@ -151,6 +160,7 @@ export default class SectionContributors extends React.PureComponent {
           collectiveId={collective.id}
           currency={collective.currency}
           maxWidthWhenNotFull={Dimensions.MAX_SECTION_WIDTH}
+          gridRef={contributorsGridRef}
         />
       </MainContainer>
     );


### PR DESCRIPTION
Resolve ... https://github.com/opencollective/opencollective/issues/7196

# Description
Whenever the filter is changed, scroll is set to point to initial item. This is done by creating a reference to ContributorsGrid which is used to change scroll position in filter's onChange function.
