### PR TITLE
Fix(HostTransactionReport): Fix formatting bug for non-defined groups

### DIFF
--- a/components/dashboard/sections/reports/preview/report-builder/build-report.ts
+++ b/components/dashboard/sections/reports/preview/report-builder/build-report.ts
@@ -58,9 +58,13 @@ export const buildReport = (
 
   // Add the remaining result groups not matched by the defined groups
   const remainderRows = remainingNodes.map(group => ({
-    label: JSON.stringify(pick(group, 'kind', 'type', 'expenseType', 'isRefund')),
     section: ReportSection.OTHER,
-    amount: group.netAmount.valueInCents,
+    amount: group.amount.valueInCents,
+    netAmount: group.netAmount.valueInCents,
+    platformFee: group.platformFee.valueInCents,
+    paymentProcessorFee: group.paymentProcessorFee.valueInCents,
+    hostFee: group.hostFee.valueInCents,
+    taxAmount: group.taxAmount.valueInCents,
     filter: pick(group, 'kind', 'type', 'expenseType', 'isRefund', 'isHost'),
     groups: [group],
   }));


### PR DESCRIPTION
### Description
Uses the "computational" label renderer for non-defined groups in the predefined groups layout, and fixes a bug with the legacy column adapter

### Screenshots

| Before | After |
| ------ | ----- |
|  ![image](https://github.com/opencollective/opencollective-frontend/assets/1552194/579aa045-793f-431b-aee9-f140e5709e77)   |  <img width="1056" alt="image" src="https://github.com/opencollective/opencollective-frontend/assets/1552194/8e45644d-ef01-4029-be28-43997aa27fbf">   |
