### PR TITLE
Add `Mailpit` instructions for e2e setup

### DIFF
--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -9,7 +9,7 @@ https://docs.opencollective.com/help/contributing/development/testing-with-cypre
 
 ## Running the E2E tests in development environment
 
-In dev environment, to execute the E2E tests, you will need to open 3 different terminals in 2 different projects.
+In dev environment, to execute the E2E tests, you will need to open 4 different terminals in 2 different projects.
 
 ### 1. API: Server
 
@@ -33,7 +33,13 @@ Behind the scenes it will do the following (so you don't have to do it):
 - build the API server: `npm run build`
 - start the API server: `npm run start`
 
-### 2. Frontend: Server
+### 2. Mail Server
+
+For E2E tests we need to start the [Mailpit](https://mailpit.axllent.org/) mail server to capture test emails. On a separate terminal navigate to the `opencollective-api` project and run:
+
+- `docker-compose -f docker-compose.dev.yml --profile mail up`
+
+### 3. Frontend: Server
 
 If it's not already setup, look at the "Install" instructions in the [README.md](../README.md).
 
@@ -59,7 +65,7 @@ When investigating a specific test, feel free to switch to the development envir
 
 - `TZ=UTC npm run dev`
 
-### 3. Frontend: Cypress
+### 4. Frontend: Cypress
 
 You can run all the Cypress tests in CLI mode with the following command:
 


### PR DESCRIPTION
Add the Mailpit startup instructions for e2e setup as otherwise the e2e tests would not run