### PR TITLE
Fix ConfirmationModal overflow on mobile

### DIFF
--- a/components/ConfirmationModal.js
+++ b/components/ConfirmationModal.js
@@ -59,7 +59,7 @@ const ConfirmationModal = ({
   const { formatMessage } = useIntl();
 
   return (
-    <StyledModal role="alertdialog" width="570px" onClose={onClose} {...props}>
+    <StyledModal role="alertdialog" onClose={onClose} {...props}>
       <ModalHeader onClose={onClose}>{header}</ModalHeader>
       <ModalBody pt={2}>{children || <P>{body}</P>}</ModalBody>
       <ModalFooter>


### PR DESCRIPTION
Fixes an issue where the ConfirmationModal overflowed on mobile:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/zQq4TRpYwmRLp4NBVpwm/cf524181-7d96-4e51-b9cf-a4beeedea77b.png)

