### PR TITLE
Fix exporting transactions from new host reports

### DIFF
--- a/components/dashboard/ExportTransactionsCSVModal.tsx
+++ b/components/dashboard/ExportTransactionsCSVModal.tsx
@@ -101,6 +101,18 @@ const makeUrl = ({ account, isHostReport, queryFilter, flattenTaxesAndPaymentPro
     }
   }
 
+  if (!isNil(queryFilter.values.isRefund)) {
+    url.searchParams.set('isRefund', queryFilter.values.isRefund ? '1' : '0');
+  }
+
+  if (queryFilter.values.orderId) {
+    url.searchParams.set('orderId', queryFilter.values.orderId);
+  }
+
+  if (queryFilter.values.expenseId) {
+    url.searchParams.set('expenseId', queryFilter.values.expenseId);
+  }
+
   if (flattenTaxesAndPaymentProcessorFees) {
     url.searchParams.set('flattenPaymentProcessorFee', '1');
     url.searchParams.set('flattenTax', '1');

--- a/components/dashboard/sections/reports/preview/HostTransactionReport.tsx
+++ b/components/dashboard/sections/reports/preview/HostTransactionReport.tsx
@@ -25,7 +25,10 @@ import { DashboardContext } from '../../../DashboardContext';
 import DashboardHeader from '../../../DashboardHeader';
 import ExportTransactionsCSVModal from '../../../ExportTransactionsCSVModal';
 import { DashboardSectionProps } from '../../../types';
-import { schema as hostTransactionsSchema } from '../../transactions/HostTransactions';
+import {
+  schema as hostTransactionsSchema,
+  toVariables as hostTransactionsToVariables,
+} from '../../transactions/HostTransactions';
 
 import { buildReport } from './report-builder/build-report';
 import { DefinitionTooltip } from './DefinitionTooltip';
@@ -78,6 +81,7 @@ const HostTransactionReport = ({ accountSlug: hostSlug, subpath }: DashboardSect
   // Query filter for the export transactions modal and for linking to the host transactions page with filters applied
   const hostTransactionsQueryFilter = useQueryFilter({
     schema: hostTransactionsSchema,
+    toVariables: hostTransactionsToVariables,
     filters: {},
     skipRouter: true, // we don't want to update the URL (already done by the main query filter)
   });

--- a/components/dashboard/sections/transactions/HostTransactions.tsx
+++ b/components/dashboard/sections/transactions/HostTransactions.tsx
@@ -49,7 +49,7 @@ type FilterMeta = CommonFilterMeta & {
 
 // Only needed when values and key of filters are different
 // to expected key and value of QueryVariables
-const toVariables: FiltersToVariables<FilterValues, TransactionsTableQueryVariables, FilterMeta> = {
+export const toVariables: FiltersToVariables<FilterValues, TransactionsTableQueryVariables, FilterMeta> = {
   ...commonToVariables,
   account: hostedAccountFilter.toVariables,
   excludeHost: excludeHost => ({ includeHost: !excludeHost }),

--- a/components/dashboard/sections/transactions/filters.tsx
+++ b/components/dashboard/sections/transactions/filters.tsx
@@ -41,7 +41,7 @@ export const schema = z.object({
   virtualCard: isMulti(z.string()).optional(),
   expenseType: isMulti(z.nativeEnum(ExpenseType)).optional(),
   expenseId: integer.optional(),
-  contributionId: integer.optional(),
+  orderId: integer.optional(),
   openTransactionId: z.string().optional(),
   group: z.string().optional(),
   isRefund: boolean.optional(),
@@ -63,7 +63,7 @@ export const toVariables: FiltersToVariables<FilterValues, TransactionsTableQuer
   amount: amountFilter.toVariables,
   virtualCard: (virtualCardIds, key) => ({ [key]: virtualCardIds.map(id => ({ id })) }),
   expenseId: id => ({ expense: { legacyId: id } }),
-  contributionId: id => ({ order: { legacyId: id } }),
+  orderId: id => ({ order: { legacyId: id } }),
 };
 
 // The filters config is used to populate the Filters component.
@@ -141,7 +141,7 @@ export const filters: FilterComponentConfigs<FilterValues, FilterMeta> = {
     ),
     valueRenderer: ({ value, intl }) => i18nExpenseType(intl, value),
   },
-  contributionId: {
+  orderId: {
     labelMsg: defineMessage({ defaultMessage: 'Contribution ID' }),
     Component: ({ value, onChange }) => {
       return (


### PR DESCRIPTION
Fix for exporting transactions from the new host reports (`toVariables` object was missing).

Also making sure to include the newly added filters in the variables to the REST API: https://github.com/opencollective/opencollective-rest/pull/548