### PR TITLE
PersonalTokens: prevent scope reset

### DIFF
--- a/components/personal-token/PersonalTokenSettings.js
+++ b/components/personal-token/PersonalTokenSettings.js
@@ -168,6 +168,7 @@ const PersonalTokenSettings = ({ backPath, id }) => {
                   values: {
                     ...result.data.updatePersonalToken,
                     expiresAt: stripTime(result.data.updatePersonalToken.expiresAt),
+                    scope: (data.personalToken.scope || []).map(scope => ({ value: scope, label: scope })),
                   },
                 });
               } catch (e) {


### PR DESCRIPTION
Apply the same approach done in `initialValues`