### PR TITLE
Fixing responsiveness for order filter

### DIFF
--- a/components/dashboard/filters/Filterbar.tsx
+++ b/components/dashboard/filters/Filterbar.tsx
@@ -117,7 +117,7 @@ export function Filterbar<FV extends Record<string, any>, FM>({
           )}
         </div>
         {filters.orderBy && (
-          <div className="flex flex-1 justify-end">
+          <div className="flex flex-1">
             <filters.orderBy.StandaloneComponent
               onChange={value => setFilter('orderBy', value)}
               value={values.orderBy}

--- a/components/dashboard/filters/Filterbar.tsx
+++ b/components/dashboard/filters/Filterbar.tsx
@@ -117,7 +117,7 @@ export function Filterbar<FV extends Record<string, any>, FM>({
           )}
         </div>
         {filters.orderBy && (
-          <div className="flex flex-1">
+          <div className="flex w-full flex-1 justify-end">
             <filters.orderBy.StandaloneComponent
               onChange={value => setFilter('orderBy', value)}
               value={values.orderBy}

--- a/components/dashboard/filters/OrderFilter.tsx
+++ b/components/dashboard/filters/OrderFilter.tsx
@@ -49,7 +49,7 @@ function OrderFilter({ onChange, value }: { onChange: (value: OrderFilterValue) 
   const Icon = value === 'CREATED_AT,DESC' ? ArrowDownNarrowWide : ArrowDownWideNarrow;
   return (
     <Select onValueChange={value => onChange(value as OrderFilterValue)} value={value}>
-      <Button size="sm" variant="outline" asChild className="max-w-[160px] rounded-full">
+      <Button size="sm" variant="outline" asChild className="w-fit rounded-full">
         <SelectTrigger>
           <div className="flex items-center gap-2 font-medium">
             <Icon className="-ml-0.5 h-5 w-5 text-slate-400" aria-hidden="true" />

--- a/components/dashboard/filters/OrderFilter.tsx
+++ b/components/dashboard/filters/OrderFilter.tsx
@@ -49,10 +49,10 @@ function OrderFilter({ onChange, value }: { onChange: (value: OrderFilterValue) 
   const Icon = value === 'CREATED_AT,DESC' ? ArrowDownNarrowWide : ArrowDownWideNarrow;
   return (
     <Select onValueChange={value => onChange(value as OrderFilterValue)} value={value}>
-      <Button size="sm" variant="outline" asChild className="w-fit rounded-full">
+      <Button size="sm" variant="outline" asChild className="max-w-fit rounded-full">
         <SelectTrigger>
-          <div className="flex items-center gap-2 font-medium">
-            <Icon className="-ml-0.5 h-5 w-5 text-slate-400" aria-hidden="true" />
+          <div className="flex items-center gap-2 overflow-hidden font-medium">
+            <Icon className="-ml-0.5 h-5 w-5 shrink-0 text-slate-400" aria-hidden="true" />
 
             <span className="block truncate">{option.label}</span>
           </div>


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/7226

# Description

- Made the order filter responsive on the new dashboard.
- Removed the order filter from always being at the end of the section, so it breaks correctly to the next line when needed.

# Screenshots

![image](https://github.com/opencollective/opencollective-frontend/assets/50931490/6df57eef-a756-46fd-9f74-2d851c3da209)

![image](https://github.com/opencollective/opencollective-frontend/assets/50931490/7ee286c3-d8bf-4372-894e-61b00e456942)

