### PR TITLE
fix(Dashboard): filter grants from submitted expenses

### DIFF
--- a/components/dashboard/menu-items.ts
+++ b/components/dashboard/menu-items.ts
@@ -283,7 +283,7 @@ export const getMenuItems = ({ intl, account, LoggedInUser }): MenuItem[] => {
       Icon: Shuffle,
     },
     {
-      if: isIndividual && hasIssuedGrantRequests,
+      if: isIndividual,
       Icon: Award,
       label: intl.formatMessage({ defaultMessage: 'Grant Requests', id: 'fng2Fr' }),
       section: ALL_SECTIONS.SUBMITTED_GRANTS,

--- a/components/dashboard/sections/expenses/SubmittedExpenses.tsx
+++ b/components/dashboard/sections/expenses/SubmittedExpenses.tsx
@@ -20,7 +20,7 @@ import { Pagination } from '../../filters/Pagination';
 import type { DashboardSectionProps } from '../../types';
 
 import type { FilterMeta } from './filters';
-import { ExpenseAccountingCategoryKinds, filters, schema, toVariables } from './filters';
+import { filters, schema, toVariables } from './filters';
 import { accountExpensesQuery } from './queries';
 
 const ROUTE_PARAMS = ['slug', 'section', 'subpath'];
@@ -33,10 +33,16 @@ const SubmittedExpenses = ({ accountSlug }: DashboardSectionProps) => {
 
   const omitExpenseTypes = [ExpenseType.GRANT];
 
-  const queryFilter = useQueryFilter<typeof schema, { type: ExpenseType }>({
+  const filterMeta: FilterMeta = {
+    currency: (LoggedInUser?.collective?.currency || 'USD') as Currency,
+    omitExpenseTypes,
+  };
+
+  const queryFilter = useQueryFilter<typeof schema, { type: ExpenseType }, FilterMeta>({
     schema,
     toVariables,
     filters,
+    meta: filterMeta,
   });
   const createdByAccount = accountSlug === LoggedInUser?.collective.slug ? { slug: accountSlug } : null;
   const fromAccount = !createdByAccount ? { slug: accountSlug } : null;
@@ -59,12 +65,6 @@ const SubmittedExpenses = ({ accountSlug }: DashboardSectionProps) => {
   } = useQuery(accountExpensesQuery, {
     variables,
   });
-
-  const filterMeta: FilterMeta = {
-    currency: (LoggedInUser?.collective?.currency || 'USD') as Currency,
-    omitExpenseTypes,
-    accountingCategoryKinds: ExpenseAccountingCategoryKinds,
-  };
 
   const pageRoute = `/dashboard/${accountSlug}/submitted-expenses`;
 


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/8566

# Description

- Filter out grants from "Submitted Expenses"
- Always show "Grant Requests" for individuals (was conditionally rendered based on if you had submitted any)