### PR TITLE
fix(HostedCollective): Activity description

### DIFF
--- a/components/dashboard/sections/collectives/queries.ts
+++ b/components/dashboard/sections/collectives/queries.ts
@@ -376,6 +376,12 @@ export const hostedCollectiveDetailQuery = gql`
           name
           imageUrl
         }
+        host {
+          id
+          name
+          slug
+          type
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes missing host name in messages:
![image](https://github.com/user-attachments/assets/30ed64ac-9dc3-44c9-be20-f0ac5272f8ef)
