### PR TITLE
fix(ExpenseForm): misc fixes when triggered from expense page

### DIFF
--- a/components/collective-navbar/index.js
+++ b/components/collective-navbar/index.js
@@ -485,6 +485,7 @@ const CollectiveNavbar = ({
   onlyInfos = false,
   useAnchorsForCategories = false,
   showSelectedCategoryOnMobile = false,
+  onSubmitExpenseModalOpenChange = undefined,
 }) => {
   const router = useRouter();
   const intl = useIntl();
@@ -499,7 +500,11 @@ const CollectiveNavbar = ({
     skip: !collective?.slug || !LoggedInUser,
   });
 
-  const [isSubmitExpenseModalOpen, setIsSubmitExpenseModalOpen] = React.useState(false);
+  const [isSubmitExpenseModalOpen, _setIsSubmitExpenseModalOpen] = React.useState(false);
+  const setIsSubmitExpenseModalOpen = open => {
+    _setIsSubmitExpenseModalOpen(open);
+    onSubmitExpenseModalOpenChange?.(open);
+  };
 
   const loading = isLoading || dataLoading;
 

--- a/components/expenses/ExpenseMoreActionsButton.js
+++ b/components/expenses/ExpenseMoreActionsButton.js
@@ -114,6 +114,7 @@ const ExpenseMoreActionsButton = ({
   onExpenseUpdate,
   isViewingExpenseInHostContext = false,
   enableKeyboardShortcuts,
+  onCloneModalOpenChange,
   ...props
 }) => {
   const [processModal, setProcessModal] = React.useState(false);
@@ -355,11 +356,12 @@ const ExpenseMoreActionsButton = ({
                 onClick={() => {
                   setDuplicateExpenseId(expense.legacyId);
                   setIsExpenseFlowOpen(true);
+                  onCloneModalOpenChange?.(true);
                 }}
                 disabled={processExpense.loading || isDisabled}
                 data-cy="duplicate-expense-btn"
               >
-                <Copy size="16px" />
+                <Copy size="16px" color="#888" />
                 <FormattedMessage defaultMessage="Duplicate Expense" id="MXaO+R" />
               </Action>
             )}
@@ -390,6 +392,7 @@ const ExpenseMoreActionsButton = ({
             onClose={submittedExpense => {
               setDuplicateExpenseId(null);
               setIsExpenseFlowOpen(false);
+              onCloneModalOpenChange?.(false);
               if (submittedExpense) {
                 onExpenseUpdate?.();
               }

--- a/components/expenses/ExpenseSummary.js
+++ b/components/expenses/ExpenseSummary.js
@@ -103,6 +103,7 @@ const ExpenseSummary = ({
   openFileViewer,
   enableKeyboardShortcuts,
   openedItemId,
+  onCloneModalOpenChange = undefined,
   ...props
 }) => {
   const intl = useIntl();
@@ -149,6 +150,7 @@ const ExpenseSummary = ({
     >
       <ExpenseMoreActionsButton
         onEdit={LoggedInUser?.hasPreviewFeatureEnabled(PREVIEW_FEATURE_KEYS.INLINE_EDIT_EXPENSE) ? undefined : onEdit}
+        onCloneModalOpenChange={onCloneModalOpenChange}
         expense={expense}
         isViewingExpenseInHostContext={isViewingExpenseInHostContext}
         enableKeyboardShortcuts={enableKeyboardShortcuts}

--- a/pages/expense.tsx
+++ b/pages/expense.tsx
@@ -15,7 +15,7 @@ import { addParentToURLIfMissing, getCollectivePageCanonicalURL } from '../lib/u
 import CollectiveNavbar from '../components/collective-navbar';
 import { NAVBAR_CATEGORIES } from '../components/collective-navbar/constants';
 import ErrorPage from '../components/ErrorPage';
-import Expense from '../components/expenses/Expense';
+import Expense, { EXPENSE_PAGE_POLLING_INTERVAL } from '../components/expenses/Expense';
 import ExpenseInfoSidebar from '../components/expenses/ExpenseInfoSidebar';
 import { expensePageQuery } from '../components/expenses/graphql/queries';
 import MobileCollectiveInfoStickyBar from '../components/expenses/MobileCollectiveInfoStickyBar';
@@ -105,6 +105,18 @@ export default function ExpensePage(props: InferGetServerSidePropsType<typeof ge
   const data = queryResult.data;
   const error = queryResult.error;
   const { refetch, fetchMore, startPolling, stopPolling } = queryResult;
+
+  const onSubmitExpenseModalOpenChange = React.useCallback(
+    isOpen => {
+      if (isOpen) {
+        stopPolling?.();
+      } else {
+        startPolling?.(EXPENSE_PAGE_POLLING_INTERVAL);
+      }
+    },
+    [startPolling, stopPolling],
+  );
+
   if (!queryResult.loading) {
     if (!data || error) {
       return <ErrorPage data={data} />;
@@ -125,7 +137,12 @@ export default function ExpensePage(props: InferGetServerSidePropsType<typeof ge
 
   return (
     <Page collective={collective} canonicalURL={`${getCollectivePageCanonicalURL(collective)}/expense`} {...metadata}>
-      <CollectiveNavbar collective={collective} isLoading={!collective} selectedCategory={NAVBAR_CATEGORIES.BUDGET} />
+      <CollectiveNavbar
+        collective={collective}
+        isLoading={!collective}
+        selectedCategory={NAVBAR_CATEGORIES.BUDGET}
+        onSubmitExpenseModalOpenChange={onSubmitExpenseModalOpenChange}
+      />
       <Flex flexDirection={['column', 'row']} px={[2, 3, 4]} py={[0, 5]} mt={3} data-cy="expense-page-content">
         <Box width={SIDE_MARGIN_WIDTH}></Box>
         <Box flex="1 1 650px" minWidth={300} maxWidth={[null, null, null, 792]} mr={[null, 2, 3, 4]} px={2}>


### PR DESCRIPTION
- Fix "Copy" icon colors on new duplicate expense button (from https://github.com/opencollective/opencollective-frontend/pull/11505)
- Stop polling on the expense page  when creating or cloning an expense