### PR TITLE
Sentry: await for error reporting

### DIFF
--- a/components/contribute-cards/ContributeTier.js
+++ b/components/contribute-cards/ContributeTier.js
@@ -143,6 +143,7 @@ const ContributeTier = ({ intl, collective, tier, isPreview, ...props }) => {
       {...props}
     >
       <Flex flexDirection="column" justifyContent="space-between" height="100%">
+        {tier.pleaseCrashThePage.soICanTestSentry}
         <Box>
           {tier.maxQuantity > 0 && (
             <P fontSize="0.7rem" color="#e69900" textTransform="uppercase" fontWeight="500" letterSpacing="1px" mb={2}>

--- a/pages/500.js
+++ b/pages/500.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import ErrorPage from '../components/ErrorPage';
+
+export default function Custom500(props) {
+  return <ErrorPage />;
+}

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -129,6 +129,7 @@ export default class IntlDocument extends Document {
       'CAPTCHA_PROVIDER',
       'DISABLE_MOCK_UPLOADS',
       'LEDGER_SEPARATE_TAXES_AND_PAYMENT_PROCESSOR_FEES',
+      'OC_ENV',
     ]);
   }
 

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -11,12 +11,12 @@ import ErrorPage from '../components/ErrorPage';
  * rendering, typically 404 errors.
  */
 class NextJSErrorPage extends React.Component {
-  static getInitialProps(context) {
+  static async getInitialProps(context) {
     const { res, err, req } = context;
 
     // In case this is running in a serverless function, await this in order to give Sentry
     // time to send the error before the lambda exits
-    Sentry.captureUnderscoreErrorException(context);
+    await Sentry.captureUnderscoreErrorException(context);
 
     const statusCode = res ? res.statusCode : err ? err.statusCode : null;
     return { statusCode, err, requestUrl: req && req.originalUrl };


### PR DESCRIPTION
To match https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/