### PR TITLE
chore(deps): upgrade copy-to-clipboard to v4 and update call sites

### DIFF
--- a/components/ErrorPage.js
+++ b/components/ErrorPage.js
@@ -202,12 +202,14 @@ class ErrorPage extends React.Component {
                         <Button
                           size="xs"
                           variant="outline"
-                          onClick={() => {
+                          onClick={async () => {
                             const formattedMessage = `Error: ${message || ''}`;
                             const formattedDetails = `Details: ${formatStacktrace()}`;
-                            copy(`${formattedMessage}\n${formattedDetails}`);
-                            this.setState({ copiedErrorMessage: true });
-                            setTimeout(() => this.setState({ copiedErrorMessage: false }), 2000);
+                            const ok = await copy(`${formattedMessage}\n${formattedDetails}`);
+                            if (ok) {
+                              this.setState({ copiedErrorMessage: true });
+                              setTimeout(() => this.setState({ copiedErrorMessage: false }), 2000);
+                            }
                           }}
                         >
                           {this.state.copiedErrorMessage ? (

--- a/components/tier-page/ShareButtons.js
+++ b/components/tier-page/ShareButtons.js
@@ -71,16 +71,18 @@ const ShareButtons = ({ pageUrl, intl, collective: { name, twitterHandle } }) =>
       >
         <StyledRoundButton
           size={40}
-          onClick={() => {
-            copy(pageUrl);
-            setCopied(true);
-            if (updateCopyBtnTimeout) {
-              clearTimeout(updateCopyBtnTimeout);
+          onClick={async () => {
+            const ok = await copy(pageUrl);
+            if (ok) {
+              setCopied(true);
+              if (updateCopyBtnTimeout) {
+                clearTimeout(updateCopyBtnTimeout);
+              }
+              updateCopyBtnTimeout = setTimeout(() => {
+                setCopied(false);
+                updateCopyBtnTimeout = null;
+              }, 3000);
             }
-            updateCopyBtnTimeout = setTimeout(() => {
-              setCopied(false);
-              updateCopyBtnTimeout = null;
-            }, 3000);
           }}
         >
           <Clipboard size={15} />

--- a/lib/hooks/useClipboard.js
+++ b/lib/hooks/useClipboard.js
@@ -12,16 +12,22 @@ const useClipboard = ({ timeout = 3000 } = {}) => {
 
   const copyCallback = React.useCallback(
     async value => {
-      copy(value);
-      setCopied(true);
+      try {
+        const ok = await copy(value);
+        if (ok) {
+          setCopied(true);
 
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
+          if (timeoutRef.current) {
+            clearTimeout(timeoutRef.current);
+          }
+
+          timeoutRef.current = setTimeout(() => {
+            setCopied(false);
+          }, timeout);
+        }
+      } catch {
+        // Unhandled copy failures: leave isCopied false
       }
-
-      timeoutRef.current = setTimeout(() => {
-        setCopied(false);
-      }, [timeout]);
     },
     [timeout],
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "cmdk": "1.1.1",
         "cookie": "^1.0.1",
         "cookie-parser": "1.4.7",
-        "copy-to-clipboard": "3.3.3",
+        "copy-to-clipboard": "4.0.2",
         "copy-webpack-plugin": "14.0.0",
         "country-currency-emoji-flags": "1.1.1",
         "csv-parse": "6.2.1",
@@ -13606,13 +13606,10 @@
       "license": "MIT"
     },
     "node_modules/copy-to-clipboard": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
-      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
-      "license": "MIT",
-      "dependencies": {
-        "toggle-selection": "^1.0.6"
-      }
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-4.0.2.tgz",
+      "integrity": "sha512-gklSft7IuhriZKHKpuoA1fpJSLPNgvUMWMo5BlnzAJm0zNKnznoSv23IjtNqclx8eKi6ZcdvFFzYEER/+U1LoQ==",
+      "license": "MIT"
     },
     "node_modules/copy-webpack-plugin": {
       "version": "14.0.0",
@@ -27836,12 +27833,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/toggle-selection": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
-      "license": "MIT"
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "cmdk": "1.1.1",
     "cookie": "^1.0.1",
     "cookie-parser": "1.4.7",
-    "copy-to-clipboard": "3.3.3",
+    "copy-to-clipboard": "4.0.2",
     "copy-webpack-plugin": "14.0.0",
     "country-currency-emoji-flags": "1.1.1",
     "csv-parse": "6.2.1",

--- a/pages/search.js
+++ b/pages/search.js
@@ -272,12 +272,14 @@ class SearchPage extends React.Component {
     router.push({ pathname: '/search', query: pickBy(query, value => !isNil(value)) });
   };
 
-  handleCopy = () => {
-    copy(window.location.href);
-    toast({
-      variant: 'success',
-      message: <FormattedMessage defaultMessage="Search Result Copied!" id="3x3DF3" />,
-    });
+  handleCopy = async () => {
+    const ok = await copy(window.location.href);
+    if (ok) {
+      toast({
+        variant: 'success',
+        message: <FormattedMessage defaultMessage="Search Result Copied!" id="3x3DF3" />,
+      });
+    }
   };
 
   render() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Relates to https://github.com/opencollective/opencollective-frontend/pull/12123

# Description

Upgrades `copy-to-clipboard` from 3.3.3 to 4.0.2. In v4, `copy()` is async and returns `Promise<boolean>` instead of a synchronous boolean.

- **`useClipboard`**: Awaits `copy()`, sets the “copied” state only when the promise resolves to `true`, and wraps the call in try/catch. Also fixes a bug where `setTimeout` used `[timeout]` as the delay (invalid) instead of `timeout` milliseconds.
- **Direct `copy` usage** (not via the hook): `ShareButtons.js`, `pages/search.js`, and `ErrorPage.js` now use `async` handlers, await `copy`, and only show success feedback when copy succeeds.

All other `copy` usages go through `useClipboard` and pick up the hook change.

# Screenshots

Not applicable (behavioral / dependency change only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02ed47df-7aa1-4766-94b9-fac80b74fff4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02ed47df-7aa1-4766-94b9-fac80b74fff4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

