### PR TITLE
Fix(EmojiReactions): Add emoji font stack

### DIFF
--- a/components/conversations/EmojiReactionPicker.js
+++ b/components/conversations/EmojiReactionPicker.js
@@ -144,7 +144,7 @@ const EmojiReactionPicker = ({ comment, update }) => {
       isSelected = update.userReactions?.includes(emoji);
     }
     return {
-      children: <Emoji>{emoji}</Emoji>,
+      children: <Emoji className="font-emoji">{emoji}</Emoji>,
       isSelected,
       onClick: () => {
         setOpen(false);

--- a/components/conversations/EmojiReactions.js
+++ b/components/conversations/EmojiReactions.js
@@ -23,7 +23,7 @@ const EmojiReactions = ({ reactions }) => {
     .map(emoji => {
       return (
         <EmojiLabel key={emoji}>
-          {emoji}&nbsp;&nbsp;{reactions[emoji]}
+          <span className="font-emoji">{emoji}</span>&nbsp;&nbsp;{reactions[emoji]}
         </EmojiLabel>
       );
     });

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -55,6 +55,14 @@ module.exports = {
       },
       fontFamily: {
         sans: ['var(--font-sans)', ...fontFamily.sans],
+        emoji: [
+          'AppleColorEmoji',
+          'Segoe UI Emoji',
+          'NotoColorEmoji',
+          'Segoe UI Symbol',
+          'Android Emoji',
+          'EmojiSymbols',
+        ],
       },
       keyframes: {
         'accordion-down': {


### PR DESCRIPTION
# Description

Small fix to make sure to use emoji fonts for Emoji reactions if they are available, most notably fixing the black heart reaction to use the proper emoji available on the system:

# Screenshots

| Before | After |
| --- | --- |
| <img width="373" alt="Screenshot 2024-01-24 at 15 23 41" src="https://github.com/opencollective/opencollective-frontend/assets/1552194/a5ce5ec9-95da-4891-82c2-aa1d2a2a6a73"> | <img width="375" alt="image" src="https://github.com/opencollective/opencollective-frontend/assets/1552194/87f9ae8f-ee29-4436-bff4-58baf86b7a18"> |

