### PR TITLE
fix: scrollbar in contribution embed

### DIFF
--- a/components/EmbeddedPage.js
+++ b/components/EmbeddedPage.js
@@ -8,6 +8,9 @@ import Header from '../components/Header';
 import { withUser } from './UserProvider';
 
 const GlobalStyles = createGlobalStyle`
+  body {
+    overflow-y: auto;
+  }
   body > div:first-child {
     height: 100%;
   }


### PR DESCRIPTION
Verified this fixed the always on scrollbar.

**Before**: 
`https://opencollective.com/embed/webpack/donate`
![Screenshot 2025-01-15 at 5 09 22 PM](https://github.com/user-attachments/assets/dcf0454f-e619-4270-95bb-db6613bce658)

**After**: 
`https://opencollective-frontend-git-fork-jpoehnelt-main-opencollective.vercel.app/embed/webpack/donate`
![Screenshot 2025-01-15 at 5 09 06 PM](https://github.com/user-attachments/assets/dc9fd79b-7b4d-465b-a331-0065c2009eb3)
