### PR TITLE
Fix crash on Collective Overview/Spent page

### DIFF
--- a/components/dashboard/sections/overview/CollectiveOverview.tsx
+++ b/components/dashboard/sections/overview/CollectiveOverview.tsx
@@ -163,7 +163,7 @@ export function CollectiveOverview({ accountSlug }: DashboardSectionProps) {
           <Filterbar hideSeparator {...queryFilter} />
 
           <Metric {...metric} loading={loading} expanded showTimeSeries showCurrencyCode>
-            <AccountTable queryFilter={queryFilter} accountSlug={accountSlug} metric={metric} />
+            <AccountTable queryFilter={queryFilter} accountSlug={router.query?.as ?? accountSlug} metric={metric} />
           </Metric>
         </div>
       );

--- a/components/dashboard/sections/overview/Metric.tsx
+++ b/components/dashboard/sections/overview/Metric.tsx
@@ -86,14 +86,14 @@ export function Metric({
   return (
     <Comp
       className={clsx(
-        'group flex flex-col gap-1  rounded-xl border transition-all',
+        'group flex flex-col gap-1 rounded-xl border transition-all',
         isButton &&
           'cursor-pointer text-left ring-ring ring-offset-2 hover:shadow-lg focus:outline-none focus-visible:ring-2',
         className,
       )}
       {...(isButton && { onClick: props.onClick })}
     >
-      <div className="space-y-1 p-3">
+      <div className="w-full space-y-1 p-3">
         <div>
           {label && (
             <div className="flex items-center gap-1">

--- a/components/dashboard/sections/overview/queries.ts
+++ b/components/dashboard/sections/overview/queries.ts
@@ -197,7 +197,7 @@ export const metricsPerAccountQuery = gql`
     }
     spent: stats @include(if: $includeSpent) {
       id
-      current: totalAmountSpent(dateFrom: $dateFrom, dateTo: $dateTo, net: true) @include(if: $includeComparison) {
+      current: totalAmountSpent(dateFrom: $dateFrom, dateTo: $dateTo, net: true) {
         currency
         valueInCents
       }
@@ -209,7 +209,7 @@ export const metricsPerAccountQuery = gql`
     }
     received: stats @include(if: $includeReceived) {
       id
-      current: totalAmountReceived(dateFrom: $dateFrom, dateTo: $dateTo, net: true) @include(if: $includeReceived) {
+      current: totalAmountReceived(dateFrom: $dateFrom, dateTo: $dateTo, net: true) {
         currency
         valueInCents
       }


### PR DESCRIPTION
- Fix error/crash on "Spent" page. The query was not fetching the expected results when not including a comparison (due to incorrect `@include` directive)
- Drive-by:
  - Fixes loading Skeleton to be the correct width inside the Metric box
  - Make sure to use impersonation `?as=` query variable for metric detail pages.
