### PR TITLE
ExpenseForm: limit item currency edition to RECEIPTs only

### DIFF
--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -24,7 +24,12 @@ import { userMustSetAccountingCategory } from './lib/accounting-categories';
 import { expenseTypeSupportsAttachments } from './lib/attachments';
 import { addNewExpenseItem, newExpenseItem } from './lib/items';
 import { checkExpenseSupportsOCR, updateExpenseFormWithUploadResult } from './lib/ocr';
-import { checkRequiresAddress, getSupportedCurrencies, validateExpenseTaxes } from './lib/utils';
+import {
+  checkRequiresAddress,
+  expenseTypeSupportsItemCurrency,
+  getSupportedCurrencies,
+  validateExpenseTaxes,
+} from './lib/utils';
 
 import ConfirmationModal from '../ConfirmationModal';
 import { Box, Flex } from '../Grid';
@@ -416,6 +421,14 @@ const ExpenseFormBody = ({
     // Reset the accounting category (if not supported by the new expense type)
     if (values.accountingCategory && !isSupportedExpenseCategory(values.type, values.accountingCategory, isHostAdmin)) {
       formik.setFieldValue('accountingCategory', undefined);
+    }
+
+    // If the new type does not support setting items currency, reset it
+    if (!expenseTypeSupportsItemCurrency(values.type)) {
+      const itemHasExpenseCurrency = item => !item.amountV2?.currency || item.amountV2?.currency === values.currency;
+      const resetItemAmount = item => ({ ...item, amount: null, amountV2: null });
+      const updatedItems = values.items.map(item => (itemHasExpenseCurrency(item) ? item : resetItemAmount(item)));
+      formik.setFieldValue('items', updatedItems);
     }
   }, [values.type]);
 

--- a/components/expenses/ExpenseFormItems.js
+++ b/components/expenses/ExpenseFormItems.js
@@ -10,6 +10,7 @@ import { i18nTaxType } from '../../lib/i18n/taxes';
 import { attachmentDropzoneParams } from './lib/attachments';
 import { expenseItemsMustHaveFiles, newExpenseItem } from './lib/items';
 import { compareItemOCRValues, itemHasOCR, updateExpenseFormWithUploadResult } from './lib/ocr';
+import { expenseTypeSupportsItemCurrency } from './lib/utils';
 
 import { Box, Flex } from '../Grid';
 import { I18nBold } from '../I18nFormatters';
@@ -152,6 +153,7 @@ class ExpenseFormItems extends React.PureComponent {
     const isGrant = values.type === expenseTypes.GRANT;
     const isInvoice = values.type === expenseTypes.INVOICE;
     const isCreditCardCharge = values.type === expenseTypes.CHARGE;
+    const itemsHaveCurrencyPicker = expenseTypeSupportsItemCurrency(values.type);
     const items = values.items || [];
     const hasItems = items.length > 0;
     const itemsWithOCR = items.filter(itemHasOCR);
@@ -228,6 +230,7 @@ class ExpenseFormItems extends React.PureComponent {
             hasOCRFeature={hasOCRFeature}
             collective={collective}
             ocrComparison={itemsOCRComparisons[attachment.id]}
+            hasCurrencyPicker={itemsHaveCurrencyPicker}
           />
         ))}
         {/** Do not display OCR warnings for OCR charges since date/amount can't be changed */}

--- a/components/expenses/ExpenseItemForm.js
+++ b/components/expenses/ExpenseItemForm.js
@@ -306,6 +306,7 @@ const ExpenseItemForm = ({
   isInvoice,
   hasOCRFeature,
   ocrComparison,
+  hasCurrencyPicker,
 }) => {
   const intl = useIntl();
   const form = useFormikContext();
@@ -478,7 +479,7 @@ const ExpenseItemForm = ({
                           min={isOptional ? undefined : 1}
                           maxWidth="100%"
                           placeholder="0.00"
-                          hasCurrencyPicker={true}
+                          hasCurrencyPicker={hasCurrencyPicker}
                           loadingExchangeRate={loadingExchangeRate}
                           exchangeRate={field.value?.exchangeRate}
                           minFxRate={referenceExchangeRate?.value * (1 - FX_RATE_ERROR_THRESHOLD) || undefined}
@@ -600,6 +601,7 @@ ExpenseItemForm.propTypes = {
   editOnlyDescriptiveInfo: PropTypes.bool,
   itemIdx: PropTypes.number.isRequired,
   ocrComparison: PropTypes.object,
+  hasCurrencyPicker: PropTypes.bool,
 };
 
 ExpenseItemForm.defaultProps = {

--- a/components/expenses/lib/utils.ts
+++ b/components/expenses/lib/utils.ts
@@ -140,3 +140,7 @@ export const getSupportedCurrencies = (collective, payoutMethod) => {
     );
   }
 };
+
+export const expenseTypeSupportsItemCurrency = expenseType => {
+  return expenseType === expenseTypes.RECEIPT;
+};


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/7234