### PR TITLE
Expense flow UI tweaks: Reordering of expense items and margin/padding fixes

### DIFF
--- a/components/Dropzone.tsx
+++ b/components/Dropzone.tsx
@@ -166,7 +166,12 @@ const Dropzone = ({
           ) : (
             <React.Fragment>
               {!value ? (
-                <div className={cn('px-2 text-sm', errorMsg ? 'text-destructive' : 'text-muted-foreground')}>
+                <div
+                  className={cn(
+                    'flex flex-col items-center justify-center px-2 text-sm text-balance',
+                    errorMsg ? 'text-destructive' : 'text-muted-foreground',
+                  )}
+                >
                   {errorMsg ? (
                     <div className="flex flex-col items-center gap-1">
                       <CircleAlert size={20} />

--- a/components/submit-expense/SubmitExpenseFlow.tsx
+++ b/components/submit-expense/SubmitExpenseFlow.tsx
@@ -479,6 +479,7 @@ function ExpenseFormikContainer(props: {
       inviteeAccountType: InviteeAccountType.INDIVIDUAL,
       expenseItems: [
         {
+          key: 'initial', // "key" is only used for enabling FlipMove animations
           amount: {
             valueInCents: 0,
             currency: 'USD',

--- a/components/submit-expense/SubmittedExpense.tsx
+++ b/components/submit-expense/SubmittedExpense.tsx
@@ -43,7 +43,7 @@ export function SubmittedExpense(props: SubmittedExpenseProps) {
   return (
     <div>
       {showTaxFormMsg && <TaxFormMessage expense={expense} refetch={query.refetch} />}
-      <div className="flex grow flex-col gap-8 px-4 sm:p-0 lg:flex-row">
+      <div className="flex grow flex-col gap-8 px-4 sm:p-0 sm:pb-12 lg:flex-row">
         <div className="flex-1 flex-grow-2">
           <ExpenseSummary
             onDelete={() => {}}
@@ -61,7 +61,7 @@ export function SubmittedExpense(props: SubmittedExpenseProps) {
             collective={expense?.account}
           />
         </div>
-        <div className="flex-1 md:max-w-96">
+        <div className="flex-1 pb-12 md:max-w-96">
           <CreateExpenseFAQ defaultOpen />
         </div>
       </div>

--- a/components/submit-expense/form/SummarySection.tsx
+++ b/components/submit-expense/form/SummarySection.tsx
@@ -603,7 +603,7 @@ function RecurrenceOptionBox(props: { form: ExpenseForm }) {
         {isEditingRecurrence && (
           <div>
             <div className="my-4 border-t border-dotted border-gray-400" />
-            <Label className="mb-2">
+            <Label className="mb-2 block">
               <FormattedMessage defaultMessage="Frequency" id="Frequency" />
             </Label>
             <Select
@@ -640,7 +640,7 @@ function RecurrenceOptionBox(props: { form: ExpenseForm }) {
 
             {recurrenceFrequency && recurrenceFrequency !== 'none' && (
               <React.Fragment>
-                <Label htmlFor="expenseRecurrenceEndAt" className="mt-4 mb-2">
+                <Label htmlFor="expenseRecurrenceEndAt" className="mt-4 mb-2 block">
                   <FormattedMessage defaultMessage="End Date" id="EndDate" />
                 </Label>
                 <Input

--- a/components/submit-expense/useExpenseForm.ts
+++ b/components/submit-expense/useExpenseForm.ts
@@ -50,6 +50,7 @@ export enum InviteeAccountType {
 }
 
 type ExpenseItem = {
+  key?: string; // used to enable FlipMove animations (will either be a generated uuid on "Add item", or using the expense item id)
   description?: string;
   incurredAt?: string;
   amount?: {
@@ -1589,6 +1590,7 @@ export function useExpenseForm(opts: {
       setFieldValue(
         'expenseItems',
         formOptions.expense.draft?.items?.map(ei => ({
+          key: ei.id,
           attachment: ei.url,
           description: ei.description ?? '',
           incurredAt: dayjs.utc(ei.incurredAt).toISOString().substring(0, 10),
@@ -1609,6 +1611,7 @@ export function useExpenseForm(opts: {
       setFieldValue(
         'expenseItems',
         formOptions.expense.items?.map(ei => ({
+          key: ei.id,
           attachment: !startOptions.current.duplicateExpense ? ei.url : null,
           description: ei.description ?? '',
           incurredAt: !startOptions.current.duplicateExpense


### PR DESCRIPTION
Project https://github.com/opencollective/opencollective/issues/7726

# Description

- Fixes margins/padding in success screen and inside the expense recurrence message box
- Adds ability to reorder expense items

# Screenshots

https://github.com/user-attachments/assets/815713c2-594c-4336-b3c0-3e88f99f829e

