### PR TITLE
Correct the Link Pointing to Install Instructions

### DIFF
--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -35,7 +35,7 @@ Behind the scenes it will do the following (so you don't have to do it):
 
 ### 2. Frontend: Server
 
-If it's not already setup, look at the "Install" instructions in the [README](README.md).
+If it's not already setup, look at the "Install" instructions in the [README.md](../README.md).
 
 Make sure the Frontend is talking to the local API:
 


### PR DESCRIPTION
Just a small correction point to the correct link in the end to end setup