### PR TITLE
Create new payment intent on charge attempt error

### DIFF
--- a/components/contribution-flow/PaymentMethodList.tsx
+++ b/components/contribution-flow/PaymentMethodList.tsx
@@ -107,7 +107,7 @@ type PaymentMethodListProps = {
   disabledPaymentMethodTypes: string[];
   stepSummary: object;
   stepDetails: { amount: number; currency: string; interval?: string };
-  stepPayment: { key: string; isKeyOnly?: boolean };
+  stepPayment: { key: string; isKeyOnly?: boolean; chargeAttempt: number };
   isEmbed: boolean;
   isSubmitting: boolean;
   hideCreditCardPostalCode: boolean;
@@ -132,6 +132,7 @@ export default function PaymentMethodList(props: PaymentMethodListProps) {
 
   const hostSupportedPaymentMethods = props.host?.supportedPaymentMethods ?? [];
   const [paymentIntent, stripe, loadingPaymentIntent, paymentIntentCreateError] = usePaymentIntent({
+    chargeAttempt: props.stepPayment?.chargeAttempt,
     skip: !hostSupportedPaymentMethods.includes(PaymentMethodLegacyType.PAYMENT_INTENT),
     amount: { valueInCents: props.stepDetails.amount, currency: props.stepDetails.currency },
     fromAccount: props.stepProfile.isGuest

--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -395,7 +395,11 @@ class ContributionFlow extends React.Component {
         this.setState({ isSubmitted: true, isSubmitting: false });
         return this.handleSuccess(order);
       } catch (e) {
-        this.setState({ isSubmitting: false, error: e.message });
+        this.setState({
+          isSubmitting: false,
+          error: e.message,
+          stepPayment: { ...this.state.stepPayment, chargeAttempt: (this.state.stepPayment?.chargeAttempt || 0) + 1 },
+        });
       }
     } else if (stripeError) {
       return this.handleStripeError(order, stripeError, email, guestToken);

--- a/lib/stripe/usePaymentIntent.ts
+++ b/lib/stripe/usePaymentIntent.ts
@@ -18,6 +18,7 @@ const createPaymentIntentMutation = gql`
 `;
 
 type UsePaymentIntentOptions = {
+  chargeAttempt: number;
   amount: { valueInCents: number; currency: string };
   fromAccount?: AccountReferenceInput;
   guestInfo?: GuestInfoInput;
@@ -29,6 +30,7 @@ type UsePaymentIntentOptions = {
 type StripePaymentIntent = PaymentIntent & { stripeAccount: string };
 
 export default function usePaymentIntent({
+  chargeAttempt,
   amount,
   fromAccount,
   guestInfo,
@@ -105,7 +107,7 @@ export default function usePaymentIntent({
       setPaymentIntent(null);
       setStripe(null);
     };
-  }, [skip, guestInfo?.captcha?.token]);
+  }, [skip, guestInfo?.captcha?.token, chargeAttempt]);
 
   return [paymentIntent, stripe, loading, error];
 }


### PR DESCRIPTION
When a payment intent confirmation fails (decline card, insufficient funds, etc), create a new payment intent to prevent reusing a an already used one attached to an order as https://github.com/opencollective/opencollective-api/pull/10336/files will prevent a new order created with a duplicated payment intent.