### PR TITLE
ExpenseFlow: Fix Payout Method currency coercion

### DIFF
--- a/components/submit-expense/form/ExpenseItemsSection.tsx
+++ b/components/submit-expense/form/ExpenseItemsSection.tsx
@@ -257,7 +257,7 @@ type ExpenseItemProps = {
 
 function getExpenseItemProps(form: ExpenseForm) {
   return {
-    ...pick(form, ['setFieldValue', 'isSubmitting']),
+    ...pick(form, ['setFieldValue', 'isSubmitting', 'setFieldTouched']),
     ...pick(form.options, [
       'allowExpenseItemAttachment',
       'isAdminOfPayee',
@@ -298,10 +298,13 @@ const ExpenseItem = memoWithGetFormProps(function ExpenseItem(props: ExpenseItem
   const hasAttachment = props.allowExpenseItemAttachment;
   const attachmentId = useId();
 
-  const { setFieldValue } = props;
+  const { setFieldValue, setFieldTouched } = props;
 
   const onCurrencyChange = React.useCallback(
-    v => setFieldValue(`expenseItems.${props.index}.amount.currency`, v),
+    v => {
+      setFieldTouched('expenseItems');
+      setFieldValue(`expenseItems.${props.index}.amount.currency`, v);
+    },
     [props.index, setFieldValue],
   );
 

--- a/components/submit-expense/useExpenseForm.ts
+++ b/components/submit-expense/useExpenseForm.ts
@@ -1551,6 +1551,12 @@ async function buildFormOptions(
       options.expenseCurrency = options.expense.currency;
     } else if (values.expenseTypeOption === ExpenseType.GRANT) {
       options.expenseCurrency = options.account?.currency;
+    } else if (
+      options.account?.currency &&
+      values.expenseItems.length > 0 &&
+      values.expenseItems.every(item => item.amount.currency === options.account?.currency)
+    ) {
+      options.expenseCurrency = options.account.currency;
     } else if (options.payoutMethod) {
       options.expenseCurrency = options.payoutMethod.data?.currency || options.account?.currency;
     } else {


### PR DESCRIPTION
Related to https://github.com/opencollective/opencollective/issues/7908

This improves the Expense flow allowing the user to submit the expense in collective.currency by setting all items to the matching currency.