### PR TITLE
enhancement(Tiers): make presets coherent with min amount

### DIFF
--- a/components/InputFieldPresets.js
+++ b/components/InputFieldPresets.js
@@ -23,6 +23,7 @@ class InputFieldPresets extends React.Component {
     pre: PropTypes.string,
     options: PropTypes.object,
     onChange: PropTypes.func,
+    min: PropTypes.number,
   };
 
   constructor(props) {
@@ -56,6 +57,7 @@ class InputFieldPresets extends React.Component {
         value={this.state.values[index]}
         options={this.props.options}
         pre={this.props.pre}
+        min={this.props.min}
         onChange={val => this.handleChange(index, val)}
       />
     );

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -130,7 +130,7 @@ const StepDetails = ({ onChange, stepDetails, collective, tier, showPlatformTip,
                 id="amount.belowMinimum"
                 defaultMessage="Please enter an amount of {minAmount} or more"
                 values={{
-                  minAmount: formatCurrency(minAmount, currency),
+                  minAmount: formatCurrency(minAmount, currency, { locale: intl.locale }),
                 }}
               />
             </div>

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -124,7 +124,7 @@ const StepDetails = ({ onChange, stepDetails, collective, tier, showPlatformTip,
 
       {!isFixedContribution ? (
         <Box mb="30px">
-          {amount < minAmount && (
+          {amount && amount < minAmount && (
             <div className="mb-2 text-red-400">
               <FormattedMessage
                 id="amount.belowMinimum"

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -124,11 +124,14 @@ const StepDetails = ({ onChange, stepDetails, collective, tier, showPlatformTip,
 
       {!isFixedContribution ? (
         <Box mb="30px">
-          {amount && amount < minAmount && (
+          {typeof amount === 'number' && !isNaN(amount) && amount < minAmount && (
             <div className="mb-2 text-red-400">
               <FormattedMessage
                 id="amount.belowMinimum"
-                defaultMessage={`Please enter an amount of ${formatCurrency(minAmount, currency)} or more`}
+                defaultMessage="Please enter an amount of {minAmount} or more"
+                values={{
+                  minAmount: formatCurrency(minAmount, currency),
+                }}
               />
             </div>
           )}

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { isEmpty, isNil } from 'lodash';
 import { withRouter } from 'next/router';
 import { FormattedMessage, useIntl } from 'react-intl';
-
 import { AnalyticsEvent } from '../../lib/analytics/events';
 import { track } from '../../lib/analytics/plausible';
 import { AnalyticsProperty } from '../../lib/analytics/properties';
@@ -124,6 +123,14 @@ const StepDetails = ({ onChange, stepDetails, collective, tier, showPlatformTip,
 
       {!isFixedContribution ? (
         <Box mb="30px">
+          {amount < minAmount && (
+            <div className="mb-2 text-red-400">
+              <FormattedMessage
+                id="amount.belowMinimum"
+                defaultMessage={`Please enter an amount of ${formatCurrency(minAmount, currency)} or more`}
+              />
+            </div>
+          )}
           <StyledAmountPicker
             currency={currency}
             presets={presets}

--- a/components/contribution-flow/StepDetails.js
+++ b/components/contribution-flow/StepDetails.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { isEmpty, isNil } from 'lodash';
 import { withRouter } from 'next/router';
 import { FormattedMessage, useIntl } from 'react-intl';
+
 import { AnalyticsEvent } from '../../lib/analytics/events';
 import { track } from '../../lib/analytics/plausible';
 import { AnalyticsProperty } from '../../lib/analytics/properties';

--- a/components/edit-collective/tiers/EditTierModal.js
+++ b/components/edit-collective/tiers/EditTierModal.js
@@ -549,6 +549,7 @@ FormFields.propTypes = {
     type: PropTypes.string,
     amountType: PropTypes.string,
     interval: PropTypes.string,
+    minimumAmount: PropTypes.shape({ valueInCents: PropTypes.number, currency: PropTypes.string }),
   }),
   hideTypeSelect: PropTypes.bool,
   tier: PropTypes.shape({

--- a/components/edit-collective/tiers/EditTierModal.js
+++ b/components/edit-collective/tiers/EditTierModal.js
@@ -275,6 +275,7 @@ function FormFields({ collective, values, hideTypeSelect }) {
           {({ field, form }) => (
             <InputFieldPresets
               {...field}
+              min={values.minimumAmount?.valueInCents || 0}
               defaultValue={field.value}
               onChange={value => form.setFieldValue(field.name, value)}
             />

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -433,6 +433,7 @@
   "Amj+Gh": "By contributing, you agree to our <TOSLink>Terms of Service</TOSLink> and <PrivacyPolicyLink>Privacy Policy</PrivacyPolicyLink>.",
   "Amount": "{amount} {currencyCode}",
   "Amount.AllShort": "Tot",
+  "amount.belowMinimum": "Please enter an amount of {minAmount} or more",
   "Amount.Free": "Free",
   "Amount.RangeFrom": "{minAmount} and above",
   "Amount.RangeFromTo": "{minAmount} to {maxAmount}",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -433,6 +433,7 @@
   "Amj+Gh": "By contributing, you agree to our <TOSLink>Terms of Service</TOSLink> and <PrivacyPolicyLink>Privacy Policy</PrivacyPolicyLink>.",
   "Amount": "{amount} {currencyCode}",
   "Amount.AllShort": "Vše",
+  "amount.belowMinimum": "Please enter an amount of {minAmount} or more",
   "Amount.Free": "Zdarma",
   "Amount.RangeFrom": "{minAmount} a více",
   "Amount.RangeFromTo": "{minAmount} do {maxAmount}",

--- a/lang/de.json
+++ b/lang/de.json
@@ -433,6 +433,7 @@
   "Amj+Gh": "Indem Sie beitragen, stimmen Sie unseren <TOSLink>Nutzungsbedingungen</TOSLink> und unserer <PrivacyPolicyLink>Datenschutzerklärung</PrivacyPolicyLink> zu.",
   "Amount": "{amount} {currencyCode}",
   "Amount.AllShort": "Alle",
+  "amount.belowMinimum": "Please enter an amount of {minAmount} or more",
   "Amount.Free": "Kostenlos",
   "Amount.RangeFrom": "{minAmount} und höher",
   "Amount.RangeFromTo": "{minAmount} bis {maxAmount}",

--- a/lang/en.json
+++ b/lang/en.json
@@ -433,6 +433,7 @@
   "Amj+Gh": "By contributing, you agree to our <TOSLink>Terms of Service</TOSLink> and <PrivacyPolicyLink>Privacy Policy</PrivacyPolicyLink>.",
   "Amount": "{amount} {currencyCode}",
   "Amount.AllShort": "All",
+  "amount.belowMinimum": "Please enter an amount of {minAmount} or more",
   "Amount.Free": "Free",
   "Amount.RangeFrom": "{minAmount} and above",
   "Amount.RangeFromTo": "{minAmount} to {maxAmount}",

--- a/lang/es.json
+++ b/lang/es.json
@@ -433,6 +433,7 @@
   "Amj+Gh": "Al contribuir, aceptas nuestros <TOSLink>Términos de servicio</TOSLink> y <PrivacyPolicyLink>Política de privacidad</PrivacyPolicyLink>.",
   "Amount": "{amount} {currencyCode}",
   "Amount.AllShort": "Todo",
+  "amount.belowMinimum": "Please enter an amount of {minAmount} or more",
   "Amount.Free": "Gratis",
   "Amount.RangeFrom": "{minAmount} y más",
   "Amount.RangeFromTo": "{minAmount} hasta {maxAmount}",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -433,6 +433,7 @@
   "Amj+Gh": "En contribuant, vous acceptez nos <TOSLink>Conditions Générales d'Utilisation</TOSLink> et notre <PrivacyPolicyLink>Politique de confidentialité</PrivacyPolicyLink>.",
   "Amount": "{amount} {currencyCode}",
   "Amount.AllShort": "Tout",
+  "amount.belowMinimum": "Please enter an amount of {minAmount} or more",
   "Amount.Free": "Gratuit",
   "Amount.RangeFrom": "{minAmount} et plus",
   "Amount.RangeFromTo": "{minAmount} à {maxAmount}",

--- a/lang/he.json
+++ b/lang/he.json
@@ -433,6 +433,7 @@
   "Amj+Gh": "בתרומתך הנך מאשר/ת את <TOSLink>תנאי השירות</TOSLink> ואת <PrivacyPolicyLink>מדיניות הפרטיות</PrivacyPolicyLink>.",
   "Amount": "{amount} {currencyCode}",
   "Amount.AllShort": "כולם",
+  "amount.belowMinimum": "Please enter an amount of {minAmount} or more",
   "Amount.Free": "חינם",
   "Amount.RangeFrom": "{minAmount} ומעלה",
   "Amount.RangeFromTo": "{minAmount} עד {maxAmount}",

--- a/lang/it.json
+++ b/lang/it.json
@@ -433,6 +433,7 @@
   "Amj+Gh": "Contribuendo accetti i nostri <TOSLink>Termini di Servizio</TOSLink> e <PrivacyPolicyLink>Informativa sulla Privacy</PrivacyPolicyLink>.",
   "Amount": "{amount} {currencyCode}",
   "Amount.AllShort": "Tutti",
+  "amount.belowMinimum": "Please enter an amount of {minAmount} or more",
   "Amount.Free": "Gratuito",
   "Amount.RangeFrom": "{minAmount} e oltre",
   "Amount.RangeFromTo": "da {minAmount} a {maxAmount}",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -433,6 +433,7 @@
   "Amj+Gh": "貢献することで、<TOSLink>利用規約</TOSLink>と<PrivacyPolicyLink>プライバシーポリシー</PrivacyPolicyLink>に同意したことになります。",
   "Amount": "{amount}{currencyCode}",
   "Amount.AllShort": "すべて",
+  "amount.belowMinimum": "Please enter an amount of {minAmount} or more",
   "Amount.Free": "無料",
   "Amount.RangeFrom": "{minAmount} 以上",
   "Amount.RangeFromTo": "{minAmount} 〜 {maxAmount}",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -433,6 +433,7 @@
   "Amj+Gh": "기부하면 <TOSLink>이용약관</TOSLink>에 동의하는 것으로 간주돼요. <PrivacyPolicyLink>개인정보 처리방침</PrivacyPolicyLink>에서 개인정보가 어떻게 처리되는지 확인할 수 있어요.",
   "Amount": "{amount} {currencyCode}",
   "Amount.AllShort": "모두",
+  "amount.belowMinimum": "Please enter an amount of {minAmount} or more",
   "Amount.Free": "무료",
   "Amount.RangeFrom": "{minAmount} and above",
   "Amount.RangeFromTo": "{minAmount} to {maxAmount}",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -433,6 +433,7 @@
   "Amj+Gh": "By contributing, you agree to our <TOSLink>Terms of Service</TOSLink> and <PrivacyPolicyLink>Privacy Policy</PrivacyPolicyLink>.",
   "Amount": "{amount}{currencyCode}",
   "Amount.AllShort": "Alle",
+  "amount.belowMinimum": "Please enter an amount of {minAmount} or more",
   "Amount.Free": "Gratis",
   "Amount.RangeFrom": "{minAmount} en hoger",
   "Amount.RangeFromTo": "{minAmount} tot {maxAmount}",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -433,6 +433,7 @@
   "Amj+Gh": "Wnosząc swój wkład, zgadzasz się na nasze <TOSLink>Warunki korzystania z usługi</TOSLink> i <PrivacyPolicyLink>Politykę prywatności</PrivacyPolicyLink>.",
   "Amount": "{amount} {currencyCode}",
   "Amount.AllShort": "Wszystko",
+  "amount.belowMinimum": "Please enter an amount of {minAmount} or more",
   "Amount.Free": "Za darmo",
   "Amount.RangeFrom": "{minAmount} i więcej",
   "Amount.RangeFromTo": "od {minAmount} do {maxAmount}",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -433,6 +433,7 @@
   "Amj+Gh": "Ao contribuir, você concorda com nossos <TOSLink>Termos de Serviço</TOSLink> e a <PrivacyPolicyLink>Política de Privacidade</PrivacyPolicyLink>.",
   "Amount": "{amount} {currencyCode}",
   "Amount.AllShort": "Todos",
+  "amount.belowMinimum": "Please enter an amount of {minAmount} or more",
   "Amount.Free": "Grátis",
   "Amount.RangeFrom": "A partir de {minAmount}",
   "Amount.RangeFromTo": "{minAmount} até {maxAmount}",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -433,6 +433,7 @@
   "Amj+Gh": "By contributing, you agree to our <TOSLink>Terms of Service</TOSLink> and <PrivacyPolicyLink>Privacy Policy</PrivacyPolicyLink>.",
   "Amount": "{amount} {currencyCode}",
   "Amount.AllShort": "Todos",
+  "amount.belowMinimum": "Please enter an amount of {minAmount} or more",
   "Amount.Free": "Gratuito",
   "Amount.RangeFrom": "{minAmount} and above",
   "Amount.RangeFromTo": "{minAmount} to {maxAmount}",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -433,6 +433,7 @@
   "Amj+Gh": "Внося свой вклад, вы соглашаетесь с нашими <TOSLink>Условиями использования</TOSLink> и <PrivacyPolicyLink>Политикой конфиденциальности</PrivacyPolicyLink>.",
   "Amount": "{amount} {currencyCode}",
   "Amount.AllShort": "Все",
+  "amount.belowMinimum": "Please enter an amount of {minAmount} or more",
   "Amount.Free": "Бесплатно",
   "Amount.RangeFrom": "{minAmount} и больше",
   "Amount.RangeFromTo": "от {minAmount} до {maxAmount}",

--- a/lang/sk-SK.json
+++ b/lang/sk-SK.json
@@ -433,6 +433,7 @@
   "Amj+Gh": "Poskytnutím príspevku vyjadrujete súhlas s našimi <TOSLink>Podmienkami poskytovania služieb</TOSLink> a <PrivacyPolicyLink>Zásadami ochrany osobných údajov</PrivacyPolicyLink>.",
   "Amount": "{amount} {currencyCode}",
   "Amount.AllShort": "Všetko",
+  "amount.belowMinimum": "Please enter an amount of {minAmount} or more",
   "Amount.Free": "Zadarmo",
   "Amount.RangeFrom": "{minAmount} a viac",
   "Amount.RangeFromTo": "od {minAmount} do {maxAmount}",

--- a/lang/sv-SE.json
+++ b/lang/sv-SE.json
@@ -433,6 +433,7 @@
   "Amj+Gh": "Genom att bidra godkänner du våra <TOSLink>användarvillkor</TOSLink> och <PrivacyPolicyLink>integritetspolicy</PrivacyPolicyLink>.",
   "Amount": "{amount} {currencyCode}",
   "Amount.AllShort": "Alla",
+  "amount.belowMinimum": "Please enter an amount of {minAmount} or more",
   "Amount.Free": "Gratis",
   "Amount.RangeFrom": "{minAmount} och högre",
   "Amount.RangeFromTo": "{minAmount} till {maxAmount}",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -433,6 +433,7 @@
   "Amj+Gh": "Роблячи внесок, ви погоджуєтеся з нашими <TOSLink>Умовами користування</TOSLink> та <PrivacyPolicyLink>Політикою приватності</PrivacyPolicyLink>.",
   "Amount": "{amount} {currencyCode}",
   "Amount.AllShort": "Всі",
+  "amount.belowMinimum": "Please enter an amount of {minAmount} or more",
   "Amount.Free": "Безплатно",
   "Amount.RangeFrom": "{minAmount} і більше",
   "Amount.RangeFromTo": "{minAmount} до {maxAmount}",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -433,6 +433,7 @@
   "Amj+Gh": "继续贡献，即代表你同意我们的 <TOSLink>服务条款</TOSLink>和<PrivacyPolicyLink>隐私政策</PrivacyPolicyLink>。",
   "Amount": "{amount} {currencyCode}",
   "Amount.AllShort": "全部",
+  "amount.belowMinimum": "Please enter an amount of {minAmount} or more",
   "Amount.Free": "免费",
   "Amount.RangeFrom": "{minAmount} 及以上",
   "Amount.RangeFromTo": "{minAmount} 到 {maxAmount}",


### PR DESCRIPTION
Resolve [Issue with validation within tiers](https://github.com/opencollective/opencollective/issues/7176#issuecomment-2450190403)


# Description

This PR adds a validation message when a user is trying to pay lesser than the minimum amount for a collective and also trys to prevent that when setting tiers on the dashboard.

# Screenshots

![ezgif-5-5fe4c9d7ae](https://github.com/user-attachments/assets/b145e5ea-adfe-487c-b3b7-bd89aa2067ff)

