### PR TITLE
Plug Formik and Zod together

### DIFF
--- a/components/FormikZod.tsx
+++ b/components/FormikZod.tsx
@@ -1,0 +1,230 @@
+import React from 'react';
+import { Formik, FormikConfig, FormikValues, useFormik } from 'formik';
+import { get, isNil, max, set } from 'lodash';
+import { IntlShape, useIntl } from 'react-intl';
+import { z, ZodEffects, ZodIssue, ZodObject } from 'zod';
+
+import { RICH_ERROR_MESSAGES } from '../lib/form-utils';
+
+/**
+ * Attributes that can be set on an input element, inferred from a Zod schema.
+ */
+type InputAttributesFromZodSchema = {
+  name?: string;
+  required?: boolean;
+} & (
+  | {}
+  | {
+      type: 'text';
+      minLength?: number;
+      maxLength?: number;
+    }
+  | {
+      type: 'number';
+      min?: number;
+      max?: number;
+    }
+);
+
+/**
+ * A Zod schema that can be used in a Formik form. It can be a plain Zod object or a Zod effect that wraps a Zod object.
+ */
+type AcceptedZodSchema = z.AnyZodObject | ZodEffects<z.AnyZodObject>;
+
+/**
+ * @returns a Zod error map that uses the provided `intl` object to internationalize the error messages.
+ */
+const getCustomZodErrorMap =
+  (intl: IntlShape) =>
+  (error: ZodIssue, ctx: { defaultError: string; data: any }): { message: string } => {
+    if (error.message && error.message !== ctx.defaultError) {
+      return { message: error.message }; // If a custom message was provided, use it
+    }
+
+    let message = error.message;
+    if (error.code === 'too_big') {
+      message = intl.formatMessage(RICH_ERROR_MESSAGES.maxLength, { count: error.maximum as number });
+    } else if (error.code === 'too_small') {
+      message = intl.formatMessage(RICH_ERROR_MESSAGES.minLength, { count: error.minimum as number });
+    } else if (error.code === 'invalid_string') {
+      message = intl.formatMessage(RICH_ERROR_MESSAGES.format);
+    } else if (error.code === 'invalid_enum_value') {
+      message = intl.formatMessage(RICH_ERROR_MESSAGES.enum, { options: error.options.join(', ') });
+    }
+
+    return { message: message || intl.formatMessage(RICH_ERROR_MESSAGES.invalidValue) };
+  };
+
+/**
+ * @returns A function that can be used as a Formik `validate` function for a Zod schema. The function will
+ * check the values against the Zod schema and return an object of internationalized error messages.
+ */
+const getErrorsObjectFromZodSchema = (
+  intl: IntlShape,
+  zodSchema: AcceptedZodSchema,
+  values: z.infer<typeof zodSchema>,
+): Record<string, string> => {
+  const errors = {};
+  const result = zodSchema.safeParse(values, { errorMap: getCustomZodErrorMap(intl) });
+  if (!result.success) {
+    const errorResult = result as z.SafeParseError<typeof values>;
+    for (const error of errorResult.error.issues) {
+      if (!get(errors, error.path)) {
+        set(errors, error.path, error.message);
+      }
+    }
+  }
+
+  return errors;
+};
+
+const isOptionalField = (field: z.ZodTypeAny): boolean => {
+  return ['ZodOptional', 'ZodNullable'].includes(field._def.typeName);
+};
+
+const getTypeFromOptionalField = (field: z.ZodTypeAny): z.ZodTypeAny => {
+  if (isOptionalField(field)) {
+    return getTypeFromOptionalField(field._def['innerType']);
+  } else {
+    return field;
+  }
+};
+
+const getStringOptionFromUnion = (field: z.ZodTypeAny): z.ZodString | undefined => {
+  for (const option of field._def.options) {
+    const type = getTypeFromOptionalField(option);
+    if (type._def.typeName === 'ZodString') {
+      return type as z.ZodString;
+    }
+  }
+};
+
+/**
+ * Retrieves the given nested field from a Zod schema.
+ */
+const getNestedFieldFromSchema = (schema: z.ZodTypeAny, fullPath: string[]): z.ZodTypeAny => {
+  if (schema._def.typeName === 'ZodObject') {
+    const [path, ...subPath] = fullPath;
+    const field = (schema as z.AnyZodObject).shape[path];
+    if (!field || subPath.length === 0) {
+      return field;
+    } else {
+      const mainField = getTypeFromOptionalField(field); // Make sure we properly traverse optional parents
+      return getNestedFieldFromSchema(mainField, subPath);
+    }
+  } else if (schema._def.typeName === 'ZodEffects') {
+    return getNestedFieldFromSchema(schema._def.schema, fullPath);
+  }
+
+  return null;
+};
+
+/**
+ * @param name a dot-separated path to the field in the schema.
+ * @returns the attributes that should be set on an input element.
+ */
+export const getInputAttributesFromZodSchema = (
+  schema: AcceptedZodSchema,
+  name: string,
+): InputAttributesFromZodSchema => {
+  if (!schema) {
+    return {};
+  }
+
+  let field = getNestedFieldFromSchema(schema, name.split('.'));
+  if (!field) {
+    return {};
+  }
+
+  const attributes = { name, required: true };
+
+  // Handle optional/required
+  if (isOptionalField(field)) {
+    attributes.required = false;
+    field = getTypeFromOptionalField(field);
+  } else if (field._def.typeName === 'ZodUnion') {
+    // If any of the options is optional, the field is optional
+    attributes.required = !field._def.options.some(option => isOptionalField(option));
+
+    // It's common to have an union between a string and a literal(''), to allow empty strings while enforcing a minimum length.
+    // In this case, we should use the string's attributes.
+    const stringOption = getStringOptionFromUnion(field);
+    if (stringOption) {
+      field = stringOption;
+    }
+  }
+
+  // Handle type-specific attributes
+  if (field._def.typeName === 'ZodString') {
+    attributes['type'] = 'text';
+    if (!isNil(field['minLength'])) {
+      attributes['minLength'] = field['minLength'];
+    }
+    if (!isNil(field['maxLength'])) {
+      attributes['maxLength'] = field['maxLength'];
+    }
+  } else if (field._def.typeName === 'ZodNumber') {
+    attributes['type'] = 'number';
+    const minChecks = field._def.checks.filter(check => check.kind === 'min').map(check => check.value);
+    const minValue = max(minChecks); // Get the least restrictive minimum
+    if (!isNil(minValue)) {
+      attributes['min'] = minValue;
+    }
+
+    const maxChecks = field._def.checks.filter(check => check.kind === 'max').map(check => check.value);
+    const maxValue = max(maxChecks); // Get the most restrictive maximum
+    if (!isNil(maxValue)) {
+      attributes['max'] = maxValue;
+    }
+  }
+
+  return attributes;
+};
+
+/**
+ * @returns the Zod schema from a Formik form (if defined)
+ */
+export const getSchemaFromFormik = (formik: FormikValues): AcceptedZodSchema | undefined => {
+  if (formik.status && (formik.status instanceof ZodObject || formik.status instanceof ZodEffects)) {
+    return formik.status;
+  }
+};
+
+/**
+ * A wrapper around `useFormik` that plugs in Zod validation.
+ *
+ * @warning In [their docs](https://formik.org/docs/api/useFormik), Formik discourages using `useFormik` directly. This
+ * component will not work out of the box with `StyledInputFormikField` and other components that rely on Formik context such as `Field` or `FastField`.
+ * If you are trying to access Formik state via context, use `useFormikContext`. Only use this hook if you are NOT using <Formik> or withFormik.
+ */
+export function useFormikZod<Values extends FormikValues = FormikValues>({
+  schema,
+  ...props
+}: Omit<FormikConfig<Values>, 'initialValues' | 'validate' | 'initialValues'> & {
+  schema: AcceptedZodSchema;
+  initialValues: z.infer<typeof schema> & Values;
+}) {
+  const intl = useIntl();
+  const validate = React.useCallback(values => getErrorsObjectFromZodSchema(intl, schema, values), [intl, schema]);
+  return useFormik<Values>({ ...props, validate, initialStatus: schema });
+}
+
+/**
+ * A wrapper around `Formik` that plugs in Zod validation.
+ *
+ * Combined with `StyledInputFormikField` this components provides a simple way to have automatic
+ * form validation and HTML best practices (e.g. setting the `required` and HTML validation attributes).
+ */
+export const FormikZod = ({
+  schema,
+  ...props
+}: Omit<React.ComponentProps<typeof Formik>, 'initialStatus' | 'validate' | 'initialValues'> & {
+  schema: AcceptedZodSchema;
+  initialValues: z.infer<typeof schema>;
+}) => {
+  const intl = useIntl();
+  const validate = React.useCallback(values => getErrorsObjectFromZodSchema(intl, schema, values), [intl, schema]);
+  return <Formik initialStatus={schema} validate={validate} {...props} />;
+};
+
+// ignore unused exports useFormikZod, FormikZod, getInputAttributesFromZodSchema

--- a/components/StyledInputField.js
+++ b/components/StyledInputField.js
@@ -49,6 +49,7 @@ const StyledInputField = ({
   flexDirection = undefined,
   justifyContent = undefined,
   alignItems = undefined,
+  placeholder = undefined,
   ...props
 }) => {
   const isCheckbox = inputType === 'checkbox';
@@ -115,6 +116,7 @@ const StyledInputField = ({
               success,
               disabled,
               required,
+              placeholder,
             })
           : children}
       </Flex>

--- a/components/__tests__/FormikZod.test.js
+++ b/components/__tests__/FormikZod.test.js
@@ -1,0 +1,65 @@
+import { z } from 'zod';
+
+import { getInputAttributesFromZodSchema } from '../FormikZod';
+
+describe('FormikZod', () => {
+  describe('getInputAttributesFromZodSchema', () => {
+    const schema = z.object({
+      name: z.string().min(100).max(100),
+      optionalName: z.string().optional().nullable(),
+      age: z.number().int().positive().min(18).max(99),
+      deep: z
+        .object({ nested: z.object({ field: z.string().max(500).optional().nullable() }) })
+        .optional()
+        .nullable(),
+    });
+
+    it('gets the attributes for a string field', () => {
+      expect(getInputAttributesFromZodSchema(schema, 'name')).toEqual({
+        name: 'name',
+        maxLength: 100,
+        minLength: 100,
+        type: 'text',
+        required: true,
+      });
+    });
+
+    it('gets the attributes for an optional string field', () => {
+      expect(getInputAttributesFromZodSchema(schema, 'optionalName')).toEqual({
+        name: 'optionalName',
+        type: 'text',
+        required: false,
+      });
+    });
+
+    it('gets the attributes for a number field', () => {
+      expect(getInputAttributesFromZodSchema(schema, 'age')).toEqual({
+        name: 'age',
+        type: 'number',
+        required: true,
+        min: 18,
+        max: 99,
+      });
+    });
+
+    it('gets the attributes for a nested field', () => {
+      expect(getInputAttributesFromZodSchema(schema, 'deep.nested.field')).toEqual({
+        name: 'deep.nested.field',
+        type: 'text',
+        required: false,
+        maxLength: 500,
+      });
+    });
+
+    it('works with ZodEffects', () => {
+      const schemaWithEffects = schema.superRefine(() => {}).superRefine(() => {});
+      expect(getInputAttributesFromZodSchema(schemaWithEffects, 'name')).toEqual({
+        name: 'name',
+        maxLength: 100,
+        minLength: 100,
+        type: 'text',
+        required: true,
+      });
+    });
+  });
+});

--- a/components/__tests__/StyledInputFormikField.test.js
+++ b/components/__tests__/StyledInputFormikField.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Formik } from 'formik';
+import { z } from 'zod';
+
+import { snapshotWithoutClassNames as snapshot } from '../../test/snapshot-helpers';
+
+import { FormikZod } from '../FormikZod';
+import StyledInputFormikField from '../StyledInputFormikField';
+
+describe('StyledInputFormikField', () => {
+  it('renders default options', () => {
+    snapshot(<Formik>{() => <StyledInputFormikField name="myAttribute" />}</Formik>);
+  });
+
+  describe('With Zod schema', () => {
+    it('automatically adds attributes from Zod schema', () => {
+      const schema = z.object({ myAttribute: z.string().min(10).max(100) });
+      snapshot(<FormikZod schema={schema}>{() => <StyledInputFormikField name="myAttribute" />}</FormikZod>);
+    });
+
+    it('automatically adds attributes from Zod schema on nested field', () => {
+      const schema = z.object({ my: z.object({ nested: z.object({ attribute: z.string().min(10).max(100) }) }) });
+      snapshot(<FormikZod schema={schema}>{() => <StyledInputFormikField name="my.nested.attribute" />}</FormikZod>);
+    });
+
+    it('automatically adds attributes from Zod schema on optional field', () => {
+      const schema = z.object({ myAttribute: z.string().optional() });
+      snapshot(<FormikZod schema={schema}>{() => <StyledInputFormikField name="myAttribute" />}</FormikZod>);
+    });
+
+    it('automatically adds attributes from Zod schema on nullable field', () => {
+      const schema = z.object({ myAttribute: z.string().nullable() });
+      snapshot(<FormikZod schema={schema}>{() => <StyledInputFormikField name="myAttribute" />}</FormikZod>);
+    });
+
+    it('automatically adds attributes from Zod schema on number field', () => {
+      const schema = z.object({ myAttribute: z.number().min(10).max(100) });
+      snapshot(<FormikZod schema={schema}>{() => <StyledInputFormikField name="myAttribute" />}</FormikZod>);
+    });
+  });
+});

--- a/components/__tests__/__snapshots__/StyledInputFormikField.test.js.snap
+++ b/components/__tests__/__snapshots__/StyledInputFormikField.test.js.snap
@@ -1,0 +1,125 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StyledInputFormikField With Zod schema automatically adds attributes from Zod schema 1`] = `
+<div>
+  <div
+    data-cy="InputField-myAttribute"
+  >
+    <div>
+      <input
+        fontSize="14px"
+        id="input-myAttribute"
+        maxLength={100}
+        minLength={10}
+        name="myAttribute"
+        onBlur={[Function]}
+        onChange={[Function]}
+        required={true}
+        type="text"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`StyledInputFormikField With Zod schema automatically adds attributes from Zod schema on nested field 1`] = `
+<div>
+  <div
+    data-cy="InputField-my.nested.attribute"
+  >
+    <div>
+      <input
+        fontSize="14px"
+        id="input-my.nested.attribute"
+        maxLength={100}
+        minLength={10}
+        name="my.nested.attribute"
+        onBlur={[Function]}
+        onChange={[Function]}
+        required={true}
+        type="text"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`StyledInputFormikField With Zod schema automatically adds attributes from Zod schema on nullable field 1`] = `
+<div>
+  <div
+    data-cy="InputField-myAttribute"
+  >
+    <div>
+      <input
+        fontSize="14px"
+        id="input-myAttribute"
+        name="myAttribute"
+        onBlur={[Function]}
+        onChange={[Function]}
+        required={false}
+        type="text"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`StyledInputFormikField With Zod schema automatically adds attributes from Zod schema on number field 1`] = `
+<div>
+  <div
+    data-cy="InputField-myAttribute"
+  >
+    <div>
+      <input
+        fontSize="14px"
+        id="input-myAttribute"
+        max={100}
+        min={10}
+        name="myAttribute"
+        onBlur={[Function]}
+        onChange={[Function]}
+        required={true}
+        type="number"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`StyledInputFormikField With Zod schema automatically adds attributes from Zod schema on optional field 1`] = `
+<div>
+  <div
+    data-cy="InputField-myAttribute"
+  >
+    <div>
+      <input
+        fontSize="14px"
+        id="input-myAttribute"
+        name="myAttribute"
+        onBlur={[Function]}
+        onChange={[Function]}
+        required={false}
+        type="text"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`StyledInputFormikField renders default options 1`] = `
+<div>
+  <div
+    data-cy="InputField-myAttribute"
+  >
+    <div>
+      <input
+        fontSize="14px"
+        id="input-myAttribute"
+        name="myAttribute"
+        onBlur={[Function]}
+        onChange={[Function]}
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -1551,6 +1551,7 @@
   "form.processing": "processing",
   "Form.yourEmail": "Your email address",
   "Form.yourPassword": "Your password",
+  "FormError.enum": "Must be one of: {options}",
   "FormError.InvalidValue": "Invalid value",
   "FormError.max": "The value is too high",
   "FormError.maxLength": "The value is too long",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -1551,6 +1551,7 @@
   "form.processing": "zpracování",
   "Form.yourEmail": "Your email address",
   "Form.yourPassword": "Your password",
+  "FormError.enum": "Must be one of: {options}",
   "FormError.InvalidValue": "Neplatná hodnota",
   "FormError.max": "Hodnota je příliš vysoká",
   "FormError.maxLength": "Hodnota je příliš dlouhá",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1551,6 +1551,7 @@
   "form.processing": "In Bearbeitung",
   "Form.yourEmail": "Ihre E-Mail-Adresse",
   "Form.yourPassword": "Dein Passwort",
+  "FormError.enum": "Must be one of: {options}",
   "FormError.InvalidValue": "Ungültiger Wert",
   "FormError.max": "Der Wert ist zu hoch",
   "FormError.maxLength": "Der Wert ist zu lang",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1551,6 +1551,7 @@
   "form.processing": "processing",
   "Form.yourEmail": "Your email address",
   "Form.yourPassword": "Your password",
+  "FormError.enum": "Must be one of: {options}",
   "FormError.InvalidValue": "Invalid value",
   "FormError.max": "The value is too high",
   "FormError.maxLength": "The value is too long",

--- a/lang/es.json
+++ b/lang/es.json
@@ -1551,6 +1551,7 @@
   "form.processing": "procesando",
   "Form.yourEmail": "Tu dirección de correo electrónico",
   "Form.yourPassword": "Tu contraseña",
+  "FormError.enum": "Must be one of: {options}",
   "FormError.InvalidValue": "Valor no válido",
   "FormError.max": "El valor es demasiado alto",
   "FormError.maxLength": "El valor es demasiado largo",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1551,6 +1551,7 @@
   "form.processing": "en cours de traitement",
   "Form.yourEmail": "Votre adresse e-mail",
   "Form.yourPassword": "Votre mot de passe",
+  "FormError.enum": "Must be one of: {options}",
   "FormError.InvalidValue": "Valeur non valide",
   "FormError.max": "La valeur est trop élevée",
   "FormError.maxLength": "La valeur est trop longue",

--- a/lang/he.json
+++ b/lang/he.json
@@ -1551,6 +1551,7 @@
   "form.processing": "בטיפול",
   "Form.yourEmail": "כתובת המייל שלך",
   "Form.yourPassword": "Your password",
+  "FormError.enum": "Must be one of: {options}",
   "FormError.InvalidValue": "ערך לא חוקי",
   "FormError.max": "הערך גבוה מדי",
   "FormError.maxLength": "הערך ארוך מדי",

--- a/lang/it.json
+++ b/lang/it.json
@@ -1551,6 +1551,7 @@
   "form.processing": "in elaborazione",
   "Form.yourEmail": "Il tuo indirizzo email",
   "Form.yourPassword": "La tua password",
+  "FormError.enum": "Must be one of: {options}",
   "FormError.InvalidValue": "Valore non valido",
   "FormError.max": "Valore troppo alto",
   "FormError.maxLength": "Valore troppo lungo",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -1551,6 +1551,7 @@
   "form.processing": "処理中",
   "Form.yourEmail": "メールアドレス",
   "Form.yourPassword": "Your password",
+  "FormError.enum": "Must be one of: {options}",
   "FormError.InvalidValue": "Invalid value",
   "FormError.max": "The value is too high",
   "FormError.maxLength": "The value is too long",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -1551,6 +1551,7 @@
   "form.processing": "처리 중",
   "Form.yourEmail": "이메일 주소",
   "Form.yourPassword": "Your password",
+  "FormError.enum": "Must be one of: {options}",
   "FormError.InvalidValue": "Invalid value",
   "FormError.max": "The value is too high",
   "FormError.maxLength": "The value is too long",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -1551,6 +1551,7 @@
   "form.processing": "verwerken",
   "Form.yourEmail": "Je e-mailadres",
   "Form.yourPassword": "Je wachtwoord",
+  "FormError.enum": "Must be one of: {options}",
   "FormError.InvalidValue": "Ongeldige waarde",
   "FormError.max": "De waarde is te hoog",
   "FormError.maxLength": "De waarde is te lang",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -1551,6 +1551,7 @@
   "form.processing": "przetwarzanie",
   "Form.yourEmail": "Twój adres e-mail",
   "Form.yourPassword": "Twoje hasło",
+  "FormError.enum": "Must be one of: {options}",
   "FormError.InvalidValue": "Nieprawidłowa wartość",
   "FormError.max": "Wartość jest zbyt wysoka",
   "FormError.maxLength": "Wartość jest zbyt długa",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -1551,6 +1551,7 @@
   "form.processing": "processando",
   "Form.yourEmail": "Seu endereço de e-mail",
   "Form.yourPassword": "Sua senha",
+  "FormError.enum": "Must be one of: {options}",
   "FormError.InvalidValue": "Valor inválido",
   "FormError.max": "O valor é muito alto",
   "FormError.maxLength": "O valor é muito longo",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -1551,6 +1551,7 @@
   "form.processing": "processando",
   "Form.yourEmail": "Your email address",
   "Form.yourPassword": "Your password",
+  "FormError.enum": "Must be one of: {options}",
   "FormError.InvalidValue": "Valor inválido",
   "FormError.max": "O valor é muito grande",
   "FormError.maxLength": "O valor é muito longo",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1551,6 +1551,7 @@
   "form.processing": "обрабатываем",
   "Form.yourEmail": "Ваш адрес электронной почты",
   "Form.yourPassword": "Ваш пароль",
+  "FormError.enum": "Must be one of: {options}",
   "FormError.InvalidValue": "Неверное значение",
   "FormError.max": "Значение слишком большое",
   "FormError.maxLength": "Значение слишком длинное",

--- a/lang/sk-SK.json
+++ b/lang/sk-SK.json
@@ -1551,6 +1551,7 @@
   "form.processing": "spracováva sa",
   "Form.yourEmail": "Vaša e-mailová adresa",
   "Form.yourPassword": "Your password",
+  "FormError.enum": "Must be one of: {options}",
   "FormError.InvalidValue": "Neplatná hodnota",
   "FormError.max": "Hodnota je príliš vysoká",
   "FormError.maxLength": "Hodnota je príliš dlhá",

--- a/lang/sv-SE.json
+++ b/lang/sv-SE.json
@@ -1551,6 +1551,7 @@
   "form.processing": "under bearbetning",
   "Form.yourEmail": "Din e-postadress",
   "Form.yourPassword": "Ditt lösenord",
+  "FormError.enum": "Must be one of: {options}",
   "FormError.InvalidValue": "Ogiltigt värde",
   "FormError.max": "Värdet är för högt",
   "FormError.maxLength": "Värdet är för långt",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -1551,6 +1551,7 @@
   "form.processing": "обробка",
   "Form.yourEmail": "Ваша адреса електронної пошти",
   "Form.yourPassword": "Ваш пароль",
+  "FormError.enum": "Must be one of: {options}",
   "FormError.InvalidValue": "Хибне значення",
   "FormError.max": "Значення зависоке",
   "FormError.maxLength": "Значення задовге",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -1551,6 +1551,7 @@
   "form.processing": "处理中",
   "Form.yourEmail": "你的电子邮箱地址",
   "Form.yourPassword": "你的密码",
+  "FormError.enum": "Must be one of: {options}",
   "FormError.InvalidValue": "无效的值",
   "FormError.max": "数值过高",
   "FormError.maxLength": "数值过长",

--- a/lib/form-utils.ts
+++ b/lib/form-utils.ts
@@ -4,7 +4,7 @@ import { isEmail, isURL } from 'validator';
 
 import { createError, ERROR, formatErrorMessage } from './errors';
 
-const messages = defineMessages({
+export const RICH_ERROR_MESSAGES = defineMessages({
   minLength: {
     id: 'FormError.minLengthRich',
     defaultMessage: 'Please use more than {count} characters',
@@ -15,6 +15,18 @@ const messages = defineMessages({
   },
   notInRange: {
     defaultMessage: 'Value must be between {min} and {max}',
+  },
+  format: {
+    id: 'FormError.pattern',
+    defaultMessage: 'This value is not formatted properly',
+  },
+  enum: {
+    id: 'FormError.enum',
+    defaultMessage: 'Must be one of: {options}',
+  },
+  invalidValue: {
+    id: 'FormError.InvalidValue',
+    defaultMessage: 'Invalid value',
   },
 });
 
@@ -55,10 +67,10 @@ export const verifyFieldLength = (intl, errors, data, field, min, max) => {
   if (!errors[field]) {
     const length = get(data, field)?.length || 0;
     if (length < min) {
-      const message = intl.formatMessage(messages.minLength, { count: min });
+      const message = intl.formatMessage(RICH_ERROR_MESSAGES.minLength, { count: min });
       set(errors, field, createError(ERROR.FORM_FIELD_MIN_LENGTH, { message, hasI18nMessage: true }));
     } else if (length > max) {
-      const message = intl.formatMessage(messages.maxLength, { count: max });
+      const message = intl.formatMessage(RICH_ERROR_MESSAGES.maxLength, { count: max });
       set(errors, field, createError(ERROR.FORM_FIELD_MAX_LENGTH, { message, hasI18nMessage: true }));
     }
   }
@@ -71,7 +83,10 @@ export const verifyValueInRange = (intl, errors, data, field, min, max, multipli
 
   // Ignore if there's already an error on the field
   if (!errors[field] && (value < min || value > max)) {
-    const message = intl.formatMessage(messages.notInRange, { min: min * multiplier, max: max * multiplier });
+    const message = intl.formatMessage(RICH_ERROR_MESSAGES.notInRange, {
+      min: min * multiplier,
+      max: max * multiplier,
+    });
     set(errors, field, createError(ERROR.FORM_FIELD_VALUE_NOT_IN_RANGE, { message, hasI18nMessage: true }));
   }
 
@@ -111,12 +126,3 @@ export const verifyURLPattern = (errors, data, field) => {
 export const formatFormErrorMessage = (intl, error) => {
   return formatErrorMessage(intl, error, ERROR.FORM_FIELD_INVALID_VALUE);
 };
-
-/*
-export const onPressEnter = callback => e => {
-  if (e.key === 'Enter') {
-    e.preventDefault();
-    callback();
-  }
-};
-*/

--- a/test/snapshot-helpers.js
+++ b/test/snapshot-helpers.js
@@ -22,6 +22,25 @@ export const snapshot = (component, providersParams = {}) => {
 };
 
 /**
+ * Same as `snapshot` but removes all `className` from the tree
+ */
+export const snapshotWithoutClassNames = (component, providersParams = {}) => {
+  const componentWithProviders = withRequiredProviders(component, providersParams);
+  const tree = renderer.create(componentWithProviders).toJSON();
+  const removeClassName = node => {
+    if (node.props && node.props.className) {
+      delete node.props.className;
+    }
+    if (node.children) {
+      node.children.forEach(removeClassName);
+    }
+  };
+
+  removeClassName(tree);
+  return expect(tree).toMatchSnapshot();
+};
+
+/**
  * @deprecated Use `snapshot`
  * Same as `snapshot` but wraps component in a IntlProvider
  */


### PR DESCRIPTION
Extracted and completed from https://github.com/opencollective/opencollective-frontend/pull/10054

# Example with `<Formik>`

```jsx
const schema = zod.object({
  age: z.number().min(2).max(100);
});

/*
* The validate function, `type`,`min`/`max`/`required` attributes on the input will all be auto-generated.
*/
const MyForm = () => (
  <FormikZod schema={schema}>
    {() => (
      <Form>
        <StyledInputFormikField name="age" label="Age" />
      </Form>
    )}
  </FormikZod>
);
```

# Example with `useFormik`

I'm advocating not to use this helper as it is discouraged in [the official docs](https://formik.org/docs/api/useFormik). If you want to use this approach anyway, you can still use `useFormikZod` to plug validations:

```jsx
const schema = zod.object({
  age: z.number().min(2).max(100);
});

const MyForm = () => {
  const formik = useFormikZod({ schema });
  return (
    <form>
      <label htmlFor="ageInput">Name</label>
      <StyledInputField 
        id="ageInput"
        value={formik.values.age}
        onChange={e => formik.setValue('age', e.target.value)}
        {...getInputAttributesFromZodSchema(schema, "age")} // Will set type=number, name=age, required, min and max
      />
    </form>
  );
}
```