### PR TITLE
Fix(ProfileMenu): Padding for empty message

### DIFF
--- a/components/navigation/ProfileMenuMemberships.tsx
+++ b/components/navigation/ProfileMenuMemberships.tsx
@@ -274,10 +274,8 @@ const ProfileMenuMemberships = ({ user, closeDrawer }: ProfileMenuMembershipsPro
                   <MenuSectionHeader section={accountType} hidePlusIcon={sectionIsEmpty} closeDrawer={closeDrawer} />
                 )}
                 {sectionIsEmpty ? (
-                  <Box my={2}>
-                    <P fontSize="12px" lineHeight="18px" color="black.700">
-                      {intl.formatMessage(sectionData.emptyMessage)}
-                    </P>
+                  <div className="m-2">
+                    <p className="text-xs text-muted-foreground">{intl.formatMessage(sectionData.emptyMessage)}</p>
                     {Boolean(sectionData.plusButton) && (
                       <Link href={sectionData.plusButton.href} onClick={closeDrawer}>
                         <StyledButton mt="12px" mb="16px" borderRadius="8px" width="100%" fontSize="12px">
@@ -299,7 +297,7 @@ const ProfileMenuMemberships = ({ user, closeDrawer }: ProfileMenuMembershipsPro
                         </StyledButton>
                       </Link>
                     )}
-                  </Box>
+                  </div>
                 ) : accountType === 'ARCHIVED' ? (
                   <Collapse
                     buttonSize={24}


### PR DESCRIPTION
# Description

Fixes padding of empty message in profile menu memberships list.

# Screenshots


| Before | After |
| --- | --- |
| ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/zQq4TRpYwmRLp4NBVpwm/e8135436-41fd-4606-a95d-30e69ebe1b59.png) | ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/zQq4TRpYwmRLp4NBVpwm/aca558c7-cdbb-497e-bc03-15d1e510b724.png) |








