### PR TITLE
fix(UserProvider): infinite loop on 2FA modal in dev

### DIFF
--- a/components/UserProvider.js
+++ b/components/UserProvider.js
@@ -138,6 +138,13 @@ class UserProvider extends React.Component {
               allowRecovery: true,
             });
 
+            // An empty result means the prompt is already open elsewhere. This could either be due to
+            // React strict mode calling lifecycle methods twice or a developer mistake. The safest option is to early
+            // return and let the other prompt handle the result.
+            if (!result) {
+              return;
+            }
+
             const LoggedInUser = await getLoggedInUser({
               token: getFromLocalStorage(LOCAL_STORAGE_KEYS.TWO_FACTOR_AUTH_TOKEN),
               twoFactorAuthenticatorCode: result.code,


### PR DESCRIPTION
See https://oficonsortium.slack.com/archives/C06K5J91675/p1738915937753509

> My local frontend consistently goes into an infinite loop when I sign in.

Root cause:
- I [enabled](https://github.com/opencollective/opencollective-frontend/pull/10885) react strict mode a month ago, which triggers lifecycle methods like componentDidMount to be [triggered twice](https://www.scichart.com/blog/what-is-react-strict-mode-and-why-is-my-application-double-re-rendering/) in development.
- In `pages/signin.js`, the initialize method is therefore invoked twice, which calls the login method from UserProvider
- In `UserProvider#login`, we enter the while (true) loop. The first `twoFactorAuthPrompt.open` call supposedly opens .the modal, but it never appears because we're stuck in an infinite loop on this same method because it always early returns (since isOpen is true). I wonder if the tailwind update played a role here, since it touched dialogs.