### PR TITLE
AccountingCategories: display for all hosts with a chart of accounts

### DIFF
--- a/components/AccountingCategorySelect.tsx
+++ b/components/AccountingCategorySelect.tsx
@@ -15,17 +15,16 @@ import { useAsyncCall } from '../lib/hooks/useAsyncCall';
 import useLoggedInUser from '../lib/hooks/useLoggedInUser';
 import { fetchExpenseCategoryPredictions } from '../lib/ml-service';
 import { cn } from '../lib/utils';
+import { ACCOUNTING_CATEGORY_HOST_FIELDS } from './expenses/lib/accounting-categories';
 
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem } from './ui/Command';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/Popover';
 
-type RequiredAccountingCategoryFields = Pick<AccountingCategory, 'id' | 'name' | 'code' | 'kind'>;
-
 type RequiredHostFields = Pick<Host, 'slug'> & {
-  orderAccountingCategories?: { nodes: RequiredAccountingCategoryFields[] };
-  expenseAccountingCategories?: { nodes: RequiredAccountingCategoryFields[] };
-  accountingCategories?: { nodes: RequiredAccountingCategoryFields[] };
+  [K in (typeof ACCOUNTING_CATEGORY_HOST_FIELDS)[number]]?: { nodes: RequiredAccountingCategoryFields[] };
 };
+
+type RequiredAccountingCategoryFields = Pick<AccountingCategory, 'id' | 'name' | 'code' | 'kind'>;
 
 type AccountingCategorySelectProps = {
   host: RequiredHostFields;
@@ -174,7 +173,7 @@ const getOptions = (
   isHostAdmin: boolean,
 ): OptionsMap => {
   const contributionCategories = ['CONTRIBUTION', 'ADDED_FUNDS'];
-  const possibleFields = ['accountingCategories', 'expenseAccountingCategories', 'orderAccountingCategories'];
+  const possibleFields = ACCOUNTING_CATEGORY_HOST_FIELDS;
   const categories = uniq([...possibleFields.map(field => get(host, `${field}.nodes`, [])).flat()]);
   const categoriesById: OptionsMap = {};
 

--- a/components/expenses/lib/accounting-categories.ts
+++ b/components/expenses/lib/accounting-categories.ts
@@ -33,6 +33,13 @@ export const collectiveAdminsMustConfirmAccountingCategory = (
   return Boolean(policy?.requiredForCollectiveAdmins);
 };
 
+// Defines the fields in the `Host` object where the accounting categories are stored
+export const ACCOUNTING_CATEGORY_HOST_FIELDS = [
+  'orderAccountingCategories',
+  'expenseAccountingCategories',
+  'accountingCategories',
+] as const;
+
 export const shouldDisplayExpenseCategoryPill = (
   user: LoggedInUser | null,
   expense: Expense,
@@ -42,7 +49,7 @@ export const shouldDisplayExpenseCategoryPill = (
   return Boolean(
     expense?.accountingCategory ||
       (user &&
-        get(host, 'accountingCategories.nodes', []).length > 0 &&
+        ACCOUNTING_CATEGORY_HOST_FIELDS.some(field => get(host, `${field}.nodes`)?.length > 0) &&
         (userMustSetAccountingCategory(user, account, host) ||
           user.hasPreviewFeatureEnabled('EXPENSE_CATEGORIZATION'))),
   );


### PR DESCRIPTION
Fix the display of accounting categories for hosts that have not yet opted in for the policies.