### PR TITLE
fix: Hide empty sidebar menu groups

### DIFF
--- a/components/dashboard/DashboardSidebar.tsx
+++ b/components/dashboard/DashboardSidebar.tsx
@@ -201,6 +201,11 @@ function DashboardSidebarMenuGroup({ item, isSectionActive, onNavigate }) {
   const desktopSidebarCollapsed = !isMobile && state === 'collapsed';
   const isRootItemActive = hasActiveSubItem && (!open || desktopSidebarCollapsed);
 
+  // Hide menu group if all it's submenu items are hidden
+  if (!item.subMenu?.length) {
+    return null;
+  }
+
   const trigger = (
     <SidebarMenuButton isActive={isRootItemActive} tooltip={item.label} data-cy={`menu-item-${item.label}`}>
       {item.Icon && <item.Icon />}


### PR DESCRIPTION
Follow up to https://github.com/opencollective/opencollective-frontend/pull/11649

# Description

Makes sure to hide empty sidebar menu groups (this was implemented in the previous sidebar menu)
