### PR TITLE
feat: Enable '@' as an import alias

### DIFF
--- a/components/dashboard/filters/AmountFilter/AmountFilterValue.tsx
+++ b/components/dashboard/filters/AmountFilter/AmountFilterValue.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import type { Currency } from '../../../../lib/graphql/types/v2/schema';
+import type { Currency } from '@/lib/graphql/types/v2/schema';
 
-import FormattedMoneyAmount from '../../../FormattedMoneyAmount';
+import FormattedMoneyAmount from '@/components/FormattedMoneyAmount';
 
 import type { AmountFilterValueType } from './schema';
 import { AmountFilterType } from './schema';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,11 @@
     "moduleResolution": "node",
     "typeRoots": ["node_modules/@types", "lib/custom_typings"],
     "jsx": "preserve",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "paths": {
+      "@/components/*": ["./components/*"],
+      "@/lib/*": ["./lib/*"]
+    }
   },
   "include": [
     ".eslintrc.js",


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/6845

- Only enabled for Typescript for simplicity, assuming that new files are TS only anyway.
- Not migrating all files to prevent a gigantic diff, and because we don't want to enforce the new format at this stage.