### PR TITLE
debt: Remove default label styling from app.css

### DIFF
--- a/public/static/styles/app.css
+++ b/public/static/styles/app.css
@@ -391,12 +391,6 @@ h4 {
 }
 
 /* TODO: Migrate away from these default styles below */
-label {
-  font-size: 14px;
-  display: inline-block;
-  font-weight: 700;
-}
-
 summary {
   color: #337ab7;
   cursor: pointer;


### PR DESCRIPTION
# Description

Removes default label styling from app.css which conflicted with Tailwind defaults and styling.
