### PR TITLE
Fix(CollectiveOverview): Don't show balance if account is not active

### DIFF
--- a/components/dashboard/queries.ts
+++ b/components/dashboard/queries.ts
@@ -13,6 +13,7 @@ export const adminPanelQuery = gql`
       type
       settings
       isArchived
+      isActive
       isIncognito
       imageUrl(height: 256)
       pendingExpenses: expenses(status: PENDING, direction: RECEIVED, includeChildrenExpenses: true, limit: 0) {

--- a/components/dashboard/sections/overview/CollectiveOverview.tsx
+++ b/components/dashboard/sections/overview/CollectiveOverview.tsx
@@ -83,9 +83,9 @@ export function CollectiveOverview({ accountSlug }: DashboardSectionProps) {
           default:
             return {
               includeReceived: true,
-              includeBalance: true,
+              includeBalance: account.isActive, // only showing Balance if account is active
               includeSpent: true,
-              includeBalanceTimeseries: true,
+              includeBalanceTimeseries: account.isActive, // only showing Balance if account is active
               includeContributionsCount: true,
               includeReceivedTimeseries: true,
             };
@@ -127,6 +127,7 @@ export function CollectiveOverview({ accountSlug }: DashboardSectionProps) {
       showCurrencyCode: true,
       isSnapshot: true,
       showTimeSeries: true,
+      hide: !account.isActive,
     },
     {
       id: 'received',
@@ -146,6 +147,7 @@ export function CollectiveOverview({ accountSlug }: DashboardSectionProps) {
       id: 'contributions',
       label: <FormattedMessage id="Contributions" defaultMessage="Contributions" />,
       count: data?.account.contributionsCount,
+      hide: !account.isActive,
     },
   ];
 
@@ -235,14 +237,16 @@ export function CollectiveOverview({ accountSlug }: DashboardSectionProps) {
         <Filterbar hideSeparator {...queryFilter} />
 
         <div className="grid grid-flow-dense grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-1 lg:grid-cols-3  ">
-          {metrics.map(metric => (
-            <Metric
-              key={metric.id}
-              {...metric}
-              loading={loading}
-              onClick={() => queryFilter.setFilter('subpath', metric.id)}
-            />
-          ))}
+          {metrics
+            .filter(metric => !metric.hide)
+            .map(metric => (
+              <Metric
+                key={metric.id}
+                {...metric}
+                loading={loading}
+                onClick={() => queryFilter.setFilter('subpath', metric.id)}
+              />
+            ))}
         </div>
       </div>
 
@@ -253,7 +257,7 @@ export function CollectiveOverview({ accountSlug }: DashboardSectionProps) {
           <TodoList />
           <Timeline accountSlug={router.query?.as ?? accountSlug} />
         </div>
-        {!account.parent && (
+        {!account.parent && account.isActive && (
           <div className="-order-1 space-y-6 lg:order-none">
             <Accounts accountSlug={router.query?.as ?? accountSlug} />
           </div>

--- a/components/dashboard/sections/overview/Metric.tsx
+++ b/components/dashboard/sections/overview/Metric.tsx
@@ -46,6 +46,7 @@ interface BaseMetricProps {
   expanded?: boolean;
   currency?: Currency;
   isSnapshot?: boolean;
+  hide?: boolean;
 }
 
 type MetricDivProps = BaseMetricProps & Omit<React.ComponentPropsWithoutRef<'div'>, 'onClick'>;

--- a/components/dashboard/sections/overview/queries.ts
+++ b/components/dashboard/sections/overview/queries.ts
@@ -261,6 +261,7 @@ export const overviewMetricsQuery = gql`
   ) {
     account(slug: $slug) {
       id
+      isActive
       ...AccountHoverCardFields
       balance: stats @include(if: $includeBalance) {
         id


### PR DESCRIPTION
Fix to not show balance (or the Accounts list with projects and events with balances) in the Collective Overview if the account is not active.

Also hiding the contributions count and the accounts list (projects/events and their balances) when account is not active.