### PR TITLE
Fix(style): Add cursor: pointer as default for all buttons

### DIFF
--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -8,7 +8,7 @@ import { cn } from '../../lib/utils';
 import StyledSpinner from '../StyledSpinner';
 
 const buttonVariants = cva(
-  'relative inline-flex cursor-pointer items-center justify-center gap-1 rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50',
+  'relative inline-flex items-center justify-center gap-1 rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {

--- a/public/static/styles/app.css
+++ b/public/static/styles/app.css
@@ -127,6 +127,9 @@
   ::file-selector-button {
     border-color: var(--color-gray-200, currentColor);
   }
+  button:not(:disabled), [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
Follow up fix for https://github.com/opencollective/opencollective-frontend/pull/10990

# Description

This restores the style of all non-disabled buttons to `cursor: pointer`, [as it was in Tailwind v3](https://tailwindcss.com/docs/upgrade-guide#buttons-use-the-default-cursor), instead of fixing it for a particular button implementation as in the previous PR.