### PR TITLE
Fix netAmount on expenses with splitPaymentProcessorFee

### DIFF
--- a/components/expenses/graphql/fragments.ts
+++ b/components/expenses/graphql/fragments.ts
@@ -584,6 +584,7 @@ export const expensePageExpenseFieldsFragment = gql`
           id
           currency
           amount
+          feesPayer
         }
         relatedTransactions(kind: PAYMENT_PROCESSOR_FEE) {
           id

--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -103,7 +103,10 @@ export const renderDetailsString = ({
       paymentProcessorFee.currency,
       { locale: intl.locale },
     );
-    const netExpenseAmount = formatCurrency(Math.abs(_netAmount.valueInCents), _netAmount.currency, {
+    const netValueInCents = splitPaymentProcessorFee
+      ? Math.abs(_netAmount.valueInCents) + Math.abs(paymentProcessorFee.valueInCents)
+      : Math.abs(_netAmount.valueInCents);
+    const netExpenseAmount = formatCurrency(netValueInCents, _netAmount.currency, {
       locale: intl.locale,
     });
     const hasPaymentProcessorCover = paymentProcessorCover !== undefined;


### PR DESCRIPTION
**Multi-currency with split payment processor fee:**
![Screenshot from 2024-02-02 14-24-47](https://github.com/opencollective/opencollective-frontend/assets/2119706/cd953ec0-1dcc-48ff-8fa4-c19029e54b01)

**Single-currency without split payment processor fee:**
![Screenshot from 2024-02-02 14-24-35](https://github.com/opencollective/opencollective-frontend/assets/2119706/03cfbf59-a206-49af-b398-014004e2b4b2)
