### PR TITLE
fix(ExpenseItemPreview): remove portal

### DIFF
--- a/components/expenses/Expense.tsx
+++ b/components/expenses/Expense.tsx
@@ -44,7 +44,6 @@ import StyledButton from '../StyledButton';
 import StyledCheckbox from '../StyledCheckbox';
 import StyledLink from '../StyledLink';
 import { H1, H5, Span } from '../Text';
-import { DialogPortal } from '../ui/Dialog';
 
 import { editExpenseMutation } from './graphql/mutations';
 import { expensePageQuery } from './graphql/queries';
@@ -793,24 +792,22 @@ function Expense(props) {
       )}
 
       {state.showFilesViewerModal && (
-        <DialogPortal>
-          <FilesViewerModal
-            allowOutsideInteraction={isDrawer}
-            files={files}
-            parentTitle={intl.formatMessage(
-              {
-                defaultMessage: 'Expense #{expenseId} attachment',
-                id: 'At2m8o',
-              },
-              { expenseId: expense.legacyId },
-            )}
-            openFileUrl={openUrl}
-            onClose={
-              isDrawer && isDesktop ? onClose : () => setState(state => ({ ...state, showFilesViewerModal: false }))
-            }
-            hideCloseButton={isDrawer && isDesktop}
-          />
-        </DialogPortal>
+        <FilesViewerModal
+          allowOutsideInteraction={isDrawer}
+          files={files}
+          parentTitle={intl.formatMessage(
+            {
+              defaultMessage: 'Expense #{expenseId} attachment',
+              id: 'At2m8o',
+            },
+            { expenseId: expense.legacyId },
+          )}
+          openFileUrl={openUrl}
+          onClose={
+            isDrawer && isDesktop ? onClose : () => setState(state => ({ ...state, showFilesViewerModal: false }))
+          }
+          hideCloseButton={isDrawer && isDesktop}
+        />
       )}
     </Box>
   );

--- a/components/expenses/Expense.tsx
+++ b/components/expenses/Expense.tsx
@@ -791,24 +791,26 @@ function Expense(props) {
         </Fragment>
       )}
 
-      {state.showFilesViewerModal && (
-        <FilesViewerModal
-          allowOutsideInteraction={isDrawer}
-          files={files}
-          parentTitle={intl.formatMessage(
-            {
-              defaultMessage: 'Expense #{expenseId} attachment',
-              id: 'At2m8o',
-            },
-            { expenseId: expense.legacyId },
-          )}
-          openFileUrl={openUrl}
-          onClose={
-            isDrawer && isDesktop ? onClose : () => setState(state => ({ ...state, showFilesViewerModal: false }))
-          }
-          hideCloseButton={isDrawer && isDesktop}
-        />
-      )}
+      {state.showFilesViewerModal &&
+        createPortal(
+          <FilesViewerModal
+            allowOutsideInteraction={isDrawer}
+            files={files}
+            parentTitle={intl.formatMessage(
+              {
+                defaultMessage: 'Expense #{expenseId} attachment',
+                id: 'At2m8o',
+              },
+              { expenseId: expense.legacyId },
+            )}
+            openFileUrl={openUrl}
+            onClose={
+              isDrawer && isDesktop ? onClose : () => setState(state => ({ ...state, showFilesViewerModal: false }))
+            }
+            hideCloseButton={isDrawer && isDesktop}
+          />,
+          document.body,
+        )}
     </Box>
   );
 }


### PR DESCRIPTION
Follow-up on https://github.com/opencollective/opencollective-frontend/pull/10674
Initially reported in https://opencollective.slack.com/archives/GFH4N961L/p1727789612367709

This PR fixes the following error that prevented opening expense items:
![image](https://github.com/user-attachments/assets/176d6c8c-fa73-4f8a-9a0c-5dcf1f0201dc)
