### PR TITLE
perf: Remove contributors counts

### DIFF
--- a/components/collective-page/sections/Contributions.js
+++ b/components/collective-page/sections/Contributions.js
@@ -262,10 +262,6 @@ const contributionsSectionQuery = gql`
                 backgroundImageUrl(height: 200)
               }
             }
-            stats {
-              id
-              contributorsCount
-            }
           }
         }
       }

--- a/pages/search.js
+++ b/pages/search.js
@@ -599,7 +599,6 @@ const searchPageQuery = gql`
         currency
         stats {
           id
-          contributorsCount
           totalAmountReceived(useCache: true) {
             currency
             valueInCents


### PR DESCRIPTION
The contributors count has terrible performance when used in lists (see https://github.com/opencollective/opencollective/issues/7911). Other frontend components already support this data missing, so we don't need to update them.

Should unblock the profile page for large fiscal hosts and the search page.

![image](https://github.com/user-attachments/assets/f9a259a0-d4b6-4aa6-9184-32715f43e651)

![image](https://github.com/user-attachments/assets/62263c5b-6498-4c05-b44f-1de08557dccc)
