### PR TITLE
enhancement(Sidebar): Show disbursement tools for self-managed orgs

### DIFF
--- a/components/dashboard/menu-items.ts
+++ b/components/dashboard/menu-items.ts
@@ -139,6 +139,8 @@ export const getMenuItems = ({ intl, account, LoggedInUser }): MenuItem[] => {
   const hasIncomingOutgoingReorg = LoggedInUser?.hasPreviewFeatureEnabled(
     PREVIEW_FEATURE_KEYS.SIDEBAR_REORG_INCOMING_OUTGOING,
   );
+  const isOrgWithMoneyManagementNoHosting = isOrganization && hasMoneyManagement && !hasHosting;
+  const showDisbursementWorkflowTools = hasHosting || (hasIncomingOutgoingReorg && isOrgWithMoneyManagementNoHosting);
 
   const hasIssuedGrantRequests = account.issuedGrantRequests?.totalCount > 0;
   const hasReceivedGrantRequests = account.receivedGrantRequests?.totalCount > 0;
@@ -183,7 +185,7 @@ export const getMenuItems = ({ intl, account, LoggedInUser }): MenuItem[] => {
       Icon: Receipt,
       subMenu: [
         {
-          if: hasHosting,
+          if: showDisbursementWorkflowTools,
           section: ALL_SECTIONS.PAY_DISBURSEMENTS,
           label: intl.formatMessage({ defaultMessage: 'Pay Disbursements', id: 'El6h63' }),
         },
@@ -196,17 +198,17 @@ export const getMenuItems = ({ intl, account, LoggedInUser }): MenuItem[] => {
           }),
         },
         {
-          if: hasHosting,
+          if: showDisbursementWorkflowTools,
           section: ALL_SECTIONS.APPROVE_PAYMENT_REQUESTS,
           label: intl.formatMessage({ defaultMessage: 'Approve Payment Requests', id: 'ApprovePaymentRequests' }),
         },
         {
-          if: hasHosting,
+          if: showDisbursementWorkflowTools,
           section: ALL_SECTIONS.HOST_PAYMENT_REQUESTS,
           label: intl.formatMessage({ defaultMessage: 'All Payment Requests', id: 'HostPaymentRequests' }),
         },
         {
-          if: !isIndividual && !hasHosting,
+          if: !isIndividual && !hasHosting && !showDisbursementWorkflowTools,
           section: ALL_SECTIONS.PAYMENT_REQUESTS,
           label: intl.formatMessage({ defaultMessage: 'Payment Requests', id: 'PaymentRequests' }),
         },

--- a/components/dashboard/sections/expenses/ApprovePaymentRequests.tsx
+++ b/components/dashboard/sections/expenses/ApprovePaymentRequests.tsx
@@ -126,12 +126,16 @@ const ApprovePaymentRequests = ({ accountSlug: hostSlug }: DashboardSectionProps
     },
     views,
     lockViewFilters: true,
-    skipFiltersOnReset: ['hostContext'],
+    ...(account.hasHosting ? { skipFiltersOnReset: ['hostContext'] } : {}),
   });
+
+  const expenseFilterVariables = account.hasHosting
+    ? queryFilter.variables
+    : omit(queryFilter.variables, 'hostContext');
 
   const variables = {
     hostSlug,
-    ...queryFilter.variables,
+    ...expenseFilterVariables,
     status: [ExpenseStatusFilter.PENDING, ExpenseStatusFilter.UNVERIFIED],
     fetchGrantHistory: false,
   };
@@ -154,11 +158,13 @@ const ApprovePaymentRequests = ({ accountSlug: hostSlug }: DashboardSectionProps
         title={
           <div className="flex flex-1 flex-wrap items-center justify-between gap-4">
             <FormattedMessage defaultMessage="Approve Payment Requests" id="ApprovePaymentRequests" />
-            <HostContextFilter
-              value={queryFilter.values.hostContext}
-              onChange={val => queryFilter.setFilter('hostContext', val)}
-              intl={intl}
-            />
+            {account.hasHosting && (
+              <HostContextFilter
+                value={queryFilter.values.hostContext}
+                onChange={val => queryFilter.setFilter('hostContext', val)}
+                intl={intl}
+              />
+            )}
           </div>
         }
         description={<FormattedMessage defaultMessage="Approve payment requests" id="DKcbG3" />}

--- a/components/dashboard/sections/expenses/HostPaymentRequests.tsx
+++ b/components/dashboard/sections/expenses/HostPaymentRequests.tsx
@@ -335,12 +335,16 @@ const HostPaymentRequests = ({ accountSlug: hostSlug, subpath }: DashboardSectio
       hideExpensesMetaStatuses: true,
     },
     views,
-    skipFiltersOnReset: ['hostContext'],
+    ...(account.hasHosting ? { skipFiltersOnReset: ['hostContext'] } : {}),
   });
+
+  const expenseFilterVariables = account.hasHosting
+    ? queryFilter.variables
+    : omit(queryFilter.variables, 'hostContext');
 
   const variables = {
     hostSlug,
-    ...queryFilter.variables,
+    ...expenseFilterVariables,
     fetchGrantHistory: false,
   };
 
@@ -351,7 +355,7 @@ const HostPaymentRequests = ({ accountSlug: hostSlug, subpath }: DashboardSectio
   const { data: metaData } = useQuery(hostPaymentRequestsMetadataQuery, {
     variables: {
       hostSlug,
-      hostContext: queryFilter.values.hostContext,
+      ...(account.hasHosting ? { hostContext: queryFilter.values.hostContext } : {}),
     },
   });
 
@@ -388,11 +392,13 @@ const HostPaymentRequests = ({ accountSlug: hostSlug, subpath }: DashboardSectio
         title={
           <div className="flex flex-1 flex-wrap items-center justify-between gap-4">
             <FormattedMessage defaultMessage="All Payment Requests" id="HostPaymentRequests" />
-            <HostContextFilter
-              value={queryFilter.values.hostContext}
-              onChange={val => queryFilter.setFilter('hostContext', val)}
-              intl={intl}
-            />
+            {account.hasHosting && (
+              <HostContextFilter
+                value={queryFilter.values.hostContext}
+                onChange={val => queryFilter.setFilter('hostContext', val)}
+                intl={intl}
+              />
+            )}
           </div>
         }
         description={<FormattedMessage defaultMessage="All submitted payment requests" id="vpLBRJ" />}

--- a/components/dashboard/sections/expenses/PayDisbursements.tsx
+++ b/components/dashboard/sections/expenses/PayDisbursements.tsx
@@ -198,8 +198,12 @@ const PayDisbursements = ({ accountSlug: hostSlug }: DashboardSectionProps) => {
       accountingCategoryKinds: ExpenseAccountingCategoryKinds,
     },
     views,
-    skipFiltersOnReset: ['hostContext'],
+    ...(account.hasHosting ? { skipFiltersOnReset: ['hostContext'] } : {}),
   });
+
+  const expenseFilterVariables = account.hasHosting
+    ? queryFilter.variables
+    : omit(queryFilter.variables, 'hostContext');
 
   const {
     data: metaData,
@@ -208,7 +212,7 @@ const PayDisbursements = ({ accountSlug: hostSlug }: DashboardSectionProps) => {
   } = useQuery(hostDashboardMetadataQuery, {
     variables: {
       hostSlug,
-      hostContext: queryFilter.values.hostContext,
+      ...(account.hasHosting ? { hostContext: queryFilter.values.hostContext } : {}),
     },
   });
 
@@ -223,7 +227,7 @@ const PayDisbursements = ({ accountSlug: hostSlug }: DashboardSectionProps) => {
 
   const variables = {
     hostSlug,
-    ...queryFilter.variables,
+    ...expenseFilterVariables,
     fetchGrantHistory: false,
   };
 
@@ -244,11 +248,13 @@ const PayDisbursements = ({ accountSlug: hostSlug }: DashboardSectionProps) => {
         title={
           <div className="flex flex-1 flex-wrap items-center justify-between gap-4">
             <FormattedMessage defaultMessage="Pay Disbursements" id="El6h63" />
-            <HostContextFilter
-              value={queryFilter.values.hostContext}
-              onChange={val => queryFilter.setFilter('hostContext', val)}
-              intl={intl}
-            />
+            {account.hasHosting && (
+              <HostContextFilter
+                value={queryFilter.values.hostContext}
+                onChange={val => queryFilter.setFilter('hostContext', val)}
+                intl={intl}
+              />
+            )}
           </div>
         }
         description={

--- a/components/dashboard/sections/overview/TodoList.tsx
+++ b/components/dashboard/sections/overview/TodoList.tsx
@@ -5,6 +5,7 @@ import { ArrowRight, Award, Building, HandCoins, MailOpen, Receipt } from 'lucid
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { hasAccountMoneyManagement } from '../../../../lib/collective';
+import { PREVIEW_FEATURE_KEYS } from '../../../../lib/preview-features';
 import { getDashboardRoute } from '../../../../lib/url-helpers';
 import { gql } from '@/lib/graphql/helpers';
 import useLoggedInUser from '@/lib/hooks/useLoggedInUser';
@@ -306,8 +307,13 @@ type AccountTodoItem = {
 // For Hosted Collectives and Orgs with money management (but without hosting)
 export const AccountTodoList = () => {
   const { account } = React.useContext(DashboardContext);
+  const { LoggedInUser } = useLoggedInUser();
 
   const isOrgWithMoneyManagment = account?.type === 'ORGANIZATION' && hasAccountMoneyManagement(account);
+  const hasIncomingOutgoingReorg = LoggedInUser?.hasPreviewFeatureEnabled(
+    PREVIEW_FEATURE_KEYS.SIDEBAR_REORG_INCOMING_OUTGOING,
+  );
+  const useDisbursementWorkflowLinks = isOrgWithMoneyManagment && !account?.hasHosting && hasIncomingOutgoingReorg;
 
   // Additional query for orgs with money management
   const { data } = useQuery(moneyManagingOrgTodoQuery, {
@@ -327,6 +333,12 @@ export const AccountTodoList = () => {
   const toPayExpenseCount = data?.toPayExpenses?.totalCount || 0;
 
   const expensesHref = getDashboardRoute(account, ALL_SECTIONS.PAYMENT_REQUESTS);
+  const pendingExpensesHref = useDisbursementWorkflowLinks
+    ? getDashboardRoute(account, ALL_SECTIONS.APPROVE_PAYMENT_REQUESTS)
+    : expensesHref;
+  const toPayExpensesHref = useDisbursementWorkflowLinks
+    ? getDashboardRoute(account, ALL_SECTIONS.PAY_DISBURSEMENTS)
+    : expensesHref;
 
   const createLink = (href: string) => (chunks: React.ReactNode) => (
     <Link className="font-medium text-primary hover:underline" href={href}>
@@ -344,7 +356,7 @@ export const AccountTodoList = () => {
           defaultMessage="{pendingExpenseCount, plural, one {<Link>{pendingExpenseCount} expense</Link> has} other {<Link>{pendingExpenseCount} expenses</Link> have}} not been reviewed"
           id="PcyeDN"
           values={{
-            Link: createLink(`${expensesHref}?status=PENDING`),
+            Link: createLink(`${pendingExpensesHref}?status=PENDING`),
             pendingExpenseCount,
           }}
         />
@@ -359,7 +371,7 @@ export const AccountTodoList = () => {
           defaultMessage="{toPayExpenseCount, plural, one {<Link>{toPayExpenseCount} expense</Link> is} other {<Link>{toPayExpenseCount} expenses</Link> are}} ready to pay"
           id="SelfHostedTodo.ExpensesToPay"
           values={{
-            Link: createLink(`${expensesHref}?status=READY_TO_PAY`),
+            Link: createLink(`${toPayExpensesHref}?status=READY_TO_PAY`),
             toPayExpenseCount,
           }}
         />


### PR DESCRIPTION
# Description
Align disbursement tools for non-host money managing organizations, with the sidebar/tools for host organizations.

Replacing the singular "Payment Requests" tool with
- Pay Disbursements
- Approve Payment Requests
- All Payment Requests

# Screenshots

<img width="1679" height="569" alt="image" src="https://github.com/user-attachments/assets/8ec47c54-46c9-4336-96bf-096794abc50e" />
