### PR TITLE
Fix transaction page checkboxes

### DIFF
--- a/components/transactions/TransactionsPageContent.tsx
+++ b/components/transactions/TransactionsPageContent.tsx
@@ -154,9 +154,13 @@ const Transactions = ({
   }
 
   function buildFilterLinkParams(params) {
-    const queryParameters = {
-      ...omit(params, ['offset', 'collectiveType', 'parentCollectiveSlug']),
-    };
+    const queryParameters = omit({ ...router.query, ...params }, [
+      'offset',
+      'collectiveSlug',
+      'slug',
+      'section',
+      'parentCollectiveSlug',
+    ]);
 
     return { ...omitBy(queryParameters, value => !value), ...pick(queryParameters, ['displayPendingContributions']) };
   }
@@ -237,7 +241,7 @@ const Transactions = ({
         flexDirection={['column', 'row']}
         alignItems={['stretch', 'flex-end']}
       >
-        {true && (
+        {state.hasProcessingOrders && (
           <StyledCheckbox
             checked={router.query.displayPendingContributions !== 'false' ? true : false}
             onChange={({ checked }) => updateFilters({ displayPendingContributions: checked })}
@@ -249,7 +253,7 @@ const Transactions = ({
             }
           />
         )}
-        {true && (
+        {state.hasChildren && (
           <StyledCheckbox
             checked={router.query.ignoreChildrenTransactions ? true : false}
             onChange={({ checked }) => updateFilters({ ignoreChildrenTransactions: checked })}
@@ -261,7 +265,7 @@ const Transactions = ({
             }
           />
         )}
-        {true && (
+        {state.hasGiftCards && (
           <StyledCheckbox
             checked={router.query.ignoreGiftCardsTransactions ? true : false}
             onChange={({ checked }) => updateFilters({ ignoreGiftCardsTransactions: checked })}
@@ -270,7 +274,7 @@ const Transactions = ({
             }
           />
         )}
-        {true && (
+        {state.hasIncognito && (
           <StyledCheckbox
             checked={router.query.ignoreIncognitoTransactions ? true : false}
             onChange={({ checked }) => updateFilters({ ignoreIncognitoTransactions: checked })}


### PR DESCRIPTION
Fixes for the transaction page
- Make the checkbox filters dynamically show again
- Fix for the checkbox filters so that they no longer overwrite all other filter values.