### PR TITLE
fix(HostedAccounts): NaN flashing in count

### DIFF
--- a/components/Tabs.tsx
+++ b/components/Tabs.tsx
@@ -80,7 +80,7 @@ const Tabs = ({ tabs, selectedId, onChange, ...props }: TabsProps) => {
               )}
             >
               <div className="font-bold">{tab.label}</div>
-              {!isNil(tab.count) && <div className="text-xs text-slate-600">({tab.count})</div>}
+              {!isNil(tab.count) && !isNaN(tab.count) && <div className="text-xs text-slate-600">({tab.count})</div>}
             </button>
           );
         })}


### PR DESCRIPTION
The line generating it is https://github.com/opencollective/opencollective-frontend/blob/fix/hosted-accounts-nan/components/dashboard/sections/accounts/index.tsx#L92, but it appears more future-proof to fix it by handling `NaN` at a lower level.

![image](https://github.com/user-attachments/assets/226c17a0-36d1-478e-bd56-32f836cd8441)
