### PR TITLE
Fix(Expense form): Expense item & attachment layout bug

### DIFF
--- a/components/submit-expense/form/ExpenseItemsSection.tsx
+++ b/components/submit-expense/form/ExpenseItemsSection.tsx
@@ -323,8 +323,8 @@ const ExpenseItem = memoWithGetFormProps(function ExpenseItem(props: ExpenseItem
   }
 
   return (
-    <div className="mb-4 rounded-md border border-slate-300 p-4">
-      <div className="flex flex-wrap gap-4">
+    <div className="@container mb-4 rounded-md border border-slate-300 p-4">
+      <div className="flex flex-col gap-4 @md:flex-row">
         {hasAttachment && (
           <div className="flex flex-col">
             <div className="flex grow justify-center">


### PR DESCRIPTION
Project https://github.com/opencollective/opencollective/issues/7726

# Description

Fix for the expense item attachment being on it's own row even when the viewport is large (but will be on it's own row when the container is smaller, using new Tailwind v4 container queries).

# Screenshots

Before
<img width="814" alt="Screenshot 2025-02-17 at 11 44 31" src="https://github.com/user-attachments/assets/2481330c-fee0-4c44-96ff-d66bbd389080" />

After
<img width="852" alt="Screenshot 2025-02-17 at 11 43 47" src="https://github.com/user-attachments/assets/d2f3d2f9-fb80-4a0d-9bb4-9ff28f19abd2" />
