### PR TITLE
enhancement(Contributions): show contributor legal name in dashboard views

### DIFF
--- a/components/AccountHoverCard.tsx
+++ b/components/AccountHoverCard.tsx
@@ -338,6 +338,7 @@ export const AccountHoverCard = ({
   const infoItems = getInfoItems(account);
   const asyncInfoItems = getInfoItemsFromMembershipData(data);
   const accountUrl = context?.getProfileUrl?.(account) || getCollectivePageRoute(account);
+  const legalName = account.legalName !== account.name && account.legalName;
   return (
     // HoverCard currently disabled for Vendors (need to fix styling, appropriate links, etc)
     <HoverCard open={open && !isVendor} onOpenChange={setOpen}>
@@ -363,9 +364,12 @@ export const AccountHoverCard = ({
             </div>
 
             <div className="overflow-hidden">
-              <div className="flex items-center gap-1">
-                <Link href={accountUrl}>
-                  <span className="block truncate font-medium hover:underline">{account.name}</span>
+              <div className="flex items-start gap-1">
+                <Link href={accountUrl} className="min-w-0 break-words">
+                  <span className="font-medium hover:underline">
+                    {account.name}
+                    {legalName && <span className="font-normal text-muted-foreground">{` (${legalName})`}</span>}
+                  </span>
                 </Link>
                 <AccountTrustBadge account={account} />
               </div>

--- a/components/contributions/ContributionDrawer.tsx
+++ b/components/contributions/ContributionDrawer.tsx
@@ -311,6 +311,9 @@ export function ContributionDrawer({
   const isLoading = !query.called || query.loading || !query.data || query.data.order?.legacyId !== orderId;
   const dropdownTriggerRef = React.useRef(undefined);
   const order = query.data?.order;
+  const contributorAccount = order?.fromAccount?.mainProfile ?? order?.fromAccount;
+  const contributorLegalName =
+    contributorAccount?.legalName !== contributorAccount?.name && contributorAccount?.legalName;
 
   const actions = React.useMemo(
     () => (order ? getActions(order, dropdownTriggerRef) : null),
@@ -401,13 +404,18 @@ export function ContributionDrawer({
                         <Skeleton className="h-6 w-48" />
                       ) : (
                         <LinkCollective
-                          collective={query.data.order.fromAccount.mainProfile ?? query.data.order.fromAccount}
-                          className="hover:text-primary hover:underline"
+                          collective={contributorAccount}
+                          className="group hover:text-primary hover:underline"
                           withHoverCard
                         >
-                          <div className="flex items-center gap-1">
+                          <div className="flex min-w-0 items-center gap-1">
                             <Avatar radius={24} collective={query.data.order.fromAccount} />
-                            {(query.data.order.fromAccount.mainProfile ?? query.data.order.fromAccount).name}
+                            <span className="min-w-0">
+                              {contributorAccount.name}
+                              {contributorLegalName && (
+                                <span className="text-muted-foreground group-hover:text-primary">{` (${contributorLegalName})`}</span>
+                              )}
+                            </span>
                           </div>
                         </LinkCollective>
                       )

--- a/components/dashboard/sections/contributions/IncompleteContributions.tsx
+++ b/components/dashboard/sections/contributions/IncompleteContributions.tsx
@@ -10,7 +10,7 @@ import DashboardHeader from '../../DashboardHeader';
 import { HostContextFilter, hostContextFilter } from '../../filters/HostContextFilter';
 import type { DashboardSectionProps } from '../../types';
 
-import ContributionsTable from './ContributionsTable';
+import ContributionsTable, { defaultVisibility } from './ContributionsTable';
 import type { FilterMeta } from './filters';
 import { ContributionAccountingCategoryKinds, filters, schema as baseSchema, toVariables } from './filters';
 import { dashboardOrdersQuery } from './queries';
@@ -173,7 +173,7 @@ export default function IncompleteContributions({ accountSlug }: DashboardSectio
         nbPlaceholders={queryFilter.values.limit}
         error={error}
         refetch={handleRefetch}
-        columnVisibility={{ lastChargedAt: false, createdAt: true, expectedAt: false }}
+        columnVisibility={{ ...defaultVisibility, lastChargedAt: false, createdAt: true, expectedAt: false }}
       />
     </div>
   );

--- a/components/dashboard/sections/contributions/columns.tsx
+++ b/components/dashboard/sections/contributions/columns.tsx
@@ -48,10 +48,11 @@ export const columns: ColumnDef<ManagedOrderFieldsFragment>[] = [
       const fromAccount = row.original.fromAccount;
       const displayAccount = fromAccount.mainProfile ?? fromAccount;
       const createdBy = fromAccount.type !== AccountType.INDIVIDUAL && row.original.createdByAccount;
+      const legalName = displayAccount.legalName !== displayAccount.name && displayAccount.legalName;
 
       return (
-        <div className="flex items-center gap-5">
-          <div className="relative">
+        <div className="flex min-w-0 items-center gap-5">
+          <div className="relative shrink-0">
             <div>
               <AccountHoverCard
                 account={displayAccount}
@@ -75,9 +76,12 @@ export const columns: ColumnDef<ManagedOrderFieldsFragment>[] = [
               </div>
             )}
           </div>
-          <div className="overflow-hidden">
-            <div className="overflow-hidden text-sm leading-5 text-ellipsis whitespace-nowrap">
-              {displayAccount.name || displayAccount.slug}
+          <div className="min-w-0 flex-1 overflow-hidden">
+            <div className="flex min-w-0 overflow-hidden text-sm leading-5">
+              <span className="min-w-0 shrink truncate">{displayAccount.name || displayAccount.slug}</span>
+              {legalName && (
+                <span className="ml-1 max-w-[45%] shrink-0 truncate text-muted-foreground">{` (${legalName})`}</span>
+              )}
             </div>
 
             <div className="overflow-hidden text-xs leading-4 font-normal text-ellipsis whitespace-nowrap text-slate-700">


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/8814

# Description
- Show contributor legal name alongside display name in contribution tables, the contribution drawer, and account hover cards (muted, in parentheses, only when it differs from the display name, same as the People tool)
- Truncate display name before legal name in table cells when space is tight
- Hide the **Created by** column on Incomplete Contributions to match Incoming Contributions (caused some layout issues, was a leftover from the sidebar reorg)

# Screenshots

<img width="1425" height="710" alt="Screenshot 2026-05-26 at 13 22 10" src="https://github.com/user-attachments/assets/bb7c9f19-59c4-4eca-a2af-37fed5a22e5d" />
<img width="675" height="737" alt="Screenshot 2026-05-26 at 13 22 21" src="https://github.com/user-attachments/assets/8b97ecb4-83d6-44e2-877c-189862080b6d" />
<img width="357" height="219" alt="Screenshot 2026-05-26 at 13 22 27" src="https://github.com/user-attachments/assets/9d9df06b-a509-45d8-b783-05cb418257e6" />
