### PR TITLE
Suppress legal name mismatch warning for cross-host expenses

### DIFF
--- a/components/submit-expense/form/PayoutMethodSection.tsx
+++ b/components/submit-expense/form/PayoutMethodSection.tsx
@@ -311,6 +311,7 @@ export const PayoutMethodFormContent = memoWithGetFormProps(function PayoutMetho
                 disableWarningMessages={
                   payeeIsCollectiveFamilyType && !LoggedInUser.isAdminOfCollective(props.payee['host'])
                 }
+                disableNameMismatchWarning={payeeIsCollectiveFamilyType && !payeeIsSameHost}
                 isPaypalConnectEnabled={props['isPaypalConnectEnabled']}
               />
             ))}
@@ -668,6 +669,8 @@ type PayoutMethodRadioGroupItemProps = {
   archived?: boolean;
   /** Hide quick actions to correct missing currency or mismatch name */
   disableWarningMessages?: boolean;
+  /** Hide the legal name mismatch warning (e.g. cross-host payments where the payout method belongs to the recipient Host, not the payee) */
+  disableNameMismatchWarning?: boolean;
   onPaymentMethodDeleted: (deletedPayoutMethodId) => void;
   onPaymentMethodEdited: (newPayoutMethodId: string) => void;
   setNameMismatchReason?: (reason: string) => void;
@@ -1030,7 +1033,7 @@ export const PayoutMethodRadioGroupItem = function PayoutMethodRadioGroupItem(pr
                     </MessageBox>
                   </div>
                 )}
-                {hasLegalNameMismatch && !props.disableWarningMessages && (
+                {hasLegalNameMismatch && !props.disableWarningMessages && !props.disableNameMismatchWarning && (
                   <MessageBox type="warning">
                     <div className="mb-2 font-bold">
                       <FormattedMessage defaultMessage="The names you provided do not match." id="XAPZa0" />


### PR DESCRIPTION
In a cross-host expense the payout method belongs to the recipient Host, not the payee. Comparing the Host's bank account holder name against the payee collective's (often empty) legal name always reports a mismatch and renders a confusing warning. Skip the name mismatch warning when the "between different Hosts" case applies.

<img width="793" height="575" alt="Screenshot 2026-05-29 at 10 25 26" src="https://github.com/user-attachments/assets/12a99383-8da2-44f0-a6e6-b81ece2896bf" />

