### PR TITLE
fix(StyledButton): center spinner

### DIFF
--- a/components/StyledButton.tsx
+++ b/components/StyledButton.tsx
@@ -153,7 +153,7 @@ const StyledButton: ForwardRefExoticComponent<StyledButtonProps> = React.forward
       type="button"
       ref={allRefs}
     >
-      <Spinner size="0.9em" />
+      <Spinner className="mx-auto" size="0.9em" />
     </StyledButtonContent>
   );
 });


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/opencollective/opencollective-frontend/pull/11490

| Before | After |
|--------|--------|
| <img width="340" height="92" alt="Screenshot From 2025-10-14 09-31-13" src="https://github.com/user-attachments/assets/713957dd-f680-486e-895f-ec71e9dd33cb" /> | <img width="324" height="65" alt="image" src="https://github.com/user-attachments/assets/afbed0da-d3c5-4df0-841e-8df6f569ac49" /> | 

