### PR TITLE
fix(Expenses): Preserve payout method when editing or duplicating expenses

### DIFF
--- a/components/submit-expense/form/PayoutMethodSection.tsx
+++ b/components/submit-expense/form/PayoutMethodSection.tsx
@@ -63,6 +63,7 @@ function getFormProps(form: ExpenseForm) {
   return {
     ...pick(form, ['setFieldTouched', 'setFieldValue', 'initialLoading', 'refresh', 'isSubmitting']),
     ...pick(form.values, ['payeeSlug', 'payoutMethodId', 'expenseTypeOption']),
+    ...pick(form.startOptions, ['isInlineEdit']),
     ...pick(form.options, [
       'account',
       'host',
@@ -134,13 +135,20 @@ export const PayoutMethodFormContent = memoWithGetFormProps(function PayoutMetho
       setLastUsedPayoutMethod(null);
     }
 
-    if (!props.payoutMethodId && lastUsed) {
-      setFieldValue('payoutMethodId', lastUsed?.id);
-    } else if (
-      props.payoutMethodId !== NEW_PAYOUT_METHOD_ID &&
-      (!props.payoutMethodId || !payoutMethods.some(p => p.id === props.payoutMethodId))
-    ) {
-      setFieldValue('payoutMethodId', payoutMethods.at(0)?.id ?? '');
+    const expensePayoutMethodId = props.expense?.payoutMethod?.id;
+    const isEditingExistingExpensePayoutMethod =
+      expensePayoutMethodId &&
+      (props.payeeSlug === props.expense?.payee?.slug || (props.isInlineEdit && !props.payeeSlug));
+
+    if (!isEditingExistingExpensePayoutMethod) {
+      if (!props.payoutMethodId && lastUsed) {
+        setFieldValue('payoutMethodId', lastUsed?.id);
+      } else if (
+        props.payoutMethodId !== NEW_PAYOUT_METHOD_ID &&
+        (!props.payoutMethodId || !payoutMethods.some(p => p.id === props.payoutMethodId))
+      ) {
+        setFieldValue('payoutMethodId', payoutMethods.at(0)?.id ?? '');
+      }
     }
 
     if (!props.initialLoading) {
@@ -148,8 +156,11 @@ export const PayoutMethodFormContent = memoWithGetFormProps(function PayoutMetho
     }
   }, [
     props.initialLoading,
+    props.isInlineEdit,
     props.payeeSlug,
     props.recentlySubmittedExpenses,
+    props.expense?.payee?.slug,
+    props.expense?.payoutMethod?.id,
     setFieldValue,
     props.payoutMethodId,
     props.payoutMethods,

--- a/components/submit-expense/useExpenseForm.ts
+++ b/components/submit-expense/useExpenseForm.ts
@@ -2499,11 +2499,12 @@ export function useExpenseForm(opts: {
   }, [formOptions.expenseCurrency, expenseForm.values.expenseItems, setFieldValue, expenseLoaded]);
 
   React.useEffect(() => {
-    // Reset selection if the payout method is not supported
+    // Reset selection if the payout method is not supported (only once payout methods have loaded)
     if (
       expenseForm.values.payoutMethodId &&
       !expenseForm.values.payoutMethodId.startsWith('__') &&
-      !formOptions.payoutMethods?.some(p => p.id === expenseForm.values.payoutMethodId)
+      formOptions.payoutMethods !== undefined &&
+      !formOptions.payoutMethods.some(p => p.id === expenseForm.values.payoutMethodId)
     ) {
       setFieldValue('payoutMethodId', null);
     }


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/8820
Resolve https://github.com/opencollective/opencollective/issues/8821

# Description

- Fix a race condition where the wrong payout method was selected by default when opening the "Edit payout method" dialog on a pending expense (e.g. a USD account instead of the EUR account used at submission).
- The same race affected **duplicate expense**: the source expense's payout method was loaded from the API, then overwritten by last-used or first-in-list auto-selection before payout methods finished loading.
- In `useExpenseForm`, only clear an invalid `payoutMethodId` after the payee's payout methods list has actually loaded, avoiding a premature reset while data is still fetching.
- In `PayoutMethodSection`, skip last-used / first-method auto-selection when pre-filling from an existing expense for the same payee (inline edit or duplicate), so the loaded value is not overwritten.
