### PR TITLE
Dashboard/Contributions: recurring contributions filter

### DIFF
--- a/components/dashboard/sections/contributions/Contributions.tsx
+++ b/components/dashboard/sections/contributions/Contributions.tsx
@@ -73,7 +73,7 @@ const dashboardContributionsMetadataQuery = gql`
       ALL: orders(filter: $filter) {
         totalCount
       }
-      RECURRING: orders(filter: $filter, onlyActiveSubscriptions: true, includeIncognito: true) {
+      RECURRING: orders(filter: $filter, onlySubscriptions: true, includeIncognito: true) {
         totalCount
       }
       ONETIME: orders(filter: $filter, frequency: ONETIME, status: [PAID], includeIncognito: true, minAmount: 1) {
@@ -98,7 +98,7 @@ const dashboardContributionsQuery = gql`
     $filter: AccountOrdersFilter!
     $frequency: ContributionFrequency
     $status: [OrderStatus!]
-    $onlyActiveSubscriptions: Boolean
+    $onlySubscriptions: Boolean
     $includeIncognito: Boolean
     $minAmount: Int
     $maxAmount: Int
@@ -110,7 +110,7 @@ const dashboardContributionsQuery = gql`
         filter: $filter
         frequency: $frequency
         status: $status
-        onlyActiveSubscriptions: $onlyActiveSubscriptions
+        onlySubscriptions: $onlySubscriptions
         includeIncognito: $includeIncognito
         minAmount: $minAmount
         maxAmount: $maxAmount


### PR DESCRIPTION
[The flag](https://github.com/opencollective/opencollective-frontend/blob/88ed3aa0008b213e99229ba999426ae2df0f93ae/components/dashboard/sections/contributions/filters.tsx#L68) we were setting in the filters was not used in the query, resulting in all errors being showed in the Recurring tab (including one-time contributions errors).
