### PR TITLE
fix(AccountSwitcher): Fix styling of "Create" button inside account switcher when empty

### DIFF
--- a/components/dashboard/AccountSwitcher.tsx
+++ b/components/dashboard/AccountSwitcher.tsx
@@ -294,16 +294,16 @@ const AccountSwitcher = ({ activeSlug }: { activeSlug: string }) => {
                   {EMPTY_GROUP_STATE[collectiveType] && accounts.length === 0 && (
                     <div className="mx-1 flex flex-col">
                       <p className="text-xs text-muted-foreground">{EMPTY_GROUP_STATE[collectiveType].emptyMessage}</p>
-                      <Link
-                        className="my-3 inline-flex items-center rounded-lg border border-input px-6 py-4 text-accent-foreground shadow-xs transition-colors hover:bg-slate-50 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
-                        href={CREATE_NEW_LINKS[collectiveType] || '/create'}
-                        onClick={handleClose}
-                      >
-                        <div className="mr-3 rounded-full border bg-white p-2 text-muted-foreground">
+                      <Button asChild variant="outline" size="xs">
+                        <Link
+                          className="my-2"
+                          href={CREATE_NEW_LINKS[collectiveType] || '/create'}
+                          onClick={handleClose}
+                        >
                           <Plus size={12} />
-                        </div>
-                        {EMPTY_GROUP_STATE[collectiveType].linkLabel}
-                      </Link>
+                          {EMPTY_GROUP_STATE[collectiveType].linkLabel}
+                        </Link>
+                      </Button>
                     </div>
                   )}
                   {accounts


### PR DESCRIPTION
Follow up to https://github.com/opencollective/opencollective-frontend/pull/11649

# Description
Fixes the styling of the create collective/organization button that shows up when the account type category is empty inside the Account switcher.

# Screenshots

| Before | After |
| ------ | ----- |
| <img width="261" height="670" alt="Screenshot 2025-12-15 at 13 20 10" src="https://github.com/user-attachments/assets/9400c64a-4aaa-46d3-a323-8303a8013995" /> | <img width="269" height="622" alt="Screenshot 2025-12-15 at 13 19 44" src="https://github.com/user-attachments/assets/99cc754d-88ba-4b5a-88fd-02d771548485" />  |


