### PR TITLE
Fix(Thread): Revert comment thread ordering to oldest first

### DIFF
--- a/components/HTMLContent.js
+++ b/components/HTMLContent.js
@@ -7,6 +7,8 @@ import { FormattedMessage } from 'react-intl';
 import styled, { css } from 'styled-components';
 import { space, typography } from 'styled-system';
 
+import { Button } from './ui/Button';
+
 /**
  * React-Quill usually saves something like `<p><br/></p` when saving with an empty
  * editor. This function tries to detect this and returns true if there's no real
@@ -28,18 +30,6 @@ export const isEmptyHTMLValue = value => {
     return cleanStr.length === 0;
   }
 };
-
-const ReadFullLink = styled.a`
-  margin-top: 4px;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  cursor: pointer;
-  font-size: 12px;
-  > svg {
-    vertical-align: baseline;
-  }
-`;
 
 const InlineDisplayBox = styled.div`
   overflow-y: hidden;
@@ -129,10 +119,11 @@ const HTMLContent = styled(
           />
         </DisplayBox>
         {!isOpen && isCollapsed && !hideViewMoreLink && (
-          <ReadFullLink
+          <Button
+            variant="outline"
+            className="mt-4"
+            size="xs"
             onClick={() => setOpen(true)}
-            {...props}
-            role="button"
             tabIndex={0}
             onKeyDown={event => {
               if (event.key === 'Enter') {
@@ -143,13 +134,14 @@ const HTMLContent = styled(
           >
             {readMoreMessage || <FormattedMessage id="ExpandDescription" defaultMessage="Read full description" />}
             <ChevronDown size={10} />
-          </ReadFullLink>
+          </Button>
         )}
         {isOpen && isCollapsed && (
-          <ReadFullLink
+          <Button
+            variant="outline"
+            className="mt-4"
+            size="xs"
             onClick={() => setOpen(false)}
-            {...props}
-            role="button"
             tabIndex={0}
             onKeyDown={event => {
               if (event.key === 'Enter') {
@@ -160,7 +152,7 @@ const HTMLContent = styled(
           >
             <FormattedMessage defaultMessage="Collapse" id="W/V6+Y" />
             <ChevronUp size={10} />
-          </ReadFullLink>
+          </Button>
         )}
       </div>
     );

--- a/components/conversations/SmallComment.tsx
+++ b/components/conversations/SmallComment.tsx
@@ -25,16 +25,16 @@ export default function SmallComment(props: CommentProps) {
 
   return (
     <div
-      className="relative w-full border-slate-200 py-4 first:border-none first:pt-0 [&:last-child_.timeline-indicator]:-bottom-4 [&:last-child_.timeline-separator]:hidden"
+      className="relative w-full border-slate-200 py-4 first:border-none first:pt-0 [&:first-child_.timeline-indicator]:top-0 [&:last-child_.timeline-indicator]:-bottom-4 [&:last-child_.timeline-separator]:hidden"
       data-cy="comment"
       id={anchorHash}
     >
-      <div className="timeline-separator absolute bottom-0 left-[20px] right-0 border-b" />
+      <div className="timeline-separator absolute bottom-0 left-5 right-0 border-b" />
       <div className="flex justify-between">
         <div className="flex gap-4">
           <div className="relative">
             <div
-              className={clsx('timeline-indicator absolute bottom-[-16px] left-[20px] top-[-16px] border-l', {
+              className={clsx('timeline-indicator absolute -bottom-4 -top-4 left-5 border-l', {
                 'border-blue-400': isPrivateNote,
               })}
             />
@@ -44,7 +44,7 @@ export default function SmallComment(props: CommentProps) {
                 <div className="relative">
                   <Avatar collective={comment.fromAccount} radius={40} />
                   {isPrivateNote && (
-                    <div className="absolute bottom-[-4px] right-[-4px] flex h-[20px] w-[20px] items-center justify-center rounded-full bg-white shadow">
+                    <div className="absolute bottom-[-4px] right-[-4px] flex h-5 w-5 items-center justify-center rounded-full bg-white shadow">
                       <Lock size={16} className="text-blue-400" />
                     </div>
                   )}
@@ -76,7 +76,7 @@ export default function SmallComment(props: CommentProps) {
                   !isEditing ? (
                     <HTMLContent
                       fontSize="14px"
-                      maxCollapsedHeight={140}
+                      maxCollapsedHeight={400}
                       collapsable
                       collapsePadding={22}
                       content={comment.html}

--- a/components/conversations/SmallThread.tsx
+++ b/components/conversations/SmallThread.tsx
@@ -33,27 +33,6 @@ export default function SmallThread(props: SmallThreadProps) {
 
   return (
     <React.Fragment>
-      {props.canComment && (
-        <div className="flex gap-4 pb-4">
-          <div className="relative">
-            <div className="absolute -bottom-4 left-5 top-10 border-l" />
-            <Avatar collective={LoggedInUser.collective} radius={40} />
-          </div>
-          <div className="flex-grow">
-            <CommentForm
-              {...props.CommentEntity}
-              submitButtonJustify="end"
-              submitButtonVariant="outline"
-              minHeight={60}
-              isDisabled={props.loading || loading}
-              replyingToComment={replyingToComment}
-              onSuccess={props.onCommentCreated}
-              canUsePrivateNote={props.canUsePrivateNote}
-              defaultType={props.defaultType}
-            />
-          </div>
-        </div>
-      )}
       <div data-cy="thread">
         {props.loading && <Loading />}
         {!props.loading &&
@@ -90,6 +69,28 @@ export default function SmallThread(props: SmallThreadProps) {
           </div>
         )}
       </div>
+      {props.canComment && (
+        <div className="flex gap-4 py-4">
+          <div className="relative">
+            {props.items?.length > 0 && <div className="absolute -top-4 left-5 h-4 border-l" />}
+
+            <Avatar collective={LoggedInUser.collective} radius={40} />
+          </div>
+          <div className="flex-grow">
+            <CommentForm
+              {...props.CommentEntity}
+              submitButtonJustify="end"
+              submitButtonVariant="outline"
+              minHeight={60}
+              isDisabled={props.loading || loading}
+              replyingToComment={replyingToComment}
+              onSuccess={props.onCommentCreated}
+              canUsePrivateNote={props.canUsePrivateNote}
+              defaultType={props.defaultType}
+            />
+          </div>
+        </div>
+      )}
     </React.Fragment>
   );
 }

--- a/components/conversations/SmallThreadActivity.tsx
+++ b/components/conversations/SmallThreadActivity.tsx
@@ -32,7 +32,7 @@ export default function SmallThreadActivity(props: SmallThreadActivityProps) {
 
   return (
     <div
-      className="relative w-full border-slate-200 py-4 first:border-none first:pt-0 [&:last-child_.timeline-indicator]:-bottom-4 [&:last-child_.timeline-separator]:hidden"
+      className="relative w-full border-slate-200 py-4 first:border-none first:pt-0 [&:first-child_.timeline-indicator]:top-0 [&:last-child_.timeline-indicator]:-bottom-4 [&:last-child_.timeline-separator]:hidden"
       data-cy="activity"
     >
       <div className="timeline-separator absolute bottom-0 left-5 right-0 border-b" />

--- a/components/dashboard/sections/collectives/HostApplicationDrawer.tsx
+++ b/components/dashboard/sections/collectives/HostApplicationDrawer.tsx
@@ -178,7 +178,7 @@ function HostApplication({
       query HostApplicationThread($hostApplication: HostApplicationReferenceInput!, $offset: Int!, $limit: Int!) {
         hostApplication(hostApplication: $hostApplication) {
           ...HostApplicationFields
-          threadComments: comments(limit: $limit, offset: $offset, orderBy: { field: CREATED_AT, direction: DESC }) {
+          threadComments: comments(limit: $limit, offset: $offset, orderBy: { field: CREATED_AT, direction: ASC }) {
             totalCount
             offset
             limit
@@ -484,10 +484,6 @@ function HostApplication({
             <div className="mb-5 text-sm leading-3 text-[#344256]">
               <span className="font-bold">
                 <FormattedMessage defaultMessage="Comments" id="wCgTu5" />
-              </span>
-              <span>
-                &nbsp;
-                <FormattedMessage defaultMessage="(Latest first)" id="K78a3C" />
               </span>
             </div>
 

--- a/components/expenses/Expense.tsx
+++ b/components/expenses/Expense.tsx
@@ -253,7 +253,7 @@ function Expense(props) {
   const threadItems = React.useMemo(() => {
     const comments = expense?.comments?.nodes || [];
     const activities = expense?.activities || [];
-    return orderBy([...comments, ...activities], 'createdAt', inDrawer ? 'desc' : 'asc');
+    return orderBy([...comments, ...activities], 'createdAt', 'asc');
   }, [expense, inDrawer]);
 
   const isEditing = status === PAGE_STATUS.EDIT || status === PAGE_STATUS.EDIT_SUMMARY;

--- a/components/expenses/ExpenseDrawer.tsx
+++ b/components/expenses/ExpenseDrawer.tsx
@@ -35,7 +35,7 @@ export default function ExpenseDrawer({ openExpenseLegacyId, handleClose, initia
       getExpense({
         variables: {
           ...getVariablesFromQuery({ ExpenseId: openExpenseLegacyId }),
-          orderBy: { field: OrderByFieldType.CREATED_AT, direction: OrderDirection.DESC },
+          orderBy: { field: OrderByFieldType.CREATED_AT, direction: OrderDirection.ASC },
         },
       });
     }

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -2253,7 +2253,6 @@
   "K1uUiB": "Account Type",
   "K2C2LL": "Expenses from Hosted Collective accounts",
   "K2coI/": "Your expense has been submitted successfully!",
-  "K78a3C": "(Latest first)",
   "K7AkdL": "Show",
   "k8izBg": "Expected Funds created with reference #{orderId}",
   "k8RfQ/": "The file is still uploading, please wait",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -2253,7 +2253,6 @@
   "K1uUiB": "Account Type",
   "K2C2LL": "Expenses from Hosted Collective accounts",
   "K2coI/": "Your expense has been submitted successfully!",
-  "K78a3C": "(Latest first)",
   "K7AkdL": "Show",
   "k8izBg": "Expected Funds created with reference #{orderId}",
   "k8RfQ/": "The file is still uploading, please wait",

--- a/lang/de.json
+++ b/lang/de.json
@@ -2253,7 +2253,6 @@
   "K1uUiB": "Kontotyp",
   "K2C2LL": "Expenses from Hosted Collective accounts",
   "K2coI/": "Your expense has been submitted successfully!",
-  "K78a3C": "(Latest first)",
   "K7AkdL": "Anzeigen",
   "k8izBg": "Expected Funds created with reference #{orderId}",
   "k8RfQ/": "Die Datei wird noch hochgeladen, bitte warten",

--- a/lang/en.json
+++ b/lang/en.json
@@ -2253,7 +2253,6 @@
   "K1uUiB": "Account Type",
   "K2C2LL": "Expenses from Hosted Collective accounts",
   "K2coI/": "Your expense has been submitted successfully!",
-  "K78a3C": "(Latest first)",
   "K7AkdL": "Show",
   "k8izBg": "Expected Funds created with reference #{orderId}",
   "k8RfQ/": "The file is still uploading, please wait",

--- a/lang/es.json
+++ b/lang/es.json
@@ -2253,7 +2253,6 @@
   "K1uUiB": "Tipo de cuenta",
   "K2C2LL": "Gastos de cuentas de Colectivos con Anfitrión Fiscal",
   "K2coI/": "Tu gasto se ha enviado correctamente.",
-  "K78a3C": "(Latest first)",
   "K7AkdL": "Mostrar",
   "k8izBg": "Fondos Previstos creados con la referencia #{orderId}",
   "k8RfQ/": "El archivo todavía se está cargando, por favor espera",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2253,7 +2253,6 @@
   "K1uUiB": "Type de compte",
   "K2C2LL": "Dépenses des comptes Collectifs hébergés",
   "K2coI/": "Votre dépense a été soumise avec succès !",
-  "K78a3C": "(Latest first)",
   "K7AkdL": "Afficher",
   "k8izBg": "Fonds attendus créés avec la référence #{orderId}",
   "k8RfQ/": "Le fichier est toujours en cours de téléchargement, veuillez patienter",

--- a/lang/he.json
+++ b/lang/he.json
@@ -2253,7 +2253,6 @@
   "K1uUiB": "Account Type",
   "K2C2LL": "Expenses from Hosted Collective accounts",
   "K2coI/": "Your expense has been submitted successfully!",
-  "K78a3C": "(Latest first)",
   "K7AkdL": "הצגה",
   "k8izBg": "Expected Funds created with reference #{orderId}",
   "k8RfQ/": "The file is still uploading, please wait",

--- a/lang/it.json
+++ b/lang/it.json
@@ -2253,7 +2253,6 @@
   "K1uUiB": "Account Type",
   "K2C2LL": "Expenses from Hosted Collective accounts",
   "K2coI/": "Your expense has been submitted successfully!",
-  "K78a3C": "(Latest first)",
   "K7AkdL": "Mostra",
   "k8izBg": "Expected Funds created with reference #{orderId}",
   "k8RfQ/": "The file is still uploading, please wait",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -2253,7 +2253,6 @@
   "K1uUiB": "Account Type",
   "K2C2LL": "Expenses from Hosted Collective accounts",
   "K2coI/": "Your expense has been submitted successfully!",
-  "K78a3C": "(Latest first)",
   "K7AkdL": "Show",
   "k8izBg": "Expected Funds created with reference #{orderId}",
   "k8RfQ/": "The file is still uploading, please wait",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -2253,7 +2253,6 @@
   "K1uUiB": "Account Type",
   "K2C2LL": "Expenses from Hosted Collective accounts",
   "K2coI/": "Your expense has been submitted successfully!",
-  "K78a3C": "(Latest first)",
   "K7AkdL": "Show",
   "k8izBg": "Expected Funds created with reference #{orderId}",
   "k8RfQ/": "The file is still uploading, please wait",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -2253,7 +2253,6 @@
   "K1uUiB": "Account Type",
   "K2C2LL": "Expenses from Hosted Collective accounts",
   "K2coI/": "Your expense has been submitted successfully!",
-  "K78a3C": "(Latest first)",
   "K7AkdL": "Weergeven",
   "k8izBg": "Expected Funds created with reference #{orderId}",
   "k8RfQ/": "The file is still uploading, please wait",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -2253,7 +2253,6 @@
   "K1uUiB": "Typ konta",
   "K2C2LL": "Expenses from Hosted Collective accounts",
   "K2coI/": "Your expense has been submitted successfully!",
-  "K78a3C": "(Latest first)",
   "K7AkdL": "Pokaż",
   "k8izBg": "Expected Funds created with reference #{orderId}",
   "k8RfQ/": "The file is still uploading, please wait",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -2253,7 +2253,6 @@
   "K1uUiB": "Account Type",
   "K2C2LL": "Expenses from Hosted Collective accounts",
   "K2coI/": "Your expense has been submitted successfully!",
-  "K78a3C": "(Latest first)",
   "K7AkdL": "Show",
   "k8izBg": "Expected Funds created with reference #{orderId}",
   "k8RfQ/": "The file is still uploading, please wait",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -2253,7 +2253,6 @@
   "K1uUiB": "Account Type",
   "K2C2LL": "Expenses from Hosted Collective accounts",
   "K2coI/": "Your expense has been submitted successfully!",
-  "K78a3C": "(Latest first)",
   "K7AkdL": "Show",
   "k8izBg": "Expected Funds created with reference #{orderId}",
   "k8RfQ/": "The file is still uploading, please wait",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -2253,7 +2253,6 @@
   "K1uUiB": "Account Type",
   "K2C2LL": "Expenses from Hosted Collective accounts",
   "K2coI/": "Your expense has been submitted successfully!",
-  "K78a3C": "(Latest first)",
   "K7AkdL": "Show",
   "k8izBg": "Expected Funds created with reference #{orderId}",
   "k8RfQ/": "The file is still uploading, please wait",

--- a/lang/sk-SK.json
+++ b/lang/sk-SK.json
@@ -2253,7 +2253,6 @@
   "K1uUiB": "Account Type",
   "K2C2LL": "Expenses from Hosted Collective accounts",
   "K2coI/": "Your expense has been submitted successfully!",
-  "K78a3C": "(Latest first)",
   "K7AkdL": "Zobraziť",
   "k8izBg": "Expected Funds created with reference #{orderId}",
   "k8RfQ/": "The file is still uploading, please wait",

--- a/lang/sv-SE.json
+++ b/lang/sv-SE.json
@@ -2253,7 +2253,6 @@
   "K1uUiB": "Kontotyp",
   "K2C2LL": "Expenses from Hosted Collective accounts",
   "K2coI/": "Your expense has been submitted successfully!",
-  "K78a3C": "(Latest first)",
   "K7AkdL": "Visa",
   "k8izBg": "Expected Funds created with reference #{orderId}",
   "k8RfQ/": "The file is still uploading, please wait",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -2253,7 +2253,6 @@
   "K1uUiB": "Account Type",
   "K2C2LL": "Expenses from Hosted Collective accounts",
   "K2coI/": "Your expense has been submitted successfully!",
-  "K78a3C": "(Latest first)",
   "K7AkdL": "Показати",
   "k8izBg": "Expected Funds created with reference #{orderId}",
   "k8RfQ/": "The file is still uploading, please wait",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -2253,7 +2253,6 @@
   "K1uUiB": "账号类型",
   "K2C2LL": "Expenses from Hosted Collective accounts",
   "K2coI/": "Your expense has been submitted successfully!",
-  "K78a3C": "(Latest first)",
   "K7AkdL": "显示",
   "k8izBg": "Expected Funds created with reference #{orderId}",
   "k8RfQ/": "The file is still uploading, please wait",


### PR DESCRIPTION
Fix for https://opencollective.slack.com/archives/GFH4N961L/p1726090623946189, reverting comment thread ordering to oldest first.

Also enhances the "Read more" button to use the ui/shadcn button when there is a collapsed comment, and enhances the cutoff limit to collapse comments, based on this feedback: https://opencollective.slack.com/archives/GPEHHTM4G/p1727191110964869?thread_ts=1727189295.448359&cid=GPEHHTM4G