### PR TITLE
Guest Contribution: Old validation allow user to bypass legalName if name is set

### DIFF
--- a/components/contribution-flow/StepProfileGuestForm.js
+++ b/components/contribution-flow/StepProfileGuestForm.js
@@ -163,7 +163,7 @@ const StepProfileGuestForm = ({ stepDetails, onChange, data, isEmbed, onSignInCl
         labelFontWeight="700"
         isPrivate
         hideOptionalLabel={requiredInformation.legalName}
-        required={requiredInformation.legalName && !data?.name}
+        required={requiredInformation.legalName}
         hint={
           requiredInformation.legalName && useGenericLegalNameHint ? (
             <FormattedMessage

--- a/test/cypress/integration/18-contribution-flow-guest.test.js
+++ b/test/cypress/integration/18-contribution-flow-guest.test.js
@@ -173,7 +173,8 @@ describe('Contribution Flow: Guest contributions', () => {
       cy.get('input[name="city"]:invalid').should('have.length', 1); // Empty
 
       // Fill profile info
-      cy.get('input[name=name]').type('Rick Astley');
+      cy.get('input[name=name]').type('Rick');
+      cy.getByDataCy('input-legalName').type('Rick Astley');
       cy.get('input[name=email]').type(`{selectall}${secondEmail}`);
       cy.get('input[name="address1"]').type('323 Logic Street');
       cy.get('input[name="postalCode"]').type('83740');


### PR DESCRIPTION
Legacy behavior would allow the user to bypass legal name if name was properly set. The problem with this UX is that we're directing people to omit their legal name even if required.