### PR TITLE
Display collective payment method when donating from host to collective

### DIFF
--- a/components/contribution-flow/utils.js
+++ b/components/contribution-flow/utils.js
@@ -67,7 +67,9 @@ export const generatePaymentMethodOptions = (
 
   uniquePMs = uniquePMs.filter(
     ({ paymentMethod }) =>
-      paymentMethod.type !== PAYMENT_METHOD_TYPE.COLLECTIVE || collective.host.id === stepProfile.host?.id,
+      paymentMethod.type !== PAYMENT_METHOD_TYPE.COLLECTIVE ||
+      collective.host.id === stepProfile.host?.id ||
+      collective.host.id === stepProfile.id,
   );
 
   if (paymentIntent) {


### PR DESCRIPTION
Fix: https://github.com/opencollective/opencollective/issues/7849

Root issue is likely that we're not returning the host property here in `contributionFlowAccountQuery` as an Organization is not officialy in GraphQL an `AccountWithHost`.

```
          ... on AccountWithHost {
            host {
              id
              slug
              name
              imageUrl(height: 64)
            }
          }
```
