### PR TITLE
Fix filter pagination bug when opening drawer

### DIFF
--- a/components/dashboard/sections/transactions/AccountTransactions.tsx
+++ b/components/dashboard/sections/transactions/AccountTransactions.tsx
@@ -106,7 +106,7 @@ const AccountTransactions = ({ accountSlug }: DashboardSectionProps) => {
             nbPlaceholders={20}
             onClickRow={row => {
               setTransactionInDrawer(row);
-              queryFilter.setFilter('openTransactionId', row.id);
+              queryFilter.setFilter('openTransactionId', row.id, false);
             }}
             queryFilter={queryFilter}
           />
@@ -128,7 +128,7 @@ const AccountTransactions = ({ accountSlug }: DashboardSectionProps) => {
         resetFilters={queryFilter.resetFilters}
         setOpen={open => {
           if (!open) {
-            queryFilter.setFilter('openTransactionId', undefined);
+            queryFilter.setFilter('openTransactionId', undefined, false);
           }
         }}
         transactionId={queryFilter.values.openTransactionId}

--- a/components/dashboard/sections/transactions/HostTransactions.tsx
+++ b/components/dashboard/sections/transactions/HostTransactions.tsx
@@ -192,7 +192,7 @@ const HostTransactions = ({ accountSlug: hostSlug }: DashboardSectionProps) => {
             nbPlaceholders={20}
             onClickRow={row => {
               setTransactionInDrawer(row);
-              queryFilter.setFilter('openTransactionId', row.id);
+              queryFilter.setFilter('openTransactionId', row.id, false);
             }}
             queryFilter={queryFilter}
             useAltTestLayout={layout === TestLayout.DEBITCREDIT}
@@ -215,7 +215,7 @@ const HostTransactions = ({ accountSlug: hostSlug }: DashboardSectionProps) => {
         resetFilters={queryFilter.resetFilters}
         setOpen={open => {
           if (!open) {
-            queryFilter.setFilter('openTransactionId', undefined);
+            queryFilter.setFilter('openTransactionId', undefined, false);
           }
         }}
         transactionId={queryFilter.values.openTransactionId}

--- a/lib/filters/filter-types.ts
+++ b/lib/filters/filter-types.ts
@@ -38,7 +38,7 @@ type DropdownFilter<FilterValue, Meta> = {
   valueRenderer?: ValueRenderer<FilterValue, Meta>;
 };
 
-export type SetFilter<FV> = <K extends keyof FV>(filter: K, value: FV[K]) => void;
+export type SetFilter<FV> = <K extends keyof FV>(filter: K, value: FV[K], resetPagination?: boolean) => void;
 export type SetFilters<FV> = (filters: Partial<FV>, newPath?: string) => void;
 export type resetFilters<FV> = (filters: Partial<FV>, newPath?: string) => void;
 

--- a/lib/hooks/useQueryFilter.ts
+++ b/lib/hooks/useQueryFilter.ts
@@ -154,7 +154,8 @@ export default function useQueryFilter<S extends z.ZodObject<z.ZodRawShape, any,
   );
 
   const setFilter = React.useCallback(
-    (filterName, filterValue) => resetFilters({ ...omit(values, 'offset'), [filterName]: filterValue }),
+    (filterName, filterValue, resetPagination = true) =>
+      resetFilters({ ...(resetPagination ? omit(values, 'offset') : values), [filterName]: filterValue }),
     [values, resetFilters],
   );
 


### PR DESCRIPTION
Follow up fix from https://github.com/opencollective/opencollective-frontend/pull/10326 that introduced a bug when using the queryFilter hook to store the open transaction ID in the query, causing the pagination to reset when opening the drawer.