### PR TITLE
ExpenseForm: require amount for drafts

### DIFF
--- a/components/expenses/ExpenseItemForm.js
+++ b/components/expenses/ExpenseItemForm.js
@@ -450,7 +450,7 @@ const ExpenseItemForm = ({
                 error={getError('amountV2')}
                 htmlFor={`${getFieldName('amountV2')}-amount`}
                 label={formatMessage(msg.amountLabel)}
-                required={!isOptional}
+                required
                 labelFontSize="13px"
                 inputType="number"
                 flexGrow={1}


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/7118
Fix https://github.com/opencollective/opencollective/issues/6587
Fix https://open-collective.sentry.io/issues/4637984981/?project=5199682&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=90d&stream_index=13

Ideally, the system should accept the amount to be empty. For now, this will at least prevent server-side errors from occurring.