### PR TITLE
Self-hosted to use Ledger dashboard menu

### DIFF
--- a/components/dashboard/Menu.tsx
+++ b/components/dashboard/Menu.tsx
@@ -358,12 +358,12 @@ export const getMenuItems = ({ intl, account, LoggedInUser }): MenuItem[] => {
       Icon: HeartHandshake,
     },
     {
-      if: !isHost && !isCommunityManagerOnly,
+      if: !(isHost || isSelfHosted) && !isCommunityManagerOnly,
       section: ALL_SECTIONS.TRANSACTIONS,
       Icon: ArrowRightLeft,
     },
     {
-      if: isHost && !isCommunityManagerOnly,
+      if: (isHost || isSelfHosted) && !isCommunityManagerOnly,
       type: 'group',
       label: intl.formatMessage({ defaultMessage: 'Ledger', id: 'scwekL' }),
       Icon: ArrowRightLeft,


### PR DESCRIPTION
Instead of direct Transactions page link. So self-hosted collectives can also access Bank Account Sync and CSV Imports.