### PR TITLE
fix(Edit expense): Attach ID to prevent creating new expense items

### DIFF
--- a/components/expenses/EditExpenseDialog.tsx
+++ b/components/expenses/EditExpenseDialog.tsx
@@ -70,6 +70,7 @@ const EditPayee = ({ expense, onSubmit }) => {
           payeeLocation: values.payeeLocation,
           currency: formOptions.expenseCurrency,
           items: values.expenseItems.map(ei => ({
+            id: ei.id,
             description: ei.description,
             amountV2: {
               valueInCents: ei.amount.valueInCents,
@@ -186,6 +187,7 @@ const EditPayoutMethod = ({ expense, onSubmit }) => {
         payeeLocation: values.payeeLocation,
         currency: formOptions.expenseCurrency,
         items: values.expenseItems.map(ei => ({
+          id: ei.id,
           description: ei.description,
           amountV2: {
             valueInCents: ei.amount.valueInCents,
@@ -364,6 +366,7 @@ const EditExpenseItems = ({ expense, onSubmit }) => {
   const transformedOnSubmit = values => {
     const editValues = {
       items: values.expenseItems.map(ei => ({
+        id: ei.id,
         description: ei.description,
         amountV2: {
           valueInCents: ei.amount.valueInCents,

--- a/components/submit-expense/useExpenseForm.ts
+++ b/components/submit-expense/useExpenseForm.ts
@@ -58,6 +58,7 @@ export enum InviteeAccountType {
 }
 
 type ExpenseItem = {
+  id?: string;
   key?: string; // used to enable FlipMove animations (will either be a generated uuid on "Add item", or using the expense item id)
   description?: string;
   incurredAt?: string;
@@ -1496,9 +1497,7 @@ async function buildFormOptions(
         options.payoutMethod = values.newPayoutMethod;
       }
 
-      // Allow setting this flag to true with the `isInlineEdit` flag in start options to enable full editing experience (i.e. editing payotu method)
       options.isAdminOfPayee =
-        startOptions.isInlineEdit ||
         options.payoutProfiles.some(p => p.slug === values.payeeSlug) ||
         values.payeeSlug === '__findAccountIAdminister';
     } else {
@@ -1756,6 +1755,7 @@ export function useExpenseForm(opts: {
                   ? { url: typeof values.invoiceFile === 'string' ? values.invoiceFile : values.invoiceFile.url }
                   : undefined,
             items: values.expenseItems.map(ei => ({
+              id: ei.id,
               description: ei.description,
               amountV2: {
                 valueInCents: ei.amount.valueInCents,
@@ -2013,6 +2013,7 @@ export function useExpenseForm(opts: {
       setFieldValue(
         'expenseItems',
         formOptions.expense.draft?.items?.map(ei => ({
+          id: ei.id,
           key: ei.id,
           attachment: ei.url,
           description: ei.description ?? '',
@@ -2027,6 +2028,7 @@ export function useExpenseForm(opts: {
       setFieldValue(
         'expenseItems',
         formOptions.expense.items?.map(ei => ({
+          id: ei.id,
           key: ei.id,
           attachment: !startOptions.current.duplicateExpense ? ei.url : null,
           description: ei.description ?? '',
@@ -2277,7 +2279,8 @@ export function useExpenseForm(opts: {
       selectedPayoutMethod &&
       selectedPayoutMethod.data?.currency &&
       !expenseForm.touched.expenseItems &&
-      expenseForm.values.expenseItems[0]?.amount?.currency !== selectedPayoutMethod.data?.currency
+      expenseForm.values.expenseItems[0]?.amount?.currency !== selectedPayoutMethod.data?.currency &&
+      !startOptions.current.isInlineEdit // expenseItems will not be touched when editing the payout method, we don't want to update the expense items currency then
     ) {
       setFieldValue(
         'expenseItems',

--- a/components/submit-expense/useExpenseForm.ts
+++ b/components/submit-expense/useExpenseForm.ts
@@ -2013,7 +2013,7 @@ export function useExpenseForm(opts: {
       setFieldValue(
         'expenseItems',
         formOptions.expense.draft?.items?.map(ei => ({
-          id: ei.id,
+          id: !startOptions.current.duplicateExpense ? ei.id : undefined,
           key: ei.id,
           attachment: ei.url,
           description: ei.description ?? '',
@@ -2028,7 +2028,7 @@ export function useExpenseForm(opts: {
       setFieldValue(
         'expenseItems',
         formOptions.expense.items?.map(ei => ({
-          id: ei.id,
+          id: !startOptions.current.duplicateExpense ? ei.id : undefined,
           key: ei.id,
           attachment: !startOptions.current.duplicateExpense ? ei.url : null,
           description: ei.description ?? '',


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/7933

# Description

Fix to always attach the expense item IDs when editing things that will update them in some way, to prevent deleting and creating new expense items.

Flyby fix: don't try to support editing payout method in inline edit if you are not admin of payee (prior assumption based on the general `canEditExpense`, the actual mutation would still block it)