### PR TITLE
Fix(SiteMenu): remove double drawer close button

### DIFF
--- a/components/navigation/preview/SiteMenu.tsx
+++ b/components/navigation/preview/SiteMenu.tsx
@@ -7,7 +7,7 @@ import useLoggedInUser from '../../../lib/hooks/useLoggedInUser';
 import { Flex } from '../../Grid';
 import Image from '../../Image';
 import Link from '../../Link';
-import { DrawerCloseButton, DrawerMenu, DrawerMenuItem } from '../DrawerMenu';
+import { DrawerMenu, DrawerMenuItem } from '../DrawerMenu';
 
 export default function SiteMenu() {
   const { LoggedInUser } = useLoggedInUser();
@@ -32,7 +32,6 @@ export default function SiteMenu() {
               </Link>
               <Image height={20} width={120} src="/static/images/logotype.svg" alt="Open Collective" />
             </Flex>
-            <DrawerCloseButton onClick={onClose} />
           </Flex>
 
           <Flex flex={1} flexDirection="column" overflowY="auto">


### PR DESCRIPTION
Fixes an issue with two buttons to close the SiteMenu drawer (dynamic top bar preview feature)
