### PR TITLE
Wise: remove outdated BRL transfer details constraint

### DIFF
--- a/components/expenses/PayExpenseModal.tsx
+++ b/components/expenses/PayExpenseModal.tsx
@@ -203,12 +203,8 @@ const DEFAULT_PAYMENT_METHOD_SERVICE = {
 
 const getPayoutOptionValue = (payoutMethod, isAuto, host) => {
   const payoutMethodType = payoutMethod?.type;
-  const canAddTransferDetails = host.settings?.transferwise?.transferDetails === true;
   if (payoutMethodType === PayoutMethodType.OTHER) {
     return { forceManual: true, action: 'PAY', paymentMethodService: null };
-  } else if (payoutMethod?.data?.type === 'brazil' && !canAddTransferDetails) {
-    // TODO: remove this when we release transfer details for everyone.
-    return { forceManual: true, action: 'PAY' };
   } else if (payoutMethodType === PayoutMethodType.BANK_ACCOUNT && !host.transferwise) {
     return { forceManual: true, action: 'PAY', paymentMethodService: 'WISE' };
   } else if (!isAuto) {


### PR DESCRIPTION
Transfer details was already shipped as default feature.