### PR TITLE
Generate default reference for Wise transactions

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -20,7 +20,7 @@ export function truncate(str, length) {
 }
 
 export function truncateMiddle(str, length, divider = '…') {
-  if (str.length <= length) {
+  if (!str || typeof str !== 'string' || str.length <= length) {
     return str;
   }
   const splitLength = Math.floor(length / 2);


### PR DESCRIPTION
Fixes https://github.com/opencollective/opencollective/issues/7765

When paying an expense with Wise that has no pre-defined reference, it automatically generates a value that mixes the collective name and expense ID while still following the max-length defined by Wise.

Please, notice that `truncateMiddle` will only act on manually informed references. Automatically generated references will always truncate the name and separate it from the ID for better readability.

**Preview**
Sustain (US)
![image](https://github.com/user-attachments/assets/f11cc8c0-a17d-4519-90bf-37873804b09e)

GitHub Education (India)
![image](https://github.com/user-attachments/assets/f8f6fb5e-948b-4cd4-ac99-9511060c6c8a)

Expense Submitted with Reference:
![image](https://github.com/user-attachments/assets/7ce31172-4cb3-428a-8b5a-15d73258b26c)

