### PR TITLE
Fix(TwoFactorAuth): Always allow cancelling 2fa modal

### DIFF
--- a/components/UserProvider.js
+++ b/components/UserProvider.js
@@ -143,7 +143,6 @@ class UserProvider extends React.Component {
             const result = await twoFactorAuthPrompt.open({
               supportedMethods: decodedToken.supported2FAMethods,
               authenticationOptions: decodedToken.authenticationOptions,
-              isRequired: true,
               allowRecovery: true,
             });
 
@@ -169,18 +168,22 @@ class UserProvider extends React.Component {
             return LoggedInUser;
           } catch (e) {
             this.setState({ loadingLoggedInUser: false, errorLoggedInUser: e.message });
-            toast({
-              variant: 'error',
-              message: e.message,
-            });
 
-            // stop trying to get the code.
+            // Stop loop if user cancelled the prompt
+            if (e.type === 'TWO_FACTOR_AUTH_CANCELED') {
+              throw new Error(formatErrorMessage(intl, e));
+            }
+
+            // Stop loop if too many requests or token is invalid
             if (
               e.type === 'too_many_requests' ||
               (e.type === 'unauthorized' && e.message.includes('Cannot use this token'))
             ) {
               throw new Error(e.message);
             }
+
+            // Otherwise, retry 2fa prompt and show error
+            toast({ variant: 'error', message: e.message });
           }
         }
       } else {

--- a/lib/two-factor-authentication/TwoFactorAuthenticationContext.js
+++ b/lib/two-factor-authentication/TwoFactorAuthenticationContext.js
@@ -6,21 +6,19 @@ class TwoFactorAuthPrompt {
     this.resolvePromise = () => {};
     this.rejectPromise = () => {};
     this.isOpen = false;
-    this.isRequired = false;
     this.allowRecovery = false;
     this.supportedMethods = [];
     this.listeners = [];
     this.authenticationOptions = {};
   }
 
-  open = async ({ supportedMethods, authenticationOptions, isRequired, allowRecovery } = {}) => {
+  open = async ({ supportedMethods, authenticationOptions, allowRecovery } = {}) => {
     if (this.isOpen) {
       return;
     }
 
     this.supportedMethods = supportedMethods || [];
     this.authenticationOptions = authenticationOptions || {};
-    this.isRequired = isRequired || false;
     this.allowRecovery = allowRecovery || false;
 
     this.setIsOpen(true);


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/7109

# Description

Fix to always allow cancelling the 2FA modal. 

Users could end up in and infinite loop when trying to login, but not being able to cancel the 2fa prompt without successfully completing it.

# Screenshots

![Screenshot 2024-01-25 at 13.54.35.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/zQq4TRpYwmRLp4NBVpwm/5db2cc1b-4c47-48ab-b3e7-e554cf870379.png)

Added modal close button in top right corner.