### PR TITLE
Update .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,20 @@
 public/*
 .next/*
+dist/
+storybook-static/
+build/
+stage/
+out/
+
+# Coverage and test artifacts
+coverage/
+test/cypress/screenshots/
+test/cypress/videos/
+.nyc_output/
+
 # Auto-generated files
 lib/graphql/types/v2/*
+scripts/publish-components/.tmp/
+.rollup.cache/
+tsconfig.tsbuildinfo
+next-env.d.ts


### PR DESCRIPTION
Experienced a fair bit of slow processing with prettier (**EDIT**: specifically the VSCode Prettier extension, which doesn't consider `.gitignore` at this time), this updates the ignore file to be a bit wider in scope.