### PR TITLE
fix: ExpenseSummary missing permissions issue

### DIFF
--- a/components/expenses/ExpenseSummary.js
+++ b/components/expenses/ExpenseSummary.js
@@ -123,7 +123,7 @@ const ExpenseSummary = ({
   const isViewingExpenseInHostContext = isLoggedInUserExpenseHostAdmin && !isLoggedInUserExpenseAdmin;
   const useInlineExpenseEdit =
     LoggedInUser?.hasPreviewFeatureEnabled(PREVIEW_FEATURE_KEYS.NEW_EXPENSE_FLOW) &&
-    expense?.permissions.canEdit &&
+    expense?.permissions?.canEdit &&
     expense?.type !== ExpenseType.GRANT &&
     expense?.status !== ExpenseStatus.DRAFT;
 


### PR DESCRIPTION
There is a small conflict in the expense submission flow when submitting through the classic form on the collective page while the new expense flow is flagged.
Caught by JF in production.
