### PR TITLE
fix(Host Application Drawer): Prevent host applications drawer from re-opening

### DIFF
--- a/components/dashboard/sections/HostVirtualCardRequests.tsx
+++ b/components/dashboard/sections/HostVirtualCardRequests.tsx
@@ -231,7 +231,7 @@ export default function HostVirtualCardRequests({ accountSlug: hostSlug }: Dashb
       ) : (
         <React.Fragment>
           <VirtualCardRequestsTable
-            onSelectedVirtualCardRequest={vcr => queryFilter.setFilter('virtualCardRequest', vcr.legacyId)}
+            onSelectedVirtualCardRequest={vcr => queryFilter.setFilter('virtualCardRequest', vcr.legacyId, false)}
             loading={query.loading}
             virtualCardRequests={query.data?.virtualCardRequests.nodes}
           />
@@ -239,7 +239,7 @@ export default function HostVirtualCardRequests({ accountSlug: hostSlug }: Dashb
 
           <VirtualCardRequestDrawer
             open={!!queryFilter.values.virtualCardRequest}
-            onClose={() => queryFilter.setFilter('virtualCardRequest', null)}
+            onClose={() => queryFilter.setFilter('virtualCardRequest', null, false)}
             virtualCardRequestId={queryFilter.values.virtualCardRequest}
           />
         </React.Fragment>

--- a/components/dashboard/sections/collectives/HostApplicationRequests.tsx
+++ b/components/dashboard/sections/collectives/HostApplicationRequests.tsx
@@ -87,7 +87,7 @@ export default function HostApplicationRequests({
             hostApplications={applicationRequests}
             nbPlaceholders={nbPlaceholders}
             loading={loading}
-            openApplication={application => queryFilter.setFilter('hostApplicationId', application.id)}
+            openApplication={application => queryFilter.setFilter('hostApplicationId', application.id, false)}
           />
           <Pagination queryFilter={queryFilter} total={totalCount} />
         </React.Fragment>
@@ -95,7 +95,7 @@ export default function HostApplicationRequests({
 
       <HostApplicationDrawer
         open={!!queryFilter.values.hostApplicationId}
-        onClose={() => queryFilter.setFilter('hostApplicationId', null)}
+        onClose={() => queryFilter.setFilter('hostApplicationId', null, false)}
         applicationId={queryFilter.values.hostApplicationId}
         editCollectiveMutation={editCollectiveMutation}
       />

--- a/components/dashboard/sections/collectives/HostApplications.tsx
+++ b/components/dashboard/sections/collectives/HostApplications.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useQuery } from '@apollo/client';
-import { omit, omitBy } from 'lodash';
+import { omit } from 'lodash';
 import { useRouter } from 'next/router';
 import { defineMessage, FormattedMessage, useIntl } from 'react-intl';
 import { z } from 'zod';
@@ -78,14 +78,6 @@ const filters: FilterComponentConfigs<z.infer<typeof schema>> = {
     },
     valueRenderer: ({ value, intl }) => intl.formatMessage(LastCommentByFilterLabels[value]),
   },
-};
-
-const ROUTE_PARAMS = ['hostCollectiveSlug', 'slug', 'section', 'view'];
-
-const updateQuery = (router, newParams) => {
-  const query = omitBy({ ...router.query, ...newParams }, (value, key) => !value || ROUTE_PARAMS.includes(key));
-  const pathname = router.asPath.split('?')[0].split('#')[0];
-  return router.push({ pathname, query });
 };
 
 const HostApplications = ({ accountSlug: hostSlug }: DashboardSectionProps) => {
@@ -179,7 +171,7 @@ const HostApplications = ({ accountSlug: hostSlug }: DashboardSectionProps) => {
             hostApplications={hostApplications?.nodes}
             nbPlaceholders={nbPlaceholders}
             loading={loading}
-            openApplication={application => queryFilter.setFilter('hostApplicationId', application.id)}
+            openApplication={application => queryFilter.setFilter('hostApplicationId', application.id, false)}
           />
           <Pagination queryFilter={queryFilter} total={hostApplications?.totalCount} />
         </React.Fragment>
@@ -188,8 +180,7 @@ const HostApplications = ({ accountSlug: hostSlug }: DashboardSectionProps) => {
       <HostApplicationDrawer
         open={!!drawerApplicationId}
         onClose={() => {
-          updateQuery(router, { accountId: null });
-          queryFilter.setFilter('hostApplicationId', null);
+          queryFilter.setFilter('hostApplicationId', undefined, false);
         }}
         applicationId={drawerApplicationId}
       />


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/7922

# Description
Fixes the host applications drawer from re-opening due to a leftover of using the legacy way of updating the query (in addition with using the query filter helper.)

Also makes sure to not reset the pagination when opening the Host Application drawer, same fix in the Virtual Cards tables.
