### PR TITLE
Fix(Tax form message): Fix z-index issues and show tax form message on new expense flow success screen

### DIFF
--- a/components/dashboard/sections/tax-information/TaxInformationFormDialog.tsx
+++ b/components/dashboard/sections/tax-information/TaxInformationFormDialog.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
-import { Overlay } from '@radix-ui/react-dialog';
-import { X } from 'lucide-react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Avatar from '../../../Avatar';
 import LinkCollective from '../../../LinkCollective';
-import { Button } from '../../../ui/Button';
-import { Dialog } from '../../../ui/Dialog';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '../../../ui/Dialog';
 
 import { TaxInformationForm } from './TaxInformationForm';
 
@@ -39,13 +36,13 @@ export const TaxInformationFormDialog = ({ account, open, onOpenChange, onSucces
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <Overlay className="fixed inset-0 z-3000 max-h-screen min-h-full overflow-y-auto bg-white px-0 py-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in">
-        <div className="sticky top-0 z-50 flex items-center justify-between border-b border-gray-100 bg-white px-6 py-4 shadow-md">
-          <div className="text-sm">
-            <h2 className="text-xl font-bold">
-              <FormattedMessage defaultMessage="Update Tax Information" id="sVea7o" />
-            </h2>
-            <div className="mt-1 flex items-center gap-1 text-sm text-gray-600">
+      <DialogContent size="fullscreen">
+        <DialogHeader>
+          <DialogTitle>
+            <FormattedMessage defaultMessage="Update Tax Information" id="sVea7o" />
+          </DialogTitle>
+          <DialogDescription>
+            <div className="flex items-center gap-1">
               <FormattedMessage
                 defaultMessage="for {account}"
                 id="bKMsE/"
@@ -59,23 +56,17 @@ export const TaxInformationFormDialog = ({ account, open, onOpenChange, onSucces
                 }}
               />
             </div>
-          </div>
-          <Button variant="secondary" className="text-base" onClick={() => handleOpenChange(false)}>
-            <FormattedMessage id="Close" defaultMessage="Close" />
-            <X className="ml-2" size={16} />
-          </Button>
-        </div>
-        <div className="px-6 py-8 md:px-10">
-          <TaxInformationForm
-            accountId={account.id}
-            setFormDirty={setIsFormDirty}
-            onSuccess={() => {
-              onOpenChange(false);
-              onSuccess?.();
-            }}
-          />
-        </div>
-      </Overlay>
+          </DialogDescription>
+        </DialogHeader>
+        <TaxInformationForm
+          accountId={account.id}
+          setFormDirty={setIsFormDirty}
+          onSuccess={() => {
+            onOpenChange(false);
+            onSuccess?.();
+          }}
+        />
+      </DialogContent>
     </Dialog>
   );
 };

--- a/components/expenses/Expense.tsx
+++ b/components/expenses/Expense.tsx
@@ -5,7 +5,6 @@ import { Undo } from '@styled-icons/fa-solid/Undo';
 import { themeGet } from '@styled-system/theme-get';
 import dayjs from 'dayjs';
 import { cloneDeep, debounce, get, includes, orderBy, uniqBy, update } from 'lodash';
-import { FilePenLine } from 'lucide-react';
 import { useRouter } from 'next/router';
 import { createPortal } from 'react-dom';
 import { FormattedMessage, useIntl } from 'react-intl';
@@ -29,12 +28,11 @@ import ConfirmationModal from '../ConfirmationModal';
 import Container from '../Container';
 import CommentForm from '../conversations/CommentForm';
 import Thread from '../conversations/Thread';
-import { TaxInformationFormDialog } from '../dashboard/sections/tax-information/TaxInformationFormDialog';
 import { useDrawerActionsContainer } from '../Drawer';
 import FilesViewerModal from '../FilesViewerModal';
 import { Box, Flex } from '../Grid';
 import HTMLContent from '../HTMLContent';
-import { getI18nLink, WebsiteName } from '../I18nFormatters';
+import { WebsiteName } from '../I18nFormatters';
 import CommentIcon from '../icons/CommentIcon';
 import PrivateInfoIcon from '../icons/PrivateInfoIcon';
 import Link from '../Link';
@@ -58,6 +56,7 @@ import ExpenseNotesForm from './ExpenseNotesForm';
 import ExpenseRecurringBanner from './ExpenseRecurringBanner';
 import ExpenseSummary from './ExpenseSummary';
 import PrivateCommentsMessage from './PrivateCommentsMessage';
+import TaxFormMessage from './TaxFormMessage';
 
 const getVariableFromProps = props => {
   const firstOfCurrentYear = dayjs(new Date(new Date().getFullYear(), 0, 1))
@@ -150,7 +149,6 @@ function Expense(props) {
   const [openUrl, setOpenUrl] = useState(null);
   const [replyingToComment, setReplyingToComment] = useState(null);
   const [hasConfirmedOCR, setConfirmedOCR] = useState(false);
-  const [hasTaxInformationForm, setHasTaxInformationForm] = React.useState(false);
   const hasItemsWithOCR = Boolean(state.editedExpense?.items?.some(itemHasOCR));
   const mustConfirmOCR = hasItemsWithOCR && !hasConfirmedOCR;
   const pollingInterval = 60;
@@ -541,67 +539,7 @@ function Expense(props) {
           {formatErrorMessage(intl, state.error)}
         </MessageBox>
       )}
-      {showTaxFormMsg && (
-        <MessageBox type="warning" withIcon={true} mb={4}>
-          <div>
-            {LoggedInUser?.isAdminOfCollective(expense.payee) ? (
-              <div>
-                <strong>
-                  <FormattedMessage defaultMessage="We need your tax information before we can pay you." id="a6tGTW" />
-                </strong>
-                <p className="my-2">
-                  <FormattedMessage
-                    defaultMessage="United States regulations require US entities to collect certain information from payees for tax reporting purposes, even if the payee is outside the US."
-                    id="H/ROIG"
-                  />
-                </p>
-                <StyledButton
-                  buttonSize="tiny"
-                  buttonStyle="primary"
-                  className="mt-2"
-                  onClick={() => setHasTaxInformationForm(true)}
-                >
-                  <FilePenLine className="mr-1 inline-block" size={14} />
-                  <span>
-                    <FormattedMessage defaultMessage="Fill Tax Information" id="TxJpk1" />
-                  </span>
-                </StyledButton>
-                <TaxInformationFormDialog
-                  account={expense.payee}
-                  open={hasTaxInformationForm}
-                  onOpenChange={setHasTaxInformationForm}
-                  onSuccess={refetch}
-                />
-              </div>
-            ) : (
-              <div>
-                <strong>
-                  <FormattedMessage
-                    defaultMessage="This expense requires the payee to provide their tax information before it can be paid."
-                    id="XNW4Sq"
-                  />
-                </strong>
-                <p className="my-2">
-                  <FormattedMessage
-                    defaultMessage="United States regulations require US entities to collect certain information from payees for tax reporting purposes, even if the payee is outside the US."
-                    id="H/ROIG"
-                  />{' '}
-                  <FormattedMessage
-                    defaultMessage="See <HelpDocsLink>help docs</HelpDocsLink> for more information."
-                    id="f2Ypkz"
-                    values={{
-                      HelpDocsLink: getI18nLink({
-                        href: 'https://docs.opencollective.com/help/expenses-and-getting-paid/tax-information',
-                        openInNewTab: true,
-                      }),
-                    }}
-                  />
-                </p>
-              </div>
-            )}
-          </div>
-        </MessageBox>
-      )}
+      {showTaxFormMsg && <TaxFormMessage expense={expense} refetch={refetch} />}
       {status === PAGE_STATUS.VIEW &&
         ((expense?.status === ExpenseStatus.UNVERIFIED && state.createdUser) ||
           (isDraft && !isRecurring && !draftKey)) && (

--- a/components/expenses/TaxFormMessage.tsx
+++ b/components/expenses/TaxFormMessage.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { FilePenLine } from 'lucide-react';
+import { FormattedMessage } from 'react-intl';
+
+import useLoggedInUser from '@/lib/hooks/useLoggedInUser';
+
+import { TaxInformationFormDialog } from '../dashboard/sections/tax-information/TaxInformationFormDialog';
+import { getI18nLink } from '../I18nFormatters';
+import MessageBox from '../MessageBox';
+import { Button } from '../ui/Button';
+
+export default function TaxFormMessage({ expense, refetch }) {
+  const { LoggedInUser } = useLoggedInUser();
+  const [hasTaxInformationForm, setHasTaxInformationForm] = React.useState(false);
+
+  return (
+    <MessageBox type="warning" withIcon={true} mb={4}>
+      <div>
+        {LoggedInUser?.isAdminOfCollective(expense.payee) ? (
+          <div>
+            <p className="text-base font-medium">
+              <FormattedMessage defaultMessage="We need your tax information before we can pay you." id="a6tGTW" />
+            </p>
+            <p className="my-2 text-sm">
+              <FormattedMessage
+                defaultMessage="United States regulations require US entities to collect certain information from payees for tax reporting purposes, even if the payee is outside the US."
+                id="H/ROIG"
+              />
+            </p>
+            <Button size="xs" className="mt-2" onClick={() => setHasTaxInformationForm(true)}>
+              <FilePenLine className="mr-1 inline-block" size={14} />
+              <span>
+                <FormattedMessage defaultMessage="Fill Tax Information" id="TxJpk1" />
+              </span>
+            </Button>
+            <TaxInformationFormDialog
+              account={expense.payee}
+              open={hasTaxInformationForm}
+              onOpenChange={setHasTaxInformationForm}
+              onSuccess={refetch}
+            />
+          </div>
+        ) : (
+          <div>
+            <strong>
+              <FormattedMessage
+                defaultMessage="This expense requires the payee to provide their tax information before it can be paid."
+                id="XNW4Sq"
+              />
+            </strong>
+            <p className="my-2">
+              <FormattedMessage
+                defaultMessage="United States regulations require US entities to collect certain information from payees for tax reporting purposes, even if the payee is outside the US."
+                id="H/ROIG"
+              />{' '}
+              <FormattedMessage
+                defaultMessage="See <HelpDocsLink>help docs</HelpDocsLink> for more information."
+                id="f2Ypkz"
+                values={{
+                  HelpDocsLink: getI18nLink({
+                    href: 'https://docs.opencollective.com/help/expenses-and-getting-paid/tax-information',
+                    openInNewTab: true,
+                  }),
+                }}
+              />
+            </p>
+          </div>
+        )}
+      </div>
+    </MessageBox>
+  );
+}

--- a/components/submit-expense/SubmittedExpense.tsx
+++ b/components/submit-expense/SubmittedExpense.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { useQuery } from '@apollo/client';
+import { includes } from 'lodash';
 
 import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
 import type { ExpensePageQuery, ExpensePageQueryVariables } from '../../lib/graphql/types/v2/graphql';
 
 import ExpenseSummary from '../expenses/ExpenseSummary';
 import { expensePageQuery } from '../expenses/graphql/queries';
+import TaxFormMessage from '../expenses/TaxFormMessage';
 import CreateExpenseFAQ from '../faqs/CreateExpenseFAQ';
 import Loading from '../Loading';
 import MessageBoxGraphqlError from '../MessageBoxGraphqlError';
@@ -36,28 +38,32 @@ export function SubmittedExpense(props: SubmittedExpenseProps) {
   }
 
   const expense = query.data?.expense;
+  const showTaxFormMsg = includes(expense?.requiredLegalDocuments, 'US_TAX_FORM');
 
   return (
-    <div className="flex grow flex-col gap-8 px-4 sm:p-0 lg:flex-row">
-      <div className="flex-1 flex-grow-2">
-        <ExpenseSummary
-          onDelete={() => {}}
-          onEdit={() => {}}
-          openFileViewer={() => {}}
-          enableKeyboardShortcuts={false}
-          drawerActionsContainer={null}
-          canEditTags={false}
-          isEditing={false}
-          isLoadingLoggedInUser={false}
-          showProcessButtons={false}
-          expense={expense}
-          host={expense?.host}
-          isLoading={!expense}
-          collective={expense?.account}
-        />
-      </div>
-      <div className="flex-1 md:max-w-96">
-        <CreateExpenseFAQ defaultOpen />
+    <div>
+      {showTaxFormMsg && <TaxFormMessage expense={expense} refetch={query.refetch} />}
+      <div className="flex grow flex-col gap-8 px-4 sm:p-0 lg:flex-row">
+        <div className="flex-1 flex-grow-2">
+          <ExpenseSummary
+            onDelete={() => {}}
+            onEdit={() => {}}
+            openFileViewer={() => {}}
+            enableKeyboardShortcuts={false}
+            drawerActionsContainer={null}
+            canEditTags={false}
+            isEditing={false}
+            isLoadingLoggedInUser={false}
+            showProcessButtons={false}
+            expense={expense}
+            host={expense?.host}
+            isLoading={!expense}
+            collective={expense?.account}
+          />
+        </div>
+        <div className="flex-1 md:max-w-96">
+          <CreateExpenseFAQ defaultOpen />
+        </div>
       </div>
     </div>
   );

--- a/components/ui/Dialog.tsx
+++ b/components/ui/Dialog.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
+import type { VariantProps } from 'class-variance-authority';
+import { cva } from 'class-variance-authority';
 import { X } from 'lucide-react';
 import { FormattedMessage } from 'react-intl';
 
@@ -11,38 +13,59 @@ const DialogTrigger = DialogPrimitive.Trigger;
 
 const DialogPortal = DialogPrimitive.Portal;
 
+const dialogOverlayVariants = cva(
+  'fixed inset-0 z-3000 flex max-h-screen flex-col items-center overflow-y-auto bg-foreground/25 px-0 py-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
+  {
+    variants: {
+      size: {
+        default: 'sm:px-6 sm:py-20',
+        fullscreen: '',
+      },
+    },
+    defaultVariants: {
+      size: 'default',
+    },
+  },
+);
+
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay> & VariantProps<typeof dialogOverlayVariants>
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
     ref={ref}
-    className={cn(
-      'fixed inset-0 z-3000 flex max-h-screen flex-col items-center overflow-y-auto bg-foreground/25 px-0 py-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0 sm:px-6 sm:py-20',
-      className,
-    )}
+    className={cn(dialogOverlayVariants({ size: props.size, className }))}
     {...props}
   />
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
+const dialogVariants = cva(
+  'relative z-50 flex w-full grow flex-col gap-4 bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+  {
+    variants: {
+      size: {
+        default: 'sm:max-w-lg sm:grow-0 sm:rounded-lg',
+        fullscreen: 'sm:max-w-full',
+      },
+    },
+    defaultVariants: {
+      size: 'default',
+    },
+  },
+);
+
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
-    hideCloseButton?: boolean;
-    overlayClassName?: string;
-  }
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> &
+    VariantProps<typeof dialogVariants> & {
+      hideCloseButton?: boolean;
+      overlayClassName?: string;
+    }
 >(({ className, children, hideCloseButton, ...props }, ref) => (
   <DialogPortal>
-    <DialogOverlay className={props.overlayClassName}>
-      <DialogPrimitive.Content
-        ref={ref}
-        className={cn(
-          'relative z-50 flex w-full grow flex-col gap-4 bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg sm:grow-0 sm:rounded-lg',
-          className,
-        )}
-        {...props}
-      >
+    <DialogOverlay size={props.size} className={props.overlayClassName}>
+      <DialogPrimitive.Content ref={ref} className={cn(dialogVariants({ size: props.size, className }))} {...props}>
         {children}
         {!hideCloseButton && (
           <DialogPrimitive.Close className="absolute top-4 right-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/7759

# Description
- Updates Dialog to have a size variant prop to enable fullscreen dialogs more easily
- Use this Dialog size variant prop in the tax form dialog together with regular Dialog components instead of custom components to fix z-index issue when there was an attachment
- Show the tax form message in the Expense flow success screen

# Screenshots
| z-index issue | z-index issue fixed | added tax form message on success screen |
| ------------- | ------------------- | ---------------------------------------- |
| <img width="2287" alt="Screenshot 2025-02-06 at 12 42 03" src="https://github.com/user-attachments/assets/644adb4e-2491-4b5a-9b61-ba268b0bb941" />             | <img width="2281" alt="Screenshot 2025-02-06 at 12 40 06" src="https://github.com/user-attachments/assets/0c966223-65e5-49a5-a2c1-2926c5da313e" />                   | <img width="2289" alt="Screenshot 2025-02-06 at 12 41 06" src="https://github.com/user-attachments/assets/30d03827-6f97-44ca-b0ad-105e5db1a352" />                                        |
