### PR TITLE
Add cypress terminal reporter

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -28,6 +28,9 @@ module.exports = defineConfig({
     setupNodeEvents(on, config) {
       // eslint-disable-next-line n/no-unpublished-require
       require('@cypress/code-coverage/task')(on, config);
+      require('cypress-terminal-report/src/installLogsPrinter')(on, {
+        printLogsToConsole: 'onFail',
+      });
 
       on('before:browser:launch', (browser, launchOptions) => {
         if (browser.name === 'chrome') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -173,6 +173,7 @@
         "cypress": "^14.0.0",
         "cypress-mailpit": "^1.2.1",
         "cypress-real-events": "^1.12.0",
+        "cypress-terminal-report": "^7.1.0",
         "cz-conventional-changelog": "^3.3.0",
         "dot-path-value": "^0.0.11",
         "esbuild": "0.24.2",
@@ -15566,6 +15567,104 @@
         "cypress": "^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x || ^13.x"
       }
     },
+    "node_modules/cypress-terminal-report": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cypress-terminal-report/-/cypress-terminal-report-7.1.0.tgz",
+      "integrity": "sha512-CBXxY19HNX2VFcZ0uifomzs0kuYKCTb2pPgJmluiHI5XHvvbHPFufHAAacM8z/pSOtHoovo/WU+fxE5KcZ8C4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "compare-versions": "^6.1.1",
+        "fs-extra": "^10.1.0",
+        "process": "^0.11.10",
+        "superstruct": "0.14.2"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "cypress": ">=10.0.0"
+      }
+    },
+    "node_modules/cypress-terminal-report/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cypress-terminal-report/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cypress-terminal-report/node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cypress-terminal-report/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cypress-terminal-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cypress-terminal-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cypress/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -28483,6 +28582,13 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
+    },
+    "node_modules/superstruct": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.14.2.tgz",
+      "integrity": "sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -237,6 +237,7 @@
     "cypress": "^14.0.0",
     "cypress-mailpit": "^1.2.1",
     "cypress-real-events": "^1.12.0",
+    "cypress-terminal-report": "^7.1.0",
     "cz-conventional-changelog": "^3.3.0",
     "dot-path-value": "^0.0.11",
     "esbuild": "0.24.2",

--- a/test/cypress/support/index.js
+++ b/test/cypress/support/index.js
@@ -12,11 +12,19 @@
 // You can read more here:
 // https://on.cypress.io/configuration
 // ***********************************************************
+
 import '@cypress/code-coverage/support';
 import 'cypress-real-events';
 // Import commands.js using ES2015 syntax:
 import './commands';
 import './typed-commands';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+require('cypress-terminal-report/src/installLogsCollector')({
+  xhr: {
+    printRequestData: true,
+  },
+});
 
 // See https://github.com/opencollective/opencollective/issues/2676
 Cypress.on('uncaught:exception', (err, runnable, promise) => {


### PR DESCRIPTION
Print cypress test information when it fails to helps debug e2e failures in ci. Gives similar output as seen in the GUI of cypress.

For example
```
1) "before each" hook for "New user can submit invoice expense to collective hosted by e2e-host"
        cy:request ✔  DELETE http://localhost:1080/api/v1/messages
                      Status: 200
                      Request body: <EMPTY>
                      Response body: ok

....
```