### PR TITLE
Disable UI for connecting to Wise/Paypal payouts when feature is disabled

### DIFF
--- a/components/dashboard/queries.ts
+++ b/components/dashboard/queries.ts
@@ -80,6 +80,8 @@ export const adminPanelQuery = gql`
         OFF_PLATFORM_TRANSACTIONS
         TAX_FORMS
         CHART_OF_ACCOUNTS
+        PAYPAL_PAYOUTS
+        TRANSFERWISE
       }
       policies {
         id

--- a/components/edit-collective/sections/SendingMoney.js
+++ b/components/edit-collective/sections/SendingMoney.js
@@ -3,8 +3,10 @@ import PropTypes from 'prop-types';
 import { graphql } from '@apollo/client/react/hoc';
 import { FormattedMessage, injectIntl } from 'react-intl';
 
-import hasFeature, { FEATURES } from '../../../lib/allowed-features';
+import { FEATURES, isFeatureEnabled, isFeatureSupported } from '../../../lib/allowed-features';
 import { editCollectiveSettingsMutation } from '../../../lib/graphql/v1/mutations';
+
+import { UpgradeSubscriptionBlocker } from '@/components/platform-subscriptions/UpgradeSubscriptionBlocker';
 
 import MessageBox from '../../MessageBox';
 import EditPayPalAccount from '../EditPayPalAccount';
@@ -50,27 +52,53 @@ class SendingMoney extends React.Component {
     return (
       <Fragment>
         <div className="flex flex-col gap-8">
-          {hasFeature(this.props.collective, FEATURES.PAYPAL_PAYOUTS) && (
+          {isFeatureSupported(this.props.collective, FEATURES.PAYPAL_PAYOUTS) && (
             <div>
               <SettingsSectionTitle>
                 <FormattedMessage id="PayoutMethod.Type.Paypal" defaultMessage="PayPal" />
               </SettingsSectionTitle>
-              <EditPayPalAccount
-                collective={this.props.collective}
-                connectedAccount={paypalAccount}
-                variation="SENDING"
-              />
-              {this.state.error && (
-                <MessageBox type="error" withIcon my={3}>
-                  {this.state.error}
-                </MessageBox>
+              {isFeatureEnabled(this.props.collective, FEATURES.PAYPAL_PAYOUTS) ? (
+                <React.Fragment>
+                  <EditPayPalAccount
+                    collective={this.props.collective}
+                    connectedAccount={paypalAccount}
+                    variation="SENDING"
+                  />
+                  {this.state.error && (
+                    <MessageBox type="error" withIcon my={3}>
+                      {this.state.error}
+                    </MessageBox>
+                  )}
+                </React.Fragment>
+              ) : (
+                <UpgradeSubscriptionBlocker
+                  featureKey={FEATURES.PAYPAL_PAYOUTS}
+                  description={this.props.intl.formatMessage({
+                    defaultMessage:
+                      'This feature is not available on your current plan. Upgrade your subscription to be able to pay expenses with PayPal.',
+                    id: 'UpgradeSubscriptionBlocker.PayPalPayouts.description',
+                  })}
+                />
               )}
             </div>
           )}
-          <div>
-            <SettingsSectionTitle>Wise</SettingsSectionTitle>
-            <EditTransferWiseAccount collective={this.props.collective} />
-          </div>
+          {isFeatureSupported(this.props.collective, FEATURES.TRANSFERWISE) && (
+            <div>
+              <SettingsSectionTitle>Wise</SettingsSectionTitle>
+              {isFeatureEnabled(this.props.collective, FEATURES.TRANSFERWISE) ? (
+                <EditTransferWiseAccount collective={this.props.collective} />
+              ) : (
+                <UpgradeSubscriptionBlocker
+                  featureKey={FEATURES.PAYPAL_PAYOUTS}
+                  description={this.props.intl.formatMessage({
+                    defaultMessage:
+                      'This feature is not available on your current plan. Upgrade your subscription to be able to pay expenses with Wise.',
+                    id: 'UpgradeSubscriptionBlocker.Transferwise.description',
+                  })}
+                />
+              )}
+            </div>
+          )}
         </div>
       </Fragment>
     );

--- a/components/expenses/PayExpenseModal.tsx
+++ b/components/expenses/PayExpenseModal.tsx
@@ -163,6 +163,9 @@ const TransferDetailFields = ({ expense, setDisabled, host }: TransferDetailsFie
     }
   }, [data]);
 
+  // if(true) {
+  //   return <div>This feature is only available</div>
+  // }
   if (error) {
     return (
       <MessageBox fontSize="12px" type="error">

--- a/lib/graphql/v1/queries.js
+++ b/lib/graphql/v1/queries.js
@@ -271,6 +271,8 @@ export const editCollectivePageFieldsFragment = gqlV1 /* GraphQL */ `
       id
       ...NavbarFields
       VIRTUAL_CARDS
+      PAYPAL_PAYOUTS
+      TRANSFERWISE
     }
   }
   ${collectiveNavbarFieldsFragment}


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/8139

# Description
Disabling UI for connecting to Wise/Paypal in the "Sending Money" section when the feature is disabled, completely hides the UI when feature is unsupported.

# Screenshots
<img width="863" height="594" alt="image" src="https://github.com/user-attachments/assets/413e7e65-d8c2-4f41-97f8-3842eaa9299a" />

