### PR TITLE
fix(Footer): broken internal links

### DIFF
--- a/components/navigation/Footer.tsx
+++ b/components/navigation/Footer.tsx
@@ -159,9 +159,7 @@ const Footer = () => {
                   !LoggedInUser || (LoggedInUser && !(item.href === '/create-account' || item.href === '/signin')) ? (
                     <li className="text-muted-foreground hover:text-foreground" key={item.href}>
                       {item.href[0] === '/' ? (
-                        <Link href={item.href} passHref legacyBehavior>
-                          {item.label}
-                        </Link>
+                        <Link href={item.href}>{item.label}</Link>
                       ) : (
                         <a href={item.href}>
                           {item.label} <ExternalLink className="inline-block" size={12} />


### PR DESCRIPTION
Fix https://github.com/opencollective/opencollective/issues/7449

Since there's no `<a>` as a child, `passHref legacyBehavior` are not needed.

Looks like a conflict between the release of https://github.com/opencollective/opencollective-frontend/pull/8995 and https://github.com/opencollective/opencollective-frontend/pull/9315.