### PR TITLE
Update View All expenses to direct to transactions page

### DIFF
--- a/components/collective-page/sections/Budget/ExpenseBudget.js
+++ b/components/collective-page/sections/Budget/ExpenseBudget.js
@@ -231,7 +231,7 @@ const ExpenseBudget = ({ collective, defaultTimeInterval, ...props }) => {
         </React.Fragment>
       )}
       <P mt={3} textAlign="right">
-        <Link href={`${getCollectivePageRoute(collective)}/expenses`} data-cy="view-all-expenses-link">
+        <Link href={`${getCollectivePageRoute(collective)}/transactions?kind=EXPENSE`} data-cy="view-all-expenses-link">
           <FormattedMessage id="CollectivePage.SectionBudget.ViewAllExpenses" defaultMessage="View all expenses" />{' '}
           &rarr;
         </Link>


### PR DESCRIPTION
This is the expected behavior since we're displaying stats based on the transaction's created date and not necessarily when the expense was created.