### PR TITLE
Only fetch the pre-deploy branch when fetching from the predeploy remote

### DIFF
--- a/scripts/pre-deploy.sh
+++ b/scripts/pre-deploy.sh
@@ -84,7 +84,7 @@ git remote add $PRE_DEPLOY_ORIGIN $DEPLOY_ORIGIN_URL &> /dev/null
 
 # Update deploy remote
 echo "ℹ️  Fetching remote $1 state..."
-git fetch $PRE_DEPLOY_ORIGIN > /dev/null
+git fetch $PRE_DEPLOY_ORIGIN $PRE_DEPLOY_BRANCH > /dev/null
 
 echo ""
 echo "-------------- New commits --------------"


### PR DESCRIPTION
On a clean repository, when trying to deploy to heroku staging, the pre-deploy script fetches the entire remote and for some reason its failing.

```
08:28:18.326193 http.c:623              <= Recv header:
fatal: protocol error: bad line length character: fata
08:28:18.354668 http.c:664              == Info: Connection #0 to host git.heroku.com left intact
fatal: the remote end hung up unexpectedly
```

Changing it to just fetch the target branch works