### PR TITLE
test(e2e/29): Open transactions from drawer actions menu

### DIFF
--- a/test/cypress/integration/29-host.admin.test.js
+++ b/test/cypress/integration/29-host.admin.test.js
@@ -184,7 +184,8 @@ describe('host dashboard', () => {
       cy.getByDataCy('order-confirmation-modal-submit').click();
       cy.contains('Paid').should('exist');
 
-      cy.getByDataCy('view-transactions-button').click();
+      cy.contains('More actions').click();
+      cy.contains('View transactions').click();
       cy.contains('Contribution').should('exist');
       cy.contains('€500.00').should('exist');
       cy.contains('Host fee').should('exist');
@@ -232,7 +233,8 @@ describe('host dashboard', () => {
 
       // Verify transaction amounts: contribution 504 (514 - 10), platform tip 10, processor fee 4, host fee 9% of 504 = 45.36
       // Note: Platform tip (€10) is recorded in the Platform's ledger, not visible in the host's transaction view.
-      cy.getByDataCy('view-transactions-button').click();
+      cy.contains('More actions').click();
+      cy.contains('View transactions').click();
       cy.get('[data-cy="transactions-table"]').should('be.visible');
       cy.contains('Contribution').should('exist');
       cy.contains('Host fee').should('exist');

--- a/test/cypress/integration/39-recurring-contributions.test.js
+++ b/test/cypress/integration/39-recurring-contributions.test.js
@@ -34,15 +34,21 @@ describe('Recurring contributions', () => {
 
   it('Has contributions in the right categories', () => {
     cy.login({ email: user.email, redirect: `/dashboard/${user.collective.slug}/outgoing-contributions` }).then(() => {
+      cy.get('[data-cy^="datatable-row"]').should('have.length', 1);
+
       // Filter by Yearly frequency
       cy.getByDataCy('add-filter').click();
       cy.contains('Frequency').click();
-      cy.get('[data-cy="combo-select-option"][data-value=YEARLY]').click();
+      cy.contains('[data-cy="combo-select-option"]', 'Yearly').click();
+      cy.getByDataCy('apply-filter').should('not.be.disabled');
       cy.getByDataCy('apply-filter').click();
+      cy.getByDataCy('filter-frequency').should('exist');
       cy.get('[data-cy^="datatable-row"]').should('have.length', 0);
+
       // Filter by Monthly frequency
       cy.getByDataCy('filter-frequency').click();
-      cy.get('[data-cy="combo-select-option"][data-value=MONTHLY]').click();
+      cy.contains('[data-cy="combo-select-option"]', 'Monthly').click();
+      cy.getByDataCy('apply-filter').should('not.be.disabled');
       cy.getByDataCy('apply-filter').click();
       cy.get('[data-cy^="datatable-row"]').should('have.length', 1);
     });


### PR DESCRIPTION
Follow up to https://github.com/opencollective/opencollective-frontend/pull/12139

# Description

- e2e/29: Use the more actions menu to open the related transactions.
- e2e/39: Fix flakiness of the filter actions