### PR TITLE
Fix Required Expense categorization dead-end bug

### DIFF
--- a/components/AccountingCategorySelect.tsx
+++ b/components/AccountingCategorySelect.tsx
@@ -199,15 +199,6 @@ const getOptions = (
   // Allow categories that either match the expected appliesTo or have no appliesTo (meaning they apply to both)
   remove(categories, category => category.appliesTo && category.appliesTo !== expectedAppliesTo);
 
-  if (allowNone) {
-    options.push({
-      key: null,
-      value: null,
-      label: getCategoryLabel(intl, null, false, valuesByRole),
-      searchText: intl.formatMessage({ defaultMessage: "I don't know", id: 'AkIyKO' }).toLocaleLowerCase(),
-    });
-  }
-
   categories.forEach(category => {
     options.push({
       key: category.id,
@@ -216,6 +207,15 @@ const getOptions = (
       searchText: getSearchTextFromCategory(category),
     });
   });
+
+  if (allowNone || options.length === 0) {
+    options.push({
+      key: null,
+      value: null,
+      label: getCategoryLabel(intl, null, false, valuesByRole),
+      searchText: intl.formatMessage({ defaultMessage: "I don't know", id: 'AkIyKO' }).toLocaleLowerCase(),
+    });
+  }
 
   return options;
 };

--- a/components/expenses/ApproveExpenseModal.tsx
+++ b/components/expenses/ApproveExpenseModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useMutation } from '@apollo/client';
+import { isUndefined } from 'lodash';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { i18nGraphqlException } from '../../lib/errors';
@@ -29,14 +30,14 @@ export default function ApproveExpenseModal({
 }: ConfirmProcessExpenseModalProps) {
   const intl = useIntl();
   const [editExpense] = useMutation(editExpenseCategoryMutation, { context: API_V2_CONTEXT });
-  const [selectedCategory, setSelectedCategory] = React.useState(expense.accountingCategory);
+  const [selectedCategory, setSelectedCategory] = React.useState(expense.accountingCategory || undefined);
   const { toast } = useToast();
   return (
     <ConfirmationModal
       onClose={onClose}
       header={<FormattedMessage defaultMessage="Approve Expense" id="PJNkaW" />}
       maxWidth={384}
-      disableSubmit={!selectedCategory}
+      disableSubmit={isUndefined(selectedCategory)}
       continueHandler={async () => {
         try {
           // 1. Edit the accounting category if it was changed
@@ -73,6 +74,7 @@ export default function ApproveExpenseModal({
           valuesByRole={expense.valuesByRole}
           allowNone={false}
           predictionStyle="full"
+          selectFirstOptionIfSingle
         />
       </div>
     </ConfirmationModal>

--- a/components/expenses/lib/accounting-categories.ts
+++ b/components/expenses/lib/accounting-categories.ts
@@ -3,7 +3,14 @@ import { get } from 'lodash';
 import type LoggedInUser from '../../../lib/LoggedInUser';
 import { getPolicy } from '../../../lib/policies';
 import { isFeatureEnabled } from '@/lib/allowed-features';
-import type { Account, CollectiveFeatures, Expense, Host, Policies } from '@/lib/graphql/types/v2/graphql';
+import type {
+  Account,
+  CollectiveFeatures,
+  Expense,
+  ExpenseHostFieldsFragment,
+  Host,
+  Policies,
+} from '@/lib/graphql/types/v2/graphql';
 
 const getExpenseCategorizationPolicy = (
   collective: {
@@ -51,6 +58,7 @@ export const collectiveAdminsMustConfirmAccountingCategory = (
     host?: {
       policies: Pick<Policies, 'EXPENSE_CATEGORIZATION'>;
       features: Pick<CollectiveFeatures, 'CHART_OF_ACCOUNTS'>;
+      expenseAccountingCategories: ExpenseHostFieldsFragment['expenseAccountingCategories'];
     };
   },
   host = collective?.['host'],
@@ -59,8 +67,9 @@ export const collectiveAdminsMustConfirmAccountingCategory = (
     return false;
   }
 
+  const hasAvailableCategories = host?.expenseAccountingCategories?.nodes?.length > 0;
   const policy = getExpenseCategorizationPolicy(collective, host);
-  return Boolean(policy?.requiredForCollectiveAdmins);
+  return Boolean(policy?.requiredForCollectiveAdmins && hasAvailableCategories);
 };
 
 // Defines the fields in the `Host` object where the accounting categories are stored


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/7957

Adding two exceptions here:
1. If there are absolutely no available expense categories to be used, skip the ApproveExpenseModal completely;
2. If there are available categories but for some reason they don't apply to the expense, enable the "I Don't Know" option.