### PR TITLE
fix(Expense form): Update form inputs to use new inputs & improve error state

### DIFF
--- a/components/AccountingCategorySelect.tsx
+++ b/components/AccountingCategorySelect.tsx
@@ -332,7 +332,7 @@ const AccountingCategorySelect = ({
   allowNone = false,
   showCode = false,
   expenseValues = undefined,
-  buttonClassName = 'rounded-lg',
+  buttonClassName = '',
   children = null,
   selectFirstOptionIfSingle,
   disabled,
@@ -383,7 +383,7 @@ const AccountingCategorySelect = ({
               id={id}
               variant="outline"
               className={cn(
-                'w-full max-w-[300px]',
+                'w-full max-w-[300px] font-normal',
                 {
                   'ring-2 ring-destructive ring-offset-2': error,
                 },
@@ -399,7 +399,7 @@ const AccountingCategorySelect = ({
                 {getCategoryLabel(intl, selectedCategory, false, valuesByRole) ||
                   intl.formatMessage({ defaultMessage: 'Select category', id: 'RUJYth' })}
               </span>
-              <ChevronDown size="1em" className={cn({ 'text-[hsl(0,0%,80%)]': disabled })} />
+              <ChevronDown size="1em" />
             </Button>
           )}
         </PopoverTrigger>

--- a/components/AccountingCategorySelect.tsx
+++ b/components/AccountingCategorySelect.tsx
@@ -13,6 +13,7 @@ import { cn } from '../lib/utils';
 import { ACCOUNTING_CATEGORY_HOST_FIELDS } from './expenses/lib/accounting-categories';
 import { isSameAccount } from '@/lib/collective';
 
+import { Button } from './ui/Button';
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from './ui/Command';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/Popover';
 
@@ -378,16 +379,15 @@ const AccountingCategorySelect = ({
       <Popover open={isOpen} onOpenChange={setOpen}>
         <PopoverTrigger asChild onBlur={onBlur} disabled={disabled}>
           {children || (
-            <button
+            <Button
               id={id}
+              variant="outline"
               className={cn(
-                'flex w-full max-w-[300px] items-center justify-between border px-3 py-2',
-                buttonClassName,
+                'w-full max-w-[300px]',
                 {
-                  'border-red-500': error,
-                  'border-gray-300': !error,
-                  'bg-[hsl(0,0%,95%)] text-[hsl(0,0%,60%)]': disabled,
+                  'ring-2 ring-destructive ring-offset-2': error,
                 },
+                buttonClassName,
               )}
               disabled={disabled}
             >
@@ -400,7 +400,7 @@ const AccountingCategorySelect = ({
                   intl.formatMessage({ defaultMessage: 'Select category', id: 'RUJYth' })}
               </span>
               <ChevronDown size="1em" className={cn({ 'text-[hsl(0,0%,80%)]': disabled })} />
-            </button>
+            </Button>
           )}
         </PopoverTrigger>
         <PopoverContent className="min-w-[280px] p-0" style={{ width: 'var(--radix-popover-trigger-width)' }}>

--- a/components/Dropzone.tsx
+++ b/components/Dropzone.tsx
@@ -59,7 +59,7 @@ const Dropzone = ({
   showReplaceAction = true,
   className = '',
   ...props
-}: StyledDropzoneProps) => {
+}: DropzoneProps) => {
   const { toast } = useToast();
   const intl = useIntl();
   const imgUploaderParams = { isMulti, mockImageGenerator, onSuccess, onReject, kind, accept, minSize, maxSize };
@@ -307,7 +307,7 @@ type UploadedFile = {
   type: string;
 };
 
-type StyledDropzoneProps = Omit<ContainerProps, 'accept' | 'children' | 'ref' | 'onClick' | 'as'> & {
+type DropzoneProps = React.HTMLAttributes<HTMLDivElement> & {
   /** Called back with the rejected files */
   onReject?: (msg: string) => void;
   /** Called when the user drops files */

--- a/components/Dropzone.tsx
+++ b/components/Dropzone.tsx
@@ -13,7 +13,6 @@ import { cn } from '@/lib/utils';
 
 import { Button } from './ui/Button';
 import { useToast } from './ui/useToast';
-import type { ContainerProps } from './Container';
 import { getI18nLink } from './I18nFormatters';
 import LocalFilePreview from './LocalFilePreview';
 import StyledSpinner from './StyledSpinner';

--- a/components/FormField.tsx
+++ b/components/FormField.tsx
@@ -7,6 +7,7 @@ import { useIntl } from 'react-intl';
 import { isOCError } from '../lib/errors';
 import { formatFormErrorMessage, RICH_ERROR_MESSAGES } from '../lib/form-utils';
 
+import PrivateInfoIcon from './icons/PrivateInfoIcon';
 import { Input } from './ui/Input';
 import { Label } from './ui/Label';
 import { FormikZodContext, getInputAttributesFromZodSchema } from './FormikZod';
@@ -19,6 +20,7 @@ export function FormField({
   placeholder,
   children,
   error: customError,
+  isPrivate,
   ...props
 }: {
   label?: string;
@@ -26,7 +28,7 @@ export function FormField({
   name: string;
   hint?: string;
   placeholder?: string;
-  children?: (props: { form: FormikProps<any>; meta: any; field: any }) => JSX.Element;
+  children?: (props: { form: FormikProps<any>; meta: any; field: any; hasError?: boolean }) => JSX.Element;
   required?: boolean;
   min?: number;
   max?: number;
@@ -34,6 +36,7 @@ export function FormField({
   disabled?: boolean;
   htmlFor?: string;
   error?: string;
+  isPrivate?: boolean;
 }) {
   const intl = useIntl();
   const htmlFor = props.htmlFor || `input-${name}`;
@@ -73,7 +76,17 @@ export function FormField({
         }
         return (
           <div className="flex w-full flex-col gap-1">
-            {label && <Label className="leading-normal">{label}</Label>}
+            {label && (
+              <Label className="leading-normal">
+                {label}
+                {isPrivate && (
+                  <React.Fragment>
+                    &nbsp;
+                    <PrivateInfoIcon />
+                  </React.Fragment>
+                )}
+              </Label>
+            )}
             {hint && <p className="text-sm text-muted-foreground">{hint}</p>}
             {children ? children({ form, meta, field: fieldAttributes }) : <Input {...fieldAttributes} />}
             {hasError && showError && (

--- a/components/attached-files/AddNewAttachedFilesButton.tsx
+++ b/components/attached-files/AddNewAttachedFilesButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Dropzone from 'react-dropzone';
+import ReactDropzone from 'react-dropzone';
 import { FormattedMessage } from 'react-intl';
 
 import { useImageUploader } from '../../lib/hooks/useImageUploader';
@@ -18,7 +18,7 @@ const AddNewAttachedFilesButton = ({ disabled, mockImageGenerator, onSuccess, is
   });
 
   return (
-    <Dropzone {...attachmentDropzoneParams} disabled={disabled} multiple={true} onDrop={uploadFiles}>
+    <ReactDropzone {...attachmentDropzoneParams} disabled={disabled} multiple={true} onDrop={uploadFiles}>
       {({ getRootProps, getInputProps }) => (
         <div {...getRootProps()}>
           <input {...getInputProps()} />
@@ -28,7 +28,7 @@ const AddNewAttachedFilesButton = ({ disabled, mockImageGenerator, onSuccess, is
           </StyledButton>
         </div>
       )}
-    </Dropzone>
+    </ReactDropzone>
   );
 };
 

--- a/components/attached-files/AttachedFilesForm.tsx
+++ b/components/attached-files/AttachedFilesForm.tsx
@@ -5,9 +5,9 @@ import { FormattedMessage } from 'react-intl';
 import type { UploadedFileKind } from '../../lib/graphql/types/v2/graphql';
 import { attachmentDropzoneParams } from './lib/attachments';
 
+import Dropzone from '../Dropzone';
 import { Flex } from '../Grid';
 import PrivateInfoIcon from '../icons/PrivateInfoIcon';
-import StyledDropzone from '../StyledDropzone';
 import StyledHr from '../StyledHr';
 import { P, Span } from '../Text';
 
@@ -91,7 +91,7 @@ const AttachedFilesForm = ({
           }}
         />
       ) : (
-        <StyledDropzone
+        <Dropzone
           {...attachmentDropzoneParams}
           name={name}
           kind={kind}

--- a/components/attached-files/lib/attachments.ts
+++ b/components/attached-files/lib/attachments.ts
@@ -1,4 +1,4 @@
-import { DROPZONE_ACCEPT_ALL } from '../../StyledDropzone';
+import { DROPZONE_ACCEPT_ALL } from '../../Dropzone';
 
 export const attachmentDropzoneParams = {
   accept: DROPZONE_ACCEPT_ALL,

--- a/components/collective-page/hero/HeroAvatar.js
+++ b/components/collective-page/hero/HeroAvatar.js
@@ -17,10 +17,10 @@ import { getAvatarBorderRadius } from '../../../lib/image-utils';
 import Avatar from '../../Avatar';
 import ConfirmationModal from '../../ConfirmationModal';
 import Container from '../../Container';
+import { DROPZONE_ACCEPT_IMAGES } from '../../Dropzone';
 import { Box } from '../../Grid';
 import LoadingPlaceholder from '../../LoadingPlaceholder';
 import StyledButton from '../../StyledButton';
-import { DROPZONE_ACCEPT_IMAGES } from '../../StyledDropzone';
 import { P, Span } from '../../Text';
 import { useToast } from '../../ui/useToast';
 
@@ -30,7 +30,7 @@ const AVATAR_SIZE = 128;
 const DropzoneLoadingPlaceholder = () => (
   <LoadingPlaceholder height={AVATAR_SIZE} width={AVATAR_SIZE} color="primary.500" borderRadius="25%" />
 );
-const Dropzone = dynamic(() => import(/* webpackChunkName: 'react-dropzone' */ 'react-dropzone'), {
+const ReactDropzone = dynamic(() => import(/* webpackChunkName: 'react-dropzone' */ 'react-dropzone'), {
   loading: DropzoneLoadingPlaceholder,
   ssr: false,
 });
@@ -146,7 +146,7 @@ const HeroAvatar = ({ collective, isAdmin, intl }) => {
     const imgType = isIndividualAccount(collective) ? 'AVATAR' : 'LOGO';
     return (
       <Fragment>
-        <Dropzone
+        <ReactDropzone
           style={{}}
           multiple={false}
           accept={DROPZONE_ACCEPT_IMAGES}
@@ -206,7 +206,7 @@ const HeroAvatar = ({ collective, isAdmin, intl }) => {
               </EditableAvatarContainer>
             </div>
           )}
-        </Dropzone>
+        </ReactDropzone>
         {showModal && (
           <ConfirmationModal
             width="100%"

--- a/components/collective-page/hero/HeroBackgroundCropperModal.js
+++ b/components/collective-page/hero/HeroBackgroundCropperModal.js
@@ -4,7 +4,7 @@ import { useMutation } from '@apollo/client';
 import { Image as ImageIcon } from '@styled-icons/boxicons-regular/Image';
 import { AngleDoubleDown } from '@styled-icons/fa-solid/AngleDoubleDown';
 import { cloneDeep, get, set } from 'lodash';
-import Dropzone from 'react-dropzone';
+import ReactDropzone from 'react-dropzone';
 import Cropper from 'react-easy-crop';
 import { FormattedMessage, useIntl } from 'react-intl';
 import styled from 'styled-components';
@@ -17,9 +17,9 @@ import { mergeRefs } from '../../../lib/react-utils';
 
 import Container from '../../Container';
 import ContainerOverlay from '../../ContainerOverlay';
+import { DROPZONE_ACCEPT_IMAGES } from '../../Dropzone';
 import { Box, Flex } from '../../Grid';
 import StyledButton from '../../StyledButton';
-import { DROPZONE_ACCEPT_IMAGES } from '../../StyledDropzone';
 import StyledInputSlider from '../../StyledInputSlider';
 import StyledModal, { ModalBody, ModalFooter, ModalHeader } from '../../StyledModal';
 import { Span } from '../../Text';
@@ -93,7 +93,7 @@ const HeroBackgroundCropperModal = ({ onClose, collective }) => {
         </Span>
       </ModalHeader>
 
-      <Dropzone onDrop={onDrop} multiple={false} accept={DROPZONE_ACCEPT_IMAGES}>
+      <ReactDropzone onDrop={onDrop} multiple={false} accept={DROPZONE_ACCEPT_IMAGES}>
         {({ isDragActive, isDragAccept, getRootProps, getInputProps, open }) => {
           const rootProps = getRootProps();
           return (
@@ -286,7 +286,7 @@ const HeroBackgroundCropperModal = ({ onClose, collective }) => {
             </React.Fragment>
           );
         }}
-      </Dropzone>
+      </ReactDropzone>
     </StyledModal>
   );
 };

--- a/components/crowdfunding-redesign/edit/EditFundraiser.tsx
+++ b/components/crowdfunding-redesign/edit/EditFundraiser.tsx
@@ -8,9 +8,9 @@ import { i18nGraphqlException } from '../../../lib/errors';
 import { API_V2_CONTEXT } from '../../../lib/graphql/helpers';
 import { isValidUrl } from '../../../lib/utils';
 
+import Dropzone, { DROPZONE_ACCEPT_IMAGES } from '../../Dropzone';
 import { FormField } from '../../FormField';
 import { FormikZod } from '../../FormikZod';
-import StyledDropzone, { DROPZONE_ACCEPT_IMAGES } from '../../StyledDropzone';
 import Tabs from '../../Tabs';
 import { Button } from '../../ui/Button';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '../../ui/Dialog';
@@ -58,7 +58,7 @@ const CoverImageForm = ({ schema, initialValues, onSubmit }) => {
                         const hasValidUrl = field.value && isValidUrl(field.value);
 
                         return (
-                          <StyledDropzone
+                          <Dropzone
                             name={field.name}
                             kind="ACCOUNT_BANNER"
                             accept={DROPZONE_ACCEPT_IMAGES}
@@ -66,7 +66,7 @@ const CoverImageForm = ({ schema, initialValues, onSubmit }) => {
                             maxSize={10e6} // in bytes, =10MB
                             isMulti={false}
                             showActions
-                            size={196}
+                            className="size-48"
                             onSuccess={data => {
                               if (data) {
                                 formik.setFieldValue(field.name, data.url);

--- a/components/crowdfunding-redesign/edit/EditProfile.tsx
+++ b/components/crowdfunding-redesign/edit/EditProfile.tsx
@@ -8,9 +8,9 @@ import { i18nGraphqlException } from '../../../lib/errors';
 import { API_V2_CONTEXT } from '../../../lib/graphql/helpers';
 import { isValidUrl } from '../../../lib/utils';
 
+import Dropzone, { DROPZONE_ACCEPT_IMAGES } from '../../Dropzone';
 import { FormField } from '../../FormField';
 import { FormikZod } from '../../FormikZod';
-import StyledDropzone, { DROPZONE_ACCEPT_IMAGES } from '../../StyledDropzone';
 import { Button } from '../../ui/Button';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '../../ui/Dialog';
 import { Separator } from '../../ui/Separator';
@@ -39,7 +39,7 @@ const CoverImageForm = ({ schema, initialValues, onSubmit }) => {
                     {({ field }) => {
                       const hasValidUrl = field.value && isValidUrl(field.value);
                       return (
-                        <StyledDropzone
+                        <Dropzone
                           name={field.name}
                           kind="ACCOUNT_BANNER"
                           accept={DROPZONE_ACCEPT_IMAGES}
@@ -47,7 +47,7 @@ const CoverImageForm = ({ schema, initialValues, onSubmit }) => {
                           maxSize={10e6} // in bytes, =10MB
                           isMulti={false}
                           showActions
-                          size={196}
+                          className="size-48"
                           onSuccess={data => {
                             if (data) {
                               formik.setFieldValue(field.name, data.url);

--- a/components/dashboard/sections/collectives/AddFundsModal.tsx
+++ b/components/dashboard/sections/collectives/AddFundsModal.tsx
@@ -733,7 +733,6 @@ const AddFundsModalContentWithCollective = ({
                         account={account}
                         selectedCategory={field.value}
                         allowNone={true}
-                        buttonClassName="rounded"
                       />
                     )}
                   </Field>

--- a/components/dashboard/sections/contributions/CreatePendingOrderModal.tsx
+++ b/components/dashboard/sections/contributions/CreatePendingOrderModal.tsx
@@ -557,7 +557,6 @@ const CreatePendingContributionForm = ({ host, onClose, error, edit }: CreatePen
                 account={collective}
                 selectedCategory={field.value}
                 allowNone={true}
-                buttonClassName="rounded"
               />
             )}
           </Field>

--- a/components/dashboard/sections/expenses/HostCreateExpenseModal.tsx
+++ b/components/dashboard/sections/expenses/HostCreateExpenseModal.tsx
@@ -384,7 +384,7 @@ export const HostCreateExpenseModal = ({
                           expenseValues={values}
                           selectedCategory={field.value}
                           onChange={category => setFieldValue(field.name, category)}
-                          buttonClassName="rounded max-w-full"
+                          buttonClassName="max-w-full"
                           predictionStyle="inline-preload"
                           showCode
                           allowNone

--- a/components/dashboard/sections/expenses/HostCreateExpenseModal.tsx
+++ b/components/dashboard/sections/expenses/HostCreateExpenseModal.tsx
@@ -27,10 +27,10 @@ import AccountingCategorySelect from '@/components/AccountingCategorySelect';
 
 import { DefaultCollectiveLabel } from '../../../CollectivePicker';
 import CollectivePickerAsync from '../../../CollectivePickerAsync';
+import Dropzone from '../../../Dropzone';
 import { ExchangeRate } from '../../../ExchangeRate';
 import { FormikZod } from '../../../FormikZod';
 import type { BaseModalProps } from '../../../ModalContext';
-import StyledDropzone from '../../../StyledDropzone';
 import { StyledInputAmountWithDynamicFxRate } from '../../../StyledInputAmountWithDynamicFxRate';
 import StyledInputFormikField from '../../../StyledInputFormikField';
 import StyledSelect from '../../../StyledSelect';
@@ -404,7 +404,7 @@ export const HostCreateExpenseModal = ({
                     }
                   >
                     {({ form, field, meta }) => (
-                      <StyledDropzone
+                      <Dropzone
                         {...attachmentDropzoneParams}
                         kind="EXPENSE_ITEM"
                         data-cy={`${field.name}-dropzone`}
@@ -412,7 +412,6 @@ export const HostCreateExpenseModal = ({
                         isMulti={false}
                         error={(meta.touched || form.submitCount) && meta.error}
                         mockImageGenerator={() => `https://loremflickr.com/120/120/invoice?lock=0`}
-                        fontSize="13px"
                         value={field.value && isValidUrl(field.value?.url) && field.value.url}
                         useGraphQL={true}
                         parseDocument={false}

--- a/components/dashboard/sections/legal-documents/UploadTaxFormModal.tsx
+++ b/components/dashboard/sections/legal-documents/UploadTaxFormModal.tsx
@@ -7,8 +7,8 @@ import { API_V2_CONTEXT } from '../../../../lib/graphql/helpers';
 import type { Account, Host, LegalDocument } from '../../../../lib/graphql/types/v2/schema';
 import { getMessageForRejectedDropzoneFiles } from '../../../../lib/hooks/useImageUploader';
 
+import Dropzone, { DROPZONE_ACCEPT_PDF } from '../../../Dropzone';
 import type { BaseModalProps } from '../../../ModalContext';
-import StyledDropzone, { DROPZONE_ACCEPT_PDF } from '../../../StyledDropzone';
 import { Button } from '../../../ui/Button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../../../ui/Dialog';
 import { useToast } from '../../../ui/useToast';
@@ -87,7 +87,7 @@ export const UploadTaxFormModal = ({
                 }}
               />
             </p>
-            <StyledDropzone
+            <Dropzone
               name="taxFormFileInput"
               accept={DROPZONE_ACCEPT_PDF}
               collectFilesOnly
@@ -99,7 +99,7 @@ export const UploadTaxFormModal = ({
               showIcon
               showActions
               previewSize={56}
-              p="16px"
+              className="p-4"
               onSuccess={(accepted, rejected) => {
                 if (rejected.length) {
                   toast({

--- a/components/dashboard/sections/transactions-imports/StepSelectCSV.tsx
+++ b/components/dashboard/sections/transactions-imports/StepSelectCSV.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
-import StyledDropzone, { DROPZONE_ACCEPT_CSV } from '../../../StyledDropzone';
+import Dropzone, { DROPZONE_ACCEPT_CSV } from '../../../Dropzone';
 import { useStepper } from '../../../ui/Stepper';
 
 export const StepSelectCSV = ({ onFileSelected }) => {
   const { nextStep } = useStepper();
 
   return (
-    <StyledDropzone
+    <Dropzone
       accept={DROPZONE_ACCEPT_CSV}
       name="transactions-csv"
       isMulti={false}

--- a/components/expenses/AddNewAttachedFilesButton.tsx
+++ b/components/expenses/AddNewAttachedFilesButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { FileRejection } from 'react-dropzone';
-import Dropzone from 'react-dropzone';
+import ReactDropzone from 'react-dropzone';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import type { OcrParsingOptionsInput, UploadFileResult } from '../../lib/graphql/types/v2/schema';
@@ -52,7 +52,7 @@ const AddNewAttachedFilesButton = ({
   );
 
   return (
-    <Dropzone {...attachmentDropzoneParams} disabled={disabled} multiple={true} onDrop={onDrop}>
+    <ReactDropzone {...attachmentDropzoneParams} disabled={disabled} multiple={true} onDrop={onDrop}>
       {({ getRootProps, getInputProps }) => (
         <div {...getRootProps()}>
           <input name="addAttachedFile" {...getInputProps()} />
@@ -69,7 +69,7 @@ const AddNewAttachedFilesButton = ({
           </StyledButton>
         </div>
       )}
-    </Dropzone>
+    </ReactDropzone>
   );
 };
 

--- a/components/expenses/ExpenseAttachedFilesForm.tsx
+++ b/components/expenses/ExpenseAttachedFilesForm.tsx
@@ -5,9 +5,9 @@ import { FormattedMessage } from 'react-intl';
 import type { Account } from '../../lib/graphql/types/v2/schema';
 import { attachmentDropzoneParams } from './lib/attachments';
 
+import Dropzone from '../Dropzone';
 import { Flex } from '../Grid';
 import PrivateInfoIcon from '../icons/PrivateInfoIcon';
-import StyledDropzone from '../StyledDropzone';
 import StyledHr from '../StyledHr';
 import { P, Span } from '../Text';
 
@@ -67,7 +67,7 @@ const ExpenseAttachedFilesForm = ({
           }}
         />
       ) : (
-        <StyledDropzone
+        <Dropzone
           {...attachmentDropzoneParams}
           isMulti
           name="attachedFiles"

--- a/components/expenses/ExpenseFormItems.js
+++ b/components/expenses/ExpenseFormItems.js
@@ -13,11 +13,11 @@ import { expenseItemsMustHaveFiles, newExpenseItem } from './lib/items';
 import { compareItemOCRValues, itemHasOCR, updateExpenseFormWithUploadResult } from './lib/ocr';
 import { expenseTypeSupportsItemCurrency } from './lib/utils';
 
+import Dropzone from '../Dropzone';
 import { Box, Flex } from '../Grid';
 import { I18nBold } from '../I18nFormatters';
 import MessageBox from '../MessageBox';
 import StyledCheckbox from '../StyledCheckbox';
-import StyledDropzone from '../StyledDropzone';
 import StyledHr from '../StyledHr';
 import { TaxesFormikFields } from '../taxes/TaxesFormikFields';
 import { P, Span } from '../Text';
@@ -171,7 +171,7 @@ class ExpenseFormItems extends React.PureComponent {
     if (!hasItems && requireFile) {
       return (
         <React.Fragment>
-          <StyledDropzone
+          <Dropzone
             {...attachmentDropzoneParams}
             kind="EXPENSE_ITEM"
             data-cy="expense-multi-items-dropzone"
@@ -181,7 +181,7 @@ class ExpenseFormItems extends React.PureComponent {
               this.removeMultiUploadingItems();
             }}
             mockImageGenerator={index => `https://loremflickr.com/120/120/invoice?lock=${index}`}
-            mb={3}
+            className="mb-4"
             useGraphQL={hasOCRFeature}
             parseDocument={hasOCRFeature}
             parsingOptions={{ currency: values.currency }}
@@ -208,7 +208,7 @@ class ExpenseFormItems extends React.PureComponent {
                 values={{ 'i18n-bold': I18nBold }}
               />
             </P>
-          </StyledDropzone>
+          </Dropzone>
         </React.Fragment>
       );
     }

--- a/components/expenses/ExpenseItemForm.js
+++ b/components/expenses/ExpenseItemForm.js
@@ -22,12 +22,12 @@ import { FX_RATE_ERROR_THRESHOLD, getExpenseExchangeRateWarningOrError } from '.
 
 import * as ScanningAnimationJSON from '../../public/static/animations/scanning.json';
 import Container from '../Container';
+import Dropzone from '../Dropzone';
 import { ExchangeRate } from '../ExchangeRate';
 import { Box, Flex } from '../Grid';
 import PrivateInfoIcon from '../icons/PrivateInfoIcon';
 import RichTextEditor from '../RichTextEditor';
 import StyledButton from '../StyledButton';
-import StyledDropzone from '../StyledDropzone';
 import StyledHr from '../StyledHr';
 import StyledInput from '../StyledInput';
 import StyledInputAmount from '../StyledInputAmount';
@@ -337,7 +337,7 @@ const ExpenseItemForm = ({
                   required={!isOptional}
                   error={meta.error?.type !== ERROR.FORM_FIELD_REQUIRED && formatFormErrorMessage(intl, meta.error)}
                 >
-                  <StyledDropzone
+                  <Dropzone
                     {...attachmentDropzoneParams}
                     kind="EXPENSE_ITEM"
                     data-cy={`${field.name}-dropzone`}
@@ -350,8 +350,7 @@ const ExpenseItemForm = ({
                       formRef.current.setFieldValue(itemPath, { ...attachment, url, __isUploading: false })
                     }
                     mockImageGenerator={() => `https://loremflickr.com/120/120/invoice?lock=${attachmentKey}`}
-                    fontSize="13px"
-                    size={[84, 112]}
+                    className="size-20 sm:size-28"
                     value={hasValidUrl && field.value}
                     onReject={(...args) => {
                       formRef.current.setFieldValue(itemPath, { ...attachment, __isUploading: false });

--- a/components/expenses/lib/attachments.ts
+++ b/components/expenses/lib/attachments.ts
@@ -1,6 +1,6 @@
 import { ExpenseType } from '../../../lib/graphql/types/v2/schema';
 
-import { DROPZONE_ACCEPT_ALL } from '../../StyledDropzone';
+import { DROPZONE_ACCEPT_ALL } from '../../Dropzone';
 
 export const attachmentDropzoneParams = {
   accept: DROPZONE_ACCEPT_ALL,

--- a/components/submit-expense/SubmitExpenseFlow.tsx
+++ b/components/submit-expense/SubmitExpenseFlow.tsx
@@ -407,7 +407,7 @@ export function SubmitExpenseFlow(props: SubmitExpenseFlowProps) {
           </header>
           <main className="flex w-full flex-grow overflow-hidden">
             <div className="flex w-full flex-grow justify-center">
-              <div className="flex w-full flex-col overflow-scroll sm:flex sm:flex-row sm:gap-11 sm:px-8 sm:pt-10">
+              <div className="relative flex w-full flex-col overflow-y-scroll sm:flex sm:flex-row sm:gap-11 sm:px-8 sm:pt-10">
                 <ExpenseFormikContainer
                   submitExpenseTo={props.submitExpenseTo}
                   draftKey={props.draftKey}

--- a/components/submit-expense/SubmitExpenseFlowSteps.tsx
+++ b/components/submit-expense/SubmitExpenseFlowSteps.tsx
@@ -145,6 +145,15 @@ export function SubmitExpenseFlowSteps(props: SubmitExpenseFlowStepsProps) {
 
   const firstIncompleteIdx = stepOrder.findIndex(s => !isExpenseFormStepCompleted(form, s));
 
+  // Scroll to first step with error
+  const firstIncompleteSection = stepOrder.find(s => !isExpenseFormStepCompleted(form, s));
+  const submitCount = form.submitCount;
+  React.useEffect(() => {
+    if (firstIncompleteSection && submitCount > 0) {
+      document.querySelector(`#${firstIncompleteSection}`)?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [hasErrors, firstIncompleteSection, submitCount]);
+
   return (
     <div className={cn(props.className)}>
       <ol className="pl-[12px] text-sm">

--- a/components/submit-expense/SubmitExpenseFlowSteps.tsx
+++ b/components/submit-expense/SubmitExpenseFlowSteps.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { Path } from 'dot-path-value';
 import { useFormikContext } from 'formik';
 import { get, isEmpty } from 'lodash';
-import type { IntlShape, MessageDescriptor } from 'react-intl';
+import type { MessageDescriptor } from 'react-intl';
 import { defineMessage, FormattedMessage } from 'react-intl';
 
 import { cn } from '../../lib/utils';
@@ -101,14 +101,6 @@ function isExpenseFormStepCompleted(form: ExpenseForm, step: Step): boolean {
     return true;
   }
   return valueKeys.map(valueKey => isEmpty(get(form.errors, valueKey))).every(Boolean);
-}
-
-export function expenseFormStepError(intl: IntlShape, form: ExpenseForm, step: Step): string {
-  if (expenseFormStepHasError(form, step) && isExpenseFormStepTouched(form, step) && form.submitCount > 0) {
-    return intl.formatMessage({ defaultMessage: 'Required', id: 'Seanpx' });
-  }
-
-  return null;
 }
 
 function expenseFormStepHasError(form: ExpenseForm, step: Step): boolean {

--- a/components/submit-expense/form/AdditionalDetailsSection.tsx
+++ b/components/submit-expense/form/AdditionalDetailsSection.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
+import { FormField } from '@/components/FormField';
+
 import { expenseTagsQuery } from '../../dashboard/filters/ExpenseTagsFilter';
 import { AutocompleteEditTags } from '../../EditTags';
 import ExpenseTypeTag from '../../expenses/ExpenseTypeTag';
 import LoadingPlaceholder from '../../LoadingPlaceholder';
-import StyledInputFormikField from '../../StyledInputFormikField';
 import { Label } from '../../ui/Label';
 import { Step } from '../SubmitExpenseFlowSteps';
 import { type ExpenseForm } from '../useExpenseForm';
@@ -26,7 +27,7 @@ export function AdditionalDetailsSection(props: AdditionalDetailsSectionProps) {
 
   return (
     <FormSectionContainer form={props.form} step={Step.EXPENSE_TITLE} inViewChange={props.inViewChange}>
-      <StyledInputFormikField
+      <FormField
         disabled={props.form.initialLoading}
         name="title"
         placeholder={intl.formatMessage({ defaultMessage: 'Mention a brief expense title', id: 'Te2Yc2' })}

--- a/components/submit-expense/form/ExpenseCategorySection.tsx
+++ b/components/submit-expense/form/ExpenseCategorySection.tsx
@@ -13,6 +13,7 @@ import { Step } from '../SubmitExpenseFlowSteps';
 import type { ExpenseForm } from '../useExpenseForm';
 
 import { FormSectionContainer } from './FormSectionContainer';
+import { FormField } from '@/components/FormField';
 
 type ExpenseCategorySectionProps = {
   form: ExpenseForm;
@@ -44,9 +45,10 @@ export function ExpenseCategorySection(props: ExpenseCategorySectionProps) {
       step={Step.EXPENSE_CATEGORY}
       inViewChange={props.inViewChange}
     >
-      <StyledInputFormikField name="accountingCategoryId">
-        {() => (
+      <FormField name="accountingCategoryId">
+        {({ field }) => (
           <AccountingCategorySelect
+            {...field}
             id="accountingCategoryId"
             kind="EXPENSE"
             onChange={value => setFieldValue('accountingCategoryId', value?.id)}
@@ -56,10 +58,10 @@ export function ExpenseCategorySection(props: ExpenseCategorySectionProps) {
             account={props.form.options.account}
             selectedCategory={selectedAccountingCategory}
             allowNone={!props.form.options.isAccountingCategoryRequired}
-            buttonClassName="rounded max-w-full w-full"
+            buttonClassName="max-w-full w-full"
           />
         )}
-      </StyledInputFormikField>
+      </FormField>
 
       {instructions && (
         <Collapsible asChild defaultOpen>

--- a/components/submit-expense/form/ExpenseCategorySection.tsx
+++ b/components/submit-expense/form/ExpenseCategorySection.tsx
@@ -5,15 +5,14 @@ import { FormattedMessage } from 'react-intl';
 import useLoggedInUser from '../../../lib/hooks/useLoggedInUser';
 
 import AccountingCategorySelect from '../../../components/AccountingCategorySelect';
+import { FormField } from '@/components/FormField';
 
 import HTMLContent from '../../HTMLContent';
-import StyledInputFormikField from '../../StyledInputFormikField';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../../ui/Collapsible';
 import { Step } from '../SubmitExpenseFlowSteps';
 import type { ExpenseForm } from '../useExpenseForm';
 
 import { FormSectionContainer } from './FormSectionContainer';
-import { FormField } from '@/components/FormField';
 
 type ExpenseCategorySectionProps = {
   form: ExpenseForm;

--- a/components/submit-expense/form/ExpenseItemsSection.tsx
+++ b/components/submit-expense/form/ExpenseItemsSection.tsx
@@ -19,16 +19,13 @@ import {
 } from '../../expenses/lib/utils';
 
 import { FormField } from '@/components/FormField';
+import InputAmount from '@/components/InputAmount';
 import { Checkbox } from '@/components/ui/Checkbox';
 
+import Dropzone from '../../Dropzone';
 import { ExchangeRate } from '../../ExchangeRate';
 import FormattedMoneyAmount from '../../FormattedMoneyAmount';
 import LoadingPlaceholder from '../../LoadingPlaceholder';
-import StyledCheckbox from '../../StyledCheckbox';
-import StyledDropzone from '../../StyledDropzone';
-import StyledInputAmount from '../../StyledInputAmount';
-import StyledInputFormikField from '../../StyledInputFormikField';
-import StyledInputGroup from '../../StyledInputGroup';
 import StyledSelect from '../../StyledSelect';
 import { Button } from '../../ui/Button';
 import { Input, InputGroup } from '../../ui/Input';
@@ -38,7 +35,6 @@ import { Step } from '../SubmitExpenseFlowSteps';
 import { type ExpenseForm } from '../useExpenseForm';
 
 import { FormSectionContainer } from './FormSectionContainer';
-import InputAmount from '@/components/InputAmount';
 
 type ExpenseItemsSectionProps = {
   form: ExpenseForm;
@@ -215,17 +211,18 @@ function ExpenseItem(props: ExpenseItemProps) {
                 label={intl.formatMessage({ defaultMessage: 'Upload file', id: '6oOCCL' })}
                 name={`expenseItems.${props.index}.attachment`}
               >
-                {() => {
+                {({ field }) => {
                   return (
-                    <StyledDropzone
+                    <Dropzone
                       {...attachmentDropzoneParams}
+                      {...field}
                       kind="EXPENSE_ITEM"
                       id={attachmentId}
                       name={attachmentId}
                       value={typeof item.attachment === 'string' ? item.attachment : item.attachment?.url}
                       isMulti={false}
                       showActions
-                      size={112}
+                      className="size-28"
                       useGraphQL={true}
                       parseDocument={false}
                       onGraphQLSuccess={uploadResults => {
@@ -312,7 +309,7 @@ function ExpenseItem(props: ExpenseItemProps) {
                 <div className="self-end">
                   {Boolean(item.amount?.currency && props.form.options.expenseCurrency !== item.amount?.currency) && (
                     <ExchangeRate
-                      className="mt-2 text-neutral-600"
+                      className="mt-2 text-muted-foreground"
                       {...getExpenseExchangeRateWarningOrError(
                         intl,
                         item.amount.exchangeRate,
@@ -356,11 +353,11 @@ export function AdditionalAttachments(props: AdditionalAttachmentsProps) {
       </Label>
       <div className="flex flex-wrap gap-4 pt-2">
         <div>
-          <StyledDropzone
+          <Dropzone
             {...attachmentDropzoneParams}
             name="additionalAttachments"
             kind="EXPENSE_ATTACHED_FILE"
-            size={112}
+            className="size-28"
             isMulti
             disabled={props.form.initialLoading}
             isLoading={props.form.initialLoading}
@@ -381,10 +378,10 @@ export function AdditionalAttachments(props: AdditionalAttachmentsProps) {
 
         {additionalAttachments.map(at => (
           <div key={typeof at === 'string' ? at : at.id}>
-            <StyledDropzone
+            <Dropzone
               {...attachmentDropzoneParams}
               name={typeof at === 'string' ? at : at.name}
-              size={112}
+              className="size-28"
               value={typeof at === 'string' ? at : at?.url}
               collectFilesOnly
               showActions

--- a/components/submit-expense/form/ExpenseItemsSection.tsx
+++ b/components/submit-expense/form/ExpenseItemsSection.tsx
@@ -479,10 +479,9 @@ function Taxes(props: { form: ExpenseForm }) {
               )}
               inputType="number"
             >
-              {({ field, hasError }) => (
+              {({ field }) => (
                 <InputGroup
                   {...field}
-                  hasError={hasError}
                   value={field.value ? round(field.value * 100, 2) : 0}
                   onChange={e =>
                     props.form.setFieldValue(

--- a/components/submit-expense/form/FormSectionContainer.tsx
+++ b/components/submit-expense/form/FormSectionContainer.tsx
@@ -25,7 +25,7 @@ export function FormSectionContainer(props: FormSectionContainerProps) {
   const stepSubtitle = StepSubtitles[props.step];
 
   return (
-    <div ref={ref} id={props.step}>
+    <div ref={ref} id={props.step} className="scroll-m-8">
       <div className="rounded-lg border border-white bg-white p-6">
         <div className="mb-4">
           <div className="text-xl font-bold text-[#0F1729]">{props.title || <FormattedMessage {...stepTitle} />}</div>

--- a/components/submit-expense/form/FormSectionContainer.tsx
+++ b/components/submit-expense/form/FormSectionContainer.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { useInView } from 'react-intersection-observer';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
-import { cn } from '../../../lib/utils';
-
-import { expenseFormStepError, type Step, StepSubtitles, StepTitles } from '../SubmitExpenseFlowSteps';
+import { type Step, StepSubtitles, StepTitles } from '../SubmitExpenseFlowSteps';
 import type { ExpenseForm } from '../useExpenseForm';
 
 type FormSectionContainerProps = {
@@ -18,23 +16,17 @@ type FormSectionContainerProps = {
 };
 
 export function FormSectionContainer(props: FormSectionContainerProps) {
-  const intl = useIntl();
   const { ref } = useInView({
     onChange: props.inViewChange,
     rootMargin: '-50px 0px -70% 0px',
   });
 
-  const stepError = props.error || expenseFormStepError(intl, props.form, props.step);
   const stepTitle = StepTitles[props.step];
   const stepSubtitle = StepSubtitles[props.step];
 
   return (
     <div ref={ref} id={props.step}>
-      <div
-        className={cn('rounded-lg border border-white bg-white p-6', {
-          'border-red-300': !!stepError,
-        })}
-      >
+      <div className="rounded-lg border border-white bg-white p-6">
         <div className="mb-4">
           <div className="text-xl font-bold text-[#0F1729]">{props.title || <FormattedMessage {...stepTitle} />}</div>
           {props.subtitle ||
@@ -46,7 +38,6 @@ export function FormSectionContainer(props: FormSectionContainerProps) {
         </div>
         {props.children}
       </div>
-      {!!stepError && <div className="mt-2 text-right text-sm font-semibold text-red-500">{stepError}</div>}
     </div>
   );
 }

--- a/components/submit-expense/form/InviteUserOption.tsx
+++ b/components/submit-expense/form/InviteUserOption.tsx
@@ -92,7 +92,7 @@ function NewOrganizationInviteeForm() {
         name="inviteeNewOrganization.organization.slug"
       >
         {({ field }) => (
-          <InputGroup className="w-full" prepend="opencollectice.com/" id="organizationSlug" type="text" {...field} />
+          <InputGroup className="w-full" prepend="opencollective.com/" id="organizationSlug" type="text" {...field} />
         )}
       </StyledInputFormikField>
 

--- a/components/submit-expense/form/TypeOfExpenseSection.tsx
+++ b/components/submit-expense/form/TypeOfExpenseSection.tsx
@@ -171,9 +171,7 @@ export function TypeOfExpenseSection(props: TypeOfExpenseSectionProps) {
                             kind="EXPENSE_ATTACHED_FILE"
                             name="invoice"
                             className="min-h-16"
-                            // width={1}
                             minHeight={64}
-                            // height={1}
                             showActions
                             useGraphQL={true}
                             parseDocument={false}

--- a/components/submit-expense/form/TypeOfExpenseSection.tsx
+++ b/components/submit-expense/form/TypeOfExpenseSection.tsx
@@ -142,6 +142,7 @@ export function TypeOfExpenseSection(props: TypeOfExpenseSectionProps) {
             <Tabs
               value={props.form.values.hasInvoiceOption}
               onValueChange={newValue => props.form.setFieldValue('hasInvoiceOption', newValue as YesNoOption)}
+              className="space-y-4"
             >
               <TabsList>
                 <TabsTrigger value={YesNoOption.YES}>
@@ -171,7 +172,7 @@ export function TypeOfExpenseSection(props: TypeOfExpenseSectionProps) {
                             name="invoice"
                             className="min-h-16"
                             // width={1}
-                            // minHeight={64}
+                            minHeight={64}
                             // height={1}
                             showActions
                             useGraphQL={true}

--- a/components/submit-expense/form/TypeOfExpenseSection.tsx
+++ b/components/submit-expense/form/TypeOfExpenseSection.tsx
@@ -5,8 +5,9 @@ import { CollectiveType } from '../../../lib/constants/collectives';
 import { ExpenseType } from '../../../lib/graphql/types/v2/schema';
 import { attachmentDropzoneParams } from '../../expenses/lib/attachments';
 
+import { FormField } from '@/components/FormField';
+
 import StyledDropzone from '../../StyledDropzone';
-import StyledInputFormikField from '../../StyledInputFormikField';
 import { Label } from '../../ui/Label';
 import { RadioGroup, RadioGroupCard } from '../../ui/RadioGroup';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../ui/Tabs';
@@ -154,7 +155,7 @@ export function TypeOfExpenseSection(props: TypeOfExpenseSectionProps) {
                 <div className="flex items-start gap-4">
                   <div className="h-16 flex-grow basis-0">
                     <div>
-                      <StyledInputFormikField
+                      <FormField
                         required={
                           props.form.options.isAdminOfPayee || props.form.options.payee?.type === CollectiveType.VENDOR
                         }
@@ -168,7 +169,7 @@ export function TypeOfExpenseSection(props: TypeOfExpenseSectionProps) {
                             kind="EXPENSE_ATTACHED_FILE"
                             name="invoice"
                             width={1}
-                            minHeight={48}
+                            minHeight={64}
                             height={1}
                             showActions
                             useGraphQL={true}
@@ -190,11 +191,11 @@ export function TypeOfExpenseSection(props: TypeOfExpenseSectionProps) {
                             }}
                           />
                         )}
-                      </StyledInputFormikField>
+                      </FormField>
                     </div>
                   </div>
                   <div className="flex-grow basis-0">
-                    <StyledInputFormikField
+                    <FormField
                       required={
                         props.form.options.isAdminOfPayee || props.form.options.payee?.type === CollectiveType.VENDOR
                       }

--- a/components/submit-expense/form/TypeOfExpenseSection.tsx
+++ b/components/submit-expense/form/TypeOfExpenseSection.tsx
@@ -7,7 +7,7 @@ import { attachmentDropzoneParams } from '../../expenses/lib/attachments';
 
 import { FormField } from '@/components/FormField';
 
-import StyledDropzone from '../../StyledDropzone';
+import Dropzone from '../../Dropzone';
 import { Label } from '../../ui/Label';
 import { RadioGroup, RadioGroupCard } from '../../ui/RadioGroup';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../ui/Tabs';
@@ -163,14 +163,16 @@ export function TypeOfExpenseSection(props: TypeOfExpenseSectionProps) {
                         isPrivate
                         label={intl.formatMessage({ defaultMessage: 'Attach your invoice file', id: 'Oa/lhY' })}
                       >
-                        {() => (
-                          <StyledDropzone
+                        {({ field }) => (
+                          <Dropzone
+                            {...field}
                             {...attachmentDropzoneParams}
                             kind="EXPENSE_ATTACHED_FILE"
                             name="invoice"
-                            width={1}
-                            minHeight={64}
-                            height={1}
+                            className="min-h-16"
+                            // width={1}
+                            // minHeight={64}
+                            // height={1}
                             showActions
                             useGraphQL={true}
                             parseDocument={false}

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -2,7 +2,10 @@ import * as React from 'react';
 
 import { cn } from '../../lib/utils';
 
-interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  hasError?: boolean;
+  error?: boolean;
+}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type, ...props }, ref) => {
   return (
@@ -10,6 +13,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type,
       type={type}
       className={cn(
         'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        props.error && 'ring-2 ring-red-500 ring-offset-2',
         className,
       )}
       ref={ref}
@@ -21,23 +25,30 @@ Input.displayName = 'Input';
 
 const InputGroup = React.forwardRef<
   HTMLInputElement,
-  React.ComponentPropsWithoutRef<'input'> & { append?: React.ReactNode; prepend?: React.ReactNode }
->(({ className, prepend, append, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<'input'> & {
+    append?: React.ReactNode;
+    prepend?: React.ReactNode;
+    prependClassName?: string;
+    appendClassName?: string;
+    error?: boolean;
+  }
+>(({ className, prepend, append, prependClassName, appendClassName, ...props }, ref) => (
   <div
     className={cn(
-      'flex h-10 w-fit rounded-md border border-input bg-background text-sm ring-offset-background placeholder:text-muted-foreground focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
+      'flex h-10 w-fit overflow-hidden rounded-md border border-input bg-background text-sm ring-offset-background placeholder:text-muted-foreground focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
+      props.error && 'ring-2 ring-red-500 ring-offset-2',
       props.disabled && 'cursor-not-allowed opacity-50',
       className,
     )}
   >
-    {prepend && <div className="rounded-l-md bg-slate-50 px-3 py-2">{prepend}</div>}
+    {prepend && <div className={cn('bg-slate-50 px-3 py-2', prependClassName)}>{prepend}</div>}
 
     <input
       className="mx-3 my-2 w-full bg-inherit outline-none file:border-0 file:bg-transparent file:text-sm file:font-medium"
       ref={ref}
       {...props}
     />
-    {append && <div className="rounded-r-md bg-slate-50 px-3 py-2">{append}</div>}
+    {append && <div className={cn('bg-slate-50 px-3 py-2', appendClassName)}>{append}</div>}
   </div>
 ));
 InputGroup.displayName = 'InputGroup';

--- a/components/ui/RadioGroup.tsx
+++ b/components/ui/RadioGroup.tsx
@@ -47,7 +47,7 @@ const RadioGroupCard = React.forwardRef<
 >(({ className, children, showSubcontent, subContent, ...props }, ref) => {
   return (
     <div
-      className={`rounded-lg bg-card text-sm text-card-foreground shadow-sm ring-1 ring-border has-[[data-state=checked]]:ring-2 has-[[data-state=checked]]:ring-ring`}
+      className={`rounded-lg bg-card text-sm text-card-foreground shadow-sm ring-1 ring-border has-[[data-state=checked]]:ring-2 has-[[data-state=checked]]:ring-ring [&:has(:focus-visible)]:bg-primary/5`}
     >
       <RadioGroupPrimitive.Item
         ref={ref}

--- a/components/vendors/VendorForm.tsx
+++ b/components/vendors/VendorForm.tsx
@@ -19,9 +19,9 @@ import { cn, omitDeep } from '../../lib/utils';
 
 import Avatar from '../Avatar';
 import { useDrawerActionsContainer } from '../Drawer';
+import { DROPZONE_ACCEPT_IMAGES } from '../Dropzone';
 import PayoutMethodForm from '../expenses/PayoutMethodForm';
 import PayoutMethodSelect from '../expenses/PayoutMethodSelect';
-import { DROPZONE_ACCEPT_IMAGES } from '../StyledDropzone';
 import StyledInput from '../StyledInput';
 import StyledInputFormikField from '../StyledInputFormikField';
 import StyledInputGroup from '../StyledInputGroup';


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/7751 and https://github.com/opencollective/opencollective/issues/7750

# Description

- Updates form inputs to use new shadcn/ui inputs
- Improve error state of those inputs to show a bold error border
- Remove step error state, this is instead handled by the sub-fields in the section
- Scroll to first errored step/section after submit