### PR TITLE
fix(Edit expense): Fix editing payout method

### DIFF
--- a/components/expenses/EditExpenseDialog.tsx
+++ b/components/expenses/EditExpenseDialog.tsx
@@ -148,7 +148,7 @@ const EditPayoutMethod = ({ expense, onSubmit }) => {
   const startOptions = React.useRef({
     expenseId: expense.legacyId,
     isInlineEdit: true,
-    pickSchemaFiels: {
+    pickSchemaFields: {
       expenseItems: true,
       hasTax: true,
       tax: true,


### PR DESCRIPTION
Fixing a typo in the startOptions object, causing validation on fields not part of editing the payout method.