### PR TITLE
Hide "Next Charge Date" field in ContributionDrawer for Cancelled Contributions

### DIFF
--- a/components/contributions/ContributionDrawer.tsx
+++ b/components/contributions/ContributionDrawer.tsx
@@ -469,7 +469,8 @@ export function ContributionDrawer(props: ContributionDrawerProps) {
                       </DataListItem>
                     )}
                   {query.data?.order?.nextChargeDate &&
-                    query.data?.order.frequency !== ContributionFrequency.ONETIME && (
+                    query.data?.order.frequency !== ContributionFrequency.ONETIME &&
+                    query.data?.order.status !== OrderStatus.CANCELLED && (
                       <DataListItem>
                         <DataListItemLabel>
                           <FormattedMessage defaultMessage="Next Charge Date" id="oJNxUE" />


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/7965

# Description

Hide the "Next Charge Date" field in ContributributionDrawer for cancelled contributions as showing this field doesn't makes sense in this case. 

# Screenshots

![image](https://github.com/user-attachments/assets/796e0c96-58c3-48bd-84f2-b63fd3f2ba9d)

![image](https://github.com/user-attachments/assets/e498043a-c4a6-41d8-8c7c-b5d258e608fa)

