### PR TITLE
fix(Grants): Add rich text editor for item descriptions

### DIFF
--- a/components/HTMLContent.js
+++ b/components/HTMLContent.js
@@ -33,6 +33,9 @@ export const isEmptyHTMLValue = value => {
   }
 };
 
+/** Returns '' for empty rich-text scaffold HTML (e.g. Trix/React-Quill), otherwise the original value. */
+export const normalizeRichTextContent = value => (isEmptyHTMLValue(value) ? '' : value);
+
 const InlineDisplayBox = styled.div.withConfig({
   shouldForwardProp: (prop, target) => defaultShouldForwardProp(prop, target),
 })`

--- a/components/__tests__/HTMLContent.test.js
+++ b/components/__tests__/HTMLContent.test.js
@@ -4,7 +4,7 @@ import React from 'react';
 
 import { snapshot } from '../../test/snapshot-helpers';
 
-import HTMLContent from '../HTMLContent';
+import HTMLContent, { isEmptyHTMLValue, normalizeRichTextContent } from '../HTMLContent';
 
 describe('HTMLContent', () => {
   it('renders simple HTML string', () => {
@@ -38,5 +38,31 @@ describe('HTMLContent', () => {
 
   it('handles broken HTML', () => {
     snapshot(<HTMLContent content="<p>Broken <strong>HTML</body></html>" />);
+  });
+});
+
+describe('isEmptyHTMLValue', () => {
+  it('detects empty rich-text scaffold HTML', () => {
+    expect(isEmptyHTMLValue('')).toBe(true);
+    expect(isEmptyHTMLValue('<div><br></div>')).toBe(true);
+    expect(isEmptyHTMLValue('<div><!--block--><br></div>')).toBe(true);
+    expect(isEmptyHTMLValue('<p><br/></p>')).toBe(true);
+  });
+
+  it('detects non-empty rich-text content', () => {
+    expect(isEmptyHTMLValue('<p>Hello</p>')).toBe(false);
+    expect(isEmptyHTMLValue('<div><img src="x.png"></div>')).toBe(false);
+  });
+});
+
+describe('normalizeRichTextContent', () => {
+  it('returns empty string for scaffold HTML', () => {
+    expect(normalizeRichTextContent('<div><br></div>')).toBe('');
+    expect(normalizeRichTextContent('')).toBe('');
+  });
+
+  it('returns original value for real content', () => {
+    const content = '<p>Item description</p>';
+    expect(normalizeRichTextContent(content)).toBe(content);
   });
 });

--- a/components/submit-expense/form/ExpenseItemsSection.tsx
+++ b/components/submit-expense/form/ExpenseItemsSection.tsx
@@ -37,12 +37,13 @@ import InputAmount from '@/components/InputAmount';
 import { Checkbox } from '@/components/ui/Checkbox';
 import { RadioGroup, RadioGroupCard } from '@/components/ui/RadioGroup';
 import { Skeleton } from '@/components/ui/Skeleton';
-import { Textarea } from '@/components/ui/Textarea';
 
 import Dropzone, { MemoizedDropzone } from '../../Dropzone';
 import { ExchangeRate } from '../../ExchangeRate';
 import FormattedMoneyAmount from '../../FormattedMoneyAmount';
+import { normalizeRichTextContent } from '../../HTMLContent';
 import MessageBox from '../../MessageBox';
+import RichTextEditor from '../../RichTextEditor';
 import StyledSelect from '../../StyledSelect';
 import { Button } from '../../ui/Button';
 import { Input, InputGroup } from '../../ui/Input';
@@ -434,7 +435,26 @@ const ExpenseItem = memoWithGetFormProps(function ExpenseItem(props: ExpenseItem
             >
               {({ field }) => {
                 if (props.isLongFormItemDescription) {
-                  return <Textarea {...field} />;
+                  return (
+                    <RichTextEditor
+                      id={field.id}
+                      withBorders
+                      version="simplified"
+                      inputName={field.name}
+                      editorMinHeight={120}
+                      onChange={e =>
+                        setFieldValue(
+                          `expenseItems.${props.index}.description`,
+                          normalizeRichTextContent(e.target.value),
+                        )
+                      }
+                      disabled={props.isDescriptionLocked || props.isSubmitting}
+                      defaultValue={item.description}
+                      fontSize="14px"
+                      data-cy={field.name}
+                      placeholder={field.placeholder}
+                    />
+                  );
                 }
                 return <Input {...field} />;
               }}

--- a/components/submit-expense/form/SummarySection.tsx
+++ b/components/submit-expense/form/SummarySection.tsx
@@ -24,6 +24,7 @@ import { AvatarWithLink } from '../../AvatarWithLink';
 import DateTime from '../../DateTime';
 import ExpenseTypeTag from '../../expenses/ExpenseTypeTag';
 import FormattedMoneyAmount from '../../FormattedMoneyAmount';
+import HTMLContent, { isEmptyHTMLValue } from '../../HTMLContent';
 import LinkCollective from '../../LinkCollective';
 import MessageBox from '../../MessageBox';
 import { PayoutMethodLabel } from '../../PayoutMethodLabel';
@@ -238,7 +239,9 @@ const ExpenseItemsSection = React.memo(function ExpenseItemSection(
               )}
               <div className="grow">
                 <div>
-                  {ei.description || (
+                  {!isEmptyHTMLValue(ei.description) ? (
+                    <HTMLContent content={ei.description} fontSize="14px" fontWeight="500" />
+                  ) : (
                     <span className="text-muted-foreground">
                       <FormattedMessage defaultMessage="Item description" id="1TNkWq" />
                     </span>

--- a/components/submit-expense/useExpenseForm.ts
+++ b/components/submit-expense/useExpenseForm.ts
@@ -66,6 +66,7 @@ import { AccountingCategorySelectFieldsFragment } from '../AccountingCategorySel
 import { loggedInAccountExpensePayoutFieldsFragment } from '../expenses/graphql/fragments';
 import { validatePayoutMethod } from '../expenses/PayoutMethodForm';
 import { getCustomZodErrorMap } from '../FormikZod';
+import { isEmptyHTMLValue } from '../HTMLContent';
 
 import { supportsBaseExpenseTypes } from './form/helper';
 
@@ -917,7 +918,7 @@ function buildFormSchema(
                 return true;
               }
 
-              return v.length > 0;
+              return !isEmptyHTMLValue(v);
             }, requiredMessage),
           attachment: z
             .union([

--- a/test/cypress/integration/32-grant-submission.test.ts
+++ b/test/cypress/integration/32-grant-submission.test.ts
@@ -58,7 +58,7 @@ describe('Grant Submission Flow', () => {
 
     // Application content section
     cy.contains('Application Content').scrollIntoView().should('be.visible');
-    cy.get('textarea[name="expenseItems.0.description"]').type('Grant application for community project');
+    cy.get('[data-cy="expenseItems.0.description"] trix-editor').type('Grant application for community project');
     cy.get('input[name="expenseItems.0.amount.valueInCents"]').type('{selectall}1000');
 
     // Proceed to summary
@@ -126,7 +126,7 @@ describe('Grant Submission Flow', () => {
     });
 
     cy.contains('Application Content').scrollIntoView();
-    cy.get('textarea[name="expenseItems.0.description"]').type('Grant application for community project');
+    cy.get('[data-cy="expenseItems.0.description"] trix-editor').type('Grant application for community project');
     cy.get('input[name="expenseItems.0.amount.valueInCents"]').type('{selectall}1000');
 
     cy.contains('button', 'Proceed to Summary').click();
@@ -183,7 +183,7 @@ describe('Grant Submission Flow', () => {
     });
 
     cy.contains('Application Content').scrollIntoView();
-    cy.get('textarea[name="expenseItems.0.description"]').type('Grant application for community project');
+    cy.get('[data-cy="expenseItems.0.description"] trix-editor').type('Grant application for community project');
     cy.get('input[name="expenseItems.0.amount.valueInCents"]').type('{selectall}1000');
 
     cy.contains('button', 'Proceed to Summary').click();
@@ -234,7 +234,7 @@ describe('Grant Submission Flow', () => {
     });
 
     cy.contains('Application Content').scrollIntoView();
-    cy.get('textarea[name="expenseItems.0.description"]').type('Grant application for community project');
+    cy.get('[data-cy="expenseItems.0.description"] trix-editor').type('Grant application for community project');
     cy.get('input[name="expenseItems.0.amount.valueInCents"]').type('{selectall}1000');
 
     cy.contains('button', 'Proceed to Summary').click();

--- a/test/cypress/integration/41-vendor-visibility.test.ts
+++ b/test/cypress/integration/41-vendor-visibility.test.ts
@@ -443,7 +443,7 @@ describe('vendor visibility', () => {
           cy.get('#__vendor').type(name);
           cy.root().closest('html').contains('[role="option"]', name).click();
           cy.get('[name="title"]').type('Grant submit visibility test');
-          cy.get('[name="expenseItems.0.description"]').type('Grant test item');
+          cy.get('[data-cy="expenseItems.0.description"] trix-editor').type('Grant test item');
           cy.get('[name="expenseItems.0.amount.valueInCents"]').type('{selectall}1000');
           cy.contains('button', 'Proceed to Summary').click();
           cy.contains('button', 'Submit Grant Request').click();


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/8435

# Description

Enables the rich text editor for the "expense items" description when creating/editing grants, both in the submission flow and in the edit details dialog (same component used).

Also makes sure to use format html in the "Preview grant summary" step.

# Screenshots
<img width="732" height="738" alt="image" src="https://github.com/user-attachments/assets/aced142e-7b0c-4adc-b6d7-118e04879dbf" />

