### PR TITLE
Fix style regression and update AccountingCategoryDrawer

### DIFF
--- a/components/dashboard/sections/accounting/AccountingCategoryDrawer.tsx
+++ b/components/dashboard/sections/accounting/AccountingCategoryDrawer.tsx
@@ -5,6 +5,9 @@ import type { AccountingCategory } from '../../../../lib/graphql/types/v2/schema
 import { AccountingCategoryAppliesTo, AccountingCategoryKind } from '../../../../lib/graphql/types/v2/schema';
 import { i18nExpenseType } from '../../../../lib/i18n/expense';
 
+import { DataList, DataListItem, DataListItemLabel, DataListItemValue } from '@/components/ui/DataList';
+import { Separator } from '@/components/ui/Separator';
+
 import { Drawer, DrawerActions, DrawerHeader } from '../../../Drawer';
 import HTMLContent, { isEmptyHTMLValue } from '../../../HTMLContent';
 import StyledButton from '../../../StyledButton';
@@ -72,91 +75,101 @@ function AccountingCategoryDrawerView(props: AccountingCategoryDrawerViewProps) 
 
   return (
     <React.Fragment>
-      <div>
-        <label className="mt-4 mb-1 text-base">
-          <FormattedMessage defaultMessage="Accounting code" id="tvVFNA" />
-        </label>
+      <DataList className="text-sm">
+        <DataListItem>
+          <DataListItemLabel>
+            <FormattedMessage defaultMessage="Accounting code" id="tvVFNA" />
+          </DataListItemLabel>
+          <DataListItemValue>
+            <span className="rounded-xl bg-slate-50 px-2 py-1 font-bold text-slate-800">
+              {props.accountingCategory?.code}
+            </span>
+          </DataListItemValue>
+        </DataListItem>
 
-        <p>
-          <span className="inline-block rounded-xl bg-slate-50 px-2 py-1 font-bold text-slate-800">
-            {props.accountingCategory?.code}
-          </span>
-        </p>
-
-        <label className="mt-4 mb-1 text-base">
-          <FormattedMessage defaultMessage="Category name" id="kgVqk1" />
-        </label>
-        <p>{props.accountingCategory?.name}</p>
+        <DataListItem>
+          <DataListItemLabel>
+            <FormattedMessage defaultMessage="Category name" id="kgVqk1" />
+          </DataListItemLabel>
+          <DataListItemValue>{props.accountingCategory?.name}</DataListItemValue>
+        </DataListItem>
 
         {props.accountingCategory?.friendlyName && (
-          <React.Fragment>
-            <label className="mt-4 mb-1 text-base">
+          <DataListItem>
+            <DataListItemLabel>
               <FormattedMessage id="AccountingCategory.friendlyName" defaultMessage="Friendly name" />
-            </label>
-            <p className="italic">{props.accountingCategory?.friendlyName}</p>
-          </React.Fragment>
+            </DataListItemLabel>
+            <DataListItemValue className="italic">{props.accountingCategory?.friendlyName}</DataListItemValue>
+          </DataListItem>
         )}
 
         {!props.isIndependentCollective && (
-          <React.Fragment>
-            {' '}
-            <label className="mt-4 mb-1 text-base">
+          <DataListItem>
+            <DataListItemLabel>
               <FormattedMessage defaultMessage="Applies to" id="6WqHWi" />
-            </label>
-            <p>
+            </DataListItemLabel>
+            <DataListItemValue>
               {props.accountingCategory?.appliesTo && (
                 <FormattedMessage {...AccountingCategoryAppliesToI18n[props.accountingCategory?.appliesTo]} />
               )}
-            </p>
-          </React.Fragment>
+            </DataListItemValue>
+          </DataListItem>
         )}
 
-        <label className="mt-4 mb-1 text-base">
-          <FormattedMessage defaultMessage="Kind" id="Transaction.Kind" />
-        </label>
-        <p>
-          {props.accountingCategory?.kind && (
-            <FormattedMessage {...AccountingCategoryKindI18n[props.accountingCategory?.kind]} />
-          )}
-        </p>
+        <DataListItem>
+          <DataListItemLabel>
+            <FormattedMessage defaultMessage="Kind" id="Transaction.Kind" />
+          </DataListItemLabel>
+          <DataListItemValue>
+            {props.accountingCategory?.kind && (
+              <FormattedMessage {...AccountingCategoryKindI18n[props.accountingCategory?.kind]} />
+            )}
+          </DataListItemValue>
+        </DataListItem>
 
-        <label className="mt-4 mb-1 text-base">
-          <FormattedMessage defaultMessage="Visible only to host admins" id="NvBPFR" />
-        </label>
-        <p>
-          {props.accountingCategory?.hostOnly ? (
-            <FormattedMessage defaultMessage="Yes" id="a5msuh" />
-          ) : (
-            <FormattedMessage defaultMessage="No" id="oUWADl" />
-          )}
-        </p>
+        <DataListItem>
+          <DataListItemLabel>
+            <FormattedMessage defaultMessage="Visible only to host admins" id="NvBPFR" />
+          </DataListItemLabel>
+          <DataListItemValue>
+            {props.accountingCategory?.hostOnly ? (
+              <FormattedMessage defaultMessage="Yes" id="a5msuh" />
+            ) : (
+              <FormattedMessage defaultMessage="No" id="oUWADl" />
+            )}
+          </DataListItemValue>
+        </DataListItem>
 
         {props.accountingCategory?.kind === AccountingCategoryKind.EXPENSE && (
-          <React.Fragment>
-            <label className="mt-4 mb-1 text-base">
+          <DataListItem>
+            <DataListItemLabel>
               <FormattedMessage defaultMessage="Expense types" id="7oAuzt" />
-            </label>
-            <p>
+            </DataListItemLabel>
+            <DataListItemValue>
               {props.accountingCategory?.expensesTypes ? (
                 props.accountingCategory.expensesTypes.map(value => i18nExpenseType(intl, value)).join(', ')
               ) : (
                 <FormattedMessage id="AllExpenses" defaultMessage="All expenses" />
               )}
-            </p>
-          </React.Fragment>
+            </DataListItemValue>
+          </DataListItem>
         )}
 
         {!isEmptyHTMLValue(props.accountingCategory?.instructions) && (
           <React.Fragment>
-            <label className="mt-4 mb-1 text-base">
-              <FormattedMessage defaultMessage="Instructions" id="sV2v5L" />
-            </label>
-            <div>
-              <HTMLContent content={props.accountingCategory?.instructions} />
-            </div>
+            <Separator className="my-3" />
+            <DataListItem className="sm:flex-col">
+              <DataListItemLabel>
+                <FormattedMessage defaultMessage="Instructions" id="sV2v5L" />
+              </DataListItemLabel>
+              <DataListItemValue>
+                <HTMLContent content={props.accountingCategory?.instructions} />
+              </DataListItemValue>
+            </DataListItem>
           </React.Fragment>
         )}
-      </div>
+      </DataList>
+
       <DrawerActions>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>

--- a/components/ui/DataList.tsx
+++ b/components/ui/DataList.tsx
@@ -7,7 +7,7 @@ export function DataList({ children, className }: { children?: React.ReactNode; 
 }
 
 export function DataListItemValue({ children, className }: { children?: React.ReactNode; className?: string }) {
-  return <div className={cn('max-w-fit overflow-hidden break-words', className)}>{children}</div>;
+  return <div className={cn('max-w-fit break-words', className)}>{children}</div>;
 }
 
 export function DataListItemLabel({ children }: { children?: React.ReactNode }) {


### PR DESCRIPTION
# Description

Fixes a style regression in the AccountingCategoryDrawer coming from removing default Label styles in app.css.

Also updating the drawer to instead use the `ui/DataList` components, similar to other drawers.

# Screenshots


| Before style regression | Current | Updated to use DataList (this PR) |
| ----------------------- | ------- | --------------------------------- |
|<img width="503" alt="Screenshot 2025-02-19 at 11 35 38" src="https://github.com/user-attachments/assets/814f02c7-5f1c-49c5-972d-1e95f9af9630" /> |<img width="519" alt="Screenshot 2025-02-19 at 11 37 46" src="https://github.com/user-attachments/assets/16a4179f-1dba-4836-b2d7-bf9082a759cf" />|<img width="525" alt="Screenshot 2025-02-19 at 11 36 09" src="https://github.com/user-attachments/assets/e21b1d22-9f66-4f91-a170-29e48731215a" />|




