### PR TITLE
Prompt for captch if payment intent creation fails with captcha reason

### DIFF
--- a/components/Captcha.js
+++ b/components/Captcha.js
@@ -69,6 +69,9 @@ ReCaptcha.propTypes = {
   onError: PropTypes.func,
 };
 
+/**
+ * @type {React.ForwardRefExoticComponent<{ onVerify: (result) => void;}>}
+ */
 const Captcha = React.forwardRef(({ onVerify, provider = CAPTCHA_PROVIDER, ...props }, captchaRef) => {
   const HCAPTCHA_SITEKEY = getEnvVar('HCAPTCHA_SITEKEY');
   const RECAPTCHA_SITE_KEY = getEnvVar('RECAPTCHA_SITE_KEY');


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/7819

If payment intent creation requires a new captcha token, prompt for it.

[guest-order-fix.webm](https://github.com/user-attachments/assets/e0388c15-c4bc-4dcb-be1f-27bdf37e7be1)
