### PR TITLE
Add Modal provider and Hook to allow programmatic control of modals

### DIFF
--- a/components/ConfirmationModal.js
+++ b/components/ConfirmationModal.js
@@ -1,3 +1,5 @@
+// @deprecated: Use `NewConfirmationModal` instead
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import { defineMessages, useIntl } from 'react-intl';

--- a/components/ModalContext.tsx
+++ b/components/ModalContext.tsx
@@ -1,0 +1,185 @@
+import React, { createContext, useContext, useReducer } from 'react';
+
+import ConfirmationModal, { ConfirmationModalProps } from './NewConfirmationModal';
+
+export interface BaseModalProps {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  onCloseFocusRef?: React.MutableRefObject<any>;
+}
+
+type ShowModalReturnType = {
+  id: string;
+  closeModal: () => void;
+};
+
+interface ModalContextValues {
+  showModal: <P extends BaseModalProps>(
+    component: React.ComponentType<P>,
+    modalProps?: Omit<P, 'open' | 'setOpen'>,
+    id?: string,
+  ) => ShowModalReturnType;
+  showConfirmationModal: (
+    modalProps: Omit<ConfirmationModalProps, 'open' | 'setOpen'>,
+    id?: string,
+  ) => ShowModalReturnType;
+  hideModal: (id: string) => void;
+  modals: BaseModal[];
+}
+
+type BaseModal = {
+  id: string;
+  type: ModalType;
+  open: boolean;
+  component?: React.FC<any>;
+  modalProps?: any;
+};
+
+let count = 0;
+
+function genId() {
+  count = (count + 1) % Number.MAX_VALUE;
+  return count.toString();
+}
+
+const ModalContext = createContext<ModalContextValues>({
+  modals: [],
+  showModal: () => undefined,
+  showConfirmationModal: () => undefined,
+  hideModal: () => undefined,
+});
+
+const { Provider } = ModalContext;
+
+type BaseModalAction = {
+  type: 'openModal' | 'hideModal';
+  payload: {
+    id: string;
+  };
+};
+
+enum ModalType {
+  COMPONENT = 'COMPONENT',
+  CONFIRMATION = 'CONFIRMATION',
+}
+
+type OpenModalAction = BaseModalAction & {
+  type: 'openModal';
+  payload: {
+    id: string;
+    type: ModalType;
+    component?: React.FC<any>;
+    modalProps?: unknown;
+  };
+};
+
+type HideModalAction = BaseModalAction & {
+  type: 'hideModal';
+  payload: {
+    id: string;
+  };
+};
+
+type ModalAction = OpenModalAction | HideModalAction;
+
+const findModalIndex = (modals: BaseModal[], id: string) => modals.findIndex(m => m.id === id);
+
+const reducer = (state: ModalContextValues, action: ModalAction) => {
+  const index = findModalIndex(state.modals, action.payload.id);
+  switch (action.type) {
+    case 'openModal':
+      if (index > -1) {
+        const updatedModals = [...state.modals];
+        updatedModals[index] = {
+          ...updatedModals[index],
+          ...action.payload,
+          open: true,
+        };
+
+        return { ...state, modals: updatedModals };
+      } else {
+        return {
+          ...state,
+          modals: [...state.modals, { open: true, ...action.payload }],
+        };
+      }
+
+    case 'hideModal':
+      return {
+        ...state,
+        modals: state.modals.map(m => ({
+          ...m,
+          open: m.id === action.payload.id ? false : m.open,
+        })),
+      };
+    default:
+      throw new Error('Unspecified reducer action');
+  }
+};
+
+export type CloseComponentType = React.ComponentType<{
+  onClick: React.MouseEventHandler<any>;
+}>;
+
+export type ContentComponentType = React.ComponentType<{
+  className?: string;
+  children: React.ReactNode;
+}>;
+
+const ModalRoot = () => {
+  const { modals, hideModal } = useModal();
+  return modals.map(({ component: Component, modalProps, type, id, open }) => {
+    if (type === ModalType.CONFIRMATION) {
+      return (
+        <ConfirmationModal key={id} {...modalProps} open={open} setOpen={open => (!open ? hideModal(id) : null)} />
+      );
+    }
+    return (
+      <Component
+        key={id}
+        {...modalProps}
+        open={open}
+        setOpen={open => {
+          if (!open) {
+            hideModal(id);
+            modalProps.onClose?.();
+          }
+        }}
+      />
+    );
+  });
+};
+
+const ModalProvider = ({ children }) => {
+  const initialState = {
+    modals: [],
+    showModal: (component, modalProps = {}, modalId) => {
+      const id = modalId || genId();
+      dispatch({ type: 'openModal', payload: { id, component, type: ModalType.COMPONENT, modalProps } });
+      return { id, closeModal: () => dispatch({ type: 'hideModal', payload: { id } }) };
+    },
+    showConfirmationModal: (modalProps = {}, modalId) => {
+      const id = modalId || genId();
+      dispatch({ type: 'openModal', payload: { id, type: ModalType.CONFIRMATION, modalProps } });
+      return { id, closeModal: () => dispatch({ type: 'hideModal', payload: { id } }) };
+    },
+    hideModal: id => {
+      dispatch({ type: 'hideModal', payload: { id } });
+    },
+  };
+
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  return (
+    <Provider value={state}>
+      <ModalRoot />
+      {children}
+    </Provider>
+  );
+};
+
+const useModal = () => useContext(ModalContext);
+
+// ignore unused exports
+
+export { ModalProvider, useModal };

--- a/components/NewConfirmationModal.tsx
+++ b/components/NewConfirmationModal.tsx
@@ -1,0 +1,119 @@
+// TODO: Replace uses of `components/ConfirmationModal.js` with this file
+
+import React from 'react';
+import { LucideIcon } from 'lucide-react';
+import { defineMessages, useIntl } from 'react-intl';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from './ui/AlertDialog';
+import { toast } from './ui/useToast';
+import type { BaseModalProps } from './ModalContext';
+
+const messages = defineMessages({
+  cancel: {
+    id: 'actions.cancel',
+    defaultMessage: 'Cancel',
+  },
+});
+
+const confirmBtnMsgs = defineMessages({
+  confirm: {
+    id: 'confirm',
+    defaultMessage: 'Confirm',
+  },
+  delete: {
+    id: 'actions.delete',
+    defaultMessage: 'Delete',
+  },
+  remove: {
+    id: 'Remove',
+    defaultMessage: 'Remove',
+  },
+});
+
+export interface ConfirmationModalProps extends BaseModalProps {
+  title: string;
+  description?: React.ReactNode;
+  children?: React.ReactNode;
+  variant?: 'default' | 'destructive';
+  type?: 'confirm' | 'delete' | 'remove';
+  onConfirm: () => void | Promise<any>;
+  confirmLabel?: React.ReactNode;
+  ConfirmIcon?: LucideIcon;
+  onCancel?: () => void;
+  cancelLabel?: React.ReactNode;
+}
+
+const ConfirmationModal = ({
+  title,
+  description,
+  children,
+  open,
+  setOpen,
+  variant = 'default',
+  type = 'confirm',
+  cancelLabel,
+  confirmLabel,
+  ConfirmIcon,
+  onCancel,
+  onConfirm,
+  onCloseFocusRef,
+  ...props
+}: ConfirmationModalProps) => {
+  const [submitting, setSubmitting] = React.useState(false);
+  const { formatMessage } = useIntl();
+  const handleClose = () => setOpen(false);
+
+  const onCloseAutoFocus = e => {
+    if (onCloseFocusRef.current) {
+      e.preventDefault();
+      onCloseFocusRef.current.focus();
+    }
+  };
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen} {...props}>
+      <AlertDialogContent onCloseAutoFocus={onCloseAutoFocus} {...props}>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          {description && <AlertDialogDescription>{description}</AlertDialogDescription>}
+        </AlertDialogHeader>
+        {children && <div className="text-sm text-muted-foreground">{children}</div>}
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={submitting} onClick={onCancel} autoFocus data-cy="confirmation-modal-cancel">
+            {cancelLabel || formatMessage(messages.cancel)}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            variant={variant}
+            loading={submitting}
+            data-cy="confirmation-modal-continue"
+            onClick={async e => {
+              e.preventDefault();
+              try {
+                setSubmitting(true);
+                await onConfirm();
+                handleClose();
+              } catch (error) {
+                toast({ variant: 'error', message: error.message });
+              } finally {
+                setSubmitting(false);
+              }
+            }}
+          >
+            {ConfirmIcon && <ConfirmIcon size={16} />}
+            {confirmLabel || formatMessage(confirmBtnMsgs[type])}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+
+export default ConfirmationModal;

--- a/components/ui/AlertDialog.tsx
+++ b/components/ui/AlertDialog.tsx
@@ -5,7 +5,7 @@ import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
 
 import { cn } from '../../lib/utils';
 
-import { buttonVariants } from './Button';
+import { Button, ButtonProps, buttonVariants } from './Button';
 
 const AlertDialog = AlertDialogPrimitive.Root;
 
@@ -76,9 +76,11 @@ AlertDialogDescription.displayName = AlertDialogPrimitive.Description.displayNam
 
 const AlertDialogAction = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Action>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
->(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Action ref={ref} className={cn(buttonVariants(), className)} {...props} />
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action> & ButtonProps
+>((props, ref) => (
+  <AlertDialogPrimitive.Action ref={ref} asChild>
+    <Button {...props} />
+  </AlertDialogPrimitive.Action>
 ));
 AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -44,6 +44,7 @@ import sentryLib from '../server/sentry';
 
 import GlobalNewsAndUpdates from '../components/GlobalNewsAndUpdates';
 import IntlProvider from '../components/intl/IntlProvider';
+import { ModalProvider } from '../components/ModalContext';
 import NewsAndUpdatesProvider from '../components/NewsAndUpdatesProvider';
 import { TooltipProvider } from '../components/ui/Tooltip';
 
@@ -137,12 +138,14 @@ class OpenCollectiveFrontendApp extends App {
               <IntlProvider locale={locale}>
                 <TooltipProvider delayDuration={500} skipDelayDuration={100}>
                   <UserProvider>
-                    <NewsAndUpdatesProvider>
-                      <Component {...pageProps} />
-                      <Toaster />
-                      <GlobalNewsAndUpdates />
-                      <TwoFactorAuthenticationModal />
-                    </NewsAndUpdatesProvider>
+                    <ModalProvider>
+                      <NewsAndUpdatesProvider>
+                        <Component {...pageProps} />
+                        <Toaster />
+                        <GlobalNewsAndUpdates />
+                        <TwoFactorAuthenticationModal />
+                      </NewsAndUpdatesProvider>
+                    </ModalProvider>
                   </UserProvider>
                 </TooltipProvider>
               </IntlProvider>


### PR DESCRIPTION
# Description

Modal provider and `useModal` hook to provide a way to open modals programmatically, including a special function to open confirmation modals by only supplying props.