### PR TITLE
feat(actions): Add quick primary actions on hover

### DIFF
--- a/components/table/RowActionsMenu.tsx
+++ b/components/table/RowActionsMenu.tsx
@@ -12,6 +12,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '../ui/DropdownMenu';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/Tooltip';
 
 export function DropdownActionItem({ action }) {
   return (
@@ -50,40 +51,70 @@ export function RowActionsMenu<TData>({ row, actionsMenuTriggerRef, table }: Row
   };
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild ref={actionsMenuTriggerRef}>
-        <Button
-          size="icon-xs"
-          variant="outline"
-          className="border-transparent text-muted-foreground hover:bg-white hover:text-foreground hover:shadow-sm group-hover/row:border-border data-[state=open]:border-border data-[state=open]:text-foreground"
-        >
-          <MoreHorizontal size={18} />
-        </Button>
-      </DropdownMenuTrigger>
+    <div className="">
+      {primary?.length > 0 && (
+        <div className="absolute right-[2.625rem] flex items-center gap-0.5 opacity-0 transition-opacity group-hover/row:opacity-100">
+          {primary.map(action => (
+            <Tooltip delayDuration={200} key={action.key}>
+              <TooltipTrigger asChild>
+                <Button
+                  key={action.key}
+                  variant="outline"
+                  // variant={action.variant || 'outline'}
+                  size="icon-xs"
+                  className="border-transparent text-muted-foreground hover:bg-white hover:text-foreground hover:shadow-sm group-hover/row:border-border data-[state=open]:border-border data-[state=open]:text-foreground"
+                  onClick={action.onClick}
+                  disabled={action.disabled}
+                  data-cy={action['data-cy']}
+                >
+                  {action.Icon && <action.Icon size={16} />}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{action.label}</TooltipContent>
+            </Tooltip>
+          ))}
+        </div>
+      )}
+      <DropdownMenu>
+        <Tooltip delayDuration={200}>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild ref={actionsMenuTriggerRef}>
+              <Button
+                size="icon-xs"
+                variant="outline"
+                className="border-transparent text-muted-foreground hover:bg-white hover:text-foreground hover:shadow-sm group-hover/row:border-border data-[state=open]:border-border data-[state=open]:text-foreground"
+              >
+                <MoreHorizontal size={18} />
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>More</TooltipContent>
+        </Tooltip>
 
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem onClick={() => openDetails()} className="gap-2.5">
-          <PanelRightOpen className="text-muted-foreground" size={16} />
-          <FormattedMessage defaultMessage="Open details" id="iIXH4W" />
-        </DropdownMenuItem>
-        {primary?.length > 0 && (
-          <React.Fragment>
-            <DropdownMenuSeparator />
-            {primary.map(action => (
-              <DropdownActionItem key={action.key} action={action} />
-            ))}
-          </React.Fragment>
-        )}
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={() => openDetails()} className="gap-2.5">
+            <PanelRightOpen className="text-muted-foreground" size={16} />
+            <FormattedMessage defaultMessage="Open details" id="iIXH4W" />
+          </DropdownMenuItem>
+          {primary?.length > 0 && (
+            <React.Fragment>
+              <DropdownMenuSeparator />
+              {primary.map(action => (
+                <DropdownActionItem key={action.key} action={action} />
+              ))}
+            </React.Fragment>
+          )}
 
-        {secondary?.length > 0 && (
-          <React.Fragment>
-            <DropdownMenuSeparator />
-            {secondary.map(action => {
-              return <DropdownActionItem key={action.key} action={action} />;
-            })}
-          </React.Fragment>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+          {secondary?.length > 0 && (
+            <React.Fragment>
+              <DropdownMenuSeparator />
+              {secondary.map(action => {
+                return <DropdownActionItem key={action.key} action={action} />;
+              })}
+            </React.Fragment>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 }


### PR DESCRIPTION
# Description
Adds the primary actions as quick actions on hover

# Todo
- [ ] Add configure option to set whether to show quick actions or not
- [ ] Improve styling of button overlays (use button group similar to what Stripe does?)

# Screenshots

<img width="738" alt="image" src="https://github.com/opencollective/opencollective-frontend/assets/1552194/c292d734-6ec3-4a2d-9dd4-ca16db05e80f">

