### PR TITLE
fix(Vercel): favicon

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -150,6 +150,7 @@ export default class IntlDocument extends Document {
       <Html>
         <Head nonce={this.props.cspNonce}>
           <script nonce={this.props.cspNonce} defer src={languageManifest[this.props.locale]} />
+          <link rel="icon" href="/static/images/favicon.ico.png" />
         </Head>
         <body>
           <Main nonce={this.props.cspNonce} />


### PR DESCRIPTION
The favicon was working on Heroku (custom server), but not on Vercel. Consolidated according to https://github.com/vercel/next.js/discussions/50704#discussioncomment-6073844.

I'm not removing `public/static/images/favicon.ico.png` for now in case it's used somewhere else.