### PR TITLE
Make sure to show preview feature that is enabled by default for everyone

### DIFF
--- a/lib/LoggedInUser.js
+++ b/lib/LoggedInUser.js
@@ -216,8 +216,8 @@ LoggedInUser.prototype.getAvailablePreviewFeatures = function () {
     const hasClosedBetaAccess = feature.closedBetaAccessFor?.some(slug =>
       this.hasRole([ROLES.ADMIN, ROLES.MEMBER], { slug }),
     );
-    const enabledByDefault = feature.enabledByDefaultFor?.some(slug =>
-      this.hasRole([ROLES.ADMIN, ROLES.MEMBER], { slug }),
+    const enabledByDefault = feature.enabledByDefaultFor?.some(
+      slug => slug === '*' || this.hasRole([ROLES.ADMIN, ROLES.MEMBER], { slug }),
     );
     const isEnabledInEnv = !feature.env || feature.env.includes(process.env.OC_ENV);
     const isEnabledByDevEnv = feature.alwaysEnableInDev && ['development', 'staging'].includes(process.env.NODE_ENV);


### PR DESCRIPTION
Fix to respect the `enabledByDefault: ['*']` when deciding to show a preview feature in the modal or not.