### PR TITLE
fix(Overview): Restore default sections for accountants

### DIFF
--- a/components/dashboard/Menu.tsx
+++ b/components/dashboard/Menu.tsx
@@ -137,6 +137,7 @@ export const getMenuItems = ({ intl, account, LoggedInUser }): MenuItem[] => {
     {
       section: ALL_SECTIONS.OVERVIEW,
       Icon: LayoutDashboard,
+      if: !isAccountantOnly,
     },
     {
       if: isIndividual,


### PR DESCRIPTION
# Description

Fixes a bug reported on Slack where accountants end up getting a blocker when loading the platform, restoring previous default sections (and hiding the Overview from their Menu). 

We should to review if accountants should have access (and to what extent) to the new Overview.
