### PR TITLE
Remove Collective Overview preview feature flag

### DIFF
--- a/components/dashboard/Menu.tsx
+++ b/components/dashboard/Menu.tsx
@@ -113,7 +113,7 @@ export const getMenuItems = ({ intl, account, LoggedInUser }): MenuItem[] => {
 
   const items: MenuItem[] = [
     {
-      if: isIndividual || (LoggedInUser.hasPreviewFeatureEnabled(PREVIEW_FEATURE_KEYS.COLLECTIVE_OVERVIEW) && !isHost),
+      if: isIndividual || !isHost,
       section: ALL_SECTIONS.OVERVIEW,
       Icon: LayoutDashboard,
     },
@@ -495,7 +495,7 @@ const Menu = ({ onRoute, menuItems }) => {
 
   const showLinkToProfilePrototype =
     !['ROOT', 'ORGANIZATION', 'FUND', 'INDIVIDUAL'].includes(account.type) &&
-    LoggedInUser?.hasPreviewFeatureEnabled(PREVIEW_FEATURE_KEYS.COLLECTIVE_OVERVIEW);
+    LoggedInUser?.hasPreviewFeatureEnabled(PREVIEW_FEATURE_KEYS.CROWDFUNDING_REDESIGN);
 
   return (
     <div className="space-y-4">

--- a/lib/preview-features.ts
+++ b/lib/preview-features.ts
@@ -4,7 +4,6 @@ import type LoggedInUser from './LoggedInUser';
  * A map of keys used for preview features.
  */
 export enum PREVIEW_FEATURE_KEYS {
-  COLLECTIVE_OVERVIEW = 'COLLECTIVE_OVERVIEW',
   NEW_EXPENSE_FLOW = 'NEW_EXPENSE_FLOW',
   INLINE_EDIT_EXPENSE = 'INLINE_EDIT_EXPENSE',
   CROWDFUNDING_REDESIGN = 'CROWDFUNDING_REDESIGN',
@@ -46,15 +45,6 @@ const FIRST_PARTY_HOSTS = [
  * List of current preview features.
  */
 export const previewFeatures: PreviewFeature[] = [
-  {
-    key: PREVIEW_FEATURE_KEYS.COLLECTIVE_OVERVIEW,
-    title: 'Collective Overview',
-    description: 'Overview page for Collectives in Dashboard',
-    publicBeta: true,
-    alwaysEnableInDev: true,
-    enabledByDefaultFor: ['*'],
-    closedBetaAccessFor: [...PLATFORM_ACCOUNTS, ...FIRST_PARTY_HOSTS],
-  },
   {
     key: PREVIEW_FEATURE_KEYS.NEW_EXPENSE_FLOW,
     title: 'New expense submission flow',

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -8,7 +8,6 @@ import roles from '../lib/constants/roles';
 import { API_V2_CONTEXT } from '../lib/graphql/helpers';
 import useLoggedInUser from '../lib/hooks/useLoggedInUser';
 import { require2FAForAdmins } from '../lib/policies';
-import { PREVIEW_FEATURE_KEYS } from '../lib/preview-features';
 import type { Context } from '@/lib/apollo-client';
 import { loadGoogleMaps } from '@/lib/google-maps';
 import { getWhitelabelProps } from '@/lib/whitelabel';
@@ -58,10 +57,7 @@ const getDefaultSectionForAccount = (account, loggedInUser) => {
     return null;
   } else if (account.type === 'ROOT') {
     return ROOT_SECTIONS.ALL_COLLECTIVES;
-  } else if (
-    isIndividualAccount(account) ||
-    (!isHostAccount(account) && loggedInUser.hasPreviewFeatureEnabled(PREVIEW_FEATURE_KEYS.COLLECTIVE_OVERVIEW))
-  ) {
+  } else if (isIndividualAccount(account) || !isHostAccount(account)) {
     return ALL_SECTIONS.OVERVIEW;
   } else if (isHostAccount(account)) {
     return ALL_SECTIONS.HOST_EXPENSES;


### PR DESCRIPTION
### Description

Removing the Collective Overview preview feature flag (already enabled by default for everyone).

I also discovered that I had put the Crowdfunding prototype preview link behind this feature flag by mistake 🤦 