### PR TITLE
fix(Drawer): Set the drawer width without styled-components

### DIFF
--- a/components/Drawer.tsx
+++ b/components/Drawer.tsx
@@ -2,7 +2,6 @@ import React, { createContext, useContext, useEffect, useRef, useState } from 'r
 import clsx from 'clsx';
 import { X } from 'lucide-react';
 import { createPortal } from 'react-dom';
-import { createGlobalStyle } from 'styled-components';
 
 import { Sheet, SheetContent } from './ui/Sheet';
 import StyledRoundButton from './StyledRoundButton';
@@ -10,12 +9,6 @@ import StyledRoundButton from './StyledRoundButton';
 const DrawerActionsContext = createContext(null);
 
 export const useDrawerActionsContainer = () => useContext(DrawerActionsContext);
-
-const GlobalDrawerStyle = createGlobalStyle<{ drawedWidth: number }>`
-  :root {
-    --drawer-width: ${({ drawedWidth }) => drawedWidth}px;
-  }
-`;
 
 export function Drawer({
   open,
@@ -37,8 +30,7 @@ export function Drawer({
 }) {
   const [drawerActionsContainer, setDrawerActionsContainer] = useState(null);
 
-  const drawerRef = useRef();
-  const [drawedWidth, setDrawerWidth] = useState(0);
+  const drawerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!drawerRef.current) {
@@ -46,15 +38,19 @@ export function Drawer({
     }
 
     const observer = new ResizeObserver(entries => {
-      setDrawerWidth(entries[0].contentRect.width);
+      const width = entries[0].contentRect.width;
+      document.documentElement.style.setProperty('--drawer-width', `${width}px`);
     });
     observer.observe(drawerRef.current);
-    return () => drawerRef.current && observer.unobserve(drawerRef.current);
+    return () => {
+      if (drawerRef.current) {
+        observer.unobserve(drawerRef.current);
+      }
+    };
   }, [drawerRef.current]);
 
   return (
     <DrawerActionsContext.Provider value={drawerActionsContainer}>
-      <GlobalDrawerStyle drawedWidth={drawedWidth} />
       <Sheet
         open={open}
         onOpenChange={open => {


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/7926

# Description

This PR sets the `--drawer-width` (used in the files viewer) CSS variable without Styled Components, which seemed to cause a UI bug of the drawer sometimes getting stuck or partially opening.
