### PR TITLE
i18n: Use generic string for "Export CSV"

### DIFF
--- a/components/ExportTransactionsCSVModal.tsx
+++ b/components/ExportTransactionsCSVModal.tsx
@@ -367,7 +367,7 @@ const ExportTransactionsCSVModal = ({
             href={disabled ? undefined : downloadUrl}
             disabled={disabled}
           >
-            <FormattedMessage defaultMessage="Export CSV" />
+            <FormattedMessage id="Export.Format" defaultMessage="Export {format}" values={{ format: 'CSV' }} />
           </StyledButton>
         </Flex>
       </ModalFooter>

--- a/components/dashboard/ExportTransactionsCSVModal.tsx
+++ b/components/dashboard/ExportTransactionsCSVModal.tsx
@@ -377,7 +377,7 @@ const ExportTransactionsCSVModal = ({
         <DialogFooter>
           <Button asChild loading={isFetchingRows} disabled={disabled}>
             <a href={url} rel="noreferrer" target="_blank">
-              <FormattedMessage defaultMessage="Export CSV" />
+              <FormattedMessage id="Export.Format" defaultMessage="Export {format}" values={{ format: 'CSV' }} />
             </a>
           </Button>
         </DialogFooter>

--- a/components/dashboard/sections/HostDashboardReports.tsx
+++ b/components/dashboard/sections/HostDashboardReports.tsx
@@ -217,7 +217,7 @@ const HostDashboardReports = ({ accountSlug: hostSlug }: DashboardSectionProps) 
             queryFilter={queryFilter}
             trigger={
               <Button size="sm" variant="outline">
-                <FormattedMessage defaultMessage="Export CSV" />
+                <FormattedMessage id="Export.Format" defaultMessage="Export {format}" values={{ format: 'CSV' }} />
               </Button>
             }
           />

--- a/components/dashboard/sections/Transactions.tsx
+++ b/components/dashboard/sections/Transactions.tsx
@@ -208,7 +208,7 @@ const Transactions = ({ accountSlug }: DashboardSectionProps) => {
                       setDisplayExportCSVModal(true);
                     }}
                   >
-                    <FormattedMessage defaultMessage="Export CSV" />
+                    <FormattedMessage id="Export.Format" defaultMessage="Export {format}" values={{ format: 'CSV' }} />
                   </DropdownMenuItem>
                 }
               />

--- a/components/dashboard/sections/transactions/AccountTransactions.tsx
+++ b/components/dashboard/sections/transactions/AccountTransactions.tsx
@@ -81,7 +81,7 @@ const AccountTransactions = ({ accountSlug }: DashboardSectionProps) => {
             accountSlug={accountSlug}
             trigger={
               <Button size="sm" variant="outline" onClick={() => setDisplayExportCSVModal(true)}>
-                <FormattedMessage defaultMessage="Export CSV" />
+                <FormattedMessage id="Export.Format" defaultMessage="Export {format}" values={{ format: 'CSV' }} />
               </Button>
             }
           />

--- a/components/dashboard/sections/transactions/HostTransactions.tsx
+++ b/components/dashboard/sections/transactions/HostTransactions.tsx
@@ -153,7 +153,7 @@ const HostTransactions = ({ accountSlug: hostSlug }: DashboardSectionProps) => {
               hostSlug={hostSlug}
               trigger={
                 <Button size="sm" variant="outline" onClick={() => setDisplayExportCSVModal(true)}>
-                  <FormattedMessage defaultMessage="Export CSV" />
+                  <FormattedMessage id="Export.Format" defaultMessage="Export {format}" values={{ format: 'CSV' }} />
                 </Button>
               }
             />

--- a/components/host-dashboard/reports-section/HostCSVDownloadButton.js
+++ b/components/host-dashboard/reports-section/HostCSVDownloadButton.js
@@ -11,7 +11,7 @@ const HostCSVDownloadButton = ({ host, collectives, dateInterval }) => {
   return (
     <React.Fragment>
       <Button size="sm" variant="outline" className="" onClick={() => setDisplayModal(true)} disabled={!host}>
-        <FormattedMessage defaultMessage="Export CSV" />
+        <FormattedMessage id="Export.Format" defaultMessage="Export {format}" values={{ format: 'CSV' }} />
       </Button>
       {displayModal && (
         <ExportTransactionsCSVModal

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -2994,7 +2994,6 @@
   "tdQA1F": "Use global host settings",
   "TdTXXf": "Més informació",
   "tE0Vtz": "A device or platform authenticator that supports the U2F specification. This can be a hardware key (like a YubiKey) or other methods supported by your browser.",
-  "TE51b7": "Export CSV",
   "Team": "Team",
   "TffQlZ": "You are about to delete the virtual card, are you sure you want to continue ?",
   "tG3saB": "Ticket tiers",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -2994,7 +2994,6 @@
   "tdQA1F": "Use global host settings",
   "TdTXXf": "Learn more",
   "tE0Vtz": "A device or platform authenticator that supports the U2F specification. This can be a hardware key (like a YubiKey) or other methods supported by your browser.",
-  "TE51b7": "Export CSV",
   "Team": "Team",
   "TffQlZ": "You are about to delete the virtual card, are you sure you want to continue ?",
   "tG3saB": "Ticket tiers",

--- a/lang/de.json
+++ b/lang/de.json
@@ -2994,7 +2994,6 @@
   "tdQA1F": "Use global host settings",
   "TdTXXf": "Erfahre mehr",
   "tE0Vtz": "A device or platform authenticator that supports the U2F specification. This can be a hardware key (like a YubiKey) or other methods supported by your browser.",
-  "TE51b7": "Export CSV",
   "Team": "Team",
   "TffQlZ": "You are about to delete the virtual card, are you sure you want to continue ?",
   "tG3saB": "Ticket tiers",

--- a/lang/en.json
+++ b/lang/en.json
@@ -2994,7 +2994,6 @@
   "tdQA1F": "Use global host settings",
   "TdTXXf": "Learn more",
   "tE0Vtz": "A device or platform authenticator that supports the U2F specification. This can be a hardware key (like a YubiKey) or other methods supported by your browser.",
-  "TE51b7": "Export CSV",
   "Team": "Team",
   "TffQlZ": "You are about to delete the virtual card, are you sure you want to continue ?",
   "tG3saB": "Ticket tiers",

--- a/lang/es.json
+++ b/lang/es.json
@@ -2994,7 +2994,6 @@
   "tdQA1F": "Utilizar la configuración global del Host",
   "TdTXXf": "Más información",
   "tE0Vtz": "Un autenticador de dispositivo o plataforma compatible con la especificación U2F. Puede ser una clave de hardware (como una YubiKey) u otros métodos compatibles con tu navegador.",
-  "TE51b7": "Exportar CSV",
   "Team": "Team",
   "TffQlZ": "Estás a punto de eliminar la tarjeta virtual, ¿estás seguro de que quieres continuar?",
   "tG3saB": "Niveles de tickets",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2994,7 +2994,6 @@
   "tdQA1F": "Utiliser les paramètres de l'Hôte",
   "TdTXXf": "En savoir plus",
   "tE0Vtz": "Un appareil ou une plateforme d'authentification qui prend en charge la spécification U2F. Cela peut être une clé hardware (comme une YubiKey) ou d'autres méthodes prises en charge par votre navigateur.",
-  "TE51b7": "Exporter au format CSV",
   "Team": "Team",
   "TffQlZ": "Vous êtes sur le point de supprimer la carte virtuelle, êtes-vous sûr de vouloir continuer ?",
   "tG3saB": "Catégories de ticket",

--- a/lang/he.json
+++ b/lang/he.json
@@ -2994,7 +2994,6 @@
   "tdQA1F": "השתמש בהגדרות כלליות לארגון גג",
   "TdTXXf": "למידע נוסף",
   "tE0Vtz": "A device or platform authenticator that supports the U2F specification. This can be a hardware key (like a YubiKey) or other methods supported by your browser.",
-  "TE51b7": "Export CSV",
   "Team": "Team",
   "TffQlZ": "פעולה זו תמחק את הכרטיס הוירטואלי. להמשיך?",
   "tG3saB": "Ticket tiers",

--- a/lang/it.json
+++ b/lang/it.json
@@ -2994,7 +2994,6 @@
   "tdQA1F": "Use global host settings",
   "TdTXXf": "Learn more",
   "tE0Vtz": "A device or platform authenticator that supports the U2F specification. This can be a hardware key (like a YubiKey) or other methods supported by your browser.",
-  "TE51b7": "Esporta CSV",
   "Team": "Team",
   "TffQlZ": "You are about to delete the virtual card, are you sure you want to continue ?",
   "tG3saB": "Ticket tiers",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -2994,7 +2994,6 @@
   "tdQA1F": "Use global host settings",
   "TdTXXf": "さらに詳しく",
   "tE0Vtz": "A device or platform authenticator that supports the U2F specification. This can be a hardware key (like a YubiKey) or other methods supported by your browser.",
-  "TE51b7": "Export CSV",
   "Team": "Team",
   "TffQlZ": "You are about to delete the virtual card, are you sure you want to continue ?",
   "tG3saB": "Ticket tiers",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -2994,7 +2994,6 @@
   "tdQA1F": "Use global host settings",
   "TdTXXf": "Learn more",
   "tE0Vtz": "A device or platform authenticator that supports the U2F specification. This can be a hardware key (like a YubiKey) or other methods supported by your browser.",
-  "TE51b7": "Export CSV",
   "Team": "Team",
   "TffQlZ": "You are about to delete the virtual card, are you sure you want to continue ?",
   "tG3saB": "Ticket tiers",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -2994,7 +2994,6 @@
   "tdQA1F": "Use global host settings",
   "TdTXXf": "Learn more",
   "tE0Vtz": "A device or platform authenticator that supports the U2F specification. This can be a hardware key (like a YubiKey) or other methods supported by your browser.",
-  "TE51b7": "Export CSV",
   "Team": "Team",
   "TffQlZ": "You are about to delete the virtual card, are you sure you want to continue ?",
   "tG3saB": "Ticket tiers",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -2994,7 +2994,6 @@
   "tdQA1F": "Użyj globalnych ustawień gospodarza",
   "TdTXXf": "Dowiedz się więcej",
   "tE0Vtz": "A device or platform authenticator that supports the U2F specification. This can be a hardware key (like a YubiKey) or other methods supported by your browser.",
-  "TE51b7": "Eksport CSV",
   "Team": "Team",
   "TffQlZ": "Za chwilę usuniesz wirtualną kartę, czy na pewno chcesz kontynuować ?",
   "tG3saB": "Ticket tiers",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -2994,7 +2994,6 @@
   "tdQA1F": "Use global host settings",
   "TdTXXf": "Saiba mais",
   "tE0Vtz": "A device or platform authenticator that supports the U2F specification. This can be a hardware key (like a YubiKey) or other methods supported by your browser.",
-  "TE51b7": "Export CSV",
   "Team": "Team",
   "TffQlZ": "You are about to delete the virtual card, are you sure you want to continue ?",
   "tG3saB": "Ticket tiers",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -2994,7 +2994,6 @@
   "tdQA1F": "Use global host settings",
   "TdTXXf": "Learn more",
   "tE0Vtz": "A device or platform authenticator that supports the U2F specification. This can be a hardware key (like a YubiKey) or other methods supported by your browser.",
-  "TE51b7": "Export CSV",
   "Team": "Team",
   "TffQlZ": "You are about to delete the virtual card, are you sure you want to continue ?",
   "tG3saB": "Ticket tiers",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -2994,7 +2994,6 @@
   "tdQA1F": "Use global host settings",
   "TdTXXf": "Узнать больше",
   "tE0Vtz": "A device or platform authenticator that supports the U2F specification. This can be a hardware key (like a YubiKey) or other methods supported by your browser.",
-  "TE51b7": "Export CSV",
   "Team": "Team",
   "TffQlZ": "You are about to delete the virtual card, are you sure you want to continue ?",
   "tG3saB": "Ticket tiers",

--- a/lang/sk-SK.json
+++ b/lang/sk-SK.json
@@ -2994,7 +2994,6 @@
   "tdQA1F": "Use global host settings",
   "TdTXXf": "Zistiť viac",
   "tE0Vtz": "A device or platform authenticator that supports the U2F specification. This can be a hardware key (like a YubiKey) or other methods supported by your browser.",
-  "TE51b7": "Export CSV",
   "Team": "Team",
   "TffQlZ": "Chystáte sa vymazať virtuálnu kartu. Ste si istí, že chcete pokračovať?",
   "tG3saB": "Ticket tiers",

--- a/lang/sv-SE.json
+++ b/lang/sv-SE.json
@@ -2994,7 +2994,6 @@
   "tdQA1F": "Använd globala värdinställningar",
   "TdTXXf": "Läs mer",
   "tE0Vtz": "A device or platform authenticator that supports the U2F specification. This can be a hardware key (like a YubiKey) or other methods supported by your browser.",
-  "TE51b7": "Export CSV",
   "Team": "Team",
   "TffQlZ": "Du håller på att ta bort det virtuella kortet, är du säker på att du vill fortsätta?",
   "tG3saB": "Ticket tiers",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -2994,7 +2994,6 @@
   "tdQA1F": "Use global host settings",
   "TdTXXf": "Докладніше",
   "tE0Vtz": "A device or platform authenticator that supports the U2F specification. This can be a hardware key (like a YubiKey) or other methods supported by your browser.",
-  "TE51b7": "Експорт CSV",
   "Team": "Team",
   "TffQlZ": "You are about to delete the virtual card, are you sure you want to continue ?",
   "tG3saB": "Ticket tiers",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -2994,7 +2994,6 @@
   "tdQA1F": "使用全局托管设置",
   "TdTXXf": "了解更多",
   "tE0Vtz": "A device or platform authenticator that supports the U2F specification. This can be a hardware key (like a YubiKey) or other methods supported by your browser.",
-  "TE51b7": "导出 CSV",
   "Team": "Team",
   "TffQlZ": "You are about to delete the virtual card, are you sure you want to continue ?",
   "tG3saB": "Ticket tiers",


### PR DESCRIPTION
- We don't want people to translate `CSV`
- It allows re-using the same string, regardless of the format