### PR TITLE
fix(expenseinvitenotificationbanner): adds recipient collective link for collective<->collective expenses

### DIFF
--- a/components/expenses/ExpenseInviteNotificationBanner.tsx
+++ b/components/expenses/ExpenseInviteNotificationBanner.tsx
@@ -97,6 +97,11 @@ const ResendSignInEmailButton = ({ createdUser }) => {
 
 const ExpenseInviteNotificationBanner = props => {
   const canResendEmail = Boolean(props.expense.permissions?.canVerifyDraftExpense);
+  const slug = props.expense.draft?.payee?.slug ? (
+    <StyledLink href={`/${props.expense.draft?.payee?.slug}`}>@{props.expense.draft?.payee?.slug}</StyledLink>
+  ) : (
+    false
+  );
   return (
     <StyledCard py={3} px="26px" mb={4} borderStyle={'solid'} data-cy="expense-draft-banner">
       <Flex flexDirection={['column', null, 'row']} alignItems="center">
@@ -108,9 +113,9 @@ const ExpenseInviteNotificationBanner = props => {
           <P lineHeight="20px">
             <FormattedMessage
               id="Expense.InviteIsOnItsWay.Description"
-              defaultMessage="An invitation to submit this expense has been sent to {email}. Once they confirm and finish the process, it will appear on the expenses list."
+              defaultMessage="An invitation to submit this expense has been sent to {recipient}. Once they confirm and finish the process, it will appear on the expenses list."
               values={{
-                email: props.expense.draft?.payee?.email || props.expense.draft?.payee?.name,
+                recipient: props.expense.draft?.payee?.email || props.expense.draft?.payee?.name || slug,
               }}
             />
           </P>


### PR DESCRIPTION
Fixes Pt. 2 of opencollective/opencollective#8594
(I was unable to reproduce Pt. 1 so this may be the only thing that needs to be done for that issue)

# Description

The Expense Invite Notification Banner does not have the payee email or name set when an expense has been requested from one collective to another collective. In this case, it appears **only the payee’s slug has been set.**

Proposed solution: Use the payee’s slug for a stylized link to be used in the banner instead when email/name are not set. If a different solution is preferred (i.e., use the email(s) of the admins it was sent to under the payee collective instead… unsure how to fetch those at the moment), feel free to reject this.

# Screenshots

<img width="773" height="264" alt="Screenshot 2026-04-10 at 6 08 04 PM" src="https://github.com/user-attachments/assets/3edc4c89-781f-479f-a1f5-9012d2f03f98" />