### PR TITLE
Fix(Modify expense): Set expenseCurrency option to the currency of the expense

### DIFF
--- a/components/submit-expense/useExpenseForm.ts
+++ b/components/submit-expense/useExpenseForm.ts
@@ -1524,7 +1524,7 @@ async function buildFormOptions(
     } else if (options.payoutMethod) {
       options.expenseCurrency = options.payoutMethod.data?.currency || options.account?.currency;
     } else {
-      options.expenseCurrency = options.account?.currency;
+      options.expenseCurrency = options.expense?.currency ?? options.account?.currency;
     }
 
     options.isLongFormItemDescription = false;


### PR DESCRIPTION
# Description

Setting the expenseCurrency option to the currency of the expense if it exists, when building form options.

Fixes two bugs:
- updating the payout method to another currency did not update the expense currency.
- cross-currency expense items could not be updated