### PR TITLE
Add background to next root

### DIFF
--- a/public/static/styles/app.css
+++ b/public/static/styles/app.css
@@ -177,6 +177,9 @@
       'rlig' 1,
       'calt' 1;
   }
+  #__next {
+    @apply bg-background;
+  }
 }
 
 html {


### PR DESCRIPTION
This aims to fix an issue with extensions like Dark Reader where the background color is not unified when scrolling:

![image](https://github.com/opencollective/opencollective-frontend/assets/1556356/026cb407-d874-4c87-944b-06213e25c130)

