### PR TITLE
fix(ExpenseFlow): multiple fixes

### DIFF
--- a/components/submit-expense/form/TypeOfExpenseSection.tsx
+++ b/components/submit-expense/form/TypeOfExpenseSection.tsx
@@ -223,7 +223,7 @@ export const InvoiceFormOption = memoWithGetFormProps(function InvoiceFormOption
   return (
     <div className="mt-4 rounded-md border border-gray-300 p-4">
       <Label>
-        {props.isAdminOfPayee || !LoggedInUser ? (
+        {props.isAdminOfPayee || !LoggedInUser || props.payee?.type === CollectiveType.VENDOR ? (
           <FormattedMessage defaultMessage="An invoice is required. Do you have one?" id="O+LW+y" />
         ) : props.expenseTypeOption === ExpenseType.GRANT ? (
           <FormattedMessage


### PR DESCRIPTION
Fix https://oficonsortium.slack.com/archives/GFH4N961L/p1761941805291279

We're not showing the "Collective policy" on host, but when submitting an expense to the host itself, we need to validate both (the host policy IS the account policy).