### PR TITLE
Remove links to Twitter

### DIFF
--- a/components/TopBarMobileMenu.js
+++ b/components/TopBarMobileMenu.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { ChevronDown } from '@styled-icons/boxicons-regular/ChevronDown';
 import { Discord } from '@styled-icons/fa-brands/Discord';
 import { Github } from '@styled-icons/fa-brands/Github';
-import { Twitter } from '@styled-icons/fa-brands/Twitter';
 import { Blog } from '@styled-icons/icomoon/Blog';
 import { Mail } from '@styled-icons/material/Mail';
 import { FormattedMessage, injectIntl } from 'react-intl';
@@ -207,11 +206,6 @@ const TopBarMobileMenu = ({ closeMenu, useDashboard, onHomeRoute }) => {
             <StyledLink href="https://blog.opencollective.com/" openInNewTab onClick={closeMenu}>
               <StyledRoundButton size={40}>
                 <Blog size={17} color="#9D9FA3" />
-              </StyledRoundButton>
-            </StyledLink>
-            <StyledLink href="https://twitter.com/opencollect" openInNewTab onClick={closeMenu}>
-              <StyledRoundButton size={40}>
-                <Twitter size={17} color="#9D9FA3" />
               </StyledRoundButton>
             </StyledLink>
             <StyledLink href="https://github.com/opencollective" openInNewTab onClick={closeMenu}>

--- a/components/navigation/Footer.tsx
+++ b/components/navigation/Footer.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Discord } from '@styled-icons/fa-brands/Discord';
 import { Github } from '@styled-icons/fa-brands/Github';
 import { Mastodon } from '@styled-icons/fa-brands/Mastodon';
-import { Twitter } from '@styled-icons/fa-brands/Twitter';
 import { ChevronDown, ExternalLink, Mail } from 'lucide-react';
 import { FormattedMessage } from 'react-intl';
 
@@ -31,9 +30,6 @@ const SocialLink = ({ href, children, ...props }) => (
 const SocialLinks = ({ className }: { className?: string }) => {
   return (
     <div className={cn('flex items-center gap-1', className)}>
-      <SocialLink href="https://twitter.com/opencollect" rel="me" aria-label="Open Collective Twitter link">
-        <Twitter size={16} />
-      </SocialLink>
       <SocialLink
         href="https://mastodon.opencollective.com/@opencollective"
         rel="me"


### PR DESCRIPTION
- Twitter doesn't exist anymore
- The account is not our (OFiCo) property and there is no reason to promote it
- Not sure we want to create a new account to replace it in the future