### PR TITLE
chore: Refactor duplicateHandler to remove unused keyGenerator parameter

### DIFF
--- a/server/duplicate-handler.js
+++ b/server/duplicate-handler.js
@@ -1,5 +1,3 @@
-const { isEmpty } = require('lodash');
-
 const debug = require('debug')('duplicateHandler');
 
 function duplicateHandler({ skip, timeout } = {}) {
@@ -24,13 +22,6 @@ function duplicateHandler({ skip, timeout } = {}) {
   setInterval(gc, 1000);
 
   return function handleDuplicate(req, res, next) {
-    // If the request includes any cookie or sensitive headers, skip it
-    if (!isEmpty(req.cookies) || req.headers.authorization || req.headers.cookie) {
-      debug('Skipping request with sensitive headers');
-      next();
-      return;
-    }
-
     if (skip && skip(req)) {
       next();
       return;

--- a/server/duplicate-handler.js
+++ b/server/duplicate-handler.js
@@ -1,19 +1,22 @@
+const { isEmpty } = require('lodash');
+
 const debug = require('debug')('duplicateHandler');
 
-function duplicateHandler({ keyGenerator, skip, timeout } = {}) {
+function duplicateHandler({ skip, timeout } = {}) {
   timeout = Number(timeout) || 30;
 
-  const requests = {};
+  const requests = new Map();
 
   // Garbage collection (not necessary under normal operation)
   const gc = () => {
-    const ids = Object.keys(requests);
+    const ids = Array.from(requests.keys());
     if (ids.length > 0) {
       debug(`${ids.length} current registered requests`);
     }
     for (const id of ids) {
-      if (requests[id].registeredAt < new Date().getTime() - timeout * 1000) {
-        delete requests[id];
+      const request = requests.get(id);
+      if (request.registeredAt < new Date().getTime() - timeout * 1000) {
+        requests.delete(id);
       }
     }
   };
@@ -21,21 +24,27 @@ function duplicateHandler({ keyGenerator, skip, timeout } = {}) {
   setInterval(gc, 1000);
 
   return function handleDuplicate(req, res, next) {
+    // If the request includes any cookie or sensitive headers, skip it
+    if (!isEmpty(req.cookies) || req.headers.authorization || req.headers.cookie) {
+      debug('Skipping request with sensitive headers');
+      next();
+      return;
+    }
+
     if (skip && skip(req)) {
       next();
       return;
     }
 
-    const id = keyGenerator ? keyGenerator(req) : req.url;
-
-    if (requests[id]) {
+    const id = req.url;
+    if (requests.has(id)) {
       debug(`Duplicate request detected '${id}'`);
-      const origin = requests[id].origin;
+      const origin = requests.get(id).origin;
 
       // Prepare for duplicates
       // We're lazily doing it only when the first duplicate arrives
-      if (!requests[id].duplicates) {
-        requests[id].duplicates = [];
+      if (!requests.get(id).duplicates) {
+        requests.get(id).duplicates = [];
 
         const originResMethods = {};
         for (const method of ['setHeader', 'end']) {
@@ -47,9 +56,10 @@ function duplicateHandler({ keyGenerator, skip, timeout } = {}) {
             originResMethods[method].apply(origin.res, arguments);
 
             // Apply on duplicates method
-            if (requests[id]) {
-              for (const duplicate of requests[id].duplicates) {
-                // Copy properties because we don't listen when their set
+            const request = requests.get(id);
+            if (request) {
+              for (const duplicate of request.duplicates) {
+                // Copy properties because we don't listen when they're set
                 if (method === 'send') {
                   duplicate.res.statusCode = origin.res.statusCode;
                   duplicate.res.statusMessage = origin.res.statusMessage;
@@ -68,22 +78,22 @@ function duplicateHandler({ keyGenerator, skip, timeout } = {}) {
       }
 
       // Registering duplicate
-      requests[id].duplicates.push({ req, res, next });
+      requests.get(id).duplicates.push({ req, res, next });
 
       // That's all, wait on origin response to complete
       return;
     }
 
     // Registering origin request
-    requests[id] = {
+    requests.set(id, {
       registeredAt: new Date().getTime(),
       origin: { req, res, next },
-    };
+    });
 
     // Release origin request
-    req.on('close', () => delete requests[id]);
-    res.on('end', () => delete requests[id]);
-    res.on('finish', () => delete requests[id]);
+    req.on('close', () => requests.delete(id));
+    res.on('end', () => requests.delete(id));
+    res.on('finish', () => requests.delete(id));
 
     return next();
   };

--- a/server/index.js
+++ b/server/index.js
@@ -5,6 +5,7 @@ const express = require('express');
 const helmet = require('helmet');
 const cookieParser = require('cookie-parser');
 const cloudflareIps = require('cloudflare-ip/ips.json');
+const { isEmpty } = require('lodash');
 const throng = require('throng');
 
 const logger = require('./logger');
@@ -68,8 +69,12 @@ const start = id =>
       app.use(
         duplicateHandler({
           skip: req =>
+            !isEmpty(req.cookies) ||
+            req.headers.authorization ||
+            req.headers.cookie ||
             req.url.match(/^\/_/) ||
             req.url.match(/^\/static/) ||
+            req.url.match(/^\/dashboard/) ||
             req.url.match(/^\/api/) ||
             req.url.match(/^\/favicon\.ico/),
         }),


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective-frontend/security/code-scanning/11

It was a false positive because `req.url` will always start with a `/`, but:
- `keyGenerator` was unused and could be removed. Moreover, we wouldn't want another developer to provide a keyGenerator without knowing that it can result in prototype pollution. 
- Using a `Map` guarantees that no prototype pollution is possible.