### PR TITLE
fix(Expense): Collective name wrapping

### DIFF
--- a/components/expenses/Expense.tsx
+++ b/components/expenses/Expense.tsx
@@ -266,7 +266,7 @@ function Expense(props: ExpenseProps) {
     <Box ref={expenseTopRef}>
       <ExpenseHeader inDrawer={inDrawer}>
         {expense?.type && expense?.account ? (
-          <div className="flex items-center gap-1">
+          <React.Fragment>
             <FormattedMessage
               id="ExpenseTitle"
               defaultMessage="{type, select, CHARGE {Charge} INVOICE {Invoice} RECEIPT {Receipt} GRANT {Grant} SETTLEMENT {Settlement} PLATFORM_BILLING {Platform bill} other {Expense}} <LinkExpense>{id}</LinkExpense> to <LinkCollective>{collectiveName}</LinkCollective>"
@@ -288,11 +288,11 @@ function Expense(props: ExpenseProps) {
               }}
             />
             {expense?.publicId && (
-              <div className="text-sm">
+              <span className="ml-1 inline-flex align-middle text-sm">
                 <CopyID value={expense?.publicId}>{expense?.publicId?.substring(0, 8)}...</CopyID>
-              </div>
+              </span>
             )}
-          </div>
+          </React.Fragment>
         ) : (
           <LoadingPlaceholder height={32} maxWidth={'200px'} />
         )}


### PR DESCRIPTION
# Description

Fix for bug [reported on Slack](https://oficonsortium.slack.com/archives/C04CK2U11LM/p1776939388191319):

<img width="2450" height="1348" alt="image" src="https://github.com/user-attachments/assets/20209af5-4373-448b-9c34-81795522b033" />

Root cause: PR #12044 wrapped the title's FormattedMessage in a new `<div>` inside ExpenseHeader, which broke the > a direct-child CSS selector that was applying the underline/hover styles to the expense and collective links.