### PR TITLE
Fix(Expense flow): Invalid date format for custom exchange rate

### DIFF
--- a/components/expenses/EditExpenseDialog.tsx
+++ b/components/expenses/EditExpenseDialog.tsx
@@ -77,7 +77,7 @@ const EditPayee = ({ expense, onSubmit }) => {
               exchangeRate: ei.amount.exchangeRate
                 ? ({
                     ...pick(ei.amount.exchangeRate, ['source', 'rate', 'value', 'fromCurrency', 'toCurrency']),
-                    date: ei.amount.exchangeRate.date || ei.incurredAt,
+                    date: new Date(ei.amount.exchangeRate.date || ei.incurredAt),
                   } as CurrencyExchangeRateInput)
                 : null,
             },

--- a/components/submit-expense/SubmitExpenseFlow.tsx
+++ b/components/submit-expense/SubmitExpenseFlow.tsx
@@ -214,7 +214,7 @@ export function SubmitExpenseFlow(props: SubmitExpenseFlowProps) {
               exchangeRate: ei.amount.exchangeRate
                 ? ({
                     ...pick(ei.amount.exchangeRate, ['source', 'rate', 'value', 'fromCurrency', 'toCurrency']),
-                    date: ei.amount.exchangeRate.date || ei.incurredAt,
+                    date: new Date(ei.amount.exchangeRate.date || ei.incurredAt),
                   } as CurrencyExchangeRateInput)
                 : null,
             },


### PR DESCRIPTION
# Description

Fixes an issue where GraphQL complained about an invalid date format when using a custom exchange rate.

# Screenshots

<img width="561" alt="image" src="https://github.com/user-attachments/assets/6f5592d8-2855-4c49-817c-5eb55ed90433" />
