### PR TITLE
fix(PaymentMethod): handle null in limitedToHosts

### DIFF
--- a/components/orders/PaymentMethodPicker.tsx
+++ b/components/orders/PaymentMethodPicker.tsx
@@ -415,7 +415,11 @@ function paymentMethodFilter(options: PaymentMethodFilterOptions): (pm: PaymentM
     const limitedToHosts = sourcePaymentMethod.limitedToHosts || [];
     const disabledMethodTypes = options.disabledMethodTypes || [];
 
-    if (options.host && limitedToHosts.length > 0 && !pm.limitedToHosts.some(host => host.id === options.host.id)) {
+    if (
+      options.host &&
+      limitedToHosts.length > 0 &&
+      !limitedToHosts.some(host => host && host.id === options.host.id)
+    ) {
       return false;
     }
 


### PR DESCRIPTION
Fix https://opencollective.slack.com/archives/C06K5J91675/p1728073056059959
Fix https://open-collective.sentry.io/issues/5710637836

We have an edge case: when a fiscal host disconnect its Stripe account (which was the case for OCF), `limitedToHosts` for their corresponding payment methods is `[null]`). I've updated the code to return `false` when that happens, which will prevent payment methods that are limited to a single host from being used, even if that host disconnects their Stripe account.