### PR TITLE
Fix(Transaction Reports): Fix filter definition of Refunded added funds

### DIFF
--- a/components/dashboard/sections/reports/preview/report-builder/predefined-groups.ts
+++ b/components/dashboard/sections/reports/preview/report-builder/predefined-groups.ts
@@ -25,7 +25,7 @@ export const predefinedGroups: Group[] = [
   {
     section: ReportSection.CONTRIBUTIONS,
     label: 'Refunded Added funds',
-    filter: { kind: TransactionKind.ADDED_FUNDS, type: TransactionType.CREDIT, isRefund: true },
+    filter: { kind: TransactionKind.ADDED_FUNDS, type: TransactionType.DEBIT, isRefund: true },
   },
   {
     section: ReportSection.EXPENSES,
@@ -139,8 +139,13 @@ export const predefinedGroups: Group[] = [
   },
   {
     section: ReportSection.OTHER,
-    label: 'Outgoing Added Funds',
-    filter: { kind: TransactionKind.ADDED_FUNDS, type: TransactionType.DEBIT },
+    label: 'Outgoing Added funds',
+    filter: { kind: TransactionKind.ADDED_FUNDS, type: TransactionType.DEBIT, isRefund: false },
+  },
+  {
+    section: ReportSection.OTHER,
+    label: 'Refunded outgoing Added funds',
+    filter: { kind: TransactionKind.ADDED_FUNDS, type: TransactionType.CREDIT, isRefund: true },
   },
   {
     section: ReportSection.OTHER,


### PR DESCRIPTION
Bug reported on Slack where refunded Added funds were not showing up, the filter for "Refunded Added funds" in the report builder for predefined groups was defined with `type: CREDIT` instead of `type: DEBIT` as it should have been.