### PR TITLE
fix(vendors): Do not scope vendor pickers to collectives for host admins

### DIFF
--- a/components/dashboard/sections/collectives/AddFundsModal.tsx
+++ b/components/dashboard/sections/collectives/AddFundsModal.tsx
@@ -504,10 +504,7 @@ const AddFundsModalContentWithCollective = ({
   const applicableTax = getApplicableTaxType(account, host);
   const isEdit = Boolean(editOrderId);
 
-  const { createVendorFromSearch, isCreatingVendor } = useQuickCreateVendor({
-    host,
-    canBeUsedWithAccounts: collective?.slug ? [{ slug: collective.slug }] : [],
-  });
+  const { createVendorFromSearch, isCreatingVendor } = useQuickCreateVendor({ host });
 
   const [submitAddFunds, { error: fundError, loading: isLoading }] = useMutation(
     isEdit ? editAddedFundsMutation : addFundsMutation,
@@ -770,7 +767,6 @@ const AddFundsModalContentWithCollective = ({
                           collective={values.fromAccount}
                           menuPortalTarget={null}
                           includeVendorsForHostId={host?.legacyId || undefined}
-                          vendorVisibleToAccountIds={account?.legacyId ? [account.legacyId] : undefined}
                           creatable={['VENDOR']}
                           HostCollectiveId={host?.legacyId}
                           {...quickCreateVendorCollectivePickerOptions(createVendorFromSearch)}

--- a/components/dashboard/sections/contributions/CreatePendingOrderModal.tsx
+++ b/components/dashboard/sections/contributions/CreatePendingOrderModal.tsx
@@ -496,7 +496,6 @@ const CreatePendingContributionForm = ({ host, onClose, error, edit }: CreatePen
               onChange={({ value }) => form.setFieldValue(field.name, value)}
               collective={field.value}
               includeVendorsForHostId={collective?.host?.legacyId}
-              vendorVisibleToAccountIds={collective?.legacyId ? [collective.legacyId] : []}
               menuPortalTarget={null}
               creatable={['USER', 'VENDOR']}
               HostCollectiveId={host?.legacyId}

--- a/components/dashboard/sections/expenses/HostCreateExpenseModal.tsx
+++ b/components/dashboard/sections/expenses/HostCreateExpenseModal.tsx
@@ -41,11 +41,7 @@ import { useToast } from '../../../ui/useToast';
 import { TransactionsImportRowDetails } from '../transactions-imports/TransactionsImportRowDetailsAccordion';
 
 const hostCreateExpenseModalPayeeSelectQuery = gql`
-  query HostCreateExpenseModalPayeeSelect(
-    $hostId: String!
-    $forAccount: AccountReferenceInput
-    $canBeUsedWithAccounts: [AccountReferenceInput]
-  ) {
+  query HostCreateExpenseModalPayeeSelect($hostId: String!, $forAccount: AccountReferenceInput) {
     host(id: $hostId) {
       id
       slug
@@ -54,7 +50,7 @@ const hostCreateExpenseModalPayeeSelectQuery = gql`
       description
       isHost
       imageUrl(height: 64)
-      vendors(forAccount: $forAccount, canBeUsedWithAccounts: $canBeUsedWithAccounts) {
+      vendors(forAccount: $forAccount) {
         nodes {
           id
           slug
@@ -81,7 +77,6 @@ const PayeeSelect = ({
     variables: {
       hostId: host.id,
       forAccount: getAccountReferenceInput(forAccount),
-      canBeUsedWithAccounts: forAccount?.slug ? [{ slug: forAccount.slug }] : null,
     },
   });
   const recommendedVendors = data?.host?.vendors?.nodes || [];
@@ -104,7 +99,6 @@ const PayeeSelect = ({
       customOptions={defaultSourcesOptions}
       menuPortalTarget={null}
       includeVendorsForHostId={host.legacyId}
-      vendorVisibleToAccountIds={forAccount?.legacyId ? [forAccount.legacyId] : undefined}
       creatable={['USER', 'VENDOR']}
       HostCollectiveId={host.legacyId}
       isLoading={loading}

--- a/components/submit-expense/form/WhoIsGettingPaidSection.tsx
+++ b/components/submit-expense/form/WhoIsGettingPaidSection.tsx
@@ -413,7 +413,6 @@ const VendorOption = React.memo(function VendorOption(props: {
   const isBeneficiary = props.expenseTypeOption === ExpenseType.GRANT;
   const { createVendorFromSearch, isCreatingVendor } = useQuickCreateVendor({
     host: props.host,
-    canBeUsedWithAccounts: props.account?.id ? [pick(props.account, 'id')] : [],
     isBeneficiary,
   });
   // Setting a state variable to keep the Vendor option open when a vendor that is not part of the preloaded vendors is selected
@@ -457,7 +456,7 @@ const VendorOption = React.memo(function VendorOption(props: {
               setSelectedVendor(selected);
               props.setFieldValue('payeeSlug', !slug ? PAYEE_SLUG_VENDOR : slug);
             }}
-            vendorVisibleToAccountIds={props.account.legacyId}
+            vendorVisibleToAccountIds={isHostAdmin ? undefined : props.account.legacyId}
           />
         </div>
       }

--- a/test/cypress/integration/41-vendor-visibility.test.ts
+++ b/test/cypress/integration/41-vendor-visibility.test.ts
@@ -20,6 +20,12 @@ function assertVendorScopedTo(expectedAccountName: string) {
   });
 }
 
+function assertVendorVisibleToAllHostedCollectives() {
+  cy.get('[data-cy="vendor-form"]').within(() => {
+    cy.get('#whereScope-all-hosted').should('have.attr', 'data-state', 'checked');
+  });
+}
+
 function setUseVendorPolicy(
   hostSlug: string,
   policy: UseVendorPolicy | `${UseVendorPolicy}`,
@@ -453,8 +459,8 @@ describe('vendor visibility', () => {
     });
   });
 
-  describe('Add Funds source picker', () => {
-    it('shows the usable vendor and hides one scoped to a different collective in the source dropdown', function () {
+  describe('Add Funds source picker (host admin)', () => {
+    it('shows vendors scoped to other collectives when adding funds', function () {
       setupHostAndCollective().then(({ host, hostAdmin, collective }) => {
         cy.createCollectiveV2({
           email: hostAdmin.email,
@@ -462,16 +468,16 @@ describe('vendor visibility', () => {
           host: { slug: host.slug },
           collective: { name: 'Add Funds Other Collective' },
         }).then(otherCollective => {
-          const usableName = NEW_VENDOR_NAME('add-funds-usable');
-          const elsewhereName = NEW_VENDOR_NAME('add-funds-elsewhere');
+          const scopedToRecipient = NEW_VENDOR_NAME('add-funds-recipient');
+          const scopedElsewhere = NEW_VENDOR_NAME('add-funds-elsewhere');
           cy.createVendor(
             host.slug,
-            { name: usableName, canBeUsedWithAccounts: [{ slug: collective.slug }] },
+            { name: scopedToRecipient, canBeUsedWithAccounts: [{ slug: collective.slug }] },
             hostAdmin.email,
           );
           cy.createVendor(
             host.slug,
-            { name: elsewhereName, canBeUsedWithAccounts: [{ slug: otherCollective.slug }] },
+            { name: scopedElsewhere, canBeUsedWithAccounts: [{ slug: otherCollective.slug }] },
             hostAdmin.email,
           );
 
@@ -483,9 +489,9 @@ describe('vendor visibility', () => {
           cy.get('#addFunds-fromAccount').click();
           // eslint-disable-next-line cypress/no-unnecessary-waiting
           cy.wait(150);
-          cy.get('#addFunds-fromAccount').type(usableName, { delay: 50 });
-          cy.root().closest('html').contains(usableName).should('exist');
-          cy.root().closest('html').contains(elsewhereName).should('not.exist');
+          cy.get('#addFunds-fromAccount').type(scopedElsewhere, { delay: 50 });
+          cy.root().closest('html').contains(scopedToRecipient).should('exist');
+          cy.root().closest('html').contains(scopedElsewhere).should('exist');
         });
       });
     });
@@ -507,7 +513,7 @@ describe('vendor visibility', () => {
         .should('not.have.attr', 'aria-disabled', 'true')
         .click();
 
-    it('Add Funds modal: created vendor is scoped to the paying collective', function () {
+    it('Add Funds modal: host-created vendor is visible to all hosted collectives', function () {
       setupHostAndCollective().then(({ host, hostAdmin, collective }) => {
         cy.login({ email: hostAdmin.email, redirect: `/dashboard/${host.slug}/hosted-collectives` });
 
@@ -526,11 +532,11 @@ describe('vendor visibility', () => {
         clickCreateOption(`Create vendor: ${name}`);
 
         openVendorEditForm(host.slug, hostAdmin.email, name);
-        assertVendorScopedTo(collective.name);
+        assertVendorVisibleToAllHostedCollectives();
       });
     });
 
-    it('Expense flow: inline-created vendor is scoped to the paying collective', function () {
+    it('Expense flow (host admin): inline-created vendor is visible to all hosted collectives', function () {
       setupHostAndCollective().then(({ host, hostAdmin, collective }) => {
         cy.login({ email: hostAdmin.email, redirect: `/${collective.slug}/expenses/new` });
         cy.get('#WHO_IS_GETTING_PAID').within(() => {
@@ -545,11 +551,11 @@ describe('vendor visibility', () => {
         clickCreateOption(`Create vendor: ${name}`);
 
         openVendorEditForm(host.slug, hostAdmin.email, name);
-        assertVendorScopedTo(collective.name);
+        assertVendorVisibleToAllHostedCollectives();
       });
     });
 
-    it('Pending contribution modal: inline-created vendor is scoped to the receiving collective', function () {
+    it('Pending contribution modal: host-created vendor is visible to all hosted collectives', function () {
       setupHostAndCollective().then(({ host, hostAdmin, collective }) => {
         cy.login({ email: hostAdmin.email, redirect: `/dashboard/${host.slug}/expected-funds` });
         cy.getByDataCy('create-pending-contribution').click();
@@ -572,11 +578,11 @@ describe('vendor visibility', () => {
         cy.contains('button', /Create vendor/i).click();
 
         openVendorEditForm(host.slug, hostAdmin.email, name);
-        assertVendorScopedTo(collective.name);
+        assertVendorVisibleToAllHostedCollectives();
       });
     });
 
-    it('Grant flow: inline-created beneficiary is scoped to the paying collective', function () {
+    it('Grant flow (host admin): inline-created beneficiary is visible to all hosted collectives', function () {
       setupHostAndCollective({ enableGrants: true }).then(({ host, hostAdmin, collective }) => {
         cy.login({ email: hostAdmin.email, redirect: `/${collective.slug}/grants/new` });
         cy.contains('button', 'Proceed').click();
@@ -592,7 +598,7 @@ describe('vendor visibility', () => {
         clickCreateOption(`Create beneficiary: ${name}`);
 
         openVendorEditForm(host.slug, hostAdmin.email, name);
-        assertVendorScopedTo(collective.name);
+        assertVendorVisibleToAllHostedCollectives();
       });
     });
   });


### PR DESCRIPTION
# Description

Fix for issue reported on [Slack](https://oficonsortium.slack.com/archives/C03KTPY9414/p1780392274063139?thread_ts=1778785558.844509&cid=C03KTPY9414). 

Host admins were limited by per-collective vendor visibility in Add Funds, expected funds, host create expense, and expense/grant payee pickers. This removes that filtering and stops silently auto-scoping vendors to the recipient collective on inline create. Collective submitters still get scoped vendor search on expense submission.