### PR TITLE
Update Apollo fetch policy to 'cache-and-network' in CollectiveOverview

### DIFF
--- a/components/dashboard/sections/overview/AccountTable.tsx
+++ b/components/dashboard/sections/overview/AccountTable.tsx
@@ -252,7 +252,7 @@ export default function AccountTable({ accountSlug, queryFilter, metric }) {
       slug: accountSlug,
     },
     context: API_V2_CONTEXT,
-    fetchPolicy: 'cache-first',
+    fetchPolicy: 'cache-and-network',
   });
   const { account } = React.useContext(DashboardContext);
   const nbPlaceholders = account?.childrenAccounts?.nodes.length + 1;

--- a/components/dashboard/sections/overview/Accounts.tsx
+++ b/components/dashboard/sections/overview/Accounts.tsx
@@ -70,7 +70,7 @@ export function Accounts({ accountSlug }) {
   const { data, loading, error } = useQuery(collectiveBalanceQuery, {
     variables: { slug: accountSlug },
     context: API_V2_CONTEXT,
-    fetchPolicy: 'cache-first',
+    fetchPolicy: 'cache-and-network',
   });
 
   const activeChildAccounts = data?.account.childrenAccounts?.nodes.filter(child => !child.isArchived);

--- a/components/dashboard/sections/overview/CollectiveOverview.tsx
+++ b/components/dashboard/sections/overview/CollectiveOverview.tsx
@@ -108,7 +108,7 @@ export function CollectiveOverview({ accountSlug }: DashboardSectionProps) {
       ...queryFilter.variables,
       ...(account.parent && { includeChildren: false }),
     },
-    fetchPolicy: 'cache-first',
+    fetchPolicy: 'cache-and-network',
     context: API_V2_CONTEXT,
   });
 


### PR DESCRIPTION
Updating the Apollo fetch policy in CollectiveOverview from 'cache-first' to 'cache-and-network' to make sure we always show fresh results (but using what is available in the Apollo cache first)