### PR TITLE
Remove fixed widths from modals

### DIFF
--- a/components/ApplyToHostModal.js
+++ b/components/ApplyToHostModal.js
@@ -276,7 +276,7 @@ const ApplyToHostModal = ({ hostSlug, collective, onClose, onSuccess, router, ..
   }, [useTwoSteps]);
 
   return (
-    <StyledModal onClose={onClose} width="570px" {...props}>
+    <StyledModal onClose={onClose} {...props}>
       {loading ? (
         <React.Fragment>
           <ModalHeader hideCloseIcon>

--- a/components/ContactCollectiveModal.js
+++ b/components/ContactCollectiveModal.js
@@ -9,7 +9,7 @@ import { H2 } from './Text';
 const ContactCollectiveModal = ({ collective, onClose }) => {
   const [hasData, setHasData] = React.useState(false);
   return (
-    <StyledModal role="alertdialog" width="578px" onClose={onClose} hasUnsavedChanges={hasData}>
+    <StyledModal role="alertdialog" onClose={onClose} hasUnsavedChanges={hasData}>
       <ModalHeader>
         <H2 mb={2} fontSize={'28px'}>
           <FormattedMessage

--- a/components/ContributionConfirmationModal.tsx
+++ b/components/ContributionConfirmationModal.tsx
@@ -11,7 +11,7 @@ const ContributionConfirmationModal = ({ order, onClose, onSuccess }) => {
   const [submitting, setSubmitting] = useState(false);
 
   return (
-    <StyledModal width="578px" onClose={onClose}>
+    <StyledModal onClose={onClose}>
       <CollectiveModalHeader
         collective={order.toAccount}
         customText={

--- a/components/agreements/AddAgreementModal.tsx
+++ b/components/agreements/AddAgreementModal.tsx
@@ -20,7 +20,7 @@ export default function AddAgreementModal({
   ...props
 }: AddAgreementModalProps) {
   return (
-    <StyledModal width={578} onClose={onClose} trapFocus {...props}>
+    <StyledModal onClose={onClose} trapFocus {...props}>
       <ModalBody>
         <AgreementForm
           account={account}

--- a/components/agreements/AgreementForm.tsx
+++ b/components/agreements/AgreementForm.tsx
@@ -84,8 +84,8 @@ const EDIT_AGREEMENT_MUTATION = gql`
   ${AGREEMENT_MUTATION_FIELDS_FRAGMENT}
 `;
 
-const ActionButtons = ({ formik, onCancel }) => (
-  <Flex justifyContent="flex-end" width="100%">
+const ActionButtons = ({ formik, onCancel, ...props }) => (
+  <Flex justifyContent="flex-end" width="100%" {...props}>
     <StyledButton type="button" minWidth={120} mr={2} onClick={onCancel}>
       <FormattedMessage id="actions.cancel" defaultMessage="Cancel" />
     </StyledButton>
@@ -273,7 +273,7 @@ const AgreementForm = ({
               {drawerActionsContainer && !disableDrawerActions ? (
                 createPortal(<ActionButtons formik={formik} onCancel={onCancel} />, drawerActionsContainer)
               ) : (
-                <ActionButtons formik={formik} onCancel={onCancel} />
+                <ActionButtons formik={formik} onCancel={onCancel} mt={3} />
               )}
             </Form>
           );

--- a/components/contribution-flow/WhyPlatformTipModal.tsx
+++ b/components/contribution-flow/WhyPlatformTipModal.tsx
@@ -11,7 +11,7 @@ type WhyPlatformTipModalProps = {
 };
 export function WhyPlatformTipModal(props: WhyPlatformTipModalProps) {
   return (
-    <StyledModal width="490px" onClose={props.onClose}>
+    <StyledModal onClose={props.onClose}>
       <ModalHeader>
         <Flex alignItems="center" gap="12px" mr="20px">
           <Image alt="Open Collective" src="/static/images/opencollective-icon.png" width={64} height={64} />

--- a/components/dashboard/sections/Vendors.tsx
+++ b/components/dashboard/sections/Vendors.tsx
@@ -407,7 +407,7 @@ const Vendors = ({ accountSlug }: DashboardSectionProps) => {
       </div>
 
       {createEditVendor === true && (
-        <StyledModal onClose={closeDrawer} width="570px">
+        <StyledModal onClose={closeDrawer}>
           <VendorForm
             host={host}
             supportsTaxForm={host.requiredLegalDocuments.includes('US_TAX_FORM')}

--- a/components/dashboard/sections/collectives/ApplicationMessageModal.js
+++ b/components/dashboard/sections/collectives/ApplicationMessageModal.js
@@ -21,7 +21,7 @@ const ApplicationMessageModal = ({ collective, onClose, onConfirm, ...modalProps
   const setMessage = useCallback(_setMessage, [_setMessage]);
 
   return (
-    <StyledModal onClose={onClose} width="576px" {...modalProps} trapFocus>
+    <StyledModal onClose={onClose} {...modalProps} trapFocus>
       <ModalHeader hideCloseIcon>
         <Flex justifyContent="space-between" flexDirection={['column', 'row']} width="100%">
           <Flex>

--- a/components/dashboard/sections/collectives/ApplicationRejectionReasonModal.js
+++ b/components/dashboard/sections/collectives/ApplicationRejectionReasonModal.js
@@ -29,7 +29,7 @@ const ApplicationRejectionReasonModal = ({ collective, onClose, onConfirm, ...mo
   const totalAdminCount = collective.admins?.totalCount || admins.length;
 
   return (
-    <StyledModal onClose={onClose} width="576px" {...modalProps}>
+    <StyledModal onClose={onClose} {...modalProps}>
       <ModalHeader hideCloseIcon>
         <Flex justifyContent="space-between" flexDirection={['column', 'row']} width="100%">
           <Flex>

--- a/components/edit-collective/AssignVirtualCardModal.js
+++ b/components/edit-collective/AssignVirtualCardModal.js
@@ -190,7 +190,7 @@ const AssignVirtualCardModal = ({ collective = undefined, host, onSuccess, onClo
   const collectiveUsers = users?.account?.members.nodes.map(node => node.account);
 
   return (
-    <StyledModal width="382px" onClose={handleClose} trapFocus {...modalProps}>
+    <StyledModal onClose={handleClose} trapFocus {...modalProps}>
       <form onSubmit={formik.handleSubmit}>
         <ModalHeader onClose={handleClose}>
           <FormattedMessage id="Host.VirtualCards.AssignCard" defaultMessage="Assign Card" />

--- a/components/edit-collective/DeleteVirtualCardModal.js
+++ b/components/edit-collective/DeleteVirtualCardModal.js
@@ -6,10 +6,9 @@ import { FormattedMessage } from 'react-intl';
 
 import { API_V2_CONTEXT, gql } from '../../lib/graphql/helpers';
 
-import Container from '../Container';
-import StyledButton from '../StyledButton';
 import StyledModal, { ModalBody, ModalFooter, ModalHeader } from '../StyledModal';
 import { P } from '../Text';
+import { Button } from '../ui/Button';
 import { useToast } from '../ui/useToast';
 
 const deleteVirtualCardMutation = gql`
@@ -67,7 +66,7 @@ const DeleteVirtualCardModal = ({ virtualCard, onSuccess, onClose, onDeleteRefet
   };
 
   return (
-    <StyledModal width="382px" onClose={handleClose} trapFocus {...modalProps}>
+    <StyledModal onClose={handleClose} maxWidth={450} trapFocus {...modalProps}>
       <form onSubmit={formik.handleSubmit}>
         <ModalHeader onClose={handleClose}>
           <FormattedMessage defaultMessage="Delete virtual card" id="7nrRJ/" />
@@ -81,19 +80,20 @@ const DeleteVirtualCardModal = ({ virtualCard, onSuccess, onClose, onDeleteRefet
           </P>
         </ModalBody>
         <ModalFooter isFullWidth>
-          <Container display="flex" justifyContent={['center', 'flex-end']} flexWrap="Wrap">
-            <StyledButton
-              my={1}
-              minWidth={140}
-              buttonStyle="primary"
+          <div className="flex flex-wrap justify-end gap-2">
+            <Button className="min-w-36" variant="outline" onClick={handleClose} type="button">
+              <FormattedMessage defaultMessage="Cancel" id="actions.cancel" />
+            </Button>
+            <Button
+              variant="destructive"
+              className="min-w-36"
               data-cy="confirmation-modal-continue"
               loading={isBusy}
               type="submit"
-              textTransform="capitalize"
             >
               <FormattedMessage id="actions.delete" defaultMessage="Delete" />
-            </StyledButton>
-          </Container>
+            </Button>
+          </div>
         </ModalFooter>
       </form>
     </StyledModal>

--- a/components/edit-collective/EditVirtualCardModal.tsx
+++ b/components/edit-collective/EditVirtualCardModal.tsx
@@ -337,7 +337,7 @@ export default function EditVirtualCardModal({
   const collectiveUsers = users?.account?.members.nodes.map(node => node.account);
 
   return (
-    <StyledModal width="420px" onClose={handleClose} trapFocus {...modalProps}>
+    <StyledModal onClose={handleClose} trapFocus {...modalProps}>
       <form onSubmit={formik.handleSubmit}>
         <ModalHeader onClose={handleClose} hideCloseIcon={false}>
           {isEditing ? (

--- a/components/edit-collective/LeaveHostModal.tsx
+++ b/components/edit-collective/LeaveHostModal.tsx
@@ -102,7 +102,7 @@ export const LeaveHostModal = ({ account, host, onClose }) => {
   const [removeHost, { loading: submitting }] = useMutation(leaveHostMutation, { context: API_V2_CONTEXT });
   const portabilitySummary = getPortabilitySummary(data?.account);
   return (
-    <StyledModal width="570px" onClose={onClose}>
+    <StyledModal onClose={onClose}>
       <ModalHeader onClose={onClose} mb={3}>
         <FormattedMessage id="collective.editHost.leave" values={{ name: host.name }} defaultMessage="Leave {name}" />
       </ModalHeader>

--- a/components/edit-collective/RequestVirtualCardModal.js
+++ b/components/edit-collective/RequestVirtualCardModal.js
@@ -115,7 +115,7 @@ const RequestVirtualCardModal = props => {
   const currency = props.host?.currency || props.collective?.currency;
 
   return (
-    <StyledModal width="382px" onClose={handleClose} trapFocus {...props}>
+    <StyledModal onClose={handleClose} trapFocus {...props}>
       <form onSubmit={formik.handleSubmit}>
         <ModalHeader onClose={props.onClose}>
           <FormattedMessage id="Collective.VirtualCards.RequestCard" defaultMessage="Request a Card" />

--- a/components/edit-collective/SendFundsToCollectiveSection.js
+++ b/components/edit-collective/SendFundsToCollectiveSection.js
@@ -46,7 +46,7 @@ const SendFundsToCollectiveSection = ({ collective, toCollective, LoggedInUser }
         </StyledButton>
       )}
       {modal.show && (
-        <StyledModal width="570px" onClose={closeModal}>
+        <StyledModal onClose={closeModal}>
           <ModalHeader onClose={closeModal}>
             <FormattedMessage
               id="collective.emptyBalance.header"

--- a/components/edit-collective/actions/Archive.js
+++ b/components/edit-collective/actions/Archive.js
@@ -174,7 +174,7 @@ const ArchiveCollective = ({ collective }) => {
       )}
 
       {modal.show && (
-        <StyledModal width="570px" onClose={closeModal}>
+        <StyledModal onClose={closeModal}>
           <ModalHeader onClose={closeModal}>
             {modal.type === 'Unarchive' ? (
               <FormattedMessage

--- a/components/edit-collective/actions/Delete.js
+++ b/components/edit-collective/actions/Delete.js
@@ -131,7 +131,7 @@ const DeleteCollective = ({ collective, ...props }) => {
           </P>
         )}
       {showModal && (
-        <StyledModal width="570px" onClose={closeModal}>
+        <StyledModal onClose={closeModal}>
           <ModalHeader onClose={closeModal}>
             <FormattedMessage
               id="collective.delete.modal.header"

--- a/components/edit-collective/sections/FiscalHosting.js
+++ b/components/edit-collective/sections/FiscalHosting.js
@@ -242,7 +242,7 @@ const FiscalHosting = ({ collective }) => {
       )}
 
       {activateAsHostModal.show && (
-        <StyledModal width="570px" onClose={closeActivateAsHost}>
+        <StyledModal onClose={closeActivateAsHost}>
           <ModalHeader onClose={closeActivateAsHost}>
             {activateAsHostModal.type === 'Activate' && (
               <FormattedMessage id="collective.activateAsHost" defaultMessage="Activate as Host" />
@@ -345,7 +345,7 @@ const FiscalHosting = ({ collective }) => {
       )}
 
       {activateBudgetModal.show && (
-        <StyledModal width="570px" onClose={closeActivateBudget}>
+        <StyledModal onClose={closeActivateBudget}>
           <ModalHeader onClose={closeActivateBudget}>
             {activateBudgetModal.type === 'Activate' && (
               <FormattedMessage id="FiscalHosting.budget.activate" defaultMessage="Activate Host Budget" />

--- a/components/edit-collective/sections/Host.js
+++ b/components/edit-collective/sections/Host.js
@@ -340,7 +340,7 @@ class Host extends React.Component {
             (action === 'Remove' ? (
               <LeaveHostModal account={collective} host={collective.host} onClose={closeModal} />
             ) : (
-              <StyledModal width="570px" onClose={closeModal}>
+              <StyledModal onClose={closeModal}>
                 <ModalHeader onClose={closeModal}>
                   <FormattedMessage
                     id="collective.editHost.header"

--- a/components/edit-collective/sections/fiscal-host/OCFDuplicateAndApplyToHostModal.tsx
+++ b/components/edit-collective/sections/fiscal-host/OCFDuplicateAndApplyToHostModal.tsx
@@ -270,7 +270,7 @@ const OCFDuplicateAndApplyToHostModal = ({ hostSlug, collective, onClose, onSucc
 
   const currentStep = STEPS[stepKey];
   return (
-    <StyledModal onClose={() => onClose(successResult)} width="570px" {...props}>
+    <StyledModal onClose={() => onClose(successResult)} {...props}>
       {loading ? (
         <React.Fragment>
           <ModalHeader hideCloseIcon>

--- a/components/edit-collective/sections/team/EditMemberModal.js
+++ b/components/edit-collective/sections/team/EditMemberModal.js
@@ -275,7 +275,7 @@ const EditMemberModal = ({ intl, member, collective, canRemove = false, isLastAd
 
   return (
     <Container>
-      <StyledModal width={688} onClose={cancelHandler}>
+      <StyledModal onClose={cancelHandler}>
         <ModalHeader>
           <FormattedMessage id="editTeam.member.edit" defaultMessage="Edit Team Member" />
         </ModalHeader>

--- a/components/edit-collective/sections/team/InviteMemberModal.js
+++ b/components/edit-collective/sections/team/InviteMemberModal.js
@@ -115,7 +115,7 @@ const InviteMemberModal = props => {
 
   return (
     <Container>
-      <StyledModal width={688} onClose={cancelHandler} trapFocus>
+      <StyledModal onClose={cancelHandler} trapFocus>
         <ModalHeader mb={4}>
           <FormattedMessage id="editTeam.member.invite" defaultMessage="Invite Team Member" />
         </ModalHeader>

--- a/components/expenses/ConfirmProcessExpenseModal.tsx
+++ b/components/expenses/ConfirmProcessExpenseModal.tsx
@@ -247,7 +247,7 @@ export default function ConfirmProcessExpenseModal({ type, onClose, expense }: C
   }, [type, message, intl, processExpense]);
 
   return (
-    <StyledModal role="alertdialog" width="432px" onClose={onClose} trapFocus>
+    <StyledModal role="alertdialog" onClose={onClose} trapFocus>
       <ModalHeader>{intl.formatMessage(MessagesPerType[type].title)}</ModalHeader>
       <ModalBody pt={2}>
         <P mb={3} color="black.700" lineHeight="20px">

--- a/components/expenses/ExpenseRecurringBanner.js
+++ b/components/expenses/ExpenseRecurringBanner.js
@@ -58,8 +58,10 @@ const ExpenseRecurringEditModal = ({ onClose, expense }) => {
   };
 
   return (
-    <StyledModal role="alertdialog" width="432px" onClose={onClose} padding="auto" px={4} py="20px" trapFocus>
-      <ModalHeader onClose={onClose}>Recurring Expense Setting</ModalHeader>
+    <StyledModal role="alertdialog" onClose={onClose} padding="auto" px={4} py="20px" trapFocus>
+      <ModalHeader onClose={onClose}>
+        <FormattedMessage defaultMessage="Recurring Expense Settings" id="L/TmUV" />
+      </ModalHeader>
       <ModalBody pt={2}>
         <Flex flexDirection={'column'}>
           <P color="black.700" fontWeight="400" fontSize="14px" lineHeight="20px" mt={0} mb={2}>

--- a/components/expenses/SecurityChecksModal.js
+++ b/components/expenses/SecurityChecksModal.js
@@ -118,7 +118,7 @@ const SecurityChecksModal = ({ expense, onClose, onConfirm, ...modalProps }) => 
   const [scope, setScope] = React.useState();
 
   return (
-    <StyledModal trapFocus onClose={onClose} width="680px" data-cy="security-check-modal" {...modalProps}>
+    <StyledModal trapFocus onClose={onClose} data-cy="security-check-modal" {...modalProps}>
       <ModalHeader onClose={onClose}>
         <Box>
           <H1 color="black.900" fontSize="20px" lineHeight="28px">

--- a/components/oauth/CreateOauthApplicationModal.js
+++ b/components/oauth/CreateOauthApplicationModal.js
@@ -47,7 +47,7 @@ const CreateOauthApplicationModal = ({ account, onSuccess, onClose, ...props }) 
   });
 
   return (
-    <StyledModal width="576px" onClose={onClose} data-cy="create-oauth-app-modal" {...props}>
+    <StyledModal onClose={onClose} data-cy="create-oauth-app-modal" {...props}>
       <ModalHeader>
         <FormattedMessage defaultMessage="Create OAuth app" id="m6BfW0" />
       </ModalHeader>

--- a/components/personal-token/CreatePersonalTokenModal.js
+++ b/components/personal-token/CreatePersonalTokenModal.js
@@ -55,7 +55,7 @@ const CreatePersonalTokenModal = ({ account, onSuccess, onClose, ...props }) => 
   });
 
   return (
-    <StyledModal width="576px" onClose={onClose} data-cy="create-personal-token-modal" {...props}>
+    <StyledModal onClose={onClose} data-cy="create-personal-token-modal" {...props}>
       <ModalHeader>
         <FormattedMessage defaultMessage="Create Personal token" id="MMyZfL" />
       </ModalHeader>

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -2279,6 +2279,7 @@
   "l+tve8": "{virtualCardProgramName} Visa® Commercial Credit cards are issued by Celtic Bank.",
   "l/JVrq": "The handle (URL identifier on the website) for the transaction opposite account.",
   "l/qt37": "The above text will override the customized message set by the parent Collective of this Event or Project.",
+  "L/TmUV": "Recurring Expense Settings",
   "L0xyX3": "Invalid file",
   "L0zynD": "Value must be greater than or equal to {min}",
   "l15EJO": "Allow expense submission on behalf of vendors by all users",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -2279,6 +2279,7 @@
   "l+tve8": "{virtualCardProgramName} Visa® Commercial Credit cards are issued by Celtic Bank.",
   "l/JVrq": "The handle (URL identifier on the website) for the transaction opposite account.",
   "l/qt37": "The above text will override the customized message set by the parent Collective of this Event or Project.",
+  "L/TmUV": "Recurring Expense Settings",
   "L0xyX3": "Invalid file",
   "L0zynD": "Value must be greater than or equal to {min}",
   "l15EJO": "Allow expense submission on behalf of vendors by all users",

--- a/lang/de.json
+++ b/lang/de.json
@@ -2279,6 +2279,7 @@
   "l+tve8": "{virtualCardProgramName} Kommerzielle Kreditkarten von Visa® werden von der Celtic Bank ausgestellt.",
   "l/JVrq": "The handle (URL identifier on the website) for the transaction opposite account.",
   "l/qt37": "Der obige Text wird die benutzerdefinierte Nachricht des übergeordneten Kollektivs dieses Ereignisses oder Projekts überschreiben.",
+  "L/TmUV": "Recurring Expense Settings",
   "L0xyX3": "Invalid file",
   "L0zynD": "Value must be greater than or equal to {min}",
   "l15EJO": "Ermöglicht die Einreichung von Ausgaben im Auftrag von Herstellern durch alle Benutzer",

--- a/lang/en.json
+++ b/lang/en.json
@@ -2279,6 +2279,7 @@
   "l+tve8": "{virtualCardProgramName} Visa® Commercial Credit cards are issued by Celtic Bank.",
   "l/JVrq": "The handle (URL identifier on the website) for the transaction opposite account.",
   "l/qt37": "The above text will override the customized message set by the parent Collective of this Event or Project.",
+  "L/TmUV": "Recurring Expense Settings",
   "L0xyX3": "Invalid file",
   "L0zynD": "Value must be greater than or equal to {min}",
   "l15EJO": "Allow expense submission on behalf of vendors by all users",

--- a/lang/es.json
+++ b/lang/es.json
@@ -2279,6 +2279,7 @@
   "l+tve8": "Las tarjetas de crédito comerciales {virtualCardProgramName} Visa® son emitidas por Celtic Bank.",
   "l/JVrq": "El \"handle\" (identificador de URL en el sitio web) para la cuenta de transacciones contrarias.",
   "l/qt37": "El texto anterior sustituirá al mensaje personalizado establecido por el Colectivo principal de este Evento o Proyecto.",
+  "L/TmUV": "Recurring Expense Settings",
   "L0xyX3": "Archivo inválido",
   "L0zynD": "El valor debe ser mayor o igual a {min}",
   "l15EJO": "Permitir la presentación de gastos en nombre de los proveedores a todos los usuarios",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2279,6 +2279,7 @@
   "l+tve8": "Les cartes de crédit commerciales {virtualCardProgramName} Visa®️ sont émises par Celtic Bank.",
   "l/JVrq": "Le gestionnaire (identifiant d'URL sur le site Web) pour la transaction du compte de contribution.",
   "l/qt37": "Le texte ci-dessus remplacera le message personnalisé défini par le Collectif principal (parent) de cet Événement ou de ce Projet.",
+  "L/TmUV": "Recurring Expense Settings",
   "L0xyX3": "Fichier non valide",
   "L0zynD": "La valeur doit être supérieure ou égale à {min}",
   "l15EJO": "Permettre à tous les utilisateurs de soumettre des dépenses au nom des fournisseurs",

--- a/lang/he.json
+++ b/lang/he.json
@@ -2279,6 +2279,7 @@
   "l+tve8": "{virtualCardProgramName} Visa® Commercial Credit cards are issued by Celtic Bank.",
   "l/JVrq": "The handle (URL identifier on the website) for the transaction opposite account.",
   "l/qt37": "The above text will override the customized message set by the parent Collective of this Event or Project.",
+  "L/TmUV": "Recurring Expense Settings",
   "L0xyX3": "Invalid file",
   "L0zynD": "Value must be greater than or equal to {min}",
   "l15EJO": "Allow expense submission on behalf of vendors by all users",

--- a/lang/it.json
+++ b/lang/it.json
@@ -2279,6 +2279,7 @@
   "l+tve8": "{virtualCardProgramName} Visa® Commercial Credit cards are issued by Celtic Bank.",
   "l/JVrq": "The handle (URL identifier on the website) for the transaction opposite account.",
   "l/qt37": "The above text will override the customized message set by the parent Collective of this Event or Project.",
+  "L/TmUV": "Recurring Expense Settings",
   "L0xyX3": "Invalid file",
   "L0zynD": "Value must be greater than or equal to {min}",
   "l15EJO": "Allow expense submission on behalf of vendors by all users",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -2279,6 +2279,7 @@
   "l+tve8": "{virtualCardProgramName} Visa® Commercial Credit cards are issued by Celtic Bank.",
   "l/JVrq": "The handle (URL identifier on the website) for the transaction opposite account.",
   "l/qt37": "The above text will override the customized message set by the parent Collective of this Event or Project.",
+  "L/TmUV": "Recurring Expense Settings",
   "L0xyX3": "Invalid file",
   "L0zynD": "Value must be greater than or equal to {min}",
   "l15EJO": "Allow expense submission on behalf of vendors by all users",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -2279,6 +2279,7 @@
   "l+tve8": "{virtualCardProgramName} Visa® Commercial Credit cards are issued by Celtic Bank.",
   "l/JVrq": "The handle (URL identifier on the website) for the transaction opposite account.",
   "l/qt37": "The above text will override the customized message set by the parent Collective of this Event or Project.",
+  "L/TmUV": "Recurring Expense Settings",
   "L0xyX3": "Invalid file",
   "L0zynD": "Value must be greater than or equal to {min}",
   "l15EJO": "Allow expense submission on behalf of vendors by all users",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -2279,6 +2279,7 @@
   "l+tve8": "{virtualCardProgramName} Visa® Commercial Credit cards are issued by Celtic Bank.",
   "l/JVrq": "The handle (URL identifier on the website) for the transaction opposite account.",
   "l/qt37": "The above text will override the customized message set by the parent Collective of this Event or Project.",
+  "L/TmUV": "Recurring Expense Settings",
   "L0xyX3": "Ongeldig bestand",
   "L0zynD": "Value must be greater than or equal to {min}",
   "l15EJO": "Allow expense submission on behalf of vendors by all users",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -2279,6 +2279,7 @@
   "l+tve8": "{virtualCardProgramName} Visa® Commercial Credit cards are issued by Celtic Bank.",
   "l/JVrq": "The handle (URL identifier on the website) for the transaction opposite account.",
   "l/qt37": "Powyższy tekst zastąpi niestandardową wiadomość ustawioną przez macierzystą zbiórkę tego Wydarzenia lub Projektu.",
+  "L/TmUV": "Recurring Expense Settings",
   "L0xyX3": "Invalid file",
   "L0zynD": "Value must be greater than or equal to {min}",
   "l15EJO": "Allow expense submission on behalf of vendors by all users",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -2279,6 +2279,7 @@
   "l+tve8": "{virtualCardProgramName} Visa® Commercial Credit cards are issued by Celtic Bank.",
   "l/JVrq": "The handle (URL identifier on the website) for the transaction opposite account.",
   "l/qt37": "The above text will override the customized message set by the parent Collective of this Event or Project.",
+  "L/TmUV": "Recurring Expense Settings",
   "L0xyX3": "Invalid file",
   "L0zynD": "Value must be greater than or equal to {min}",
   "l15EJO": "Allow expense submission on behalf of vendors by all users",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -2279,6 +2279,7 @@
   "l+tve8": "{virtualCardProgramName} Visa® Commercial Credit cards are issued by Celtic Bank.",
   "l/JVrq": "The handle (URL identifier on the website) for the transaction opposite account.",
   "l/qt37": "The above text will override the customized message set by the parent Collective of this Event or Project.",
+  "L/TmUV": "Recurring Expense Settings",
   "L0xyX3": "Invalid file",
   "L0zynD": "Value must be greater than or equal to {min}",
   "l15EJO": "Allow expense submission on behalf of vendors by all users",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -2279,6 +2279,7 @@
   "l+tve8": "{virtualCardProgramName} Visa® Commercial Credit cards are issued by Celtic Bank.",
   "l/JVrq": "The handle (URL identifier on the website) for the transaction opposite account.",
   "l/qt37": "The above text will override the customized message set by the parent Collective of this Event or Project.",
+  "L/TmUV": "Recurring Expense Settings",
   "L0xyX3": "Invalid file",
   "L0zynD": "Value must be greater than or equal to {min}",
   "l15EJO": "Allow expense submission on behalf of vendors by all users",

--- a/lang/sk-SK.json
+++ b/lang/sk-SK.json
@@ -2279,6 +2279,7 @@
   "l+tve8": "{virtualCardProgramName} Visa® Commercial Credit cards are issued by Celtic Bank.",
   "l/JVrq": "The handle (URL identifier on the website) for the transaction opposite account.",
   "l/qt37": "Vyššie uvedený text nahradí prispôsobenú správu, ktorú nastavil nadradený Kolektív tohto Podujatia alebo Projektu.",
+  "L/TmUV": "Recurring Expense Settings",
   "L0xyX3": "Invalid file",
   "L0zynD": "Value must be greater than or equal to {min}",
   "l15EJO": "Allow expense submission on behalf of vendors by all users",

--- a/lang/sv-SE.json
+++ b/lang/sv-SE.json
@@ -2279,6 +2279,7 @@
   "l+tve8": "{virtualCardProgramName} Visa® Commercial Credit cards are issued by Celtic Bank.",
   "l/JVrq": "The handle (URL identifier on the website) for the transaction opposite account.",
   "l/qt37": "Ovanstående text kommer att bortse från det anpassade meddelandet som satts av överordnade kollektiv av detta event eller projekt.",
+  "L/TmUV": "Recurring Expense Settings",
   "L0xyX3": "Invalid file",
   "L0zynD": "Value must be greater than or equal to {min}",
   "l15EJO": "Allow expense submission on behalf of vendors by all users",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -2279,6 +2279,7 @@
   "l+tve8": "{virtualCardProgramName} Visa® Commercial Credit cards are issued by Celtic Bank.",
   "l/JVrq": "The handle (URL identifier on the website) for the transaction opposite account.",
   "l/qt37": "The above text will override the customized message set by the parent Collective of this Event or Project.",
+  "L/TmUV": "Recurring Expense Settings",
   "L0xyX3": "Invalid file",
   "L0zynD": "Value must be greater than or equal to {min}",
   "l15EJO": "Allow expense submission on behalf of vendors by all users",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -2279,6 +2279,7 @@
   "l+tve8": "{virtualCardProgramName} Visa® Commercial Credit cards are issued by Celtic Bank.",
   "l/JVrq": "The handle (URL identifier on the website) for the transaction opposite account.",
   "l/qt37": "The above text will override the customized message set by the parent Collective of this Event or Project.",
+  "L/TmUV": "Recurring Expense Settings",
   "L0xyX3": "Invalid file",
   "L0zynD": "Value must be greater than or equal to {min}",
   "l15EJO": "Allow expense submission on behalf of vendors by all users",


### PR DESCRIPTION
For https://github.com/opencollective/opencollective-frontend/compare/fix/modals-responsiveness

These legacy `width` broke responsiveness after the https://github.com/opencollective/opencollective-frontend/pull/9819 update.