### PR TITLE
fix(PayPal): hide 'disable payouts' option if not connected

### DIFF
--- a/components/edit-collective/sections/SendingMoney.js
+++ b/components/edit-collective/sections/SendingMoney.js
@@ -65,7 +65,7 @@ class SendingMoney extends React.Component {
           connectedAccounts={this.props.collective.connectedAccounts}
           services={services}
         />
-        {services.includes('paypal') && (
+        {services.includes('paypal') && this.props.collective.connectedAccounts?.find(c => c.service === 'paypal') && (
           <Fragment>
             <SettingsSectionTitle>
               <FormattedMessage id="PayoutMethod.Type.Paypal" defaultMessage="PayPal" />


### PR DESCRIPTION
Follow-up on https://github.com/opencollective/opencollective-frontend/pull/10788