### PR TITLE
ExpenseFlow: Disable payout method type field when no transfer methods are available

### DIFF
--- a/components/expenses/PayoutBankInformationForm.js
+++ b/components/expenses/PayoutBankInformationForm.js
@@ -412,7 +412,7 @@ const DetailsForm = ({
   return (
     <div className="mt-2 flex flex-col">
       <FormField
-        disabled={disabled}
+        disabled={disabled || transactionTypeValues.length === 0}
         name={transactionMethodFieldName}
         label={transactionMethodLabel}
         validate={validateRequiredInput(intl, { name: transactionMethodLabel }, !disabled)}


### PR DESCRIPTION
It seems that some recipient types may be omitted by Wise rendering a form that allows a specific currency to be picked even without any option for the recipient type to be informed.

In this case, we're rendering a drop-down that has no options and to mitigate this problem I'm disabling the field.