### PR TITLE
Adding .envrc to allow use of envrc to configure local runtime variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .next
 .env
 .env.*
+.envrc
 node_modules
 npm-debug.log.*
 ./report.*.json


### PR DESCRIPTION
Using [direnv](https://direnv.net/) to manage local runtime variables that need to be set before node runs (e.g. before .env.development runs)
```
export NODE_OPTIONS=--max_old_space_size=8192
```