### PR TITLE
Do not display WelcomeCollective component on children collectives

### DIFF
--- a/components/dashboard/sections/overview/Welcome.tsx
+++ b/components/dashboard/sections/overview/Welcome.tsx
@@ -400,6 +400,10 @@ export const WelcomeCollective = ({ account: _account, setOpen, open }) => {
     }
   }, [data?.account, open, setOpen, LoggedInUser]);
 
+  if (_account?.parent) {
+    return null;
+  }
+
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
       <CollapsibleContent>


### PR DESCRIPTION
Hiding the Welcome component since current actions do not really make sense in the context of Events and Projects.
We should review if there's any desired actions for these type of collectives.