### PR TITLE
fix(RooActions): query parameters for moving expense

### DIFF
--- a/components/ExpensesPickerAsync.js
+++ b/components/ExpensesPickerAsync.js
@@ -13,7 +13,7 @@ import StyledTag from './StyledTag';
 import { Span } from './Text';
 
 const expensesSearchQuery = gql`
-  query ExpensesPickerSearch($account: AccountReferenceInput, $searchTerm: String, $status: ExpenseStatusFilter) {
+  query ExpensesPickerSearch($account: AccountReferenceInput, $searchTerm: String, $status: [ExpenseStatusFilter]) {
     expenses(account: $account, limit: 100, searchTerm: $searchTerm, status: $status) {
       nodes {
         id


### PR DESCRIPTION
Reported in https://opencollective.slack.com/archives/GFH4N961L/p1724952844715619
Follow-up on https://github.com/opencollective/opencollective-api/pull/10111

Though Apollo is flexible and allows using lists with a single value, we must make sure the query parameters themselves match the API.