### PR TITLE
Fix showing amount filter value when there is no currency provided

### DIFF
--- a/components/dashboard/filters/AmountFilter/AmountFilterValue.tsx
+++ b/components/dashboard/filters/AmountFilter/AmountFilterValue.tsx
@@ -8,7 +8,10 @@ import FormattedMoneyAmount from '../../../FormattedMoneyAmount';
 import type { AmountFilterValueType } from './schema';
 import { AmountFilterType } from './schema';
 
-const Amount = ({ amount, currency }: { amount: number; currency: Currency }) => {
+const Amount = ({ amount, currency }: { amount: number; currency?: Currency }) => {
+  if (!currency) {
+    return amount ? amount / 100 : '';
+  }
   return (
     <FormattedMoneyAmount
       amount={amount}


### PR DESCRIPTION
On the root admin dashboard, we don't provide a currency to the amount filter. This is a small fix to instead just display the number without currency.
