### PR TITLE
Display net amount for payee and payer on expense transaction detail

### DIFF
--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -106,11 +106,18 @@ export const renderDetailsString = ({
 
     const feesPayer = expense?.feesPayer || 'COLLECTIVE';
 
-    const netValueInCents = splitPaymentProcessorFee
-      ? Math.abs(_netAmount.valueInCents) +
-        (isCredit && feesPayer === 'PAYEE' ? 0 : Math.abs(paymentProcessorFee.valueInCents))
+    const netValueInCentsForPayer = splitPaymentProcessorFee
+      ? Math.abs(_netAmount.valueInCents) + (feesPayer === 'PAYEE' ? 0 : Math.abs(paymentProcessorFee.valueInCents))
       : Math.abs(_netAmount.valueInCents);
-    const netExpenseAmount = formatCurrency(netValueInCents, _netAmount.currency, {
+
+    const netValueInCentsForPayee = splitPaymentProcessorFee
+      ? Math.abs(_netAmount.valueInCents) + (feesPayer !== 'PAYEE' ? 0 : -Math.abs(paymentProcessorFee.valueInCents))
+      : Math.abs(_netAmount.valueInCents);
+
+    const netExpenseAmountForPayer = formatCurrency(netValueInCentsForPayer, _netAmount.currency, {
+      locale: intl.locale,
+    });
+    const netExpenseAmountForPayee = formatCurrency(netValueInCentsForPayee, _netAmount.currency, {
       locale: intl.locale,
     });
     const hasPaymentProcessorCover = paymentProcessorCover !== undefined;
@@ -179,9 +186,18 @@ export const renderDetailsString = ({
           <FormattedMessage
             defaultMessage="Net Amount for {collectiveName}: {netExpenseAmount}"
             id="6ZJG0I"
-            values={{ collectiveName: isCredit ? payee : payer, netExpenseAmount }}
+            values={{ collectiveName: payer, netExpenseAmount: netExpenseAmountForPayer }}
           />
         </Container>
+        {fromAccount.slug !== toAccount.slug && (
+          <Container>
+            <FormattedMessage
+              defaultMessage="Net Amount for {collectiveName}: {netExpenseAmount}"
+              id="6ZJG0I"
+              values={{ collectiveName: payee, netExpenseAmount: netExpenseAmountForPayee }}
+            />
+          </Container>
+        )}
       </React.Fragment>
     );
   } else {


### PR DESCRIPTION
Related https://github.com/opencollective/opencollective-frontend/pull/11389

For expenses where the payment processor fee is paid by the payee, the net amount was incorrectly displayed. Added detail on both payee and payer side of transaction.
 
Fee on payee
Before (issue)
<img width="813" height="384" alt="image" src="https://github.com/user-attachments/assets/8967a013-6679-4113-8c54-9076799331dc" />

After
<img width="839" height="409" alt="image" src="https://github.com/user-attachments/assets/8ca38ee6-8610-4993-964e-4092ba6bdb01" />

Fee on payer
Before (ok)
<img width="458" height="190" alt="image" src="https://github.com/user-attachments/assets/1ba4247c-de8c-4a64-ae81-db2d09aa0849" />

After (ok)
<img width="512" height="221" alt="image" src="https://github.com/user-attachments/assets/6aee352c-dcf6-49b4-9e4d-f2fc7a84bd67" />


