### PR TITLE
Fix passwords E2E test to skip timeline rendering

### DIFF
--- a/test/cypress/integration/07-password.test.js
+++ b/test/cypress/integration/07-password.test.js
@@ -5,6 +5,7 @@ describe('passwords', () => {
 
   before(() => {
     cy.signup({ user: { name: 'Mr Bungle' } }).then(u => (user = u));
+    cy.logout();
   });
 
   it('can be set from the settings page', () => {
@@ -147,7 +148,7 @@ describe('passwords', () => {
     cy.enableTwoFactorAuth({ userEmail: user.email, userSlug: user.collective.slug, secret: secret.base32 });
 
     // Sign-in flow
-    cy.visit(`/signin`);
+    cy.visit(`/signin?next=/dashboard/${user.collective.slug}/info`);
     cy.get('input[name="email"]').type(user.email);
     cy.getByDataCy('signin-btn').click();
     cy.get('input[name="password"]:visible').type('strongNewP@ssword<>?');


### PR DESCRIPTION
The idea here is to try to make this test run faster so we don't end up with invalid TOTP tokens.