### PR TITLE
fix(PDFViewer): Import pdfjs-dist worker in recommended way

### DIFF
--- a/components/PDFViewer.tsx
+++ b/components/PDFViewer.tsx
@@ -9,7 +9,7 @@ import Container from './Container';
 import { getI18nLink } from './I18nFormatters';
 import Loading from './Loading';
 
-pdfjs.GlobalWorkerOptions.workerSrc = '/static/scripts/pdf.worker.min.js';
+pdfjs.GlobalWorkerOptions.workerSrc = new URL('pdfjs-dist/build/pdf.worker.min.js', import.meta.url).toString();
 
 const DocumentContainer = styled.div`
   .pdf-page {

--- a/next.config.js
+++ b/next.config.js
@@ -93,21 +93,6 @@ const nextConfig = {
       }),
     );
 
-    // Copy pdfjs worker to public folder (used by PDFViewer component)
-    // (Workaround for working with react-pdf and CommonJS - if moving to ESM this can be removed)
-    // TODO(ESM): Move this to standard ESM
-    config.plugins.push(
-      new CopyPlugin({
-        patterns: [
-          {
-            // eslint-disable-next-line node/no-extraneous-require
-            from: require.resolve('pdfjs-dist/build/pdf.worker.min.js'),
-            to: path.join(__dirname, 'public/static/scripts'),
-          },
-        ],
-      }),
-    );
-
     // generates a manifest of languages and the respective webpack chunk url
     config.plugins.push(
       new WebpackManifestPlugin({


### PR DESCRIPTION
Fix for issue reported on Slack: https://opencollective.slack.com/archives/C0429NTTABF/p1713182303518359

# Description

The current approach of copying the pdf-worker to the static folder caused version mismatch issues from the caching policy that are on the files in the `/public/static` directory (86400 seconds).

Updating to the  [recommended approach to import the pdf worker from `react-pdf`](https://github.com/wojtekmaj/react-pdf?tab=readme-ov-file#import-worker-recommended) (`import.meta.url` didn't work previously but seems to work fine now)
