### PR TITLE
ExpenseForm: improvements on currency select

### DIFF
--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -331,7 +331,7 @@ const ExpenseFormBody = ({
   const stepTwoCompleted = isInvite
     ? true
     : (stepOneCompleted || isCreditCardCharge) && hasBaseFormFieldsCompleted && values.items.length > 0;
-  const availableCurrencies = getSupportedCurrencies(collective, values.payoutMethod);
+  const availableCurrencies = getSupportedCurrencies(collective, values.payoutMethod, values.type, values.currency);
   const [step, setStep] = React.useState(() => getDefaultStep(defaultStep, stepOneCompleted, isCreditCardCharge));
   const [initWithOCR, setInitWithOCR] = React.useState(null);
 

--- a/components/expenses/ExpenseForm.js
+++ b/components/expenses/ExpenseForm.js
@@ -331,7 +331,7 @@ const ExpenseFormBody = ({
   const stepTwoCompleted = isInvite
     ? true
     : (stepOneCompleted || isCreditCardCharge) && hasBaseFormFieldsCompleted && values.items.length > 0;
-  const availableCurrencies = getSupportedCurrencies(collective, values.payoutMethod, values.type, values.currency);
+  const availableCurrencies = getSupportedCurrencies(collective, values);
   const [step, setStep] = React.useState(() => getDefaultStep(defaultStep, stepOneCompleted, isCreditCardCharge));
   const [initWithOCR, setInitWithOCR] = React.useState(null);
 

--- a/components/expenses/lib/utils.ts
+++ b/components/expenses/lib/utils.ts
@@ -6,7 +6,6 @@ import { Currency, PayPalSupportedCurrencies } from '../../../lib/constants/curr
 import expenseTypes from '../../../lib/constants/expenseTypes';
 import { PayoutMethodType } from '../../../lib/constants/payout-method';
 import { diffExchangeRates } from '../../../lib/currency-utils';
-import { ExpenseType } from '../../../lib/graphql/types/v2/graphql';
 
 import { validateTaxInput } from '../../taxes/TaxesFormikFields';
 import { ExpenseItemFormValues } from '../types/FormValues';
@@ -118,10 +117,10 @@ export const validateExpenseTaxes = (intl, taxes) => {
  * Returns the list of supported currencies for this expense / payout method.
  * The collective currency always comes first.
  */
-export const getSupportedCurrencies = (collective, payoutMethod, expenseType: ExpenseType, baseCurrency: string) => {
+export const getSupportedCurrencies = (collective, { payee, payoutMethod, type, currency }) => {
   // We don't allow changing the currency for virtual card charges
-  if (expenseType === expenseTypes.CHARGE) {
-    return [baseCurrency];
+  if (type === expenseTypes.CHARGE) {
+    return [currency];
   }
 
   // Multi-currency opt-out
@@ -131,6 +130,11 @@ export const getSupportedCurrencies = (collective, payoutMethod, expenseType: Ex
     payoutMethod?.type === PayoutMethodType.ACCOUNT_BALANCE
   ) {
     return [collective.currency];
+  }
+
+  // Allow any currency for invites
+  if (payee?.isInvite && !payoutMethod?.data?.currency) {
+    return Currency;
   }
 
   // Adapt based on payout method type


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/7228
Fix https://github.com/opencollective/opencollective/issues/7238

- Do not allow changing the currency for charges
- Allow any currency for expense invitations