### PR TITLE
Drop default Kind filter in transactions page

### DIFF
--- a/components/transactions/TransactionsPageContent.tsx
+++ b/components/transactions/TransactionsPageContent.tsx
@@ -8,8 +8,13 @@ import roles from '../../lib/constants/roles';
 import { getErrorFromGraphqlException } from '../../lib/errors';
 import { usePrevious } from '../../lib/hooks/usePrevious';
 import { API_V2_CONTEXT } from '@/lib/graphql/helpers';
-import type { Account, PaymentMethod, PaymentMethodType, Transaction } from '@/lib/graphql/types/v2/schema';
-import { TransactionKind } from '@/lib/graphql/types/v2/schema';
+import type {
+  Account,
+  PaymentMethod,
+  PaymentMethodType,
+  Transaction,
+  TransactionKind,
+} from '@/lib/graphql/types/v2/schema';
 import useQueryFilter from '@/lib/hooks/useQueryFilter';
 import type LoggedInUser from '@/lib/LoggedInUser';
 import { cn } from '@/lib/utils';
@@ -317,15 +322,6 @@ const filters /* : FilterComponentConfigs<FilterValues, FilterMeta>*/ = {
   account: childAccountFilter.filter,
 };
 
-export const defaultFilterValues = {
-  kind: [
-    TransactionKind.ADDED_FUNDS,
-    TransactionKind.CONTRIBUTION,
-    TransactionKind.EXPENSE,
-    TransactionKind.BALANCE_TRANSFER,
-  ] as TransactionKind[],
-};
-
 const Transactions = ({ LoggedInUser, account, ...props }: TransactionsProps) => {
   const prevLoggedInUser = usePrevious(LoggedInUser);
   const [displayExportCSVModal, setDisplayExportCSVModal] = React.useState(false);
@@ -341,7 +337,6 @@ const Transactions = ({ LoggedInUser, account, ...props }: TransactionsProps) =>
       accountSlug: account.slug,
       childrenAccounts: account.childrenAccounts?.nodes ?? [],
     },
-    defaultFilterValues,
     shallow: true,
   });
 

--- a/pages/transactions.tsx
+++ b/pages/transactions.tsx
@@ -20,7 +20,6 @@ import Header from '../components/Header';
 import Footer from '../components/navigation/Footer';
 import PageFeatureNotSupported from '../components/PageFeatureNotSupported';
 import Transactions, {
-  defaultFilterValues,
   schema,
   toVariables,
   transactionsPageQuery,
@@ -49,7 +48,7 @@ const transactionsPageQueryHelper = getSSRQueryHelpers<
   query: transactionsPageQuery,
   getPropsFromContext: ctx => ({ query: ctx.query as TransactionsPageProps['query'] }),
   getVariablesFromContext: ctx => ({
-    ...getSSRVariablesFromQuery({ query: ctx.query, schema, toVariables, defaultFilterValues }),
+    ...getSSRVariablesFromQuery({ query: ctx.query, schema, toVariables }),
     slug: ctx.query.collectiveSlug,
   }),
   context: API_V2_CONTEXT,


### PR DESCRIPTION
This makes the public and admin dashboard experiences coherent, and it also contributes to transparency.