### PR TITLE
Help and support page search will not redirect if no search results are found

### DIFF
--- a/components/SearchForm.js
+++ b/components/SearchForm.js
@@ -95,6 +95,7 @@ class SearchForm extends React.Component {
       className,
       onClearFilter,
       intl,
+      onKeyPress,
     } = this.props;
     return (
       <form action="/search" method="GET" onSubmit={onSubmit} className={className}>
@@ -130,6 +131,7 @@ class SearchForm extends React.Component {
             defaultValue={defaultValue}
             value={value}
             onChange={onChange && (e => onChange(e.target.value))}
+            onKeyPress={onKeyPress}
             disabled={disabled}
             onFocus={onFocus}
             autoComplete={autoComplete}
@@ -185,6 +187,7 @@ SearchForm.propTypes = {
   closeSearchModal: PropTypes.func,
   onClearFilter: PropTypes.func,
   intl: PropTypes.object,
+  onKeyPress: PropTypes.func,
 };
 
 const composedFunction = compose(withRouter, injectIntl);

--- a/components/help-and-support/SearchTopicsSection.js
+++ b/components/help-and-support/SearchTopicsSection.js
@@ -81,6 +81,7 @@ const SearchTopics = () => {
   const [searchResults, setSearchResults] = React.useState([]);
   const [searchQuery, setSearchQuery] = React.useState('');
   const [isLoading, setIsLoading] = React.useState(false);
+  const [allowSubmit, setAllowSubmit] = React.useState(true);
   const { toast } = useToast();
   const { styles, attributes } = usePopper(refElement, popperElement, {
     placement: 'bottom',
@@ -104,6 +105,7 @@ const SearchTopics = () => {
     try {
       const results = await searchDocs(query);
       setSearchResults(results.items);
+      setAllowSubmit(results.items.length > 0);
     } catch (error) {
       toast({
         variant: 'error',
@@ -127,12 +129,19 @@ const SearchTopics = () => {
         ),
       });
       setSearchResults([]);
+      setAllowSubmit(false);
     } finally {
       setIsLoading(false);
     }
   };
 
   const debouncedSearch = React.useCallback(debounce(search, 500), []);
+
+  const handleKeyPress = event => {
+    if (event.key === 'Enter' && !allowSubmit) {
+      event.preventDefault();
+    }
+  };
 
   return (
     <Flex justifyContent="center" alignItems="center" px="16px">
@@ -162,6 +171,7 @@ const SearchTopics = () => {
             lineHeight="20px"
             letterSpacing="normal"
             fontWeight="400"
+            onKeyPress={handleKeyPress}
           />
         </Box>
         {showSearchResults && (


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/7267

# Description

Searching on the help and support page will not redirect anymore if no search results are found and Enter is pressed

