### PR TITLE
ExchangeRate: always fetch fromCurrency/toCurrency

### DIFF
--- a/components/dashboard/sections/expenses/queries.ts
+++ b/components/dashboard/sections/expenses/queries.ts
@@ -66,6 +66,8 @@ export const accountExpensesQuery = gql`
             value
             source
             isApproximate
+            fromCurrency
+            toCurrency
           }
         }
         host @include(if: $fetchHostForExpenses) {

--- a/components/expenses/PayExpenseModal.tsx
+++ b/components/expenses/PayExpenseModal.tsx
@@ -43,6 +43,8 @@ const quoteExpenseQuery = gql`
       amountInHostCurrency: amountV2(currencySource: HOST) {
         exchangeRate {
           value
+          fromCurrency
+          toCurrency
         }
       }
       host {

--- a/components/expenses/graphql/fragments.ts
+++ b/components/expenses/graphql/fragments.ts
@@ -221,6 +221,8 @@ export const expensePageExpenseFieldsFragment = gql`
         value
         source
         isApproximate
+        fromCurrency
+        toCurrency
       }
     }
     createdAt
@@ -645,6 +647,8 @@ export const expensesListFieldsFragment = gql`
         value
         source
         isApproximate
+        fromCurrency
+        toCurrency
       }
     }
     currency


### PR DESCRIPTION
These fields are used by `components/AmountWithExchangeRateInfo.js` to show the details in the tooltip.