### PR TITLE
OAuth: Support standard space separated scope parameter values

### DIFF
--- a/pages/oauth/authorize.js
+++ b/pages/oauth/authorize.js
@@ -59,7 +59,11 @@ const OAuthAuthorizePage = () => {
   const queryParams = { skip: skipQuery, variables: queryVariables, context: API_V2_CONTEXT };
   const { data, error, loading: isLoadingAuthorization } = useQuery(applicationQuery, queryParams);
   const isLoading = loadingLoggedInUser || isLoadingAuthorization;
-  const requestedScopes = query.scope ? query.scope.split(',').map(s => s.trim()) : [];
+  const requestedScopes = query.scope
+    ? decodeURIComponent(query.scope)
+        .split(/,|\s/)
+        .map(s => s.trim())
+    : [];
   const hasExistingAuthorization = isValidAuthorization(data?.application?.oAuthAuthorization, requestedScopes);
 
   return (


### PR DESCRIPTION
# Description

In the OAuth standard, the `scope` parameter for the authorization request is a space separated string, currently the OpenCollective implementation on the frontend only supports a comma separated string.

Specification: https://datatracker.ietf.org/doc/html/rfc6749#section-3.3

This should already supported on the backend, as we do handle parsing the `scope` string there based on either commas or spaces: https://github.com/opencollective/opencollective-api/blob/e0f615fe575f1fb1e0f8f1781f42fbd1a593ea60/server/lib/oauth/model.ts#L65

This would further bring OpenCollective OAuth inline with the standard.