### PR TITLE
Release Host Expense Pipeline

### DIFF
--- a/components/dashboard/sections/expenses/HostDashboardExpenses.tsx
+++ b/components/dashboard/sections/expenses/HostDashboardExpenses.tsx
@@ -14,9 +14,7 @@ import {
   PayoutMethodType,
 } from '../../../../lib/graphql/types/v2/graphql';
 import { useLazyGraphQLPaginatedResults } from '../../../../lib/hooks/useLazyGraphQLPaginatedResults';
-import useLoggedInUser from '../../../../lib/hooks/useLoggedInUser';
 import useQueryFilter from '../../../../lib/hooks/useQueryFilter';
-import { PREVIEW_FEATURE_KEYS } from '../../../../lib/preview-features';
 
 import ExpensesList from '../../../expenses/ExpensesList';
 import ExpensePipelineOverview from '../../../host-dashboard/expenses/ExpensePipelineOverview';
@@ -89,19 +87,16 @@ const ROUTE_PARAMS = ['slug', 'section'];
 const HostExpenses = ({ accountSlug: hostSlug }: DashboardSectionProps) => {
   const router = useRouter();
   const intl = useIntl();
-  const { LoggedInUser } = useLoggedInUser();
-  const expensePipelineFeatureIsEnabled = LoggedInUser?.hasPreviewFeatureEnabled(PREVIEW_FEATURE_KEYS.EXPENSE_PIPELINE);
   const query = router.query;
   const [paypalPreApprovalError, setPaypalPreApprovalError] = React.useState(null);
   const pageRoute = `/dashboard/${hostSlug}/host-expenses`;
 
   const {
     data: metaData,
-    loading: loadingMetaData,
     error: errorMetaData,
     refetch: refetchMetaData,
   } = useQuery(hostDashboardMetadataQuery, {
-    variables: { hostSlug, getViewCounts: Boolean(expensePipelineFeatureIsEnabled), withHoverCard: true },
+    variables: { hostSlug, withHoverCard: true },
     context: API_V2_CONTEXT,
   });
 
@@ -166,7 +161,7 @@ const HostExpenses = ({ accountSlug: hostSlug }: DashboardSectionProps) => {
     defaultFilterValues: views[1].filter,
     filters,
     meta,
-    views: expensePipelineFeatureIsEnabled ? views : undefined,
+    views,
   });
 
   const variables = {
@@ -264,8 +259,8 @@ const HostExpenses = ({ accountSlug: hostSlug }: DashboardSectionProps) => {
       ) : (
         <React.Fragment>
           <ExpensesList
-            isLoading={loading || loadingMetaData}
-            host={metaData?.host}
+            isLoading={loading}
+            host={data?.host}
             nbPlaceholders={paginatedExpenses.limit}
             expenses={paginatedExpenses.nodes}
             view="admin"

--- a/components/dashboard/sections/expenses/queries.ts
+++ b/components/dashboard/sections/expenses/queries.ts
@@ -174,10 +174,14 @@ export const hostDashboardExpensesQuery = gql`
         ...ExpensesListAdminFieldsFragment
       }
     }
+    host(slug: $hostSlug) {
+      id
+      ...ExpenseHostFields
+    }
   }
-
   ${expensesListFieldsFragment}
   ${expensesListAdminFieldsFragment}
+  ${expenseHostFields}
 `;
 
 const hostInfoCardFields = gql`
@@ -224,10 +228,9 @@ const hostInfoCardFields = gql`
 `;
 
 export const hostDashboardMetadataQuery = gql`
-  query HostDashboardMetadata($hostSlug: String!, $getViewCounts: Boolean!) {
+  query HostDashboardMetadata($hostSlug: String!) {
     host(slug: $hostSlug) {
       id
-      ...ExpenseHostFields
       ...HostInfoCardFields
       transferwise {
         id
@@ -238,26 +241,25 @@ export const hostDashboardMetadataQuery = gql`
         }
       }
     }
-    all: expenses(host: { slug: $hostSlug }, limit: 0) @include(if: $getViewCounts) {
+    all: expenses(host: { slug: $hostSlug }) {
       totalCount
     }
-    ready_to_pay: expenses(host: { slug: $hostSlug }, limit: 0, status: READY_TO_PAY) @include(if: $getViewCounts) {
+    ready_to_pay: expenses(host: { slug: $hostSlug }, status: READY_TO_PAY) {
       totalCount
     }
-    scheduled_for_payment: expenses(host: { slug: $hostSlug }, limit: 0, status: SCHEDULED_FOR_PAYMENT)
-      @include(if: $getViewCounts) {
+    scheduled_for_payment: expenses(host: { slug: $hostSlug }, status: SCHEDULED_FOR_PAYMENT) {
       totalCount
     }
-    on_hold: expenses(host: { slug: $hostSlug }, limit: 0, status: ON_HOLD) @include(if: $getViewCounts) {
+    on_hold: expenses(host: { slug: $hostSlug }, status: ON_HOLD) {
       totalCount
     }
-    incomplete: expenses(host: { slug: $hostSlug }, limit: 0, status: INCOMPLETE) @include(if: $getViewCounts) {
+    incomplete: expenses(host: { slug: $hostSlug }, status: INCOMPLETE) {
       totalCount
     }
-    error: expenses(host: { slug: $hostSlug }, limit: 0, status: ERROR) @include(if: $getViewCounts) {
+    error: expenses(host: { slug: $hostSlug }, status: ERROR) {
       totalCount
     }
-    paid: expenses(host: { slug: $hostSlug }, limit: 0, status: PAID) @include(if: $getViewCounts) {
+    paid: expenses(host: { slug: $hostSlug }, status: PAID) {
       totalCount
     }
 
@@ -277,6 +279,5 @@ export const hostDashboardMetadataQuery = gql`
   }
 
   ${accountHoverCardFields}
-  ${expenseHostFields}
   ${hostInfoCardFields}
 `;

--- a/components/host-dashboard/HostDashboardExpenses.js
+++ b/components/host-dashboard/HostDashboardExpenses.js
@@ -10,8 +10,6 @@ import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
 import { ExpenseStatus } from '../../lib/graphql/types/v2/graphql';
 import useQueryFilter, { BooleanFilter } from '../../lib/hooks/deprecated/useQueryFilter';
 import { useLazyGraphQLPaginatedResults } from '../../lib/hooks/useLazyGraphQLPaginatedResults';
-import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
-import { PREVIEW_FEATURE_KEYS } from '../../lib/preview-features';
 
 import { parseAmountRange } from '../budget/filters/AmountFilter';
 import DashboardViews from '../dashboard/DashboardViews';
@@ -77,13 +75,6 @@ const getVariablesFromQuery = query => {
   };
 };
 
-const enforceDefaultParamsOnQuery = query => {
-  return {
-    ...query,
-    status: query.status || 'READY_TO_PAY',
-  };
-};
-
 const ROUTE_PARAMS = ['hostCollectiveSlug', 'view', 'slug', 'section'];
 
 const hasParams = query => {
@@ -95,9 +86,7 @@ const hasParams = query => {
 const HostDashboardExpenses = ({ accountSlug: hostSlug, isDashboard }) => {
   const router = useRouter() || {};
   const intl = useIntl();
-  const { LoggedInUser } = useLoggedInUser();
-  const expensePipelineFeatureIsEnabled = LoggedInUser?.hasPreviewFeatureEnabled(PREVIEW_FEATURE_KEYS.EXPENSE_PIPELINE);
-  const query = expensePipelineFeatureIsEnabled ? router.query : enforceDefaultParamsOnQuery(router.query);
+  const query = router.query;
   const [paypalPreApprovalError, setPaypalPreApprovalError] = React.useState(null);
   const hasFilters = React.useMemo(() => hasParams(query), [query]);
   const pageRoute = isDashboard ? `/dashboard/${hostSlug}/host-expenses` : `/${hostSlug}/admin/expenses`;
@@ -121,12 +110,8 @@ const HostDashboardExpenses = ({ accountSlug: hostSlug, isDashboard }) => {
     context: API_V2_CONTEXT,
   });
 
-  const {
-    data: metaData,
-    loading: loadingMetaData,
-    refetch: refetchMetaData,
-  } = useQuery(hostDashboardMetadataQuery, {
-    variables: { hostSlug, getViewCounts: Boolean(expensePipelineFeatureIsEnabled) },
+  const { data: metaData, refetch: refetchMetaData } = useQuery(hostDashboardMetadataQuery, {
+    variables: { hostSlug },
     context: API_V2_CONTEXT,
   });
 
@@ -150,7 +135,7 @@ const HostDashboardExpenses = ({ accountSlug: hostSlug, isDashboard }) => {
     },
     {
       label: intl.formatMessage({ id: 'expense.scheduledForPayment', defaultMessage: 'Scheduled for payment' }),
-      query: { status: 'SCHEDULED_FOR_PAYMENT', payout: 'BANK_ACCOUNT', orderBy: 'CREATED_AT,ASC' },
+      query: { status: 'SCHEDULED_FOR_PAYMENT', orderBy: 'CREATED_AT,ASC' },
       id: 'scheduled_for_payment',
       count: metaData?.scheduled_for_payment?.totalCount,
     },
@@ -262,23 +247,22 @@ const HostDashboardExpenses = ({ accountSlug: hostSlug, isDashboard }) => {
 
         {metaData?.host ? (
           <div>
-            {expensePipelineFeatureIsEnabled && (
-              <DashboardViews
-                query={query}
-                omitMatchingParams={[...ROUTE_PARAMS, 'orderBy']}
-                views={views}
-                onChange={query => {
-                  router.push(
-                    {
-                      pathname: pageRoute,
-                      query,
-                    },
-                    undefined,
-                    { scroll: false },
-                  );
-                }}
-              />
-            )}
+            <DashboardViews
+              query={query}
+              omitMatchingParams={[...ROUTE_PARAMS, 'orderBy']}
+              views={views}
+              onChange={query => {
+                router.push(
+                  {
+                    pathname: pageRoute,
+                    query,
+                  },
+                  undefined,
+                  { scroll: false },
+                );
+              }}
+            />
+
             <ExpensesFilters
               collective={metaData.host}
               filters={query}
@@ -321,8 +305,8 @@ const HostDashboardExpenses = ({ accountSlug: hostSlug, isDashboard }) => {
         ) : (
           <React.Fragment>
             <ExpensesList
-              isLoading={loading || loadingMetaData}
-              host={metaData?.host}
+              isLoading={loading}
+              host={data?.host}
               nbPlaceholders={paginatedExpenses.limit}
               expenses={paginatedExpenses.nodes}
               view="admin"

--- a/lib/preview-features.ts
+++ b/lib/preview-features.ts
@@ -3,7 +3,6 @@
  */
 export enum PREVIEW_FEATURE_KEYS {
   DASHBOARD = 'dashboard',
-  EXPENSE_PIPELINE = 'EXPENSE_PIPELINE',
   EXPENSE_CATEGORIZATION = 'EXPENSE_CATEGORIZATION',
   DYNAMIC_TOP_BAR = 'DYNAMIC_TOP_BAR',
   COLLECTIVE_OVERVIEW = 'COLLECTIVE_OVERVIEW',
@@ -39,13 +38,6 @@ export const previewFeatures: PreviewFeature[] = [
     title: 'Dynamic top bar',
     publicBeta: false,
     dependsOn: PREVIEW_FEATURE_KEYS.DASHBOARD,
-  },
-  {
-    key: PREVIEW_FEATURE_KEYS.EXPENSE_PIPELINE,
-    title: 'Host Expense Pipeline',
-    description: 'Introducing tabs in the host expenses dashboard to help you manage paying expenses.',
-    publicBeta: false,
-    closedBetaAccessFor: ['opencollective', 'opensource', 'foundation', 'europe', 'design', 'engineering'],
   },
   {
     key: PREVIEW_FEATURE_KEYS.EXPENSE_CATEGORIZATION,


### PR DESCRIPTION
# Description

- Release of "Host Expense Pipeline", tabs that provide easy access to common filters on the host expenses page, removing it as a preview feature and making it available to all.
- Also moving the part of the meta data query, some host fields required by the expense list, to the main query and avoiding waiting for the metadata query to resolve before displaying the Expense list.


# Screenshots

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/zQq4TRpYwmRLp4NBVpwm/2e0029e9-80fd-4a82-b17f-7e5853136ce0.png)

