### PR TITLE
fix(ConnectedAccounts): Hide PayPal if not connected

### DIFF
--- a/components/edit-collective/sections/ConnectedAccounts.js
+++ b/components/edit-collective/sections/ConnectedAccounts.js
@@ -19,9 +19,9 @@ const TITLE_OVERRIDE = {
 const ConnectedAccounts = props => {
   const connectedAccountsByService = groupBy(props.connectedAccounts, 'service');
 
-  let services = [];
+  const services = [];
   if (props.services) {
-    services = [...props.services, ...services];
+    services.push(...props.services);
   } else {
     if (props.collective.type === 'COLLECTIVE' || props.collective.isHost) {
       services.push('twitter');

--- a/components/edit-collective/sections/SendingMoney.js
+++ b/components/edit-collective/sections/SendingMoney.js
@@ -65,7 +65,7 @@ class SendingMoney extends React.Component {
           connectedAccounts={this.props.collective.connectedAccounts}
           services={services}
         />
-        {!services.includes('paypal') && (
+        {services.includes('paypal') && (
           <Fragment>
             <SettingsSectionTitle>
               <FormattedMessage id="PayoutMethod.Type.Paypal" defaultMessage="PayPal" />


### PR DESCRIPTION
See https://oficonsortium.slack.com/archives/GFH4N961L/p1730997993074379

Removes that message:
![image](https://github.com/user-attachments/assets/4439f5b3-df65-449c-bd6f-685965fb244b)
