### PR TITLE
adjusted geo call: using browser APIs for auto-detecting country

### DIFF
--- a/components/contribution-flow/ContributionSummary.js
+++ b/components/contribution-flow/ContributionSummary.js
@@ -204,18 +204,25 @@ const ContributionSummary = ({ collective, stepDetails, stepSummary, stepPayment
       )}
       <StyledHr borderColor="black.500" my={1} />
       <P color="black.500" fontSize="11px" mt={2} mb={1}>
-        Country detection powered by{' '}
-        <StyledLink
-          href="https://www.openstreetmap.org/"
-          openInNewTab
-          color="black.900"
-          display="inline-flex"
-          alignItems="center"
-          gap={1}
-        >
-          OpenStreetMap
-          <ExternalLink size={12} style={{ display: 'inline-block' }} />
-        </StyledLink>
+        <FormattedMessage
+          id="ContributionSummary.CountryDetectionAttribution"
+          defaultMessage="Country detection powered by {osmLink}"
+          values={{
+            osmLink: (
+              <StyledLink
+                href="https://www.openstreetmap.org/"
+                openInNewTab
+                color="black.900"
+                display="inline-flex"
+                alignItems="center"
+                gap={1}
+              >
+                OpenStreetMap
+                <ExternalLink size={12} style={{ display: 'inline-block' }} />
+              </StyledLink>
+            ),
+          }}
+        />
       </P>
       {stepDetails.interval && stepDetails.interval !== INTERVALS.oneTime && (
         <P color="black.800" fontSize="12px" mt={3}>

--- a/components/contribution-flow/ContributionSummary.js
+++ b/components/contribution-flow/ContributionSummary.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { InfoCircle } from '@styled-icons/boxicons-regular/InfoCircle';
+import { ExternalLink } from 'lucide-react';
 import { get } from 'lodash';
 import { FormattedDate, FormattedMessage, useIntl } from 'react-intl';
 import { styled } from 'styled-components';
@@ -202,6 +203,20 @@ const ContributionSummary = ({ collective, stepDetails, stepSummary, stepPayment
         </React.Fragment>
       )}
       <StyledHr borderColor="black.500" my={1} />
+      <P color="black.500" fontSize="11px" mt={2} mb={1}>
+        Country detection powered by{' '}
+        <StyledLink
+          href="https://www.openstreetmap.org/"
+          openInNewTab
+          color="black.900"
+          display="inline-flex"
+          alignItems="center"
+          gap={1}
+        >
+          OpenStreetMap
+          <ExternalLink size={12} style={{ display: 'inline-block' }} />
+        </StyledLink>
+      </P>
       {stepDetails.interval && stepDetails.interval !== INTERVALS.oneTime && (
         <P color="black.800" fontSize="12px" mt={3}>
           {!stepPayment || stepPayment.isKeyOnly ? (

--- a/lib/geolocation_api.js
+++ b/lib/geolocation_api.js
@@ -1,18 +1,43 @@
 /**
- * Fetch user geolocation from third party API. It is only meant to be used on
- * client side. If called from server side, this function returns null;
+ * Fetch user geolocation using the browser's Geolocation API.
+ * It is only meant to be used on client side. If called from server side,
+ * this function returns null.
+ *
+ * Uses the standard browser Geolocation API to get coordinates, then
+ * uses the Nominatim service to reverse geocode coordinates to country code.
  *
  * @returns countryCode: {string} two-letters ISO code or null if any error occurs
  */
 const fetchGeoLocation = async () => {
-  if (!process.browser) {
+  if (!process.browser || !navigator.geolocation) {
     return null;
   }
 
   try {
-    const response = await fetch('https://wtfismyip.com/json');
-    const body = await response.json();
-    return body.YourFuckingCountryCode;
+    // Get position using browser Geolocation API
+    const position = await new Promise((resolve, reject) => {
+      navigator.geolocation.getCurrentPosition(resolve, reject, {
+        enableHighAccuracy: false,
+        timeout: 5000,
+        maximumAge: 24 * 60 * 60 * 1000, // 24 hours
+      });
+    });
+
+    const { latitude, longitude } = position.coords;
+
+    // Use Nominatim service for reverse geocoding (OpenStreetMap-based, no API key required)
+    const response = await fetch(
+      `https://nominatim.openstreetmap.org/reverse?format=json&lat=${latitude}&lon=${longitude}&zoom=18&addressdetails=1`,
+      {
+        headers: {
+          'Accept-Language': 'en',
+          'User-Agent': 'OpenCollective/1.0',
+        },
+      },
+    );
+
+    const data = await response.json();
+    return data.address?.country_code?.toUpperCase() || null;
   } catch {
     // Ignore errors
     return null;


### PR DESCRIPTION
Resolve ... [#7960](https://github.com/opencollective/opencollective/issues/7960)
Require ... <!-- If this PR depends on another PR (usually from the API), add a link here -->

# Description

This PR adjusts the functionality to auto-detect a user's country based on their location using the OpenStreetMap Nominatim API. The detection occurs when a user enters the contribution flow, clicking on a contribution option, and continuing through the flow until they reach the tax information section.

## Changes
- Modified geolocation_api.js to make calls to OpenStreetMap's API
- Added prompt for location sharing
- Implemented parsing of coordinates to retrieve country data

# Screenshots

<img width="472" alt="Screenshot 2025-05-08 at 8 34 05 PM" src="https://github.com/user-attachments/assets/609251ee-51e6-44e8-b844-d21533f85587" />
<img width="632" alt="Screenshot 2025-05-08 at 8 34 19 PM" src="https://github.com/user-attachments/assets/be156b2b-e3f1-4145-992b-e2e2d4d3b7db" />

