### PR TITLE
Let invited host admins complete cross-host draft expenses

### DIFF
--- a/components/expenses/Expense.tsx
+++ b/components/expenses/Expense.tsx
@@ -299,7 +299,11 @@ function Expense(props: ExpenseProps) {
       </ExpenseHeader>
 
       {showTaxFormMsg && <TaxFormMessage expense={expense} refetch={refetch} />}
-      {isDraft && !isRecurring && !draftKey && <ExpenseInviteNotificationBanner expense={expense} />}
+      {/* Inviter-only "invite is on its way" banner. Hidden for the invited recipient (who can decline
+          the invite), so a logged-in invitee viewing the draft without a draftKey only sees the welcome banner. */}
+      {isDraft && !isRecurring && !draftKey && !expense?.permissions?.canDeclineExpenseInvite && (
+        <ExpenseInviteNotificationBanner expense={expense} />
+      )}
       {isMissingReceipt && <ExpenseMissingReceiptNotificationBanner expense={expense} />}
 
       <Box mb={3}>

--- a/components/submit-expense/form/PayoutMethodSection.tsx
+++ b/components/submit-expense/form/PayoutMethodSection.tsx
@@ -73,6 +73,7 @@ function getFormProps(form: ExpenseForm) {
       'newPayoutMethodTypes',
       'recentlySubmittedExpenses',
       'isAdminOfPayee',
+      'isAdminOfPayeeHost',
       'loggedInAccount',
       'expense',
       'isPaypalConnectEnabled',
@@ -266,6 +267,7 @@ export const PayoutMethodFormContent = memoWithGetFormProps(function PayoutMetho
       !isVendor &&
       props.payeeSlug !== PAYEE_SLUG_NEW_VENDOR &&
       !props.isAdminOfPayee &&
+      !props.isAdminOfPayeeHost &&
       !(props.expense?.status === ExpenseStatus.DRAFT && !props.loggedInAccount) ? (
         <MessageBox type="info">
           {props.expenseTypeOption === ExpenseType.GRANT ? (
@@ -325,7 +327,9 @@ export const PayoutMethodFormContent = memoWithGetFormProps(function PayoutMetho
           {!(isLoading || isLoadingPayee) &&
             props.newPayoutMethodTypes?.length > 0 &&
             !(isVendor && payoutMethods.length > 0) &&
-            !payeeIsCollectiveFamilyType && (
+            (!payeeIsCollectiveFamilyType ||
+              // Cross-host: let an admin of the recipient host add a new payout method on the host
+              (!payeeIsSameHost && props.isAdminOfPayeeHost)) && (
               <RadioGroupCard
                 value={NEW_PAYOUT_METHOD_ID}
                 data-cy="add-new-payout-method"
@@ -414,6 +418,12 @@ const NewPayoutMethodOption = memoWithGetFormProps(function NewPayoutMethodOptio
 
   const isNewPaypalConnect = props.isPaypalConnectEnabled && props.newPayoutMethod?.type === PayoutMethodType.PAYPAL;
 
+  // Cross-host: the listed payout methods (and any new one) belong to the recipient host, not the
+  // payee collective, so a host admin completing the draft must create/connect against the host.
+  const payeeHost = props.payee && 'host' in props.payee ? props.payee.host : null;
+  const isCrossHostPayee = Boolean(payeeHost && props.host && payeeHost.id !== props.host.id);
+  const payoutMethodAccount = isCrossHostPayee ? payeeHost : props.payee;
+
   const [createPayoutMethod] = useMutation<SavePayoutMethodMutation, SavePayoutMethodMutationVariables>(
     gql`
       mutation SavePayoutMethod($payoutMethod: PayoutMethodInput!, $payeeSlug: String!) {
@@ -425,7 +435,7 @@ const NewPayoutMethodOption = memoWithGetFormProps(function NewPayoutMethodOptio
     {
       variables: {
         payoutMethod: { ...props.newPayoutMethod },
-        payeeSlug: props.payeeSlug,
+        payeeSlug: isCrossHostPayee ? payeeHost.slug : props.payeeSlug,
       },
     },
   );
@@ -632,7 +642,7 @@ const NewPayoutMethodOption = memoWithGetFormProps(function NewPayoutMethodOptio
           {isNewPaypalConnect ? (
             <PaypalConnectButton
               className="w-full"
-              accountId={props.payee.id}
+              accountId={payoutMethodAccount.id}
               onSuccess={onPaypalConnectSuccess}
               onError={onPaypalConnectError}
               loading={creatingPayoutMethod}
@@ -690,6 +700,13 @@ export const PayoutMethodRadioGroupItem = function PayoutMethodRadioGroupItem(pr
   const CardComponent = props.Component || RadioGroupCard;
   const intl = useIntl();
   const { toast } = useToast();
+
+  // Cross-host: the listed payout method belongs to the recipient host, not the payee collective,
+  // so edits/reconnects must target the host (matches the create flow in NewPayoutMethodOption).
+  const payeeHost = props.payee && 'host' in props.payee ? props.payee.host : null;
+  const payerHost = props.account && 'host' in props.account ? props.account.host : null;
+  const isCrossHostPayee = Boolean(payeeHost && payerHost && payeeHost.id !== payerHost.id);
+  const payoutMethodAccount = isCrossHostPayee ? payeeHost : props.payee;
 
   const isEditable =
     props.payoutMethod.type !== PayoutMethodType.ACCOUNT_BALANCE &&
@@ -932,7 +949,7 @@ export const PayoutMethodRadioGroupItem = function PayoutMethodRadioGroupItem(pr
                   props.isPaypalConnectEnabled &&
                   !values.editingPayoutMethod.isVerified ? (
                     <PaypalConnectButton
-                      accountId={props.payee.id}
+                      accountId={payoutMethodAccount.id}
                       payoutMethodId={values.editingPayoutMethod.id}
                       onSuccess={async ({ payoutMethodId }) => {
                         try {

--- a/components/submit-expense/useExpenseForm.ts
+++ b/components/submit-expense/useExpenseForm.ts
@@ -634,6 +634,7 @@ type ExpenseFormOptions = {
   account?: ExpenseFormSchemaQuery['account'] | ExpenseFormSchemaQuery['expense']['account'];
   payee?: ExpenseFormSchemaQuery['payee'];
   isAdminOfPayee?: boolean;
+  isAdminOfPayeeHost?: boolean;
   isHostAdmin?: boolean;
   submitter?: ExpenseFormSchemaQuery['submitter'];
   loggedInAccount?: ExpenseFormSchemaQuery['loggedInAccount'];
@@ -1530,7 +1531,13 @@ async function buildFormOptions(
       options.isAdminOfPayee =
         options.payoutProfiles.some(p => p.slug === values.payeeSlug) ||
         [PAYEE_SLUG_FIND_ACCOUNT_I_ADMINISTER, PAYEE_SLUG_CREATE_LEGAL_ENTITY].includes(values.payeeSlug);
-      if (payee && payee.type !== CollectiveType.VENDOR && options.isAdminOfPayee) {
+      // Cross-host only: the submitter administers the recipient host (e.g. a host admin completing
+      // an invited draft on behalf of a collective they don't directly administer).
+      const isAdminOfPayeeHost = Boolean(
+        payeeHost && host && payeeHost.id !== host.id && options.payoutProfiles.some(p => p.slug === payeeHost.slug),
+      );
+      options.isAdminOfPayeeHost = isAdminOfPayeeHost;
+      if (payee && payee.type !== CollectiveType.VENDOR && (options.isAdminOfPayee || isAdminOfPayeeHost)) {
         // If the payee has a host and the payer account is under a different one, show the host's payout method (cross-host expense)
         if (payee['host'] && host && payee['host'].id !== host.id) {
           options.payoutMethods = payee['host'].payoutMethods?.filter(p =>
@@ -1578,7 +1585,9 @@ async function buildFormOptions(
         options.payoutMethod = options.payoutMethods?.find(p => p.id === values.payoutMethodId);
       } else if (
         values.payoutMethodId === NEW_PAYOUT_METHOD_ID &&
-        ((options.payee?.type === CollectiveType.VENDOR && options.isHostAdmin) || options.isAdminOfPayee)
+        ((options.payee?.type === CollectiveType.VENDOR && options.isHostAdmin) ||
+          options.isAdminOfPayee ||
+          isAdminOfPayeeHost)
       ) {
         options.payoutMethod = values.newPayoutMethod;
       }


### PR DESCRIPTION
A host admin invited to complete a cross-host draft expense hit two issues: the payout method could not be added, and they saw the inviter's "Your invite is on its way" banner alongside their own "You have been invited..." welcome banner.

- useExpenseForm / PayoutMethodSection: in the cross-host case, list the recipient host's payout methods and offer "New payout method" when the submitter administers that host (not just when they admin the payee)
- Expense: gate the inviter banner on !canDeclineExpenseInvite so the invited payee only sees the welcome banner

API: https://github.com/opencollective/opencollective-api/pull/11795
