### PR TITLE
ConfirmationModal: use onClose

### DIFF
--- a/components/root-actions/BanAccountsWithSearch.js
+++ b/components/root-actions/BanAccountsWithSearch.js
@@ -262,7 +262,7 @@ const BanAccountsWithSearch = () => {
           isDanger
           continueLabel="Ban accounts"
           header="Ban accounts"
-          cancelHandler={() => setDryRunData(null)}
+          onClose={() => setDryRunData(null)}
           disableSubmit={!dryRunData.isAllowed}
           continueHandler={async () => {
             try {


### PR DESCRIPTION
If only one of `cancelHandler`/`onClosed` is used, it must be `onClosed` as `cancelHandler` already fallback to `onClose` as default.