### PR TITLE
wording: Edit unsupported feature

### DIFF
--- a/components/platform-subscriptions/UpgradeSubscriptionBlocker.tsx
+++ b/components/platform-subscriptions/UpgradeSubscriptionBlocker.tsx
@@ -49,7 +49,7 @@ export function UpgradeSubscriptionBlocker(props: UpgradeSubscriptionBlockerProp
     ) : featureAccess === CollectiveFeatureStatus.UNSUPPORTED ? (
       <FormattedMessage
         id="UpgradeSubscriptionBlocker.description.UNSUPPORTED"
-        defaultMessage="Your account type does not support this feature."
+        defaultMessage="This feature is not supported for your account."
       />
     ) : null;
 

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -4012,7 +4012,7 @@
   "uPFUUe": "Awaiting approval",
   "UpgradeSubscription": "Upgrade Subscription",
   "UpgradeSubscriptionBlocker.description.DISABLED": "This feature is not available on your current plan. Upgrade your subscription to access this feature.",
-  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "Your account type does not support this feature.",
+  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "This feature is not supported for your account.",
   "UpgradeSubscriptionBlocker.TaxForms.description": "This feature is not available on your current plan. Upgrade your subscription to start collecting tax forms from expense submitters.",
   "UpgradeSubscriptionBlocker.title.DISABLED": "Upgrade Required",
   "UpgradeSubscriptionBlocker.title.UNSUPPORTED": "Feature not supported for your account",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -4012,7 +4012,7 @@
   "uPFUUe": "Awaiting approval",
   "UpgradeSubscription": "Upgrade Subscription",
   "UpgradeSubscriptionBlocker.description.DISABLED": "This feature is not available on your current plan. Upgrade your subscription to access this feature.",
-  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "Your account type does not support this feature.",
+  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "This feature is not supported for your account.",
   "UpgradeSubscriptionBlocker.TaxForms.description": "This feature is not available on your current plan. Upgrade your subscription to start collecting tax forms from expense submitters.",
   "UpgradeSubscriptionBlocker.title.DISABLED": "Upgrade Required",
   "UpgradeSubscriptionBlocker.title.UNSUPPORTED": "Feature not supported for your account",

--- a/lang/de.json
+++ b/lang/de.json
@@ -4012,7 +4012,7 @@
   "uPFUUe": "Awaiting approval",
   "UpgradeSubscription": "Upgrade Subscription",
   "UpgradeSubscriptionBlocker.description.DISABLED": "This feature is not available on your current plan. Upgrade your subscription to access this feature.",
-  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "Your account type does not support this feature.",
+  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "This feature is not supported for your account.",
   "UpgradeSubscriptionBlocker.TaxForms.description": "This feature is not available on your current plan. Upgrade your subscription to start collecting tax forms from expense submitters.",
   "UpgradeSubscriptionBlocker.title.DISABLED": "Upgrade Required",
   "UpgradeSubscriptionBlocker.title.UNSUPPORTED": "Feature not supported for your account",

--- a/lang/en.json
+++ b/lang/en.json
@@ -4012,7 +4012,7 @@
   "uPFUUe": "Awaiting approval",
   "UpgradeSubscription": "Upgrade Subscription",
   "UpgradeSubscriptionBlocker.description.DISABLED": "This feature is not available on your current plan. Upgrade your subscription to access this feature.",
-  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "Your account type does not support this feature.",
+  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "This feature is not supported for your account.",
   "UpgradeSubscriptionBlocker.TaxForms.description": "This feature is not available on your current plan. Upgrade your subscription to start collecting tax forms from expense submitters.",
   "UpgradeSubscriptionBlocker.title.DISABLED": "Upgrade Required",
   "UpgradeSubscriptionBlocker.title.UNSUPPORTED": "Feature not supported for your account",

--- a/lang/es.json
+++ b/lang/es.json
@@ -4012,7 +4012,7 @@
   "uPFUUe": "Esperando aprobación",
   "UpgradeSubscription": "Upgrade Subscription",
   "UpgradeSubscriptionBlocker.description.DISABLED": "This feature is not available on your current plan. Upgrade your subscription to access this feature.",
-  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "Your account type does not support this feature.",
+  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "This feature is not supported for your account.",
   "UpgradeSubscriptionBlocker.TaxForms.description": "This feature is not available on your current plan. Upgrade your subscription to start collecting tax forms from expense submitters.",
   "UpgradeSubscriptionBlocker.title.DISABLED": "Upgrade Required",
   "UpgradeSubscriptionBlocker.title.UNSUPPORTED": "Feature not supported for your account",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -4012,7 +4012,7 @@
   "uPFUUe": "En attente d’approbation",
   "UpgradeSubscription": "Upgrade Subscription",
   "UpgradeSubscriptionBlocker.description.DISABLED": "This feature is not available on your current plan. Upgrade your subscription to access this feature.",
-  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "Your account type does not support this feature.",
+  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "This feature is not supported for your account.",
   "UpgradeSubscriptionBlocker.TaxForms.description": "This feature is not available on your current plan. Upgrade your subscription to start collecting tax forms from expense submitters.",
   "UpgradeSubscriptionBlocker.title.DISABLED": "Upgrade Required",
   "UpgradeSubscriptionBlocker.title.UNSUPPORTED": "Feature not supported for your account",

--- a/lang/he.json
+++ b/lang/he.json
@@ -4012,7 +4012,7 @@
   "uPFUUe": "Awaiting approval",
   "UpgradeSubscription": "Upgrade Subscription",
   "UpgradeSubscriptionBlocker.description.DISABLED": "This feature is not available on your current plan. Upgrade your subscription to access this feature.",
-  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "Your account type does not support this feature.",
+  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "This feature is not supported for your account.",
   "UpgradeSubscriptionBlocker.TaxForms.description": "This feature is not available on your current plan. Upgrade your subscription to start collecting tax forms from expense submitters.",
   "UpgradeSubscriptionBlocker.title.DISABLED": "Upgrade Required",
   "UpgradeSubscriptionBlocker.title.UNSUPPORTED": "Feature not supported for your account",

--- a/lang/it.json
+++ b/lang/it.json
@@ -4012,7 +4012,7 @@
   "uPFUUe": "Awaiting approval",
   "UpgradeSubscription": "Upgrade Subscription",
   "UpgradeSubscriptionBlocker.description.DISABLED": "This feature is not available on your current plan. Upgrade your subscription to access this feature.",
-  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "Your account type does not support this feature.",
+  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "This feature is not supported for your account.",
   "UpgradeSubscriptionBlocker.TaxForms.description": "This feature is not available on your current plan. Upgrade your subscription to start collecting tax forms from expense submitters.",
   "UpgradeSubscriptionBlocker.title.DISABLED": "Upgrade Required",
   "UpgradeSubscriptionBlocker.title.UNSUPPORTED": "Feature not supported for your account",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -4012,7 +4012,7 @@
   "uPFUUe": "Awaiting approval",
   "UpgradeSubscription": "Upgrade Subscription",
   "UpgradeSubscriptionBlocker.description.DISABLED": "This feature is not available on your current plan. Upgrade your subscription to access this feature.",
-  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "Your account type does not support this feature.",
+  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "This feature is not supported for your account.",
   "UpgradeSubscriptionBlocker.TaxForms.description": "This feature is not available on your current plan. Upgrade your subscription to start collecting tax forms from expense submitters.",
   "UpgradeSubscriptionBlocker.title.DISABLED": "Upgrade Required",
   "UpgradeSubscriptionBlocker.title.UNSUPPORTED": "Feature not supported for your account",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -4012,7 +4012,7 @@
   "uPFUUe": "Awaiting approval",
   "UpgradeSubscription": "Upgrade Subscription",
   "UpgradeSubscriptionBlocker.description.DISABLED": "This feature is not available on your current plan. Upgrade your subscription to access this feature.",
-  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "Your account type does not support this feature.",
+  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "This feature is not supported for your account.",
   "UpgradeSubscriptionBlocker.TaxForms.description": "This feature is not available on your current plan. Upgrade your subscription to start collecting tax forms from expense submitters.",
   "UpgradeSubscriptionBlocker.title.DISABLED": "Upgrade Required",
   "UpgradeSubscriptionBlocker.title.UNSUPPORTED": "Feature not supported for your account",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -4012,7 +4012,7 @@
   "uPFUUe": "Awaiting approval",
   "UpgradeSubscription": "Upgrade Subscription",
   "UpgradeSubscriptionBlocker.description.DISABLED": "This feature is not available on your current plan. Upgrade your subscription to access this feature.",
-  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "Your account type does not support this feature.",
+  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "This feature is not supported for your account.",
   "UpgradeSubscriptionBlocker.TaxForms.description": "This feature is not available on your current plan. Upgrade your subscription to start collecting tax forms from expense submitters.",
   "UpgradeSubscriptionBlocker.title.DISABLED": "Upgrade Required",
   "UpgradeSubscriptionBlocker.title.UNSUPPORTED": "Feature not supported for your account",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -4012,7 +4012,7 @@
   "uPFUUe": "Awaiting approval",
   "UpgradeSubscription": "Upgrade Subscription",
   "UpgradeSubscriptionBlocker.description.DISABLED": "This feature is not available on your current plan. Upgrade your subscription to access this feature.",
-  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "Your account type does not support this feature.",
+  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "This feature is not supported for your account.",
   "UpgradeSubscriptionBlocker.TaxForms.description": "This feature is not available on your current plan. Upgrade your subscription to start collecting tax forms from expense submitters.",
   "UpgradeSubscriptionBlocker.title.DISABLED": "Upgrade Required",
   "UpgradeSubscriptionBlocker.title.UNSUPPORTED": "Feature not supported for your account",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -4012,7 +4012,7 @@
   "uPFUUe": "Aguardando aprovação",
   "UpgradeSubscription": "Upgrade Subscription",
   "UpgradeSubscriptionBlocker.description.DISABLED": "This feature is not available on your current plan. Upgrade your subscription to access this feature.",
-  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "Your account type does not support this feature.",
+  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "This feature is not supported for your account.",
   "UpgradeSubscriptionBlocker.TaxForms.description": "This feature is not available on your current plan. Upgrade your subscription to start collecting tax forms from expense submitters.",
   "UpgradeSubscriptionBlocker.title.DISABLED": "Upgrade Required",
   "UpgradeSubscriptionBlocker.title.UNSUPPORTED": "Feature not supported for your account",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -4012,7 +4012,7 @@
   "uPFUUe": "Awaiting approval",
   "UpgradeSubscription": "Upgrade Subscription",
   "UpgradeSubscriptionBlocker.description.DISABLED": "This feature is not available on your current plan. Upgrade your subscription to access this feature.",
-  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "Your account type does not support this feature.",
+  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "This feature is not supported for your account.",
   "UpgradeSubscriptionBlocker.TaxForms.description": "This feature is not available on your current plan. Upgrade your subscription to start collecting tax forms from expense submitters.",
   "UpgradeSubscriptionBlocker.title.DISABLED": "Upgrade Required",
   "UpgradeSubscriptionBlocker.title.UNSUPPORTED": "Feature not supported for your account",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -4012,7 +4012,7 @@
   "uPFUUe": "Awaiting approval",
   "UpgradeSubscription": "Upgrade Subscription",
   "UpgradeSubscriptionBlocker.description.DISABLED": "This feature is not available on your current plan. Upgrade your subscription to access this feature.",
-  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "Your account type does not support this feature.",
+  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "This feature is not supported for your account.",
   "UpgradeSubscriptionBlocker.TaxForms.description": "This feature is not available on your current plan. Upgrade your subscription to start collecting tax forms from expense submitters.",
   "UpgradeSubscriptionBlocker.title.DISABLED": "Upgrade Required",
   "UpgradeSubscriptionBlocker.title.UNSUPPORTED": "Feature not supported for your account",

--- a/lang/sk-SK.json
+++ b/lang/sk-SK.json
@@ -4012,7 +4012,7 @@
   "uPFUUe": "Awaiting approval",
   "UpgradeSubscription": "Upgrade Subscription",
   "UpgradeSubscriptionBlocker.description.DISABLED": "This feature is not available on your current plan. Upgrade your subscription to access this feature.",
-  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "Your account type does not support this feature.",
+  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "This feature is not supported for your account.",
   "UpgradeSubscriptionBlocker.TaxForms.description": "This feature is not available on your current plan. Upgrade your subscription to start collecting tax forms from expense submitters.",
   "UpgradeSubscriptionBlocker.title.DISABLED": "Upgrade Required",
   "UpgradeSubscriptionBlocker.title.UNSUPPORTED": "Feature not supported for your account",

--- a/lang/sv-SE.json
+++ b/lang/sv-SE.json
@@ -4012,7 +4012,7 @@
   "uPFUUe": "Awaiting approval",
   "UpgradeSubscription": "Upgrade Subscription",
   "UpgradeSubscriptionBlocker.description.DISABLED": "This feature is not available on your current plan. Upgrade your subscription to access this feature.",
-  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "Your account type does not support this feature.",
+  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "This feature is not supported for your account.",
   "UpgradeSubscriptionBlocker.TaxForms.description": "This feature is not available on your current plan. Upgrade your subscription to start collecting tax forms from expense submitters.",
   "UpgradeSubscriptionBlocker.title.DISABLED": "Upgrade Required",
   "UpgradeSubscriptionBlocker.title.UNSUPPORTED": "Feature not supported for your account",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -4012,7 +4012,7 @@
   "uPFUUe": "Awaiting approval",
   "UpgradeSubscription": "Upgrade Subscription",
   "UpgradeSubscriptionBlocker.description.DISABLED": "This feature is not available on your current plan. Upgrade your subscription to access this feature.",
-  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "Your account type does not support this feature.",
+  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "This feature is not supported for your account.",
   "UpgradeSubscriptionBlocker.TaxForms.description": "This feature is not available on your current plan. Upgrade your subscription to start collecting tax forms from expense submitters.",
   "UpgradeSubscriptionBlocker.title.DISABLED": "Upgrade Required",
   "UpgradeSubscriptionBlocker.title.UNSUPPORTED": "Feature not supported for your account",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -4012,7 +4012,7 @@
   "uPFUUe": "Awaiting approval",
   "UpgradeSubscription": "Upgrade Subscription",
   "UpgradeSubscriptionBlocker.description.DISABLED": "This feature is not available on your current plan. Upgrade your subscription to access this feature.",
-  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "Your account type does not support this feature.",
+  "UpgradeSubscriptionBlocker.description.UNSUPPORTED": "This feature is not supported for your account.",
   "UpgradeSubscriptionBlocker.TaxForms.description": "This feature is not available on your current plan. Upgrade your subscription to start collecting tax forms from expense submitters.",
   "UpgradeSubscriptionBlocker.title.DISABLED": "Upgrade Required",
   "UpgradeSubscriptionBlocker.title.UNSUPPORTED": "Feature not supported for your account",


### PR DESCRIPTION
The reason can be other than the "account type" (e.g. country for tax forms)