### PR TITLE
Display EPC QR-Code for manual SEPA bank transfers

### DIFF
--- a/lib/payment-method-utils.js
+++ b/lib/payment-method-utils.js
@@ -7,6 +7,7 @@ import { ExchangeAlt } from '@styled-icons/fa-solid/ExchangeAlt';
 import { MoneyCheck } from '@styled-icons/fa-solid/MoneyCheck';
 import { isNil } from 'lodash';
 import { FormattedDate, FormattedMessage } from 'react-intl';
+import generateQrCode from 'sepa-payment-qr-code';
 
 import Avatar from '../components/Avatar';
 import CreditCard from '../components/icons/CreditCard';
@@ -15,6 +16,7 @@ import PayPal from '../components/icons/PayPal';
 import LinkCollective from '../components/LinkCollective';
 
 import { PAYMENT_METHOD_SERVICE, PAYMENT_METHOD_TYPE } from './constants/payment-methods';
+import { Currency } from './graphql/types/v2/schema';
 import { formatCurrency } from './currency-utils';
 import { paymentMethodExpiration } from './payment_method_label';
 
@@ -196,4 +198,21 @@ export const formatManualInstructions = (instructions, values) => {
       }
     });
   }
+};
+
+/** Creates an EPC QR-Code */
+export const formatQrCode = (bankAccount, amountInCents, currency, reference) => {
+  if (!bankAccount?.details?.IBAN || currency !== Currency.EUR) {
+    return;
+  }
+  const data = {
+    name: bankAccount.accountHolderName,
+    iban: bankAccount.details.IBAN,
+    amount: amountInCents / 100,
+    unstructuredReference: reference,
+  };
+  if (bankAccount?.details?.BIC) {
+    data.bic = bankAccount.details.BIC;
+  }
+  return generateQrCode(data);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,6 +125,7 @@
         "react-window": "1.8.11",
         "redis": "4.7.1",
         "sanitize-html": "2.17.0",
+        "sepa-payment-qr-code": "^2.0.2",
         "slugify": "1.6.6",
         "spdx-license-list": "6.10.0",
         "speakeasy": "2.0.0",
@@ -16910,6 +16911,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/iban": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/iban/-/iban-0.0.14.tgz",
+      "integrity": "sha512-+rocNKk+Ga9m8Lr9fTMWd+87JnsBrucm0ZsIx5ROOarZlaDLmd+FKdbtvb0XyoBw9GAFOYG2GuLqoNB16d+p3w==",
+      "license": "MIT"
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -24470,6 +24477,18 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
         "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/sepa-payment-qr-code": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/sepa-payment-qr-code/-/sepa-payment-qr-code-2.0.2.tgz",
+      "integrity": "sha512-TyyONY2Lzo4cjCTgSwAyb2oXYyWXvSaeSY0dIlsiXMpdTEAsR/ONB5jyE7/04+nPBGrLTpKKT3q1dw2LRPcz/g==",
+      "license": "ISC",
+      "dependencies": {
+        "iban": "0.0.14"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/serialize-javascript": {

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "react-window": "1.8.11",
     "redis": "4.7.1",
     "sanitize-html": "2.17.0",
+    "sepa-payment-qr-code": "^2.0.2",
     "slugify": "1.6.6",
     "spdx-license-list": "6.10.0",
     "speakeasy": "2.0.0",


### PR DESCRIPTION
Resolve opencollective/opencollective#5225, opencollective/opencollective#6058

# Description

Show an [EPC QR-Code](https://en.wikipedia.org/wiki/EPC_QR_code) for SEPA bank transfers (IBAN).

# Screenshots

Unfortunately, I couldn't get a test environment running to access this component. Feel free to test and push additional changes to this PR.