### PR TITLE
fix(Survey toast): Add focus scope to toast to allow focusing inside it

### DIFF
--- a/components/Survey.tsx
+++ b/components/Survey.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useMutation } from '@apollo/client';
+import { FocusScope } from '@radix-ui/react-focus-scope';
 import * as ToastPrimitives from '@radix-ui/react-toast';
 import ReactAnimateHeight from 'react-animate-height';
 import { FormattedMessage } from 'react-intl';
@@ -89,7 +90,12 @@ export function Survey({
   }
 
   return (
-    <React.Fragment>
+    <FocusScope
+      trapped={showForm}
+      loop
+      onMountAutoFocus={e => e.preventDefault()}
+      onUnmountAutoFocus={e => e.preventDefault()}
+    >
       <ReactAnimateHeight duration={150} height={completed ? 0 : 'auto'}>
         <div className="flex flex-col gap-4">
           <p className={hasParentTitle ? 'font-normal' : 'font-bold'}>{question}</p>
@@ -157,6 +163,6 @@ export function Survey({
           </p>
         )}
       </ReactAnimateHeight>
-    </React.Fragment>
+    </FocusScope>
   );
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@radix-ui/react-collapsible": "1.1.12",
     "@radix-ui/react-dialog": "1.1.15",
     "@radix-ui/react-dropdown-menu": "2.1.16",
+    "@radix-ui/react-focus-scope": "1.1.7",
     "@radix-ui/react-hover-card": "1.1.15",
     "@radix-ui/react-label": "2.1.8",
     "@radix-ui/react-popover": "1.1.15",


### PR DESCRIPTION
# Description

Fix for an issue where the submitted expense dialog prevented focusing inside the survey form.