### PR TITLE
chore: Heroku optimizations 

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,8 @@ const path = require('path');
 require('./env');
 const { REWRITES } = require('./rewrites');
 
+const isHeroku = process.env.IS_HEROKU === 'true';
+
 const nextConfig = {
   eslint: { ignoreDuringBuilds: true },
   useFileSystemPublicRoutes: true,
@@ -24,6 +26,7 @@ const nextConfig = {
   },
   images: {
     disableStaticImages: true,
+    unoptimized: isHeroku, // See https://github.com/vercel/next.js/issues/54482. Should try to remove after updating to NextJS 15.
   },
   experimental: {
     outputFileTracingExcludes: {


### PR DESCRIPTION
See https://oficonsortium.slack.com/archives/C06K5J91675/p1765799219361789

Disabling image optimizations during builds on Heroku. Should not have any impact given that we're serving our static images from Vercel.
It seem to be a [known issue](https://github.com/vercel/next.js/issues/54482) on NextJS 14, we could try reviewing that when updating to v15.