### PR TITLE
Add Platform Admin option to dynamic topbar account switcher

### DIFF
--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { themeGet } from '@styled-system/theme-get';
-import { Calendar, TestTube2 } from 'lucide-react';
+import { Calendar, TestTube2, UserCog } from 'lucide-react';
 import styled from 'styled-components';
 import type { BorderProps } from 'styled-system';
 import { border, color, layout, space } from 'styled-system';
@@ -18,6 +18,7 @@ const getInitials = name => name.split(' ').reduce((result, value) => (result +=
 const COLLECTIVE_TYPE_ICON = {
   [CollectiveType.EVENT]: Calendar,
   [CollectiveType.PROJECT]: TestTube2,
+  ROOT: UserCog,
 };
 
 type StyledAvatarProps = FlexProps &
@@ -79,6 +80,9 @@ const Avatar = ({
   ...styleProps
 }) => {
   let child = children;
+  if (collective?.type === 'ROOT') {
+    useIcon = true;
+  }
   // Use collective object instead of props
   if (collective) {
     type = collective.type;

--- a/components/dashboard/Menu.tsx
+++ b/components/dashboard/Menu.tsx
@@ -65,6 +65,7 @@ const ROOT_MENU = [
   {
     section: ALL_SECTIONS.ACTIVITY_LOG,
     Icon: ScrollText,
+    label: <FormattedMessage id="t0lUqz" defaultMessage="Activity log" />,
   },
 ];
 

--- a/components/dashboard/constants.ts
+++ b/components/dashboard/constants.ts
@@ -1,7 +1,7 @@
 import { defineMessages } from 'react-intl';
 
 export const ROOT_PROFILE_KEY = 'root-actions';
-export const ROOT_PROFILE_ACCOUNT = { slug: ROOT_PROFILE_KEY, type: 'ROOT', name: 'Profile Admin' };
+export const ROOT_PROFILE_ACCOUNT = { slug: ROOT_PROFILE_KEY, type: 'ROOT', name: 'Platform Admin' };
 
 export const SECTIONS = {
   OVERVIEW: 'overview',

--- a/components/dashboard/preview/AccountSwitcher.tsx
+++ b/components/dashboard/preview/AccountSwitcher.tsx
@@ -3,7 +3,7 @@ import { PopoverAnchor } from '@radix-ui/react-popover';
 import { cx } from 'class-variance-authority';
 import clsx from 'clsx';
 import { useCommandState } from 'cmdk';
-import { flatten, groupBy, uniqBy } from 'lodash';
+import { compact, flatten, groupBy, uniqBy } from 'lodash';
 import { Check, ChevronsUpDown, PlusCircle, Star } from 'lucide-react';
 import memoizeOne from 'memoize-one';
 // eslint-disable-next-line no-restricted-imports -- components/Link does not currently accept a ref, whichis required when used 'asChild' of Button
@@ -25,6 +25,7 @@ import { Button } from '../../ui/Button';
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '../../ui/Command';
 import { Popover, PopoverContent, PopoverTrigger } from '../../ui/Popover';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../ui/Tooltip';
+import { ROOT_PROFILE_ACCOUNT } from '../constants';
 
 const CREATE_NEW_BUTTONS = {
   [CollectiveType.COLLECTIVE]: {
@@ -219,7 +220,7 @@ const AccountsCommand = ({
 
 const getGroupedAdministratedAccounts = memoizeOne(loggedInUser => {
   let administratedAccounts =
-    loggedInUser?.memberOf.filter(m => m.role === 'ADMIN' && !m.collective.isIncognito).map(m => m.collective) || [];
+    loggedInUser.memberOf.filter(m => m.role === 'ADMIN' && !m.collective.isIncognito).map(m => m.collective) || [];
 
   // Filter out accounts if the user is also an admin of the parent of that account (since we already show the parent)
   const childAccountIds = flatten(administratedAccounts.map(a => a.children)).map((a: { id: number }) => a.id);
@@ -231,7 +232,7 @@ const getGroupedAdministratedAccounts = memoizeOne(loggedInUser => {
   const activeAccounts = administratedAccounts.filter(a => !a.isArchived);
 
   const groupedAccounts = {
-    [CollectiveType.INDIVIDUAL]: [loggedInUser.collective],
+    [CollectiveType.INDIVIDUAL]: compact([loggedInUser.collective, loggedInUser.isRoot && ROOT_PROFILE_ACCOUNT]),
     [CollectiveType.ORGANIZATION]: [],
     [CollectiveType.COLLECTIVE]: [],
     ...groupBy(activeAccounts, a => a.type),


### PR DESCRIPTION
Preview:
![image](https://github.com/opencollective/opencollective-frontend/assets/2119706/410df1dd-e6af-43b5-b2cd-6005e5be3d53)
