### PR TITLE
fix(HostTransactions): Hide view count loading indicator

### DIFF
--- a/components/dashboard/sections/transactions/HostTransactions.tsx
+++ b/components/dashboard/sections/transactions/HostTransactions.tsx
@@ -161,7 +161,7 @@ const HostTransactionsBase = ({ accountSlug: hostSlug, account }: DashboardSecti
         }
       />
 
-      <Filterbar {...queryFilter} />
+      <Filterbar {...queryFilter} hideCounts />
       {error ? (
         <MessageBoxGraphqlError error={error} />
       ) : !loading && !transactions?.nodes?.length ? (


### PR DESCRIPTION
# Description

Fix for loading indicator showing up on the filterbar view counts in Host Transactions (no counts are fetched for this page).