### PR TITLE
Update react-pdf and remove pdfjs-dist as dependency

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -21,7 +21,11 @@ const nextConfig = {
   },
   experimental: {
     outputFileTracingExcludes: {
-      '*': ['node_modules/@swc/core-linux-x64-gnu', 'node_modules/@swc/core-linux-x64-musl'],
+      '*': [
+        'node_modules/@swc/core-linux-x64-gnu',
+        'node_modules/@swc/core-linux-x64-musl',
+        'node_modules/canvas/build', // https://github.com/wojtekmaj/react-pdf/issues/1504#issuecomment-2007090872
+      ],
     },
     outputFileTracingIncludes: {
       '/_document': ['./.next/language-manifest.json'],
@@ -29,6 +33,7 @@ const nextConfig = {
   },
   webpack: (config, { webpack, isServer, dev }) => {
     config.resolve.alias['@sentry/replay'] = false;
+    config.resolve.alias['canvas'] = false; // https://github.com/wojtekmaj/react-pdf?tab=readme-ov-file#nextjs
 
     config.plugins.push(
       // Ignore __tests__
@@ -79,6 +84,7 @@ const nextConfig = {
       new CopyPlugin({
         patterns: [
           {
+            // eslint-disable-next-line node/no-extraneous-require
             from: path.join(path.dirname(require.resolve('pdfjs-dist/package.json')), 'cmaps'),
             to: path.join(__dirname, 'public/static/cmaps'),
           },
@@ -93,6 +99,7 @@ const nextConfig = {
       new CopyPlugin({
         patterns: [
           {
+            // eslint-disable-next-line node/no-extraneous-require
             from: require.resolve('pdfjs-dist/build/pdf.worker.min.js'),
             to: path.join(__dirname, 'public/static/scripts'),
           },

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,6 @@
         "next": "14.2.0",
         "node-fetch": "2.7.0",
         "nprogress": "0.2.0",
-        "pdfjs-dist": "3.6.172",
         "polished": "4.3.1",
         "prop-types": "15.8.1",
         "qrcode.react": "3.1.0",
@@ -110,7 +109,7 @@
         "react-intl": "6.6.5",
         "react-is": "18.2.0",
         "react-password-strength-bar": "0.4.1",
-        "react-pdf": "7.3.3",
+        "react-pdf": "7.7.1",
         "react-popper": "2.3.0",
         "react-scrollchor": "7.0.2",
         "react-select": "5.8.0",
@@ -6584,9 +6583,9 @@
       }
     },
     "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "optional": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -18288,7 +18287,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -27774,9 +27772,9 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
-      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
+      "integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==",
       "optional": true
     },
     "node_modules/nanoid": {
@@ -29612,6 +29610,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path2d-polyfill/-/path2d-polyfill-2.0.1.tgz",
       "integrity": "sha512-ad/3bsalbbWhmBo0D6FZ4RNMwsLsPpL6gnvhuSaU5Vm7b06Kr5ubSltQQ0T7YKsiJQO+g22zJ4dJKNTXIyOXtA==",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -29661,18 +29660,15 @@
       }
     },
     "node_modules/pdfjs-dist": {
-      "version": "3.6.172",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.6.172.tgz",
-      "integrity": "sha512-bfOhCg+S9DXh/ImWhWYTOiq3aVMFSCvzGiBzsIJtdMC71kVWDBw7UXr32xh0y56qc5wMVylIeqV3hBaRsu+e+w==",
-      "dependencies": {
-        "path2d-polyfill": "^2.0.1",
-        "web-streams-polyfill": "^3.2.1"
-      },
+      "version": "3.11.174",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.11.174.tgz",
+      "integrity": "sha512-TdTZPf1trZ8/UFu5Cx/GXB7GZM30LT+wWUNfsi6Bq8ePLnb+woNKtDymI2mxZYBpMbonNFqKmiz684DIfnd8dA==",
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "canvas": "^2.11.2"
+        "canvas": "^2.11.2",
+        "path2d-polyfill": "^2.0.1"
       }
     },
     "node_modules/peek-stream": {
@@ -31137,18 +31133,19 @@
       }
     },
     "node_modules/react-pdf": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-7.3.3.tgz",
-      "integrity": "sha512-d7WAxcsjOogJfJ+I+zX/mdip3VjR1yq/yDa4hax4XbQVjbbbup6rqs4c8MGx0MLSnzob17TKp1t4CsNbDZ6GeQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-7.7.1.tgz",
+      "integrity": "sha512-cbbf/PuRtGcPPw+HLhMI1f6NSka8OJgg+j/yPWTe95Owf0fK6gmVY7OXpTxMeh92O3T3K3EzfE0ML0eXPGwR5g==",
       "dependencies": {
         "clsx": "^2.0.0",
+        "dequal": "^2.0.3",
         "make-cancellable-promise": "^1.3.1",
         "make-event-props": "^1.6.0",
         "merge-refs": "^1.2.1",
-        "pdfjs-dist": "3.6.172",
+        "pdfjs-dist": "3.11.174",
         "prop-types": "^15.6.2",
         "tiny-invariant": "^1.0.0",
-        "tiny-warning": "^1.0.0"
+        "warning": "^4.0.0"
       },
       "funding": {
         "url": "https://github.com/wojtekmaj/react-pdf?sponsor=1"
@@ -35738,6 +35735,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
       "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "next": "14.2.0",
     "node-fetch": "2.7.0",
     "nprogress": "0.2.0",
-    "pdfjs-dist": "3.6.172",
     "polished": "4.3.1",
     "prop-types": "15.8.1",
     "qrcode.react": "3.1.0",
@@ -114,7 +113,7 @@
     "react-intl": "6.6.5",
     "react-is": "18.2.0",
     "react-password-strength-bar": "0.4.1",
-    "react-pdf": "7.3.3",
+    "react-pdf": "7.7.1",
     "react-popper": "2.3.0",
     "react-scrollchor": "7.0.2",
     "react-select": "5.8.0",
@@ -334,7 +333,8 @@
       "esbuild",
       "postcss",
       "prettier-plugin-tailwindcss",
-      "styled-jsx"
+      "styled-jsx",
+      "pdfjs-dist"
     ]
   }
 }


### PR DESCRIPTION
Updates `react-pdf` to latest version and removes `pdfjs-dist` as tracked dependency (already imported by react-pdf) to avoid any future mismatch between the libraries.