### PR TITLE
fix(Expense flow): Horizontal scroll and missing header

### DIFF
--- a/components/submit-expense/SubmitExpenseFlow.tsx
+++ b/components/submit-expense/SubmitExpenseFlow.tsx
@@ -310,7 +310,7 @@ export function SubmitExpenseFlow(props: SubmitExpenseFlowProps) {
           hideCloseButton
         >
           <div className="max-w-screen min-w-screen before:-z-1 relative flex max-h-screen min-h-screen flex-col overflow-hidden bg-[#F8FAFC] before:absolute before:left-0 before:right-0 before:top-0 before:h-44 before:rotate-180 before:[background:url('/static/images/home/fiscalhost-blue-bg-md.png')]">
-            <header className="min-w-screen z-30 flex items-center justify-between border-b border-slate-100 px-4 py-3 sm:px-10">
+            <header className="min-w-screen z-30 flex items-center justify-between border-b border-slate-100 bg-background px-4 py-3 sm:px-10">
               <span className="text-xl font-bold leading-7 text-slate-800">
                 <FormattedMessage
                   defaultMessage="Invoice #{submittedExpenseId} has been submitted successfully!"
@@ -335,13 +335,13 @@ export function SubmitExpenseFlow(props: SubmitExpenseFlowProps) {
               </Button>
             </header>
             <main className="z-10 flex w-full flex-grow overflow-hidden">
-              <div className="flex w-full flex-grow justify-center">
-                <div className="flex w-full flex-col overflow-scroll sm:flex sm:flex-row sm:gap-11 sm:px-8 sm:pt-4">
+              <div className="flex w-full flex-grow justify-center overflow-y-scroll">
+                <div className="flex w-full max-w-screen-xl flex-col pt-4 sm:flex sm:flex-row sm:gap-11 sm:px-8 sm:pt-8 lg:pt-24">
                   <SubmittedExpense expenseId={submittedExpenseId} />
                 </div>
               </div>
             </main>
-            <DialogFooter className="z-30 flex justify-center p-4 sm:justify-center sm:px-0">
+            <DialogFooter className="z-30 flex justify-center border-t p-4 sm:justify-center sm:px-0">
               <Button onClick={handleOnClose}>
                 <FormattedMessage
                   defaultMessage="View all expenses"

--- a/components/submit-expense/SubmittedExpense.tsx
+++ b/components/submit-expense/SubmittedExpense.tsx
@@ -24,7 +24,11 @@ export function SubmittedExpense(props: SubmittedExpenseProps) {
   });
 
   if (query.loading) {
-    return <Loading />;
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <Loading />
+      </div>
+    );
   }
 
   if (query.error) {
@@ -34,8 +38,8 @@ export function SubmittedExpense(props: SubmittedExpenseProps) {
   const expense = query.data?.expense;
 
   return (
-    <div className="flex flex-grow flex-wrap gap-8 px-4 sm:p-0">
-      <div className="flex-grow">
+    <div className="flex flex-grow flex-col gap-8 px-4 sm:p-0 lg:flex-row">
+      <div className="flex-1 flex-grow-[2]">
         <ExpenseSummary
           onDelete={() => {}}
           onEdit={() => {}}
@@ -52,7 +56,7 @@ export function SubmittedExpense(props: SubmittedExpenseProps) {
           collective={expense?.account}
         />
       </div>
-      <div className="md:max-w-96">
+      <div className="flex-1 md:max-w-96">
         <CreateExpenseFAQ defaultOpen />
       </div>
     </div>


### PR DESCRIPTION
Resolves 
- https://github.com/opencollective/opencollective/issues/7746
- https://github.com/opencollective/opencollective/issues/7754


# Description

Fixes the horizontal scrollbar and missing header in success screen. Also fixes the wideness of the success page.

# Screenshots

<img width="1815" alt="image" src="https://github.com/user-attachments/assets/927cb0d2-00bc-4bf5-84bc-0a2433ca3c25" />
