### PR TITLE
People Dashboard: Add Export Contributors CSV button

### DIFF
--- a/components/dashboard/ExportContributorsCSVButton.tsx
+++ b/components/dashboard/ExportContributorsCSVButton.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import { fetchCSVFileFromRESTService } from '../../lib/api';
+import { formatErrorMessage } from '@/lib/errors';
+
+import { Button } from '../ui/Button';
+import { useToast } from '../ui/useToast';
+
+type ExportContributorsCSVButtonProps = {
+  accountSlug: string;
+  label?: React.ReactNode;
+};
+
+const ExportContributorsCSVButton = ({ accountSlug, label }: ExportContributorsCSVButtonProps) => {
+  const { toast } = useToast();
+  const [isDownloadingCsv, setDownloadingCsv] = React.useState(false);
+  const intl = useIntl();
+
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      loading={isDownloadingCsv}
+      onClick={async () => {
+        try {
+          setDownloadingCsv(true);
+          const filename = `${accountSlug}-contributors`;
+          const url = `${process.env.REST_URL}/v2/${accountSlug}/contributors.csv?fetchAll=1`;
+          await fetchCSVFileFromRESTService(url, filename);
+        } catch (error) {
+          toast({
+            variant: 'error',
+            message: formatErrorMessage(intl, error),
+          });
+        } finally {
+          setDownloadingCsv(false);
+        }
+      }}
+    >
+      {label || <FormattedMessage id="Export.Format" defaultMessage="Export {format}" values={{ format: 'CSV' }} />}
+    </Button>
+  );
+};
+
+export default ExportContributorsCSVButton;

--- a/components/dashboard/sections/Contributors.tsx
+++ b/components/dashboard/sections/Contributors.tsx
@@ -3,7 +3,6 @@ import { gql, useQuery } from '@apollo/client';
 import { defineMessage, FormattedMessage, useIntl } from 'react-intl';
 import { z } from 'zod';
 
-import { fetchCSVFileFromRESTService } from '../../../lib/api';
 import type { FilterConfig } from '../../../lib/filters/filter-types';
 import { integer, isMulti } from '../../../lib/filters/schemas';
 import { MemberRole } from '../../../lib/graphql/types/v2/graphql';
@@ -16,10 +15,9 @@ import LinkCollective from '../../LinkCollective';
 import MessageBoxGraphqlError from '../../MessageBoxGraphqlError';
 import { DataTable } from '../../table/DataTable';
 import { Span } from '../../Text';
-import { Button } from '../../ui/Button';
-import { useToast } from '../../ui/useToast';
 import DashboardHeader from '../DashboardHeader';
 import { EmptyResults } from '../EmptyResults';
+import ExportContributorsCSVButton from '../ExportContributorsCSVButton';
 import ComboSelectFilter from '../filters/ComboSelectFilter';
 import { emailFilter } from '../filters/EmailFilter';
 import { Filterbar } from '../filters/Filterbar';
@@ -331,8 +329,6 @@ const Contributors = ({ accountSlug }: ContributorsProps) => {
   });
 
   const contributors = data?.account?.members.nodes || [];
-  const { toast } = useToast();
-
   const loading = metadataLoading || queryLoading;
   const error = metadataError || queryError;
 
@@ -343,38 +339,11 @@ const Contributors = ({ accountSlug }: ContributorsProps) => {
   const currentViewCount = views.find(v => v.id === queryFilter.activeViewId)?.count;
   const nbPlaceholders = currentViewCount < queryFilter.values.limit ? currentViewCount : queryFilter.values.limit;
 
-  const [isDownloadingCsv, setDownloadingCsv] = React.useState(false);
-
   return (
     <div className="flex flex-col gap-4">
       <DashboardHeader
         title={<FormattedMessage id="Contributors" defaultMessage="Contributors" />}
-        actions={
-          <div className="flex items-center gap-2">
-            <Button
-              size="sm"
-              variant="outline"
-              loading={isDownloadingCsv}
-              onClick={async () => {
-                try {
-                  setDownloadingCsv(true);
-                  const filename = `${accountSlug}-contributors`;
-                  const url = `${process.env.REST_URL}/v2/${accountSlug}/contributors.csv?fetchAll=1`;
-                  await fetchCSVFileFromRESTService(url, filename);
-                } catch (error) {
-                  toast({
-                    variant: 'error',
-                    message: error.message,
-                  });
-                } finally {
-                  setDownloadingCsv(false);
-                }
-              }}
-            >
-              <FormattedMessage id="Export.Format" defaultMessage="Export {format}" values={{ format: 'CSV' }} />
-            </Button>
-          </div>
-        }
+        actions={<ExportContributorsCSVButton accountSlug={accountSlug} />}
       />
 
       <Filterbar {...queryFilter} />

--- a/components/dashboard/sections/community/People.tsx
+++ b/components/dashboard/sections/community/People.tsx
@@ -26,6 +26,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '../../../ui/Tooltip';
 import { DashboardContext } from '../../DashboardContext';
 import DashboardHeader from '../../DashboardHeader';
 import { EmptyResults } from '../../EmptyResults';
+import ExportContributorsCSVButton from '../../ExportContributorsCSVButton';
 import { makeAmountFilter } from '../../filters/AmountFilter';
 import ComboSelectFilter from '../../filters/ComboSelectFilter';
 import { Filterbar } from '../../filters/Filterbar';
@@ -357,6 +358,12 @@ const PeopleDashboard = ({ accountSlug }: ContributorsProps) => {
         title={<FormattedMessage id="People" defaultMessage="People" />}
         description={
           <FormattedMessage id="People.Description" defaultMessage="People that interacted with your organization." />
+        }
+        actions={
+          <ExportContributorsCSVButton
+            accountSlug={accountSlug}
+            label={<FormattedMessage id="People.ExportCSV" defaultMessage="Export Contributors" />}
+          />
         }
       />
       <Filterbar {...queryFilter} hideCounts />

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -3232,6 +3232,7 @@
   "PendingContributionSummary": "{status, select, PENDING {Pending Contribution} other {Contribution}} to {account}",
   "People": "People",
   "People.Description": "People that interacted with your organization.",
+  "People.ExportCSV": "Export Contributors",
   "PEp9t9": "Expected Total Amount",
   "Period": "Period",
   "Period.days": "days",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -3232,6 +3232,7 @@
   "PendingContributionSummary": "{status, select, PENDING {Pending Contribution} other {Contribution}} to {account}",
   "People": "People",
   "People.Description": "People that interacted with your organization.",
+  "People.ExportCSV": "Export Contributors",
   "PEp9t9": "Expected Total Amount",
   "Period": "Period",
   "Period.days": "days",

--- a/lang/de.json
+++ b/lang/de.json
@@ -3232,6 +3232,7 @@
   "PendingContributionSummary": "{status, select, PENDING {Pending Contribution} other {Contribution}} to {account}",
   "People": "People",
   "People.Description": "People that interacted with your organization.",
+  "People.ExportCSV": "Export Contributors",
   "PEp9t9": "Expected Total Amount",
   "Period": "Zeitraum",
   "Period.days": "days",

--- a/lang/en.json
+++ b/lang/en.json
@@ -3232,6 +3232,7 @@
   "PendingContributionSummary": "{status, select, PENDING {Pending Contribution} other {Contribution}} to {account}",
   "People": "People",
   "People.Description": "People that interacted with your organization.",
+  "People.ExportCSV": "Export Contributors",
   "PEp9t9": "Expected Total Amount",
   "Period": "Period",
   "Period.days": "days",

--- a/lang/es.json
+++ b/lang/es.json
@@ -3232,6 +3232,7 @@
   "PendingContributionSummary": "{status, select, PENDING {Contribución pendiente} other {Contribución}} a {account}",
   "People": "People",
   "People.Description": "People that interacted with your organization.",
+  "People.ExportCSV": "Export Contributors",
   "PEp9t9": "Cantidad Total Esperada",
   "Period": "Período",
   "Period.days": "días",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -3232,6 +3232,7 @@
   "PendingContributionSummary": "{status, select, PENDING {Contribution en attente} other {Contribution}} à {account}",
   "People": "Personnes",
   "People.Description": "Personnes qui ont interagi avec votre Organisation.",
+  "People.ExportCSV": "Export Contributors",
   "PEp9t9": "Montant total attendu",
   "Period": "Période",
   "Period.days": "jours",

--- a/lang/he.json
+++ b/lang/he.json
@@ -3232,6 +3232,7 @@
   "PendingContributionSummary": "{status, select, PENDING {Pending Contribution} other {Contribution}} to {account}",
   "People": "People",
   "People.Description": "People that interacted with your organization.",
+  "People.ExportCSV": "Export Contributors",
   "PEp9t9": "Expected Total Amount",
   "Period": "תקופה",
   "Period.days": "days",

--- a/lang/it.json
+++ b/lang/it.json
@@ -3232,6 +3232,7 @@
   "PendingContributionSummary": "{status, select, PENDING {Pending Contribution} other {Contribution}} to {account}",
   "People": "People",
   "People.Description": "People that interacted with your organization.",
+  "People.ExportCSV": "Export Contributors",
   "PEp9t9": "Expected Total Amount",
   "Period": "Period",
   "Period.days": "giorni",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -3232,6 +3232,7 @@
   "PendingContributionSummary": "{status, select, PENDING {Pending Contribution} other {Contribution}} to {account}",
   "People": "People",
   "People.Description": "People that interacted with your organization.",
+  "People.ExportCSV": "Export Contributors",
   "PEp9t9": "Expected Total Amount",
   "Period": "期間",
   "Period.days": "days",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -3232,6 +3232,7 @@
   "PendingContributionSummary": "{account}로 {status, select, PENDING {대기중인 기여} other {기여}}",
   "People": "People",
   "People.Description": "People that interacted with your organization.",
+  "People.ExportCSV": "Export Contributors",
   "PEp9t9": "Expected Total Amount",
   "Period": "기간",
   "Period.days": "days",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -3232,6 +3232,7 @@
   "PendingContributionSummary": "{status, select, PENDING {Pending Contribution} other {Contribution}} to {account}",
   "People": "People",
   "People.Description": "People that interacted with your organization.",
+  "People.ExportCSV": "Export Contributors",
   "PEp9t9": "Verwacht totaalbedrag",
   "Period": "Periode",
   "Period.days": "dagen",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -3232,6 +3232,7 @@
   "PendingContributionSummary": "{status, select, PENDING {Wkład oczekujący} other {Wkład}} do {account}",
   "People": "People",
   "People.Description": "People that interacted with your organization.",
+  "People.ExportCSV": "Export Contributors",
   "PEp9t9": "Expected Total Amount",
   "Period": "Okres",
   "Period.days": "dni",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -3232,6 +3232,7 @@
   "PendingContributionSummary": "{status, select, PENDING {Contribuição pendente} other {Contribuição}} para {account}",
   "People": "People",
   "People.Description": "People that interacted with your organization.",
+  "People.ExportCSV": "Export Contributors",
   "PEp9t9": "Montante total esperado",
   "Period": "Período",
   "Period.days": "dias",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -3232,6 +3232,7 @@
   "PendingContributionSummary": "{status, select, PENDING {Pending Contribution} other {Contribution}} to {account}",
   "People": "People",
   "People.Description": "People that interacted with your organization.",
+  "People.ExportCSV": "Export Contributors",
   "PEp9t9": "Expected Total Amount",
   "Period": "Period",
   "Period.days": "days",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -3232,6 +3232,7 @@
   "PendingContributionSummary": "{status, select, PENDING {Pending Contribution} other {Contribution}} to {account}",
   "People": "People",
   "People.Description": "People that interacted with your organization.",
+  "People.ExportCSV": "Export Contributors",
   "PEp9t9": "Expected Total Amount",
   "Period": "Периодичность",
   "Period.days": "days",

--- a/lang/sk-SK.json
+++ b/lang/sk-SK.json
@@ -3232,6 +3232,7 @@
   "PendingContributionSummary": "{status, select, PENDING {Pending Contribution} other {Contribution}} to {account}",
   "People": "People",
   "People.Description": "People that interacted with your organization.",
+  "People.ExportCSV": "Export Contributors",
   "PEp9t9": "Expected Total Amount",
   "Period": "Obdobie",
   "Period.days": "days",

--- a/lang/sv-SE.json
+++ b/lang/sv-SE.json
@@ -3232,6 +3232,7 @@
   "PendingContributionSummary": "{status, select, PENDING {Pending Contribution} other {Contribution}} to {account}",
   "People": "People",
   "People.Description": "People that interacted with your organization.",
+  "People.ExportCSV": "Export Contributors",
   "PEp9t9": "Expected Total Amount",
   "Period": "Period",
   "Period.days": "dagar",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -3232,6 +3232,7 @@
   "PendingContributionSummary": "{status, select, PENDING {Pending Contribution} other {Contribution}} to {account}",
   "People": "People",
   "People.Description": "People that interacted with your organization.",
+  "People.ExportCSV": "Export Contributors",
   "PEp9t9": "Expected Total Amount",
   "Period": "Період",
   "Period.days": "days",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -3232,6 +3232,7 @@
   "PendingContributionSummary": "给 {account} 的 {status, select, PENDING {待定贡献} other {贡献}}",
   "People": "People",
   "People.Description": "People that interacted with your organization.",
+  "People.ExportCSV": "Export Contributors",
   "PEp9t9": "预计总金额",
   "Period": "时期",
   "Period.days": "天",


### PR DESCRIPTION
This is a workaround for organizations that lost the contributors dashboard in favor of the new People dashboard and are missing the Export contributors CSV button.