### PR TITLE
Document tier banner follow parameter

### DIFF
--- a/components/ExportImages.js
+++ b/components/ExportImages.js
@@ -86,6 +86,11 @@ class ExportImages extends React.Component {
                 defaultValue: 'true',
               },
               {
+                name: 'follow',
+                description: 'set to true to remove rel and emit dofollow links',
+                defaultValue: 'false',
+              },
+              {
                 name: 'format',
                 description: 'image format (replace .svg with .png or .jpg)',
               },


### PR DESCRIPTION
## Summary
- document the new follow parameter in the financial contributors widget export UI
- mark it as defaulting to false and explain that follow=true removes rel to emit dofollow links

## Testing
- not run locally; frontend dependencies were not installed for this docs-only change

Depends on the images-service implementation in opencollective/opencollective-images.

Refs opencollective/opencollective#5968