### PR TITLE
Enhancement(Expense flow): Make Category selection visible only when required

### DIFF
--- a/components/AccountingCategorySelect.tsx
+++ b/components/AccountingCategorySelect.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { get, isUndefined, pick, remove, size, throttle, uniq } from 'lodash';
+import { get, isNull, isUndefined, pick, remove, size, throttle, uniq } from 'lodash';
 import { Check, ChevronDown, Sparkles } from 'lucide-react';
 import type { IntlShape } from 'react-intl';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
@@ -39,7 +39,7 @@ type AccountingCategorySelectProps = {
   predictionStyle?: 'full' | 'inline-preload';
   selectedCategory: Pick<AccountingCategory, 'friendlyName' | 'name' | 'code' | 'id'> | undefined | null;
   valuesByRole?: Expense['valuesByRole'];
-  onChange: (category: AccountingCategory) => void;
+  onChange: (category: AccountingCategory | null) => void;
   onBlur?: () => void;
   allowNone?: boolean;
   showCode?: boolean;
@@ -198,6 +198,15 @@ const getOptions = (
 
   remove(categories, category => category.appliesTo !== expectedAppliesTo);
 
+  if (allowNone) {
+    options.push({
+      key: null,
+      value: null,
+      label: getCategoryLabel(intl, null, false, valuesByRole),
+      searchText: intl.formatMessage({ defaultMessage: "I don't know", id: 'AkIyKO' }).toLocaleLowerCase(),
+    });
+  }
+
   categories.forEach(category => {
     options.push({
       key: category.id,
@@ -206,16 +215,6 @@ const getOptions = (
       searchText: getSearchTextFromCategory(category),
     });
   });
-
-  if (allowNone) {
-    const label = getCategoryLabel(intl, null, false, valuesByRole);
-    options.push({
-      key: null,
-      value: null,
-      label,
-      searchText: intl.formatMessage({ defaultMessage: "I don't know", id: 'AkIyKO' }).toLocaleLowerCase(),
-    });
-  }
 
   return options;
 };
@@ -311,7 +310,7 @@ const shouldUsePredictions = (
   } else if (predictionStyle === 'full') {
     return true;
   } else if (predictionStyle === 'inline-preload') {
-    return !selectedCategory || isOpen; // Only preload suggestions if no category is selected
+    return isUndefined(selectedCategory) || isOpen; // Only preload suggestions if no category is selected
   } else if (predictionStyle === 'inline') {
     return isOpen;
   }
@@ -346,10 +345,12 @@ const AccountingCategorySelect = ({
   const hasPredictions = Boolean(predictions?.length);
 
   const triggerChange = newCategory => {
-    if (selectedCategory?.id !== newCategory?.id) {
+    // Allow setting `null` that represents "I don't know"
+    if (selectedCategory?.id !== newCategory?.id || (isNull(newCategory) && !isNull(selectedCategory))) {
       onChange(newCategory);
     }
   };
+
   const options = React.useMemo(
     () => getOptions(intl, host, kind, expenseType, showCode, allowNone, valuesByRole, isHostAdmin, account),
     [intl, host, kind, expenseType, allowNone, showCode, valuesByRole, isHostAdmin, account],
@@ -393,11 +394,12 @@ const AccountingCategorySelect = ({
             >
               <span
                 className={cn('mr-3 grow truncate text-start text-sm', {
-                  'text-gray-400': isUndefined(selectedCategory),
+                  'text-muted-foreground': isUndefined(selectedCategory),
                 })}
               >
-                {getCategoryLabel(intl, selectedCategory, false, valuesByRole) ||
-                  intl.formatMessage({ defaultMessage: 'Select category', id: 'RUJYth' })}
+                {!isUndefined(selectedCategory)
+                  ? getCategoryLabel(intl, selectedCategory, false, valuesByRole)
+                  : intl.formatMessage({ defaultMessage: 'Select category', id: 'RUJYth' })}
               </span>
               <ChevronDown size="1em" />
             </Button>
@@ -415,8 +417,9 @@ const AccountingCategorySelect = ({
                 <CommandGroup heading={intl.formatMessage({ defaultMessage: 'Suggested categories', id: 'ydZSPT' })}>
                   {suggestedOptions.map(({ key, label, value, searchText }) => (
                     <CommandItem
-                      key={key || 'none'}
-                      value={searchText}
+                      key={key}
+                      value={key}
+                      keywords={[searchText]}
                       onSelect={() => {
                         triggerChange(value);
                         setOpen(false);
@@ -425,7 +428,7 @@ const AccountingCategorySelect = ({
                       <div className="flex flex-1 items-center justify-between">
                         <span>{label}</span>
                         <span
-                          className="text-right text-xs text-gray-500"
+                          className="text-right text-xs text-muted-foreground"
                           title={intl.formatMessage({ defaultMessage: 'Suggested', id: 'a0lFbM' })}
                         >
                           <Sparkles size={16} className="mr-1 inline-block text-yellow-500" strokeWidth={1.5} />
@@ -443,12 +446,15 @@ const AccountingCategorySelect = ({
                 }
               >
                 {options.map(({ label, key, value, searchText }) => {
-                  const isSelected = selectedCategory?.id === key;
+                  const isSelected =
+                    (isNull(selectedCategory) && isNull(value)) ||
+                    (selectedCategory && value && selectedCategory?.id === value?.id);
                   const isPrediction = suggestedOptions.some(option => option.key === key);
                   return (
                     <CommandItem
-                      key={key || 'none'} // `CommandItem` doesn't like nil key/value
-                      value={searchText}
+                      key={key || 'none'}
+                      value={key || 'none'}
+                      keywords={[searchText]}
                       onSelect={() => {
                         triggerChange(value);
                         setOpen(false);

--- a/components/submit-expense/SubmitExpenseFlowSteps.tsx
+++ b/components/submit-expense/SubmitExpenseFlowSteps.tsx
@@ -148,7 +148,7 @@ export function SubmitExpenseFlowSteps(props: SubmitExpenseFlowStepsProps) {
     Step.EXPENSE_TITLE,
   ].filter(step => {
     if (step === Step.EXPENSE_CATEGORY) {
-      return form.options.accountingCategories?.length;
+      return form.options.isAccountingCategoryRequired && form.options.accountingCategories?.length;
     }
 
     return true;

--- a/components/submit-expense/form/ExpenseCategorySection.tsx
+++ b/components/submit-expense/form/ExpenseCategorySection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { pick } from 'lodash';
+import { isNil, pick } from 'lodash';
 import { ChevronDown } from 'lucide-react';
 import { FormattedMessage } from 'react-intl';
 
@@ -37,9 +37,11 @@ export const ExpenseCategorySection = memoWithGetFormProps(function ExpenseCateg
 
   const accountingCategories = React.useMemo(() => props.accountingCategories || [], [props.accountingCategories]);
 
-  const selectedAccountingCategory = accountingCategoryId
-    ? accountingCategories.find(a => a.id === accountingCategoryId)
-    : null;
+  // Passing along either `null` (representing "I don't know") or `undefined` (representing unset value)
+  const selectedAccountingCategory = isNil(accountingCategoryId)
+    ? accountingCategoryId
+    : accountingCategories.find(a => a.id === accountingCategoryId);
+
   const instructions = selectedAccountingCategory?.instructions;
   const { setFieldValue } = props;
 
@@ -48,7 +50,7 @@ export const ExpenseCategorySection = memoWithGetFormProps(function ExpenseCateg
 
   const onAccountingCategorySelectChange = React.useCallback(
     value => {
-      setFieldValue('accountingCategoryId', value?.id);
+      setFieldValue('accountingCategoryId', value ? value.id : null);
     },
     [setFieldValue],
   );
@@ -72,7 +74,7 @@ export const ExpenseCategorySection = memoWithGetFormProps(function ExpenseCateg
             expenseType={props.expenseTypeOption}
             account={props.account}
             selectedCategory={selectedAccountingCategory}
-            allowNone={!props.isAccountingCategoryRequired}
+            allowNone={true}
             buttonClassName="max-w-full w-full"
           />
         )}

--- a/components/submit-expense/form/SubmitExpenseFlowForm.tsx
+++ b/components/submit-expense/form/SubmitExpenseFlowForm.tsx
@@ -54,7 +54,7 @@ export function SubmitExpenseFlowForm(props: SubmitExpenseFlowFormProps) {
       <WhoIsGettingPaidSection inViewChange={onInViewChange} {...WhoIsGettingPaidSection.getFormProps(form)} />
       <PayoutMethodSection inViewChange={onInViewChange} {...PayoutMethodSection.getFormProps(form)} />
       <TypeOfExpenseSection inViewChange={onInViewChange} {...TypeOfExpenseSection.getFormProps(form)} />
-      {form.options.accountingCategories?.length > 0 && (
+      {form.options.isAccountingCategoryRequired && form.options.accountingCategories?.length > 0 && (
         <ExpenseCategorySection inViewChange={onInViewChange} {...ExpenseCategorySection.getFormProps(form)} />
       )}
       <ExpenseItemsSection inViewChange={onInViewChange} form={form} />

--- a/components/submit-expense/useExpenseForm.ts
+++ b/components/submit-expense/useExpenseForm.ts
@@ -6,7 +6,7 @@ import dayjs from 'dayjs';
 import type { Path, PathValue } from 'dot-path-value';
 import type { FieldInputProps, FormikErrors, FormikHelpers } from 'formik';
 import { useFormik } from 'formik';
-import { isEmpty, isEqual, omit, pick, set, uniqBy } from 'lodash';
+import { isEmpty, isEqual, isNull, omit, pick, set, uniqBy } from 'lodash';
 import memoizeOne from 'memoize-one';
 import type { IntlShape } from 'react-intl';
 import { useIntl } from 'react-intl';
@@ -658,7 +658,8 @@ function buildFormSchema(
           if (
             options.isAccountingCategoryRequired &&
             options.accountingCategories?.length > 0 &&
-            !options.accountingCategories.some(ac => ac.id === v)
+            !options.accountingCategories.some(ac => ac.id === v) &&
+            !isNull(v) // null represents "I don't know" and is a valid option
           ) {
             return false;
           }


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/7852

## Description
- Makes category selection visible only when required from policy
- Adds "I don't know" as a valid option
- Updates placeholder text to "Select category"