### PR TITLE
Fixing bug with enabling and disabling all notifications

### DIFF
--- a/components/admin-panel/sections/NotificationsSettings/ActivitySwitch.js
+++ b/components/admin-panel/sections/NotificationsSettings/ActivitySwitch.js
@@ -57,6 +57,14 @@ const ActivitySwitch = ({ account, activityType }) => {
     refetchQueries: [{ query: refetchEmailNotificationQuery, variables: { id: account.id }, context: API_V2_CONTEXT }],
   });
 
+  React.useEffect(() => {
+    if (isOverridedByAll) {
+      setSubscribed(false);
+    } else {
+      setSubscribed(existingSetting ? existingSetting.active : true);
+    }
+  }, [isOverridedByAll]);
+
   const handleToggle = async variables => {
     try {
       setSubscribed(variables.active);


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/7263

# Description

Fixing issue where disabling and enabling all notifications could confuse users. Now enabling all will enable all the other activities and vice versa.

# Screenshots

https://github.com/opencollective/opencollective-frontend/assets/50931490/0adfe9cb-c486-4967-98d0-be193e4f8c8b

