### PR TITLE
Fix(ui/RadioGroup): Fix focus visible styling for RadioGroupCard

### DIFF
--- a/components/ui/RadioGroup.tsx
+++ b/components/ui/RadioGroup.tsx
@@ -47,7 +47,7 @@ const RadioGroupCard = React.forwardRef<
 >(({ className, children, showSubcontent, subContent, ...props }, ref) => {
   return (
     <div
-      className={`rounded-lg bg-card text-sm text-card-foreground ring-1 shadow-xs ring-border has-data-[state=checked]:ring-2 has-data-[state=checked]:ring-ring [&:has(:focus-visible)]:bg-primary/5`}
+      className={`rounded-lg bg-card text-sm text-card-foreground ring-1 shadow-xs ring-border has-data-[state=checked]:ring-2 has-data-[state=checked]:ring-ring [&:has([role="radio"]:focus-visible)]:bg-primary/5`}
     >
       <RadioGroupPrimitive.Item
         ref={ref}


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/7828

# Description

Fixes focus visible styling to only be active when role="radio" has focus visible (and not when any button within the card has focus visible).
