### PR TITLE
Fix(Expense form): Remove "Who is paying?" when you can't change account (and include account in title)

### DIFF
--- a/components/AccountHoverCard.tsx
+++ b/components/AccountHoverCard.tsx
@@ -52,6 +52,16 @@ export const accountHoverCardFields = gql`
   }
 `;
 
+export const accountHoverCardQuery = gql`
+  query Account($slug: String!) {
+    account(slug: $slug) {
+      id
+      ...AccountHoverCardFields
+    }
+  }
+  ${accountHoverCardFields}
+`;
+
 type AccountHoverCardProps = {
   trigger: React.ReactNode;
   account: {

--- a/components/dashboard/filters/HostedAccountFilter.tsx
+++ b/components/dashboard/filters/HostedAccountFilter.tsx
@@ -8,20 +8,10 @@ import { API_V2_CONTEXT, gql } from '../../../lib/graphql/helpers';
 import type { AccountHoverCardFieldsFragment, AccountQuery } from '../../../lib/graphql/types/v2/graphql';
 import type { Account } from '../../../lib/graphql/types/v2/schema';
 
-import { AccountHoverCard, accountHoverCardFields } from '../../AccountHoverCard';
+import { AccountHoverCard, accountHoverCardFields, accountHoverCardQuery } from '../../AccountHoverCard';
 import Avatar from '../../Avatar';
 
 import ComboSelectFilter from './ComboSelectFilter';
-
-const accountQuery = gql`
-  query Account($slug: String!) {
-    account(slug: $slug) {
-      id
-      ...AccountHoverCardFields
-    }
-  }
-  ${accountHoverCardFields}
-`;
 
 const hostedAccountFilterSearchQuery = gql`
   query HostedAccountFilterSearch($searchTerm: String, $hostSlug: String, $orderBy: OrderByInput) {
@@ -44,7 +34,7 @@ export const AccountRenderer = ({
   };
   inOptionsList?: boolean; // For positioning the HoverCard to the right to prevent blocking options list
 }) => {
-  const { data } = useQuery<AccountQuery>(accountQuery, {
+  const { data } = useQuery<AccountQuery>(accountHoverCardQuery, {
     variables: { slug: account.slug },
     fetchPolicy: 'cache-first',
     context: API_V2_CONTEXT,

--- a/components/submit-expense/SubmitExpenseFlow.tsx
+++ b/components/submit-expense/SubmitExpenseFlow.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { FetchResult } from '@apollo/client';
-import { gql, useMutation } from '@apollo/client';
+import { gql, useMutation, useQuery } from '@apollo/client';
 import dayjs from 'dayjs';
 import { FormikProvider } from 'formik';
 import { pick } from 'lodash';
@@ -13,6 +13,8 @@ import { CollectiveType } from '../../lib/constants/collectives';
 import { i18nGraphqlException } from '../../lib/errors';
 import { API_V2_CONTEXT } from '../../lib/graphql/helpers';
 import type {
+  AccountHoverCardFieldsFragment,
+  AccountQuery,
   CreateExpenseFromDashboardMutation,
   CreateExpenseFromDashboardMutationVariables,
   CurrencyExchangeRateInput,
@@ -21,7 +23,7 @@ import type {
   InviteExpenseFromDashboardMutation,
   InviteExpenseFromDashboardMutationVariables,
 } from '../../lib/graphql/types/v2/graphql';
-import type { Currency, RecurringExpenseInterval } from '../../lib/graphql/types/v2/schema';
+import type { Account, Currency, RecurringExpenseInterval } from '../../lib/graphql/types/v2/schema';
 import { ExpenseStatus, ExpenseType, PayoutMethodType } from '../../lib/graphql/types/v2/schema';
 import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
 
@@ -35,6 +37,8 @@ import { useNavigationWarning } from './hooks';
 import { Step, SubmitExpenseFlowSteps } from './SubmitExpenseFlowSteps';
 import { SubmittedExpense } from './SubmittedExpense';
 import { InviteeAccountType, RecurrenceFrequencyOption, useExpenseForm, YesNoOption } from './useExpenseForm';
+import { AccountHoverCard, accountHoverCardQuery } from '../AccountHoverCard';
+import Avatar from '../Avatar';
 
 type SubmitExpenseFlowProps = {
   onClose: (submittedExpense: boolean) => void;
@@ -419,9 +423,17 @@ export function SubmitExpenseFlow(props: SubmitExpenseFlowProps) {
       >
         <div className="flex max-h-screen min-h-screen max-w-screen min-w-screen flex-col overflow-hidden bg-[#F8FAFC]">
           <header className="flex min-w-screen items-center justify-between border-b border-slate-100 px-4 py-3 sm:px-10">
-            <span className="text-xl leading-7 font-bold text-slate-800">
-              <FormattedMessage id="ExpenseForm.Submit" defaultMessage="Submit expense" />
-            </span>
+            <div className="flex grow items-center gap-2 text-xl leading-7 font-semibold">
+              {props.submitExpenseTo ? (
+                <FormattedMessage
+                  id="ExpenseForm.SubmitTo"
+                  defaultMessage="Submit expense to {account}"
+                  values={{ account: <AccountRenderer accountSlug={props.submitExpenseTo} /> }}
+                />
+              ) : (
+                <FormattedMessage id="ExpenseForm.Submit" defaultMessage="Submit expense" />
+              )}
+            </div>
             <Button
               disabled={isLoading}
               loading={isLoading}
@@ -466,6 +478,27 @@ export function SubmitExpenseFlow(props: SubmitExpenseFlowProps) {
   );
 }
 
+const AccountRenderer = ({ accountSlug }: { accountSlug: Account['slug'] }) => {
+  const { data } = useQuery<AccountQuery>(accountHoverCardQuery, {
+    variables: { slug: accountSlug },
+    fetchPolicy: 'cache-first',
+    context: API_V2_CONTEXT,
+  });
+
+  return (
+    <AccountHoverCard
+      account={data.account}
+      trigger={
+        <div className="inline-flex h-full w-full max-w-48 items-center justify-between gap-2 overflow-hidden">
+          <Avatar collective={data.account} radius={20} />
+          <div className="relative flex flex-1 items-center justify-between gap-1 overflow-hidden">
+            <span className="truncate">{data.account?.name ?? accountSlug}</span>
+          </div>
+        </div>
+      }
+    />
+  );
+};
 function ExpenseFormikContainer(props: {
   submitExpenseTo?: string;
   draftKey?: string;
@@ -480,6 +513,7 @@ function ExpenseFormikContainer(props: {
     draftKey: props.draftKey,
     duplicateExpense: props.duplicateExpense,
     expenseId: props.expenseId,
+    canChangeAccount: !props.submitExpenseTo,
   });
 
   const [activeStep, setActiveStep] = React.useState(Step.WHO_IS_PAYING);

--- a/components/submit-expense/SubmitExpenseFlowSteps.tsx
+++ b/components/submit-expense/SubmitExpenseFlowSteps.tsx
@@ -150,6 +150,9 @@ export function SubmitExpenseFlowSteps(props: SubmitExpenseFlowStepsProps) {
     if (step === Step.EXPENSE_CATEGORY) {
       return form.options.isAccountingCategoryRequired && form.options.accountingCategories?.length;
     }
+    if (step === Step.WHO_IS_PAYING) {
+      return form.options.canChangeAccount;
+    }
 
     return true;
   });

--- a/components/submit-expense/form/SubmitExpenseFlowForm.tsx
+++ b/components/submit-expense/form/SubmitExpenseFlowForm.tsx
@@ -50,7 +50,9 @@ export function SubmitExpenseFlowForm(props: SubmitExpenseFlowFormProps) {
           onExpenseInviteDeclined={props.onExpenseInviteDeclined}
         />
       )}
-      <WhoIsPayingSection inViewChange={onInViewChange} {...WhoIsPayingSection.getFormProps(form)} />
+      {form.options.canChangeAccount && (
+        <WhoIsPayingSection inViewChange={onInViewChange} {...WhoIsPayingSection.getFormProps(form)} />
+      )}
       <WhoIsGettingPaidSection inViewChange={onInViewChange} {...WhoIsGettingPaidSection.getFormProps(form)} />
       <PayoutMethodSection inViewChange={onInViewChange} {...PayoutMethodSection.getFormProps(form)} />
       <TypeOfExpenseSection inViewChange={onInViewChange} {...TypeOfExpenseSection.getFormProps(form)} />

--- a/components/submit-expense/form/WhoIsPayingSection.tsx
+++ b/components/submit-expense/form/WhoIsPayingSection.tsx
@@ -14,9 +14,11 @@ import type { ExpenseForm } from '../useExpenseForm';
 import { ExpenseAccountItem } from './ExpenseAccountItem';
 import { FormSectionContainer } from './FormSectionContainer';
 import { memoWithGetFormProps } from './helper';
+import Avatar from '@/components/Avatar';
 
 type WhoIsPayingSectionProps = {
   inViewChange: (inView: boolean, entry: IntersectionObserverEntry) => void;
+  lockPayee?: boolean;
 } & ReturnType<typeof getFormProps>;
 
 function getFormProps(form: ExpenseForm) {
@@ -36,7 +38,7 @@ export const WhoIsPayingSection = memoWithGetFormProps(function WhoIsPayingSecti
   const [isLoading, setIsLoading] = React.useState(true);
   const lastSubmittedExpense = props.recentlySubmittedExpenses?.nodes?.at?.(0);
   const lastSubmittedAccount = lastSubmittedExpense && lastSubmittedExpense.account;
-
+  console.log({ props });
   const recentlySubmittedAccounts = React.useMemo(
     () => uniqBy((props.recentlySubmittedExpenses?.nodes || []).map(e => e?.account).filter(Boolean), 'slug'),
     [props.recentlySubmittedExpenses],

--- a/components/submit-expense/useExpenseForm.ts
+++ b/components/submit-expense/useExpenseForm.ts
@@ -6,7 +6,7 @@ import dayjs from 'dayjs';
 import type { Path, PathValue } from 'dot-path-value';
 import type { FieldInputProps, FormikErrors, FormikHelpers } from 'formik';
 import { useFormik } from 'formik';
-import { isEmpty, isEqual, isNull, omit, pick, set, uniqBy } from 'lodash';
+import { isEmpty, isEqual, isNull, isUndefined, omit, pick, set, uniqBy } from 'lodash';
 import memoizeOne from 'memoize-one';
 import type { IntlShape } from 'react-intl';
 import { useIntl } from 'react-intl';
@@ -1272,10 +1272,14 @@ async function buildFormOptions(
     const payeeHost = payee && 'host' in payee ? payee.host : null;
     const submitter = options.expense?.submitter || query.data?.submitter;
 
-    if (account && options.expense?.status === ExpenseStatus.DRAFT) {
-      options.canChangeAccount = false;
+    if (isUndefined(startOptions.canChangeAccount)) {
+      if (account && options.expense?.status === ExpenseStatus.DRAFT) {
+        options.canChangeAccount = false;
+      } else {
+        options.canChangeAccount = true;
+      }
     } else {
-      options.canChangeAccount = true;
+      options.canChangeAccount = startOptions.canChangeAccount;
     }
 
     if (recentlySubmittedExpenses) {
@@ -1450,6 +1454,7 @@ type ExpenseFormStartOptions = {
   draftKey?: string;
   isInlineEdit?: boolean;
   pickSchemaFields?: Record<string, boolean>;
+  canChangeAccount?: boolean;
 };
 
 export function useExpenseForm(opts: {


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/7853


# Description

Removes "Who is paying?" section when you can't change payee, and instead include the account in the title of the flow.

# Screenshots

<img width="1355" alt="image" src="https://github.com/user-attachments/assets/0f0f8d01-5dc8-417f-913f-dd7d5891db33" />
