### PR TITLE
Dont call fixer api on e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,6 +64,9 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
+      # man-db trigger on apt install is taking some time
+      - name: Disable man-db update
+        run: sudo rm -f /var/lib/man-db/auto-update
       - name: Update apt
         run: sudo apt-get update || exit 0
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,7 @@ env:
   E2E_TEST: 1
   PGHOST: localhost
   PGUSER: postgres
+  CYPRESS_COVERAGE: false
   CYPRESS_RECORD: false
   CYPRESS_VIDEO: false
   CYPRESS_VIDEO_UPLOAD_ON_PASSES: false


### PR DESCRIPTION
Related https://github.com/opencollective/opencollective-api/pull/10694

-  man-db apt trigger is taking about a minute or so and its unnecessary