### PR TITLE
Directly import icon from react-simple-icons package

### DIFF
--- a/components/PaymentMethodLabel.tsx
+++ b/components/PaymentMethodLabel.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { SiOpencollective, SiPaypal, SiStripe, SiWise } from '@icons-pack/react-simple-icons';
+import SiOpencollective from '@icons-pack/react-simple-icons/icons/SiOpencollective';
+import SiPaypal from '@icons-pack/react-simple-icons/icons/SiPaypal';
+import SiStripe from '@icons-pack/react-simple-icons/icons/SiStripe';
+import SiWise from '@icons-pack/react-simple-icons/icons/SiWise';
 import clsx from 'clsx';
 import { useIntl } from 'react-intl';
 


### PR DESCRIPTION
Changing import method of react-simple-icons to try fix for page load crash on vercel:

> Error: EMFILE: too many open files, open '/var/task/node_modules/@icons-pack/react-simple-icons/icons/SiGitlfs.mjs'
    at async open (node:internal/fs/promises:639:25)
    at async readFile (node:internal/fs/promises:1249:14)
    at async getSource (node:internal/modules/esm/load:46:14)
    at async defaultLoad (node:internal/modules/esm/load:137:34)
    at async ModuleLoader.load (node:internal/modules/esm/loader:396:7)
    at async ModuleLoader.moduleProvider (node:internal/modules/esm/loader:278:45) {
  errno: -24,
  code: 'EMFILE',
  syscall: 'open',
  path: '/var/task/node_modules/@icons-pack/react-simple-icons/icons/SiGitlfs.mjs',
  page: '/dashboard'
}
Error: EMFILE: too many open files, open '/var/task/node_modules/@icons-pack/react-simple-icons/icons/SiGitlfs.mjs'
    at async open (node:internal/fs/promises:639:25)
    at async readFile (node:internal/fs/promises:1249:14)
    at async getSource (node:internal/modules/esm/load:46:14)
    at async defaultLoad (node:internal/modules/esm/load:137:34)
    at async ModuleLoader.load (node:internal/modules/esm/loader:396:7)
    at async ModuleLoader.moduleProvider (node:internal/modules/esm/loader:278:45) {
  errno: -24,
  code: 'EMFILE',
  syscall: 'open',
  path: '/var/task/node_modules/@icons-pack/react-simple-icons/icons/SiGitlfs.mjs',
  page: '/dashboard'
}
Node.js process exited with exit status: 1. The logs above can help with debugging the issue.
