### PR TITLE
Fix 2fa input on mobile

### DIFF
--- a/components/two-factor-authentication/TwoFactorAuthenticationModal.tsx
+++ b/components/two-factor-authentication/TwoFactorAuthenticationModal.tsx
@@ -238,14 +238,17 @@ function AuthenticatorOption(props: {
         />
       </p>
       <VerificationInput
-        inputProps={{ id: '2fa-code-input', autoComplete: 'one-time-code', className: 'opacity-0' }}
+        inputProps={{
+          id: '2fa-code-input',
+          autoComplete: 'one-time-code',
+        }}
         validChars="0-9"
         placeholder=""
         autoFocus
         classNames={{
-          container: 'w-auto pl-6 pr-12 -mr-6', // negative margin to make space for password manager browser extension icon
+          container: 'ml-6 w-auto pr-12 -mr-6', // negative margin to make space for password manager browser extension icon
           character:
-            'rounded-md border border-input bg-background text-lg ring-offset-background items-center flex justify-center',
+            'z-10 pointer-events-none rounded-md border border-input bg-background text-lg ring-offset-background items-center flex justify-center',
           characterInactive: 'bg-muted',
           characterSelected: 'ring-ring ring-2 ring-offset-2 outline-none text-foreground',
         }}


### PR DESCRIPTION
Fix for the 2fa Authenticator code input allow the underlying input to be focusable (to allow pasting 2fa codes on mobile). 

The input was set as "opacity-0" to hide the blue background on the input set by the 1password browser extension that hid the individual code characters as the input was rendered above.

This fix changes the z-index value of the code characters instead, and setting "pointer-events-none" on them instead, to have the underlying input to receive the pointer events instead.