### PR TITLE
Fix "View transactions" crash in new report

### DIFF
--- a/components/dashboard/sections/reports/preview/helpers.ts
+++ b/components/dashboard/sections/reports/preview/helpers.ts
@@ -1,4 +1,4 @@
-import { pick } from 'lodash';
+import { isNil, pick } from 'lodash';
 
 import dayjs from '../../../../../lib/dayjs';
 
@@ -22,7 +22,9 @@ export const filterToTransactionsQuery = (hostSlug, groupFilter: GroupFilter, qu
     ...(groupFilter.expenseType && {
       expenseType: groupFilter.expenseType,
     }),
-    isRefund: groupFilter.isRefund,
+    ...(!isNil(groupFilter.isRefund) && {
+      isRefund: groupFilter.isRefund,
+    }),
     'date[gte]': dayjs.utc(queryFilterValues.period.gt).format('YYYY-MM-DD'),
     'date[lte]': dayjs.utc(queryFilterValues.period.lt).format('YYYY-MM-DD'),
     'date[tz]': 'UTC',


### PR DESCRIPTION
Bug reported on Slack where the transactions page crashes from an empty "isRefund" filter.

Small fix on the new Host Reports end to make sure we don't pass along an empty "isRefund" filter to the transactions page.

Will add another followup issue to filters to not crash when filters are unexpected, I thought we already were covered from that but needs another look