### PR TITLE
SearchCommand: only query search if term is defined

### DIFF
--- a/components/search/SearchCommand.tsx
+++ b/components/search/SearchCommand.tsx
@@ -100,7 +100,7 @@ export const SearchCommand = ({ open, setOpen }) => {
 
   const { debouncedValue: debouncedInput, isDebouncing } = useDebouncedValue(input, 500);
   useEffect(() => {
-    search({ variables: { searchTerm: debouncedInput } });
+    debouncedInput?.length > 0 && search({ variables: { searchTerm: debouncedInput } });
   }, [debouncedInput, search]);
 
   const handleKeyDown = React.useCallback(


### PR DESCRIPTION
This fixes the unnecessary search call while loading the page.
Alternatively, if we use this to display pre-populated contextual results, we could check if `open === true` before calling the search query.