### PR TITLE
Display total expense amount without fees

### DIFF
--- a/components/expenses/PayExpenseModal.tsx
+++ b/components/expenses/PayExpenseModal.tsx
@@ -285,6 +285,11 @@ const getInitialValues = (expense, host) => {
 };
 
 const calculateAmounts = ({ values, expense, quote, host, feesPayer }) => {
+  const expenseAmountInHostCurrency = {
+    valueInCents: values.expenseAmountInHostCurrency,
+    currency: host.currency,
+  };
+
   if (values.forceManual) {
     const totalAmount = {
       valueInCents: values.expenseAmountInHostCurrency + (values.paymentProcessorFeeInHostCurrency || 0),
@@ -292,10 +297,6 @@ const calculateAmounts = ({ values, expense, quote, host, feesPayer }) => {
     };
     const paymentProcessorFee = {
       valueInCents: values.paymentProcessorFeeInHostCurrency,
-      currency: host.currency,
-    };
-    const expenseAmountInHostCurrency = {
-      valueInCents: values.expenseAmountInHostCurrency,
       currency: host.currency,
     };
     const grossAmount = totalAmount.valueInCents - (paymentProcessorFee.valueInCents || 0);
@@ -318,7 +319,7 @@ const calculateAmounts = ({ values, expense, quote, host, feesPayer }) => {
       expenseAmountInHostCurrency,
     };
   } else {
-    return {};
+    return { expenseAmountInHostCurrency, totalAmount: expenseAmountInHostCurrency, paymentProcessorFee: null };
   }
 };
 


### PR DESCRIPTION
In my previous refactor of this screen when implementing custom reference for Wise, I accidentally broke the amount values for PayPal expenses. This is the fix.

Preview:
![image](https://github.com/opencollective/opencollective-frontend/assets/2119706/3f5ed109-e1b8-46c4-877a-5a134d042212)
