### PR TITLE
fix(Spinner): Add 'inline-block' for consistency with previous spinner

### DIFF
--- a/components/Spinner.tsx
+++ b/components/Spinner.tsx
@@ -19,7 +19,7 @@ const Spinner: React.FC<SpinnerProps> = ({ size = '1em', title = 'Loading', clas
       size={size}
       aria-label={title}
       role="img"
-      className={cn('animate-spin', className)}
+      className={cn('inline-block animate-spin', className)}
       data-spinner="true"
       {...props}
     />

--- a/components/StyledButton.tsx
+++ b/components/StyledButton.tsx
@@ -153,7 +153,7 @@ const StyledButton: ForwardRefExoticComponent<StyledButtonProps> = React.forward
       type="button"
       ref={allRefs}
     >
-      <Spinner className="mx-auto" size="0.9em" />
+      <Spinner size="0.9em" />
     </StyledButtonContent>
   );
 });


### PR DESCRIPTION
Follow up to https://github.com/opencollective/opencollective-frontend/pull/11530 & https://github.com/opencollective/opencollective-frontend/pull/11490

# Description

Adds `display: inline-block;` css property to new spinner to make it consistent with previous spinner, which had inline-block from the previous SVG icon.
