### PR TITLE
enhancement(SearchCommand): update fetch policy to 'cache-and-network'

### DIFF
--- a/components/search/SearchCommand.tsx
+++ b/components/search/SearchCommand.tsx
@@ -81,6 +81,7 @@ export const SearchCommand = ({ open, setOpen }) => {
     variables: queryFilter.variables,
     notifyOnNetworkStatusChange: true,
     context: API_V2_CONTEXT,
+    fetchPolicy: 'cache-and-network',
   });
 
   const { debouncedValue: debouncedInput, isDebouncing } = useDebouncedValue(input, 500);


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/7626

While playing with the data, I stumbled upon an annoying situation a few times:
1. Search for something (e.g. "Amazon invoice")
2. Add the thing to the API (e.g. create an expense with the title "Amazon invoice")
3. Search again
4. => No results because we already cached a query for that string

This was not an issue before because we weren't synchronizing in real-time.

The `cache-and-network` policy should provide the same UI responsiveness while refreshing the results if there's something new in the API.