### PR TITLE
Fix(WorkspaceContext): Always update workspace context when dashboard slug changes

### DIFF
--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -207,7 +207,7 @@ const DashboardPage = () => {
 
   // Keep track of last visited workspace account and sections
   React.useEffect(() => {
-    if (activeSlug && activeSlug !== workspace.slug) {
+    if (activeSlug) {
       if (LoggedInUser) {
         const membership = LoggedInUser.memberOf.find(val => val.collective.slug === activeSlug);
         setWorkspace({ slug: activeSlug, isHost: membership?.collective.isHost });


### PR DESCRIPTION
Follow up to https://github.com/opencollective/opencollective-frontend/pull/11487 which introduced `isHost` in the workspace context, this PR makes sure to always update the workspace context when the dashboard slug changes.