### PR TITLE
fix(Fonts): apply Inter to html/body for portaled content

### DIFF
--- a/components/HTMLContent.js
+++ b/components/HTMLContent.js
@@ -1,6 +1,4 @@
-import React, { useEffect, useLayoutEffect, useRef } from 'react';
-
-const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+import React, { useRef } from 'react';
 import { Markup } from 'interweave';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { getLuminance } from 'polished';
@@ -8,6 +6,7 @@ import { FormattedMessage } from 'react-intl';
 import styled, { css } from 'styled-components';
 import { space, typography } from 'styled-system';
 
+import { useIsomorphicLayoutEffect } from '../lib/hooks/useIsomorphicLayoutEffect';
 import { defaultShouldForwardProp } from '../lib/styled_components_utils';
 
 import { Button } from './ui/Button';

--- a/lib/fonts.ts
+++ b/lib/fonts.ts
@@ -1,0 +1,44 @@
+import { type ReactNode } from 'react';
+import localFont from 'next/font/local';
+
+import { useIsomorphicLayoutEffect } from './hooks/useIsomorphicLayoutEffect';
+
+/**
+ * Inter loaded via next/font/local so Next.js auto-preloads the primary WOFF2
+ * and generates size-adjust CSS for the fallback font, eliminating CLS caused
+ * by font-swap. ApplyDocumentFont sets html/body classes for portaled content;
+ * _app.js also wraps the app in inter.variable + inter.className for SSR.
+ */
+export const inter = localFont({
+  src: [
+    { path: '../public/static/fonts/inter/Inter-Regular.woff2', weight: '400', style: 'normal' },
+    { path: '../public/static/fonts/inter/Inter-Italic.woff2', weight: '400', style: 'italic' },
+    { path: '../public/static/fonts/inter/Inter-Medium.woff2', weight: '500', style: 'normal' },
+    { path: '../public/static/fonts/inter/Inter-MediumItalic.woff2', weight: '500', style: 'italic' },
+    { path: '../public/static/fonts/inter/Inter-SemiBold.woff2', weight: '600', style: 'normal' },
+    { path: '../public/static/fonts/inter/Inter-SemiBoldItalic.woff2', weight: '600', style: 'italic' },
+    { path: '../public/static/fonts/inter/Inter-Bold.woff2', weight: '700', style: 'normal' },
+    { path: '../public/static/fonts/inter/Inter-BoldItalic.woff2', weight: '700', style: 'italic' },
+    { path: '../public/static/fonts/inter/Inter-ExtraBold.woff2', weight: '800', style: 'normal' },
+    { path: '../public/static/fonts/inter/Inter-ExtraBoldItalic.woff2', weight: '800', style: 'italic' },
+    { path: '../public/static/fonts/inter/Inter-Black.woff2', weight: '900', style: 'normal' },
+    { path: '../public/static/fonts/inter/Inter-BlackItalic.woff2', weight: '900', style: 'italic' },
+  ],
+  display: 'swap',
+  variable: '--font-inter',
+  adjustFontFallback: 'Arial',
+});
+
+export function ApplyDocumentFont({ children }: { children: ReactNode }) {
+  useIsomorphicLayoutEffect(() => {
+    document.documentElement.classList.add(inter.variable);
+    document.body.classList.add(inter.className);
+
+    return () => {
+      document.documentElement.classList.remove(inter.variable);
+      document.body.classList.remove(inter.className);
+    };
+  }, []);
+
+  return children;
+}

--- a/lib/hooks/useIsomorphicLayoutEffect.ts
+++ b/lib/hooks/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,4 @@
+import { useEffect, useLayoutEffect } from 'react';
+
+/** useLayoutEffect on the client, useEffect on the server (avoids SSR warnings). */
+export const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 import { ApolloProvider } from '@apollo/client';
 import { polyfill as PolyfillInterweaveSSR } from 'interweave-ssr';
 import App from 'next/app';
-import localFont from 'next/font/local';
 import Router from 'next/router';
 import NProgress from 'nprogress';
 import { StyleSheetManager, ThemeProvider } from 'styled-components';
 
 import '../lib/dayjs'; // Import first to make sure plugins are initialized
 import '../lib/analytics/plausible';
+import { ApplyDocumentFont, inter } from '../lib/fonts';
 import { API_V1_CONTEXT } from '../lib/graphql/helpers';
 import { getIntlProps } from '../lib/i18n/request';
 import theme from '../lib/theme';
@@ -26,31 +26,6 @@ import 'nprogress/nprogress.css';
 import 'trix/dist/trix.css';
 import '../public/static/styles/app.css';
 import 'react-lite-youtube-embed/dist/LiteYouTubeEmbed.css';
-
-/**
- * Inter loaded via next/font/local so Next.js auto-preloads the primary WOFF2
- * and generates size-adjust CSS for the fallback font, eliminating CLS caused
- * by font-swap. Applied via inter.variable + inter.className on the app wrapper.
- */
-const inter = localFont({
-  src: [
-    { path: '../public/static/fonts/inter/Inter-Regular.woff2', weight: '400', style: 'normal' },
-    { path: '../public/static/fonts/inter/Inter-Italic.woff2', weight: '400', style: 'italic' },
-    { path: '../public/static/fonts/inter/Inter-Medium.woff2', weight: '500', style: 'normal' },
-    { path: '../public/static/fonts/inter/Inter-MediumItalic.woff2', weight: '500', style: 'italic' },
-    { path: '../public/static/fonts/inter/Inter-SemiBold.woff2', weight: '600', style: 'normal' },
-    { path: '../public/static/fonts/inter/Inter-SemiBoldItalic.woff2', weight: '600', style: 'italic' },
-    { path: '../public/static/fonts/inter/Inter-Bold.woff2', weight: '700', style: 'normal' },
-    { path: '../public/static/fonts/inter/Inter-BoldItalic.woff2', weight: '700', style: 'italic' },
-    { path: '../public/static/fonts/inter/Inter-ExtraBold.woff2', weight: '800', style: 'normal' },
-    { path: '../public/static/fonts/inter/Inter-ExtraBoldItalic.woff2', weight: '800', style: 'italic' },
-    { path: '../public/static/fonts/inter/Inter-Black.woff2', weight: '900', style: 'normal' },
-    { path: '../public/static/fonts/inter/Inter-BlackItalic.woff2', weight: '900', style: 'italic' },
-  ],
-  display: 'swap',
-  variable: '--font-inter',
-  adjustFontFallback: 'Arial',
-});
 
 Router.onRouteChangeStart = (url, { shallow }) => {
   if (!shallow) {
@@ -216,42 +191,46 @@ class OpenCollectiveFrontendApp extends App {
 
     return (
       <Fragment>
-        <div className={`${inter.variable} ${inter.className}`}>
-          <ApolloProvider
-            client={
-              this.props.apolloClient ||
-              this.getApolloClient(
-                typeof window !== 'undefined' ? window?.__NEXT_DATA__?.props?.[APOLLO_STATE_PROP_NAME] : {},
-                pageProps?.[APOLLO_STATE_PROP_NAME],
-              )
-            }
-          >
-            <StyleSheetManager shouldForwardProp={defaultShouldForwardProp}>
-              <ThemeProvider theme={theme}>
-                <StripeProviderSSR>
-                  <IntlProvider locale={locale}>
-                    <TooltipProvider delayDuration={500} skipDelayDuration={100}>
-                      <UserProvider initialLoggedInUser={LoggedInUserData ? new LoggedInUser(LoggedInUserData) : null}>
-                        <WhitelabelProviderContext.Provider value={pageProps?.whitelabel?.provider}>
-                          <WorkspaceProvider>
-                            <ModalProvider>
-                              <NewsAndUpdatesProvider>
-                                <Component {...pageProps} />
-                                <Toaster />
-                                <GlobalNewsAndUpdates />
-                                <TwoFactorAuthenticationModal />
-                              </NewsAndUpdatesProvider>
-                            </ModalProvider>
-                          </WorkspaceProvider>
-                        </WhitelabelProviderContext.Provider>
-                      </UserProvider>
-                    </TooltipProvider>
-                  </IntlProvider>
-                </StripeProviderSSR>
-              </ThemeProvider>
-            </StyleSheetManager>
-          </ApolloProvider>
-        </div>
+        <ApplyDocumentFont>
+          <div className={`${inter.variable} ${inter.className}`}>
+            <ApolloProvider
+              client={
+                this.props.apolloClient ||
+                this.getApolloClient(
+                  typeof window !== 'undefined' ? window?.__NEXT_DATA__?.props?.[APOLLO_STATE_PROP_NAME] : {},
+                  pageProps?.[APOLLO_STATE_PROP_NAME],
+                )
+              }
+            >
+              <StyleSheetManager shouldForwardProp={defaultShouldForwardProp}>
+                <ThemeProvider theme={theme}>
+                  <StripeProviderSSR>
+                    <IntlProvider locale={locale}>
+                      <TooltipProvider delayDuration={500} skipDelayDuration={100}>
+                        <UserProvider
+                          initialLoggedInUser={LoggedInUserData ? new LoggedInUser(LoggedInUserData) : null}
+                        >
+                          <WhitelabelProviderContext.Provider value={pageProps?.whitelabel?.provider}>
+                            <WorkspaceProvider>
+                              <ModalProvider>
+                                <NewsAndUpdatesProvider>
+                                  <Component {...pageProps} />
+                                  <Toaster />
+                                  <GlobalNewsAndUpdates />
+                                  <TwoFactorAuthenticationModal />
+                                </NewsAndUpdatesProvider>
+                              </ModalProvider>
+                            </WorkspaceProvider>
+                          </WhitelabelProviderContext.Provider>
+                        </UserProvider>
+                      </TooltipProvider>
+                    </IntlProvider>
+                  </StripeProviderSSR>
+                </ThemeProvider>
+              </StyleSheetManager>
+            </ApolloProvider>
+          </div>
+        </ApplyDocumentFont>
         <DefaultPaletteStyle palette={defaultColors.primary} />
         {Object.keys(scripts).map(key => (
           <script key={key} type="text/javascript" src={scripts[key]} />


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/8815

# Description

Fixes Inter not rendering in modals, popovers, and other portaled UI.

This regressed in #12147, which moved Inter from global `@font-face` CSS to `next/font/local` scoped to a wrapper div in `_app.js`. Radix components (Dialog, Sheet, Popover, etc.) and react-select dropdowns portal to `document.body`, outside that wrapper, so they inherited `sans-serif` instead of Inter.

The fix applies the font at the document root, `inter.variable` on `<html>` (defines `--font-inter`) and `inter.className` on `<body>`, matching the [Next.js root layout pattern](https://nextjs.org/docs/app/api-reference/components/font). On the Pages Router, `next/font` can't be used in `_document.js` ([#88832](https://github.com/vercel/next.js/issues/88832)), so `ApplyDocumentFont` does this imperatively via `useLayoutEffect` from `_app.js`.

Font config is extracted to `lib/fonts.ts`.