### PR TITLE
Fix unrecognized prop error

### DIFF
--- a/components/ui/AlertDialog.tsx
+++ b/components/ui/AlertDialog.tsx
@@ -33,9 +33,9 @@ const AlertDialogContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content> & {
     withBackdropBlur?: boolean;
   }
->(({ className, ...props }, ref) => (
+>(({ className, withBackdropBlur, ...props }, ref) => (
   <AlertDialogPortal>
-    <AlertDialogOverlay className={props.withBackdropBlur ? 'backdrop-blur-sm' : ''} />
+    <AlertDialogOverlay className={withBackdropBlur ? 'backdrop-blur-sm' : ''} />
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(


### PR DESCRIPTION
In `ui/AlertDialog` `withBackdropBlur` was passed along to a dom element unnecessarily causing a warning/error in the console.
