### PR TITLE
Fix language switcher on mobile

### DIFF
--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -27,7 +27,7 @@ export function LanguageSwitcher() {
   const languageOptions = React.useMemo(generateLanguageOptions, []);
   const defaultLanguage = languageOptions.find(language => language.value === intl.locale) || languageOptions[0];
   return (
-    <div className="relative">
+    <div className="relative max-w-full">
       <Select onValueChange={value => localeContext.setLocale(value)} defaultValue={defaultLanguage.value}>
         <Tooltip>
           <label className="sr-only" htmlFor="language-options">

--- a/components/navigation/Footer.tsx
+++ b/components/navigation/Footer.tsx
@@ -61,7 +61,7 @@ const Footer = () => {
   if (LoggedInUser && LoggedInUser?.hasPreviewFeatureEnabled(PREVIEW_FEATURE_KEYS.DASHBOARD)) {
     return (
       <footer className="flex justify-center border-t px-6 py-12 md:px-8">
-        <div className="flex max-w-screen-xl flex-1 flex-col items-start gap-6 sm:flex-row md:flex-col">
+        <div className="flex w-full max-w-screen-xl flex-1 flex-col items-start gap-6 sm:flex-row md:flex-col">
           <div className="flex w-full flex-1 flex-col items-start justify-between gap-6 md:flex-row md:items-center">
             <div className="flex flex-col items-start gap-4 md:flex-row md:items-center">
               <Link href="/home">
@@ -131,7 +131,7 @@ const Footer = () => {
     <footer className="flex-row border-t p-6 py-12">
       <div className="mx-auto flex w-full max-w-screen-xl flex-1 flex-col gap-8">
         <div className="flex flex-col gap-4">
-          <div className="flex items-center justify-between gap-4">
+          <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
             <Link href="/">
               <Image
                 src="/static/images/opencollectivelogo-footer-n.svg"


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/7139

## Description
Puts the language switcher on it's own row on mobile to give it space for long language names.

Also sets `max-width: 100%` on the language switcher to not make it overflow and break the layout.


## Screenshots

### Before
<img width="348" alt="Screenshot 2024-01-17 at 10 59 37" src="https://github.com/opencollective/opencollective-frontend/assets/1552194/7b3c96e6-52af-4f3b-b713-c0d866f3d74e">

### After
<img width="350" alt="image" src="https://github.com/opencollective/opencollective-frontend/assets/1552194/18a08dbc-f561-468a-82f3-eb4b734087cf">
