### PR TITLE
fix: OAuth 2.0 specifies space-delimited scopes

### DIFF
--- a/components/oauth/ApplicationApproveScreen.js
+++ b/components/oauth/ApplicationApproveScreen.js
@@ -132,7 +132,8 @@ const fetchAuthorize = (
     }
 
     if (scopes && scopes.length > 0) {
-      authorizeParams.set('scope', scopes.join(','));
+      // OAuth 2.0 specifies space-delimited scopes
+      authorizeParams.set('scope', scopes.join(' '));
     }
   }
 
@@ -149,7 +150,8 @@ const fetchAuthorize = (
 const prepareScopes = scopes => {
   return (
     scopes
-      ?.split(',')
+      // Accept whitespace (OAuth 2.0 compliance) or comma (retro-compatibility)
+      ?.split(/[\s,]+/)
       .filter(scope => has(SCOPES_INFO, scope))
       .sort() || []
   );

--- a/pages/oauth/authorize.js
+++ b/pages/oauth/authorize.js
@@ -59,7 +59,13 @@ const OAuthAuthorizePage = () => {
   const queryParams = { skip: skipQuery, variables: queryVariables, context: API_V2_CONTEXT };
   const { data, error, loading: isLoadingAuthorization } = useQuery(applicationQuery, queryParams);
   const isLoading = loadingLoggedInUser || isLoadingAuthorization;
-  const requestedScopes = query.scope ? query.scope.split(',').map(s => s.trim()) : [];
+  // Accept whitespace (OAuth 2.0 compliance) or comma (retro-compatibility)
+  const requestedScopes = query.scope
+    ? query.scope
+        .split(/[\s,]+/)
+        .map(s => s.trim())
+        .filter(Boolean)
+    : [];
   const hasExistingAuthorization = isValidAuthorization(data?.application?.oAuthAuthorization, requestedScopes);
 
   return (


### PR DESCRIPTION
keep comma support for retro-compatibility

API seems already ready for this.
