### PR TITLE
Fixes #7904: Handle undefined newPayoutMethodTypes.

### DIFF
--- a/components/submit-expense/form/PayoutMethodSection.tsx
+++ b/components/submit-expense/form/PayoutMethodSection.tsx
@@ -199,7 +199,7 @@ export const PayoutMethodFormContent = memoWithGetFormProps(function PayoutMetho
             </RadioGroupCard>
           )}
 
-          {!(isLoading || isLoadingPayee) && !isVendor && props.newPayoutMethodTypes?.length > 0 && (
+          {!(isLoading || isLoadingPayee) && !isVendor && (props.newPayoutMethodTypes && props.newPayoutMethodTypes.length > 0) && (
             <RadioGroupCard
               value="__newPayoutMethod"
               checked={isNewPayoutMethodSelected}


### PR DESCRIPTION
Resolve ... [Fixes #7904](https://github.com/opencollective/opencollective/issues/7904)
Require ... <!-- If this PR depends on another PR (usually from the API), add a link here -->

# Description


Fixed a TypeError in the expense form by adding a more robust check for newPayoutMethodTypes in PayoutMethodSection.tsx. Previously, the code was attempting to access the length property on a potentially undefined newPayoutMethodTypes object, causing a JavaScript error when users clicked the "Add new" button under the expenses section. The fix ensures the existence of the object before trying to access its properties.
