### PR TITLE
Fix(HostDashboardReports): Include children in host balance

### DIFF
--- a/components/dashboard/sections/reports/HostDashboardReports.tsx
+++ b/components/dashboard/sections/reports/HostDashboardReports.tsx
@@ -56,7 +56,7 @@ const hostReportPageQuery = gql`
       settings
       stats {
         id
-        balance(dateTo: $dateTo) {
+        balance(dateTo: $dateTo, includeChildren: true) {
           valueInCents
           currency
         }


### PR DESCRIPTION
As https://github.com/opencollective/opencollective-api/pull/9906 changes the totalMoneyManaged stats resolver to include the host children balance, we should include children when getting the host balance in HostDashboardReports. 

This will update the host balance to be correct (including host events/projects), and maintain the (correct) number for "hosted collectives" balance, that is computed in the frontend as `totalMoneyManaged - hostBalance`