### PR TITLE
fix: fix typo in code

### DIFF
--- a/components/budget/ExpenseBudgetItem.js
+++ b/components/budget/ExpenseBudgetItem.js
@@ -212,7 +212,7 @@ const ExpenseBudgetItem = ({
                               fontSize={fontSize}
                               data-cy="expense-title"
                             >
-                              {value} wh
+                              {value}
                             </H3>
                           );
                         }}


### PR DESCRIPTION
This PR fixes a typo in the code that leads to outputting ` wh` in the Expenses list.