### PR TITLE
enhancement(Expense form): Enable inline vendor creation

### DIFF
--- a/components/CollectivePicker.js
+++ b/components/CollectivePicker.js
@@ -369,7 +369,6 @@ class CollectivePicker extends React.PureComponent {
       width,
       addLoggedInUserAsAdmin,
       renderNewCollectiveOption,
-      onSelectNewCollectiveOption,
       isSearchable,
       expenseType,
       useBeneficiaryForVendor,

--- a/components/CollectivePicker.js
+++ b/components/CollectivePicker.js
@@ -94,6 +94,34 @@ const { USER, ORGANIZATION, COLLECTIVE, FUND, EVENT, PROJECT, VENDOR } = Collect
 
 const sortedAccountTypes = [VENDOR, 'INDIVIDUAL', USER, ORGANIZATION, COLLECTIVE, FUND, EVENT, PROJECT];
 
+const isSameCollective = (a, b) => {
+  if (a?.id && b?.id && a.id === b.id) {
+    return true;
+  }
+  if (a?.slug && b?.slug && a.slug === b.slug) {
+    return true;
+  }
+  return false;
+};
+
+const getCollectivesFromOptions = options => {
+  const collectives = [];
+  options.forEach(option => {
+    if (option[FLAG_COLLECTIVE_PICKER_COLLECTIVE]) {
+      collectives.push(option.value);
+    } else if (option.options) {
+      option.options.forEach(subOption => {
+        if (subOption[FLAG_COLLECTIVE_PICKER_COLLECTIVE]) {
+          collectives.push(subOption.value);
+        }
+      });
+    }
+  });
+  return collectives;
+};
+
+const isCollectiveInList = (collective, collectives) => collectives.some(c => isSameCollective(collective, c));
+
 /**
  * An overset og `StyledSelect` specialized to display, filter and pick a collective from a given list.
  * Accepts all the props from [StyledSelect](#!/StyledSelect).
@@ -159,12 +187,25 @@ class CollectivePicker extends React.PureComponent {
     });
   });
 
-  getAllOptions = memoizeOne((collectivesOptions, customOptions, createdCollectives) => {
-    const { creatable, invitable, intl, customOptionsPosition } = this.props;
+  getAllOptions = memoizeOne((collectivesOptions, customOptions, createdCollectives, searchText, loading) => {
+    const {
+      creatable,
+      invitable,
+      intl,
+      customOptionsPosition,
+      renderNewCollectiveOption,
+      onSelectNewCollectiveOption,
+    } = this.props;
+    const isSelectableNewCollectiveOption = Boolean(renderNewCollectiveOption && onSelectNewCollectiveOption);
+    const isNewCollectiveOptionDisabled = !isSelectableNewCollectiveOption || !searchText.trim() || Boolean(loading);
     let options = collectivesOptions;
 
     if (createdCollectives.length > 0) {
-      options = [...createdCollectives.map(this.buildCollectiveOption), ...options];
+      const existingCollectives = getCollectivesFromOptions(collectivesOptions);
+      const newCreatedCollectives = createdCollectives.filter(c => !isCollectiveInList(c, existingCollectives));
+      if (newCreatedCollectives.length > 0) {
+        options = [...newCreatedCollectives.map(this.buildCollectiveOption), ...options];
+      }
     }
 
     if (customOptions && customOptions.length > 0) {
@@ -203,9 +244,13 @@ class CollectivePicker extends React.PureComponent {
             {
               label: null,
               value: null,
-              isDisabled: true,
+              isDisabled: isNewCollectiveOptionDisabled,
               [FLAG_NEW_COLLECTIVE]: true,
-              __background__: 'white',
+              ...(isSelectableNewCollectiveOption
+                ? isNewCollectiveOptionDisabled
+                  ? { __background__: 'white' }
+                  : {}
+                : { __background__: 'white' }),
             },
           ],
         },
@@ -215,8 +260,16 @@ class CollectivePicker extends React.PureComponent {
     return options;
   });
 
-  onChange = (...args) => {
-    this.props.onChange(...args);
+  onChange = option => {
+    if (option?.[FLAG_NEW_COLLECTIVE] && this.props.onSelectNewCollectiveOption && this.state.searchText.trim()) {
+      this.props.onSelectNewCollectiveOption({
+        searchText: this.state.searchText,
+        onCreatedCollective: this.onNewCollectiveOptionCreated,
+      });
+      return;
+    }
+
+    this.props.onChange?.(option);
     if (this.state.showCreatedCollective) {
       this.setState({ showCreatedCollective: false });
     }
@@ -281,7 +334,9 @@ class CollectivePicker extends React.PureComponent {
     this.setState(state => ({
       menuIsOpen: false,
       createFormCollectiveType: null,
-      createdCollectives: [...state.createdCollectives, collective],
+      createdCollectives: isCollectiveInList(collective, state.createdCollectives)
+        ? state.createdCollectives
+        : [...state.createdCollectives, collective],
       showCreatedCollective: true,
     }));
   };
@@ -307,6 +362,7 @@ class CollectivePicker extends React.PureComponent {
       width,
       addLoggedInUserAsAdmin,
       renderNewCollectiveOption,
+      onSelectNewCollectiveOption,
       isSearchable,
       expenseType,
       useBeneficiaryForVendor,
@@ -314,7 +370,13 @@ class CollectivePicker extends React.PureComponent {
     } = this.props;
     const { createFormCollectiveType, createdCollectives, displayInviteMenu, searchText } = this.state;
     const collectiveOptions = this.getOptionsFromCollectives(collectives, groupByType, sortFunc, intl);
-    const allOptions = this.getAllOptions(collectiveOptions, customOptions, createdCollectives);
+    const allOptions = this.getAllOptions(
+      collectiveOptions,
+      customOptions,
+      createdCollectives,
+      searchText,
+      this.props.loading,
+    );
     const prefillValue = isEmail(searchText) ? { email: searchText } : { name: searchText };
 
     return (
@@ -395,7 +457,9 @@ class CollectivePicker extends React.PureComponent {
                   this.setState(state => ({
                     menuIsOpen: false,
                     createFormCollectiveType: null,
-                    createdCollectives: [...state.createdCollectives, collective],
+                    createdCollectives: isCollectiveInList(collective, state.createdCollectives)
+                      ? state.createdCollectives
+                      : [...state.createdCollectives, collective],
                     showCreatedCollective: true,
                   }));
                 }}

--- a/components/CollectivePicker.js
+++ b/components/CollectivePicker.js
@@ -187,81 +187,88 @@ class CollectivePicker extends React.PureComponent {
     });
   });
 
-  getAllOptions = memoizeOne((collectivesOptions, customOptions, createdCollectives, searchText, loading) => {
-    const {
-      creatable,
-      invitable,
-      intl,
-      customOptionsPosition,
-      renderNewCollectiveOption,
-      onSelectNewCollectiveOption,
-    } = this.props;
-    const isSelectableNewCollectiveOption = Boolean(renderNewCollectiveOption && onSelectNewCollectiveOption);
-    const isNewCollectiveOptionDisabled = !isSelectableNewCollectiveOption || !searchText.trim() || Boolean(loading);
-    let options = collectivesOptions;
+  getAllOptions = memoizeOne(
+    (collectivesOptions, customOptions, createdCollectives, searchText, loading, isLoading) => {
+      const {
+        creatable,
+        invitable,
+        intl,
+        customOptionsPosition,
+        renderNewCollectiveOption,
+        onSelectNewCollectiveOption,
+      } = this.props;
+      const isSelectableNewCollectiveOption = Boolean(renderNewCollectiveOption && onSelectNewCollectiveOption);
+      const isNewCollectiveOptionDisabled =
+        !isSelectableNewCollectiveOption || !searchText.trim() || Boolean(loading || isLoading);
+      let options = collectivesOptions;
 
-    if (createdCollectives.length > 0) {
-      const existingCollectives = getCollectivesFromOptions(collectivesOptions);
-      const newCreatedCollectives = createdCollectives.filter(c => !isCollectiveInList(c, existingCollectives));
-      if (newCreatedCollectives.length > 0) {
-        options = [...newCreatedCollectives.map(this.buildCollectiveOption), ...options];
+      if (createdCollectives.length > 0) {
+        const existingCollectives = getCollectivesFromOptions(collectivesOptions);
+        const newCreatedCollectives = createdCollectives.filter(c => !isCollectiveInList(c, existingCollectives));
+        if (newCreatedCollectives.length > 0) {
+          options = [...newCreatedCollectives.map(this.buildCollectiveOption), ...options];
+        }
       }
-    }
 
-    if (customOptions && customOptions.length > 0) {
-      options =
-        customOptionsPosition === CUSTOM_OPTIONS_POSITION.TOP
-          ? [...customOptions, ...options]
-          : [...options, ...customOptions];
-    }
+      if (customOptions && customOptions.length > 0) {
+        options =
+          customOptionsPosition === CUSTOM_OPTIONS_POSITION.TOP
+            ? [...customOptions, ...options]
+            : [...options, ...customOptions];
+      }
 
-    if (invitable) {
-      options = [
-        ...options,
-        {
-          label: intl.formatMessage(Messages.inviteNew).toUpperCase(),
-          options: [
-            {
-              label: null,
-              value: null,
-              isDisabled: true,
-              [FLAG_INVITE_NEW]: true,
-              __background__: 'white',
-            },
-          ],
-        },
-      ];
-    }
-    if (creatable) {
-      const isOnlyForUser = isEqual(this.props.types, [CollectiveType.USER]);
-      options = [
-        ...options,
-        {
-          label: isOnlyForUser
-            ? intl.formatMessage(Messages.inviteNew).toUpperCase()
-            : intl.formatMessage(Messages.createNew).toUpperCase(),
-          options: [
-            {
-              label: null,
-              value: null,
-              isDisabled: isNewCollectiveOptionDisabled,
-              [FLAG_NEW_COLLECTIVE]: true,
-              ...(isSelectableNewCollectiveOption
-                ? isNewCollectiveOptionDisabled
-                  ? { __background__: 'white' }
-                  : {}
-                : { __background__: 'white' }),
-            },
-          ],
-        },
-      ];
-    }
+      if (invitable) {
+        options = [
+          ...options,
+          {
+            label: intl.formatMessage(Messages.inviteNew).toUpperCase(),
+            options: [
+              {
+                label: null,
+                value: null,
+                isDisabled: true,
+                [FLAG_INVITE_NEW]: true,
+                __background__: 'white',
+              },
+            ],
+          },
+        ];
+      }
+      if (creatable) {
+        const isOnlyForUser = isEqual(this.props.types, [CollectiveType.USER]);
+        options = [
+          ...options,
+          {
+            label: isOnlyForUser
+              ? intl.formatMessage(Messages.inviteNew).toUpperCase()
+              : intl.formatMessage(Messages.createNew).toUpperCase(),
+            options: [
+              {
+                label: null,
+                value: null,
+                isDisabled: isNewCollectiveOptionDisabled,
+                [FLAG_NEW_COLLECTIVE]: true,
+                ...(isSelectableNewCollectiveOption
+                  ? isNewCollectiveOptionDisabled
+                    ? { __background__: 'white' }
+                    : {}
+                  : { __background__: 'white' }),
+              },
+            ],
+          },
+        ];
+      }
 
-    return options;
-  });
+      return options;
+    },
+  );
 
   onChange = option => {
     if (option?.[FLAG_NEW_COLLECTIVE] && this.props.onSelectNewCollectiveOption && this.state.searchText.trim()) {
+      if (this.props.loading || this.props.isLoading) {
+        return;
+      }
+
       this.props.onSelectNewCollectiveOption({
         searchText: this.state.searchText,
         onCreatedCollective: this.onNewCollectiveOptionCreated,
@@ -376,6 +383,7 @@ class CollectivePicker extends React.PureComponent {
       createdCollectives,
       searchText,
       this.props.loading,
+      this.props.isLoading,
     );
     const prefillValue = isEmail(searchText) ? { email: searchText } : { name: searchText };
 

--- a/components/CollectivePickerAsync.js
+++ b/components/CollectivePickerAsync.js
@@ -75,6 +75,16 @@ const throttledSearch = debounce((searchFunc, variables) => {
   return searchFunc({ variables });
 }, 750);
 
+const isSameCollective = (a, b) => {
+  if (a?.id && b?.id && a.id === b.id) {
+    return true;
+  }
+  if (a?.slug && b?.slug && a.slug === b.slug) {
+    return true;
+  }
+  return false;
+};
+
 const Messages = defineMessages({
   searchForType: {
     id: 'SearchFor',
@@ -182,10 +192,8 @@ const CollectivePickerAsync = ({
 
       // When loading is complete, we only need unique collectives
       if (!loading && filteredDefaultCollectives.length > 0) {
-        const apiResultIds = new Set(apiResults.map(c => c.id));
-        // Add default collectives that aren't already in the results
         filteredDefaultCollectives.forEach(c => {
-          if (!apiResultIds.has(c.id)) {
+          if (!apiResults.some(r => isSameCollective(r, c))) {
             apiResults.push(c);
           }
         });

--- a/components/CollectivePickerAsync.js
+++ b/components/CollectivePickerAsync.js
@@ -71,9 +71,7 @@ const collectivePickerSearchQuery = gqlV1 /* GraphQL */ `
 `;
 
 /** Throttle search function to limit invocations while typing */
-const throttledSearch = debounce((searchFunc, variables) => {
-  return searchFunc({ variables });
-}, 750);
+const makeThrottledSearch = () => debounce((searchFunc, variables) => searchFunc({ variables }), 750);
 
 const isSameCollective = (a, b) => {
   if (a?.id && b?.id && a.id === b.id) {
@@ -166,6 +164,13 @@ const CollectivePickerAsync = ({
   const fetchPolicy = noCache ? 'network-only' : undefined;
   const [searchCollectives, { loading, data }] = useLazyQuery(searchQuery, { context: API_V1_CONTEXT, fetchPolicy });
   const [term, setTerm] = React.useState(null);
+  const [isSearchPending, setIsSearchPending] = React.useState(false);
+  const [resolvedSearchTerm, setResolvedSearchTerm] = React.useState(null);
+  const lastSearchedTermRef = React.useRef(null);
+  const throttledSearchRef = React.useRef(null);
+  if (!throttledSearchRef.current) {
+    throttledSearchRef.current = makeThrottledSearch();
+  }
   const intl = useIntl();
 
   // Filter defaultCollectives by term if provided
@@ -186,8 +191,11 @@ const CollectivePickerAsync = ({
 
   // Combine API results with defaultCollectives
   const collectives = React.useMemo(() => {
-    // If we have search results, use them
-    if ((term || preload) && data?.search?.collectives) {
+    const currentTerm = term || '';
+    const apiResultsMatchTerm = resolvedSearchTerm === currentTerm;
+
+    // If we have search results for the current term, use them
+    if ((term || preload) && apiResultsMatchTerm && data?.search?.collectives) {
       const apiResults = [...data.search.collectives];
 
       // When loading is complete, we only need unique collectives
@@ -204,26 +212,46 @@ const CollectivePickerAsync = ({
 
     // When no search or results yet, show default collectives
     return filteredDefaultCollectives;
-  }, [term, preload, data, loading, filteredDefaultCollectives]);
+  }, [term, preload, data, loading, filteredDefaultCollectives, resolvedSearchTerm]);
 
   const filteredCollectives = filterResults ? filterResults(collectives) : collectives;
   const placeholder = getPlaceholder(intl, types, { useBeneficiaryForVendor });
 
   // If preload is true, trigger a first query on mount or when one of the query param changes
   React.useEffect(() => {
+    const throttledSearch = throttledSearchRef.current;
+    const searchTerm = term || '';
+
     if (term || preload) {
-      throttledSearch(searchCollectives, {
-        term: term || '',
-        types,
-        limit,
-        hostCollectiveIds,
-        parentCollectiveIds,
-        skipGuests,
-        includeArchived,
-        includeVendorsForHostId,
-        includeAllVendors,
-        vendorVisibleToAccountIds,
-      });
+      setIsSearchPending(true);
+      throttledSearch(
+        ({ variables }) => {
+          lastSearchedTermRef.current = variables.term;
+          return Promise.resolve(searchCollectives({ variables })).finally(() => {
+            if (lastSearchedTermRef.current === variables.term) {
+              setIsSearchPending(false);
+              setResolvedSearchTerm(variables.term);
+            }
+          });
+        },
+        {
+          term: searchTerm,
+          types,
+          limit,
+          hostCollectiveIds,
+          parentCollectiveIds,
+          skipGuests,
+          includeArchived,
+          includeVendorsForHostId,
+          includeAllVendors,
+          vendorVisibleToAccountIds,
+        },
+      );
+    } else {
+      throttledSearch.cancel();
+      lastSearchedTermRef.current = null;
+      setIsSearchPending(false);
+      setResolvedSearchTerm(null);
     }
   }, [
     types,
@@ -243,7 +271,7 @@ const CollectivePickerAsync = ({
   return (
     <CollectivePicker
       inputId={inputId}
-      isLoading={Boolean(loading || isLoading)}
+      isLoading={Boolean(loading || isLoading || isSearchPending)}
       collectives={filteredCollectives}
       groupByType={!types || types.length > 1}
       filterOption={() => true /** Filtering is done by the API */}

--- a/components/StyledSelect.tsx
+++ b/components/StyledSelect.tsx
@@ -253,17 +253,23 @@ export const makeStyledSelect = (SelectComponent, { alwaysSearchable = false } =
           }
         },
         option: (baseStyles, state) => {
-          const customStyles: Record<string, unknown> = { cursor: 'pointer' };
+          const customStyles: Record<string, unknown> = { cursor: state.isDisabled ? 'default' : 'pointer' };
 
           if (state.data.__background__) {
             // Ability to force background by setting a special option prop
             customStyles.background = state.data.__background__;
-          } else if (state.isSelected) {
+            // Interactive content (e.g. create buttons) uses isDisabled to prevent selection
+            // but should not inherit react-select's greyed-out disabled styling
+            if (state.isDisabled) {
+              customStyles.opacity = 1;
+              customStyles.color = 'inherit';
+            }
+          } else if (!state.isDisabled && state.isSelected) {
             customStyles.backgroundColor = theme.colors.primary[200];
             customStyles.color = undefined;
-          } else if (state.isFocused) {
+          } else if (!state.isDisabled && state.isFocused) {
             customStyles.backgroundColor = theme.colors.primary[100];
-          } else {
+          } else if (!state.isDisabled) {
             customStyles['&:hover'] = { backgroundColor: theme.colors.primary[100] };
           }
 

--- a/components/dashboard/sections/collectives/AddFundsModal.tsx
+++ b/components/dashboard/sections/collectives/AddFundsModal.tsx
@@ -4,7 +4,7 @@ import { accountHasGST, accountHasVAT, TaxType } from '@opencollective/taxes';
 import { InfoCircle } from '@styled-icons/boxicons-regular/InfoCircle';
 import { Form, Formik } from 'formik';
 import { get, isEmpty } from 'lodash-es';
-import { ArrowLeft, Lock, PlusCircle, Unlock } from 'lucide-react';
+import { ArrowLeft, Lock, Unlock } from 'lucide-react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import styled, { css } from 'styled-components';
 
@@ -20,20 +20,17 @@ import type {
   Tier,
   TierReferenceInput,
   TransactionReferenceInput,
-  VendorFieldsFragment,
 } from '../../../../lib/graphql/types/v2/graphql';
 import useLoggedInUser from '../../../../lib/hooks/useLoggedInUser';
 import { i18nTaxType } from '../../../../lib/i18n/taxes';
 import { require2FAForAdmins } from '../../../../lib/policies';
 import { getCollectivePageRoute } from '../../../../lib/url-helpers';
-import { i18nGraphqlException } from '@/lib/errors';
 
-import { I18nBold } from '@/components/I18nFormatters';
 import { Checkbox } from '@/components/ui/Checkbox';
 import { Skeleton } from '@/components/ui/Skeleton';
 import { Switch } from '@/components/ui/Switch';
-import { toast } from '@/components/ui/useToast';
-import { vendorFieldFragment } from '@/components/vendors/queries';
+import { quickCreateVendorRenderOption } from '@/components/vendors/QuickCreateVendorCollectiveOption';
+import { useQuickCreateVendor } from '@/components/vendors/useQuickCreateVendor';
 
 import { AccountHoverCard, accountHoverCardFields } from '../../../AccountHoverCard';
 import AccountingCategorySelect from '../../../AccountingCategorySelect';
@@ -506,46 +503,7 @@ const AddFundsModalContentWithCollective = ({
   const applicableTax = getApplicableTaxType(account, host);
   const isEdit = Boolean(editOrderId);
 
-  const [createVendor, { loading: isCreatingVendor }] = useMutation(gql`
-    mutation CreateAddFundsVendor($vendor: VendorCreateInput!, $host: AccountReferenceInput!) {
-      createVendor(host: $host, vendor: $vendor) {
-        id
-        ...VendorFields
-      }
-    }
-    ${vendorFieldFragment}
-  `);
-
-  const onCreateVendorClick = React.useCallback(
-    async (
-      searchText: string,
-      { onSuccess, onError }: { onSuccess: (vendor: VendorFieldsFragment) => void; onError: (error: Error) => void },
-    ) => {
-      try {
-        const result = await createVendor({
-          variables: {
-            vendor: {
-              name: searchText,
-            },
-            host: { id: host.id },
-          },
-        });
-
-        toast({
-          variant: 'success',
-          message: intl.formatMessage({ defaultMessage: 'Vendor created', id: 'Ra9inC' }),
-        });
-        onSuccess(result.data.createVendor);
-      } catch (error) {
-        toast({
-          variant: 'error',
-          message: i18nGraphqlException(intl, error),
-        });
-        onError(error);
-      }
-    },
-    [createVendor, host?.id, intl],
-  );
+  const { createVendorFromSearch, isCreatingVendor } = useQuickCreateVendor({ host });
 
   const [submitAddFunds, { error: fundError, loading: isLoading }] = useMutation(
     isEdit ? editAddedFundsMutation : addFundsMutation,
@@ -810,41 +768,10 @@ const AddFundsModalContentWithCollective = ({
                           includeVendorsForHostId={host?.legacyId || undefined}
                           creatable={['VENDOR']}
                           HostCollectiveId={host?.legacyId}
-                          renderNewCollectiveOption={({ searchText, onCreatedCollective }) => {
-                            if (searchText.length > 0) {
-                              return (
-                                <Button
-                                  type="button"
-                                  variant="ghost"
-                                  loading={isCreatingVendor}
-                                  className="flex w-full items-center justify-between gap-2 text-sm text-gray-500"
-                                  onClick={() =>
-                                    onCreateVendorClick(searchText, {
-                                      onSuccess: vendor => {
-                                        onCreatedCollective(vendor);
-                                      },
-                                      onError: () => {},
-                                    })
-                                  }
-                                >
-                                  <span>
-                                    <FormattedMessage
-                                      defaultMessage="Create vendor: <b>{vendorName}</b>"
-                                      id="buY7Uz"
-                                      values={{ vendorName: searchText, b: I18nBold }}
-                                    />
-                                  </span>
-                                  <PlusCircle size={16} />
-                                </Button>
-                              );
-                            }
-
-                            return (
-                              <div>
-                                <FormattedMessage defaultMessage="Begin typing to create a vendor" id="Jx28lM" />
-                              </div>
-                            );
-                          }}
+                          renderNewCollectiveOption={quickCreateVendorRenderOption(
+                            createVendorFromSearch,
+                            isCreatingVendor,
+                          )}
                           formatOptionLabel={(option, context) => {
                             if (context.context === 'value') {
                               return (

--- a/components/dashboard/sections/collectives/AddFundsModal.tsx
+++ b/components/dashboard/sections/collectives/AddFundsModal.tsx
@@ -29,7 +29,7 @@ import { getCollectivePageRoute } from '../../../../lib/url-helpers';
 import { Checkbox } from '@/components/ui/Checkbox';
 import { Skeleton } from '@/components/ui/Skeleton';
 import { Switch } from '@/components/ui/Switch';
-import { quickCreateVendorRenderOption } from '@/components/vendors/QuickCreateVendorCollectiveOption';
+import { quickCreateVendorCollectivePickerOptions } from '@/components/vendors/QuickCreateVendorCollectiveOption';
 import { useQuickCreateVendor } from '@/components/vendors/useQuickCreateVendor';
 
 import { AccountHoverCard, accountHoverCardFields } from '../../../AccountHoverCard';
@@ -768,10 +768,7 @@ const AddFundsModalContentWithCollective = ({
                           includeVendorsForHostId={host?.legacyId || undefined}
                           creatable={['VENDOR']}
                           HostCollectiveId={host?.legacyId}
-                          renderNewCollectiveOption={quickCreateVendorRenderOption(
-                            createVendorFromSearch,
-                            isCreatingVendor,
-                          )}
+                          {...quickCreateVendorCollectivePickerOptions(createVendorFromSearch)}
                           formatOptionLabel={(option, context) => {
                             if (context.context === 'value') {
                               return (

--- a/components/submit-expense/form/WhoIsGettingPaidSection.tsx
+++ b/components/submit-expense/form/WhoIsGettingPaidSection.tsx
@@ -3,11 +3,13 @@ import { useMutation } from '@apollo/client';
 import type { FieldMetaProps } from 'formik';
 import { Field, useFormikContext } from 'formik';
 import { isEmpty, pick } from 'lodash-es';
-import { AlertCircle, Lock } from 'lucide-react';
+import { AlertCircle, Lock, PlusCircle } from 'lucide-react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { CollectiveType } from '../../../lib/constants/collectives';
 import { i18nGraphqlException } from '../../../lib/errors';
+import { gql } from '../../../lib/graphql/helpers';
+import type { VendorFieldsFragment } from '../../../lib/graphql/types/v2/graphql';
 import { AccountType, ExpenseStatus, ExpenseType } from '../../../lib/graphql/types/v2/graphql';
 import {
   PAYEE_SLUG_CREATE_LEGAL_ENTITY,
@@ -21,11 +23,12 @@ import {
 import useLoggedInUser from '@/lib/hooks/useLoggedInUser';
 
 import { FormField } from '@/components/FormField';
+import { I18nBold } from '@/components/I18nFormatters';
 import LoginBtn from '@/components/LoginBtn';
 import { Alert, AlertDescription } from '@/components/ui/Alert';
 import { Skeleton } from '@/components/ui/Skeleton';
 import { Textarea } from '@/components/ui/Textarea';
-import VendorForm from '@/components/vendors/VendorForm';
+import { vendorFieldFragment } from '@/components/vendors/queries';
 
 import CollectivePicker from '../../CollectivePicker';
 import CollectivePickerAsync from '../../CollectivePickerAsync';
@@ -409,6 +412,8 @@ const VendorOption = React.memo(function VendorOption(props: {
   refresh: ExpenseForm['refresh'];
   expenseTypeOption: ExpenseForm['values']['expenseTypeOption'];
 }) {
+  const intl = useIntl();
+  const { toast } = useToast();
   const { LoggedInUser } = useLoggedInUser();
   const isHostAdmin = LoggedInUser?.isAdminOfCollective(props.host);
   // Setting a state variable to keep the Vendor option open when a vendor that is not part of the preloaded vendors is selected
@@ -420,6 +425,48 @@ const VendorOption = React.memo(function VendorOption(props: {
     selectedVendor?.slug === props.payeeSlug;
 
   const isBeneficiary = props.expenseTypeOption === ExpenseType.GRANT;
+
+  const [createVendor, { loading: isCreatingVendor }] = useMutation(gql`
+    mutation CreateExpenseVendor($vendor: VendorCreateInput!, $host: AccountReferenceInput!) {
+      createVendor(host: $host, vendor: $vendor) {
+        id
+        ...VendorFields
+      }
+    }
+    ${vendorFieldFragment}
+  `);
+
+  const onCreateVendorClick = React.useCallback(
+    async (
+      searchText: string,
+      { onSuccess, onError }: { onSuccess: (vendor: VendorFieldsFragment) => void; onError: (error: Error) => void },
+    ) => {
+      try {
+        const result = await createVendor({
+          variables: {
+            vendor: {
+              name: searchText,
+            },
+            host: { id: props.host.id },
+          },
+        });
+
+        toast({
+          variant: 'success',
+          message: intl.formatMessage({ defaultMessage: 'Vendor created', id: 'Ra9inC' }),
+        });
+        onSuccess(result.data.createVendor);
+        props.refresh();
+      } catch (error) {
+        toast({
+          variant: 'error',
+          message: i18nGraphqlException(intl, error),
+        });
+        onError(error);
+      }
+    },
+    [createVendor, props.host?.id, props.refresh, intl, toast],
+  );
 
   return (
     <RadioGroupCard
@@ -434,6 +481,7 @@ const VendorOption = React.memo(function VendorOption(props: {
             inputId={PAYEE_SLUG_VENDOR}
             useBeneficiaryForVendor={isBeneficiary}
             isSearchable
+            loading={isCreatingVendor}
             types={['VENDOR']}
             creatable={isHostAdmin ? ['VENDOR'] : false}
             includeVendorsForHostId={props.host.legacyId}
@@ -444,11 +492,45 @@ const VendorOption = React.memo(function VendorOption(props: {
                 ? null
                 : selectedVendor || props.payee
             }
-            handleCreateForm
-            onCreateClick={() => {
-              props.setFieldValue('payeeSlug', PAYEE_SLUG_NEW_VENDOR);
-              setSelectedVendor(null);
-            }}
+            renderNewCollectiveOption={
+              isHostAdmin
+                ? ({ searchText, onCreatedCollective }) => {
+                    if (searchText.length > 0) {
+                      return (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          loading={isCreatingVendor}
+                          className="flex w-full items-center justify-between gap-2 text-sm text-gray-500"
+                          onClick={() =>
+                            onCreateVendorClick(searchText, {
+                              onSuccess: vendor => {
+                                onCreatedCollective(vendor);
+                              },
+                              onError: () => {},
+                            })
+                          }
+                        >
+                          <span>
+                            <FormattedMessage
+                              defaultMessage="Create vendor: <b>{vendorName}</b>"
+                              id="buY7Uz"
+                              values={{ vendorName: searchText, b: I18nBold }}
+                            />
+                          </span>
+                          <PlusCircle size={16} />
+                        </Button>
+                      );
+                    }
+
+                    return (
+                      <div>
+                        <FormattedMessage defaultMessage="Begin typing to create a vendor" id="Jx28lM" />
+                      </div>
+                    );
+                  }
+                : undefined
+            }
             onChange={e => {
               const selected = e.value;
               const slug = selected?.slug;
@@ -457,28 +539,6 @@ const VendorOption = React.memo(function VendorOption(props: {
             }}
             vendorVisibleToAccountIds={props.account.legacyId}
           />
-          {props.payeeSlug === PAYEE_SLUG_NEW_VENDOR && (
-            <React.Fragment>
-              <Separator className="mt-3" />
-              <div className="mt-3">
-                <VendorForm
-                  isBeneficiary={isBeneficiary}
-                  limitVisibilityOptionToAccount={props.account}
-                  onSuccess={selected => {
-                    props.setFieldValue('payeeSlug', selected?.slug);
-                    setSelectedVendor(selected);
-                  }}
-                  hidePayoutMethod
-                  host={props.host}
-                  supportsTaxForm={false}
-                  onCancel={() => {
-                    props.setFieldValue('payeeSlug', PAYEE_SLUG_VENDOR);
-                    setSelectedVendor(null);
-                  }}
-                />
-              </div>
-            </React.Fragment>
-          )}
         </div>
       }
     >

--- a/components/submit-expense/form/WhoIsGettingPaidSection.tsx
+++ b/components/submit-expense/form/WhoIsGettingPaidSection.tsx
@@ -25,7 +25,7 @@ import LoginBtn from '@/components/LoginBtn';
 import { Alert, AlertDescription } from '@/components/ui/Alert';
 import { Skeleton } from '@/components/ui/Skeleton';
 import { Textarea } from '@/components/ui/Textarea';
-import { quickCreateVendorRenderOption } from '@/components/vendors/QuickCreateVendorCollectiveOption';
+import { quickCreateVendorCollectivePickerOptions } from '@/components/vendors/QuickCreateVendorCollectiveOption';
 import { useQuickCreateVendor } from '@/components/vendors/useQuickCreateVendor';
 
 import CollectivePicker from '../../CollectivePicker';
@@ -445,9 +445,7 @@ const VendorOption = React.memo(function VendorOption(props: {
                 ? null
                 : selectedVendor || props.payee
             }
-            renderNewCollectiveOption={
-              isHostAdmin ? quickCreateVendorRenderOption(createVendorFromSearch, isCreatingVendor) : undefined
-            }
+            {...(isHostAdmin ? quickCreateVendorCollectivePickerOptions(createVendorFromSearch) : {})}
             onChange={e => {
               const selected = e.value;
               const slug = selected?.slug;

--- a/components/submit-expense/form/WhoIsGettingPaidSection.tsx
+++ b/components/submit-expense/form/WhoIsGettingPaidSection.tsx
@@ -3,13 +3,11 @@ import { useMutation } from '@apollo/client';
 import type { FieldMetaProps } from 'formik';
 import { Field, useFormikContext } from 'formik';
 import { isEmpty, pick } from 'lodash-es';
-import { AlertCircle, Lock, PlusCircle } from 'lucide-react';
+import { AlertCircle, Lock } from 'lucide-react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { CollectiveType } from '../../../lib/constants/collectives';
 import { i18nGraphqlException } from '../../../lib/errors';
-import { gql } from '../../../lib/graphql/helpers';
-import type { VendorFieldsFragment } from '../../../lib/graphql/types/v2/graphql';
 import { AccountType, ExpenseStatus, ExpenseType } from '../../../lib/graphql/types/v2/graphql';
 import {
   PAYEE_SLUG_CREATE_LEGAL_ENTITY,
@@ -23,12 +21,12 @@ import {
 import useLoggedInUser from '@/lib/hooks/useLoggedInUser';
 
 import { FormField } from '@/components/FormField';
-import { I18nBold } from '@/components/I18nFormatters';
 import LoginBtn from '@/components/LoginBtn';
 import { Alert, AlertDescription } from '@/components/ui/Alert';
 import { Skeleton } from '@/components/ui/Skeleton';
 import { Textarea } from '@/components/ui/Textarea';
-import { vendorFieldFragment } from '@/components/vendors/queries';
+import { quickCreateVendorRenderOption } from '@/components/vendors/QuickCreateVendorCollectiveOption';
+import { useQuickCreateVendor } from '@/components/vendors/useQuickCreateVendor';
 
 import CollectivePicker from '../../CollectivePicker';
 import CollectivePickerAsync from '../../CollectivePickerAsync';
@@ -393,7 +391,6 @@ function VendorOptionWrapper() {
         vendorsForAccount={form.options.vendorsForAccount || []}
         account={form.options.account}
         host={form.options.host}
-        refresh={form.refresh}
         expenseTypeOption={form.values.expenseTypeOption}
       />
     );
@@ -409,13 +406,11 @@ const VendorOption = React.memo(function VendorOption(props: {
   vendorsForAccount: ExpenseForm['options']['vendorsForAccount'];
   account: ExpenseForm['options']['account'];
   host: ExpenseForm['options']['host'];
-  refresh: ExpenseForm['refresh'];
   expenseTypeOption: ExpenseForm['values']['expenseTypeOption'];
 }) {
-  const intl = useIntl();
-  const { toast } = useToast();
   const { LoggedInUser } = useLoggedInUser();
   const isHostAdmin = LoggedInUser?.isAdminOfCollective(props.host);
+  const { createVendorFromSearch, isCreatingVendor } = useQuickCreateVendor({ host: props.host });
   // Setting a state variable to keep the Vendor option open when a vendor that is not part of the preloaded vendors is selected
   const [selectedVendor, setSelectedVendor] = React.useState(undefined);
   const isVendorSelected =
@@ -425,48 +420,6 @@ const VendorOption = React.memo(function VendorOption(props: {
     selectedVendor?.slug === props.payeeSlug;
 
   const isBeneficiary = props.expenseTypeOption === ExpenseType.GRANT;
-
-  const [createVendor, { loading: isCreatingVendor }] = useMutation(gql`
-    mutation CreateExpenseVendor($vendor: VendorCreateInput!, $host: AccountReferenceInput!) {
-      createVendor(host: $host, vendor: $vendor) {
-        id
-        ...VendorFields
-      }
-    }
-    ${vendorFieldFragment}
-  `);
-
-  const onCreateVendorClick = React.useCallback(
-    async (
-      searchText: string,
-      { onSuccess, onError }: { onSuccess: (vendor: VendorFieldsFragment) => void; onError: (error: Error) => void },
-    ) => {
-      try {
-        const result = await createVendor({
-          variables: {
-            vendor: {
-              name: searchText,
-            },
-            host: { id: props.host.id },
-          },
-        });
-
-        toast({
-          variant: 'success',
-          message: intl.formatMessage({ defaultMessage: 'Vendor created', id: 'Ra9inC' }),
-        });
-        onSuccess(result.data.createVendor);
-        props.refresh();
-      } catch (error) {
-        toast({
-          variant: 'error',
-          message: i18nGraphqlException(intl, error),
-        });
-        onError(error);
-      }
-    },
-    [createVendor, props.host?.id, props.refresh, intl, toast],
-  );
 
   return (
     <RadioGroupCard
@@ -493,43 +446,7 @@ const VendorOption = React.memo(function VendorOption(props: {
                 : selectedVendor || props.payee
             }
             renderNewCollectiveOption={
-              isHostAdmin
-                ? ({ searchText, onCreatedCollective }) => {
-                    if (searchText.length > 0) {
-                      return (
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          loading={isCreatingVendor}
-                          className="flex w-full items-center justify-between gap-2 text-sm text-gray-500"
-                          onClick={() =>
-                            onCreateVendorClick(searchText, {
-                              onSuccess: vendor => {
-                                onCreatedCollective(vendor);
-                              },
-                              onError: () => {},
-                            })
-                          }
-                        >
-                          <span>
-                            <FormattedMessage
-                              defaultMessage="Create vendor: <b>{vendorName}</b>"
-                              id="buY7Uz"
-                              values={{ vendorName: searchText, b: I18nBold }}
-                            />
-                          </span>
-                          <PlusCircle size={16} />
-                        </Button>
-                      );
-                    }
-
-                    return (
-                      <div>
-                        <FormattedMessage defaultMessage="Begin typing to create a vendor" id="Jx28lM" />
-                      </div>
-                    );
-                  }
-                : undefined
+              isHostAdmin ? quickCreateVendorRenderOption(createVendorFromSearch, isCreatingVendor) : undefined
             }
             onChange={e => {
               const selected = e.value;

--- a/components/vendors/QuickCreateVendorCollectiveOption.tsx
+++ b/components/vendors/QuickCreateVendorCollectiveOption.tsx
@@ -60,14 +60,14 @@ function QuickCreateVendorCollectiveOption({ searchText }: QuickCreateVendorColl
 }
 
 /** `renderNewCollectiveOption` callback for `CollectivePicker` / `CollectivePickerAsync`. */
-export function quickCreateVendorRenderOption() {
+function quickCreateVendorRenderOption() {
   return function renderQuickCreateVendorOption({ searchText }: { searchText: string }) {
     return <QuickCreateVendorCollectiveOption searchText={searchText} />;
   };
 }
 
 /** `onSelectNewCollectiveOption` callback for `CollectivePicker` / `CollectivePickerAsync`. */
-export function quickCreateVendorOnSelect(
+function quickCreateVendorOnSelect(
   createVendorFromSearch: (searchText: string, callbacks: QuickCreateVendorCallbacks) => void | Promise<void>,
 ) {
   return function onSelectQuickCreateVendorOption({ searchText, onCreatedCollective }: QuickCreateVendorSelectArgs) {

--- a/components/vendors/QuickCreateVendorCollectiveOption.tsx
+++ b/components/vendors/QuickCreateVendorCollectiveOption.tsx
@@ -6,72 +6,83 @@ import type { VendorFieldsFragment } from '../../lib/graphql/types/v2/graphql';
 
 import { I18nBold } from '@/components/I18nFormatters';
 
-import { Button } from '../ui/Button';
+import { Flex } from '../Grid';
+import { Span } from '../Text';
 
 import type { QuickCreateVendorCallbacks } from './useQuickCreateVendor';
 
 type QuickCreateVendorCollectiveOptionProps = {
   searchText: string;
-  onCreatedCollective: (collective: VendorFieldsFragment) => void;
-  loading?: boolean;
-  createVendorFromSearch: (searchText: string, callbacks: QuickCreateVendorCallbacks) => void | Promise<void>;
 };
 
-function QuickCreateVendorCollectiveOption({
-  searchText,
-  onCreatedCollective,
-  loading,
-  createVendorFromSearch,
-}: QuickCreateVendorCollectiveOptionProps) {
+type QuickCreateVendorSelectArgs = {
+  searchText: string;
+  onCreatedCollective: (collective: VendorFieldsFragment) => void;
+};
+
+function QuickCreateVendorCollectiveOption({ searchText }: QuickCreateVendorCollectiveOptionProps) {
   const trimmed = searchText.trim();
 
   if (trimmed.length > 0) {
     return (
-      <Button
-        type="button"
-        variant="ghost"
-        loading={loading}
-        className="flex w-full items-center justify-between gap-2 text-sm text-gray-500"
-        onClick={() => createVendorFromSearch(trimmed, { onSuccess: onCreatedCollective })}
-      >
-        <span>
-          <FormattedMessage
-            defaultMessage="Create vendor: <b>{vendorName}</b>"
-            id="buY7Uz"
-            values={{ vendorName: trimmed, b: I18nBold }}
-          />
-        </span>
-        <PlusCircle size={16} />
-      </Button>
+      <Flex alignItems="center">
+        <Flex
+          alignItems="center"
+          justifyContent="center"
+          color="#999"
+          width="16px"
+          minWidth="16px"
+          height="16px"
+          flexShrink={0}
+        >
+          <PlusCircle size={14} strokeWidth={2} />
+        </Flex>
+        <Flex flexDirection="column" ml="8px" textAlign="left">
+          <Span fontSize="12px" fontWeight="500" lineHeight="18px" color="black.700">
+            <FormattedMessage
+              defaultMessage="Create vendor: <b>{vendorName}</b>"
+              id="buY7Uz"
+              values={{ vendorName: trimmed, b: I18nBold }}
+            />
+          </Span>
+        </Flex>
+      </Flex>
     );
   }
 
   return (
-    <div>
-      <FormattedMessage defaultMessage="Begin typing to create a vendor" id="Jx28lM" />
-    </div>
+    <Flex alignItems="center">
+      <Span fontSize="12px" lineHeight="18px" color="black.500">
+        <FormattedMessage defaultMessage="Begin typing to create a vendor" id="Jx28lM" />
+      </Span>
+    </Flex>
   );
 }
 
 /** `renderNewCollectiveOption` callback for `CollectivePicker` / `CollectivePickerAsync`. */
-export function quickCreateVendorRenderOption(
-  createVendorFromSearch: QuickCreateVendorCollectiveOptionProps['createVendorFromSearch'],
-  loading?: boolean,
+export function quickCreateVendorRenderOption() {
+  return function renderQuickCreateVendorOption({ searchText }: { searchText: string }) {
+    return <QuickCreateVendorCollectiveOption searchText={searchText} />;
+  };
+}
+
+/** `onSelectNewCollectiveOption` callback for `CollectivePicker` / `CollectivePickerAsync`. */
+export function quickCreateVendorOnSelect(
+  createVendorFromSearch: (searchText: string, callbacks: QuickCreateVendorCallbacks) => void | Promise<void>,
 ) {
-  return function renderQuickCreateVendorOption({
-    searchText,
-    onCreatedCollective,
-  }: {
-    searchText: string;
-    onCreatedCollective: (collective: VendorFieldsFragment) => void;
-  }) {
-    return (
-      <QuickCreateVendorCollectiveOption
-        searchText={searchText}
-        onCreatedCollective={onCreatedCollective}
-        loading={loading}
-        createVendorFromSearch={createVendorFromSearch}
-      />
-    );
+  return function onSelectQuickCreateVendorOption({ searchText, onCreatedCollective }: QuickCreateVendorSelectArgs) {
+    const trimmed = searchText.trim();
+    if (trimmed) {
+      createVendorFromSearch(trimmed, { onSuccess: onCreatedCollective });
+    }
+  };
+}
+
+export function quickCreateVendorCollectivePickerOptions(
+  createVendorFromSearch: (searchText: string, callbacks: QuickCreateVendorCallbacks) => void | Promise<void>,
+) {
+  return {
+    renderNewCollectiveOption: quickCreateVendorRenderOption(),
+    onSelectNewCollectiveOption: quickCreateVendorOnSelect(createVendorFromSearch),
   };
 }

--- a/components/vendors/QuickCreateVendorCollectiveOption.tsx
+++ b/components/vendors/QuickCreateVendorCollectiveOption.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { PlusCircle } from 'lucide-react';
+import { FormattedMessage } from 'react-intl';
+
+import type { VendorFieldsFragment } from '../../lib/graphql/types/v2/graphql';
+
+import { I18nBold } from '@/components/I18nFormatters';
+
+import { Button } from '../ui/Button';
+
+import type { QuickCreateVendorCallbacks } from './useQuickCreateVendor';
+
+type QuickCreateVendorCollectiveOptionProps = {
+  searchText: string;
+  onCreatedCollective: (collective: VendorFieldsFragment) => void;
+  loading?: boolean;
+  createVendorFromSearch: (searchText: string, callbacks: QuickCreateVendorCallbacks) => void | Promise<void>;
+};
+
+function QuickCreateVendorCollectiveOption({
+  searchText,
+  onCreatedCollective,
+  loading,
+  createVendorFromSearch,
+}: QuickCreateVendorCollectiveOptionProps) {
+  const trimmed = searchText.trim();
+
+  if (trimmed.length > 0) {
+    return (
+      <Button
+        type="button"
+        variant="ghost"
+        loading={loading}
+        className="flex w-full items-center justify-between gap-2 text-sm text-gray-500"
+        onClick={() => createVendorFromSearch(trimmed, { onSuccess: onCreatedCollective })}
+      >
+        <span>
+          <FormattedMessage
+            defaultMessage="Create vendor: <b>{vendorName}</b>"
+            id="buY7Uz"
+            values={{ vendorName: trimmed, b: I18nBold }}
+          />
+        </span>
+        <PlusCircle size={16} />
+      </Button>
+    );
+  }
+
+  return (
+    <div>
+      <FormattedMessage defaultMessage="Begin typing to create a vendor" id="Jx28lM" />
+    </div>
+  );
+}
+
+/** `renderNewCollectiveOption` callback for `CollectivePicker` / `CollectivePickerAsync`. */
+export function quickCreateVendorRenderOption(
+  createVendorFromSearch: QuickCreateVendorCollectiveOptionProps['createVendorFromSearch'],
+  loading?: boolean,
+) {
+  return function renderQuickCreateVendorOption({
+    searchText,
+    onCreatedCollective,
+  }: {
+    searchText: string;
+    onCreatedCollective: (collective: VendorFieldsFragment) => void;
+  }) {
+    return (
+      <QuickCreateVendorCollectiveOption
+        searchText={searchText}
+        onCreatedCollective={onCreatedCollective}
+        loading={loading}
+        createVendorFromSearch={createVendorFromSearch}
+      />
+    );
+  };
+}

--- a/components/vendors/VendorForm.tsx
+++ b/components/vendors/VendorForm.tsx
@@ -40,19 +40,9 @@ import { Switch } from '../ui/Switch';
 import { useToast } from '../ui/useToast';
 
 import type { VendorFieldsFragment } from './queries';
-import { vendorFieldFragment } from './queries';
+import { createVendorMutation, vendorFieldFragment } from './queries';
 
 const FIELD_LABEL_PROPS = { fontSize: 16, fontWeight: 700 };
-
-const createVendorMutation = gql`
-  mutation CreateVendor($vendor: VendorCreateInput!, $host: AccountReferenceInput!) {
-    createVendor(host: $host, vendor: $vendor) {
-      id
-      ...VendorFields
-    }
-  }
-  ${vendorFieldFragment}
-`;
 
 const editVendorMutation = gql`
   mutation EditVendor($vendor: VendorEditInput!) {

--- a/components/vendors/queries.ts
+++ b/components/vendors/queries.ts
@@ -73,6 +73,16 @@ export const vendorFieldFragment = gql`
   ${accountHoverCardFields}
 `;
 
+export const createVendorMutation = gql`
+  mutation CreateVendor($vendor: VendorCreateInput!, $host: AccountReferenceInput!) {
+    createVendor(host: $host, vendor: $vendor) {
+      id
+      ...VendorFields
+    }
+  }
+  ${vendorFieldFragment}
+`;
+
 export const setVendorArchiveMutation = gql`
   mutation SetVendorArchive($vendor: VendorEditInput!, $archive: Boolean!) {
     editVendor(archive: $archive, vendor: $vendor) {

--- a/components/vendors/useQuickCreateVendor.ts
+++ b/components/vendors/useQuickCreateVendor.ts
@@ -1,0 +1,64 @@
+import { useCallback } from 'react';
+import { useMutation } from '@apollo/client';
+import { pick } from 'lodash-es';
+import { useIntl } from 'react-intl';
+
+import { i18nGraphqlException } from '../../lib/errors';
+import type { AccountReferenceInput, VendorFieldsFragment } from '../../lib/graphql/types/v2/graphql';
+
+import { useToast } from '../ui/useToast';
+
+import { createVendorMutation } from './queries';
+
+type HostReference = Pick<AccountReferenceInput, 'id' | 'slug'>;
+
+export type QuickCreateVendorCallbacks = {
+  onSuccess: (vendor: VendorFieldsFragment) => void;
+};
+
+type UseQuickCreateVendorOptions = {
+  host: HostReference;
+};
+
+export function useQuickCreateVendor({ host }: UseQuickCreateVendorOptions) {
+  const intl = useIntl();
+  const { toast } = useToast();
+  const [createVendor, { loading: isCreatingVendor }] = useMutation(createVendorMutation);
+
+  const createVendorFromSearch = useCallback(
+    async (searchText: string, { onSuccess }: QuickCreateVendorCallbacks) => {
+      const name = searchText.trim();
+      if (!name) {
+        return;
+      }
+
+      try {
+        const result = await createVendor({
+          variables: {
+            vendor: { name },
+            host: pick(host, ['id', 'slug']),
+          },
+        });
+
+        const vendor = result.data?.createVendor;
+        if (!vendor) {
+          throw new Error('Missing createVendor response');
+        }
+
+        toast({
+          variant: 'success',
+          message: intl.formatMessage({ defaultMessage: 'Vendor created', id: 'Ra9inC' }),
+        });
+        onSuccess(vendor);
+      } catch (error) {
+        toast({
+          variant: 'error',
+          message: i18nGraphqlException(intl, error),
+        });
+      }
+    },
+    [createVendor, host, intl, toast],
+  );
+
+  return { createVendorFromSearch, isCreatingVendor };
+}

--- a/test/cypress/integration/29-host.admin.test.js
+++ b/test/cypress/integration/29-host.admin.test.js
@@ -101,7 +101,13 @@ describe('host dashboard', () => {
       cy.get('[data-cy="add-funds-amount"]').type('{selectall}20');
       cy.get('[data-cy="add-funds-description"]').type('cypress test - add funds');
       const vendorName = randStr();
+      cy.intercept('POST', '/api/graphql/v1', req => {
+        if (req.body?.operationName === 'CollectivePickerSearch' && req.body?.variables?.term === vendorName) {
+          req.alias = 'collectivePickerSearch';
+        }
+      });
       cy.get('[data-cy="add-funds-source"]').type(vendorName);
+      cy.wait('@collectivePickerSearch');
       cy.contains(`Create vendor: ${vendorName}`).click();
       cy.contains(`I confirm that`).click();
       cy.get('[data-cy="add-funds-submit-btn"]').click();

--- a/test/cypress/integration/32-grant-submission.test.ts
+++ b/test/cypress/integration/32-grant-submission.test.ts
@@ -99,13 +99,9 @@ describe('Grant Submission Flow', () => {
     cy.contains('button', 'Proceed').click();
     cy.get('#WHO_WILL_RECEIVE_FUNDS').within(() => {
       cy.contains('A beneficiary').click();
-      cy.contains('A beneficiary').parent().get('[role="combobox"]').click();
-      cy.root().closest('html').contains('Create Beneficiary').click();
-
-      cy.contains('label', "Beneficiary's name").click();
-      cy.focused().type('A beneficiary name');
-
-      cy.contains('button', 'Create beneficiary').click();
+      const beneficiaryName = 'A beneficiary name';
+      cy.contains('A beneficiary').parent().get('[role="combobox"]').click().type(beneficiaryName);
+      cy.root().closest('html').contains(`Create vendor: ${beneficiaryName}`).click();
     });
 
     cy.get('#PAYOUT_METHOD').within(() => {

--- a/test/cypress/integration/32-grant-submission.test.ts
+++ b/test/cypress/integration/32-grant-submission.test.ts
@@ -100,8 +100,15 @@ describe('Grant Submission Flow', () => {
     cy.get('#WHO_WILL_RECEIVE_FUNDS').within(() => {
       cy.contains('A beneficiary').click();
       const beneficiaryName = 'A beneficiary name';
+      cy.intercept('POST', '/api/graphql/v1', req => {
+        if (req.body?.operationName === 'CollectivePickerSearch' && req.body?.variables?.term === beneficiaryName) {
+          req.alias = 'collectivePickerSearch';
+        }
+      });
       cy.contains('A beneficiary').parent().get('[role="combobox"]').click().type(beneficiaryName);
+      cy.wait('@collectivePickerSearch');
       cy.root().closest('html').contains(`Create vendor: ${beneficiaryName}`).click();
+      cy.root().closest('html').contains('Vendor created', { timeout: 20000 }).should('be.visible');
     });
 
     cy.get('#PAYOUT_METHOD').within(() => {


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/8746

# Description

- Implements inline vendor creation to be the same as the "Add Funds" modal, where you type and get an option to create a Vendor with that name.
- Creating a shared hook and render option helper, based on the existing code in the "Add Funds" modal.
- Updates the styling of the "Create new vendor" option to be a regular collective picker option, and be selectable by keyboard. 
  - Also preventing creating a new vendor while search is loading.
# Screenshots

<img width="1564" height="498" alt="image" src="https://github.com/user-attachments/assets/5912fe44-2ea1-4513-83fa-e9be859719ea" />