### PR TITLE
Fix(Thread): Properly update comment cache on expenses

### DIFF
--- a/components/expenses/Expense.tsx
+++ b/components/expenses/Expense.tsx
@@ -17,7 +17,7 @@ import expenseTypes from '../../lib/constants/expenseTypes';
 import { formatErrorMessage, getErrorFromGraphqlException } from '../../lib/errors';
 import { getFilesFromExpense, getPayoutProfiles } from '../../lib/expenses';
 import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
-import { ExpenseStatus, OrderByFieldType, OrderDirection } from '../../lib/graphql/types/v2/graphql';
+import { ExpenseStatus } from '../../lib/graphql/types/v2/graphql';
 import useKeyboardKey, { E } from '../../lib/hooks/useKeyboardKey';
 import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
 import { usePrevious } from '../../lib/hooks/usePrevious';
@@ -285,10 +285,7 @@ function Expense(props) {
   const clonePageQueryCacheData = () => {
     const { client } = props;
     const query = expensePageQuery;
-    const variables = {
-      ...getVariableFromProps(props),
-      ...(inDrawer ? { orderBy: { field: OrderByFieldType.CREATED_AT, direction: OrderDirection.DESC } } : {}),
-    };
+    const variables = getVariableFromProps(props);
     const data = cloneDeep(client.readQuery({ query, variables }));
     return [data, query, variables];
   };

--- a/components/expenses/ExpenseDrawer.tsx
+++ b/components/expenses/ExpenseDrawer.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 import { useApolloClient, useLazyQuery } from '@apollo/client';
 
 import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
-import { OrderByFieldType, OrderDirection } from '../../lib/graphql/types/v2/graphql';
 import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
 import { PREVIEW_FEATURE_KEYS } from '../../lib/preview-features';
 
@@ -33,10 +32,7 @@ export default function ExpenseDrawer({ openExpenseLegacyId, handleClose, initia
   useEffect(() => {
     if (openExpenseLegacyId) {
       getExpense({
-        variables: {
-          ...getVariablesFromQuery({ ExpenseId: openExpenseLegacyId }),
-          orderBy: { field: OrderByFieldType.CREATED_AT, direction: OrderDirection.ASC },
-        },
+        variables: getVariablesFromQuery({ ExpenseId: openExpenseLegacyId }),
       });
     }
   }, [openExpenseLegacyId]);

--- a/components/expenses/graphql/queries.ts
+++ b/components/expenses/graphql/queries.ts
@@ -5,17 +5,11 @@ import { commentFieldsFragment } from '../../conversations/graphql';
 import { expensePageExpenseFieldsFragment, loggedInAccountExpensePayoutFieldsFragment } from './fragments';
 
 export const expensePageQuery = gql`
-  query ExpensePage(
-    $legacyExpenseId: Int!
-    $draftKey: String
-    $offset: Int
-    $totalPaidExpensesDateFrom: DateTime
-    $orderBy: ChronologicalOrderInput
-  ) {
+  query ExpensePage($legacyExpenseId: Int!, $draftKey: String, $offset: Int, $totalPaidExpensesDateFrom: DateTime) {
     expense(expense: { legacyId: $legacyExpenseId }, draftKey: $draftKey) {
       id
       ...ExpensePageExpenseFields
-      comments(limit: 100, offset: $offset, orderBy: $orderBy) {
+      comments(limit: 100, offset: $offset) {
         totalCount
         nodes {
           id


### PR DESCRIPTION
Follow up for https://github.com/opencollective/opencollective-frontend/pull/10663

The comment thread cache was not updated properly due to mismatch of variables, fixed by removing the unused orderBy argument on comments.