### PR TITLE
fix(PlatformTip): don't recompute stored tip when editing recurring contribution amount

### DIFF
--- a/components/EditOrderModal.tsx
+++ b/components/EditOrderModal.tsx
@@ -368,21 +368,30 @@ const EditPlatformTipModal = (props: Omit<EditOrderModalProps, 'action'>) => {
     props.onSuccess?.();
   };
   const { toast } = useToast();
-  const [tipAmount, setTipAmount] = React.useState(props.order.platformTipAmount?.valueInCents || 0);
+  const orderAmount = props.order.amount.valueInCents;
+  const orderCurrency = props.order.amount.currency;
+  const storedTipAmount = props.order.platformTipAmount?.valueInCents || 0;
+  const [tipAmount, setTipAmount] = React.useState(storedTipAmount);
   const [selectedTipOption, setSelectedTipOption] = React.useState(() =>
-    getPlatformTipOptionFromAmount(
-      props.order.platformTipAmount?.valueInCents || 0,
-      props.order.amount.valueInCents,
-      props.order.amount.currency,
-    ),
+    getPlatformTipOptionFromAmount(storedTipAmount, orderAmount, orderCurrency),
   );
+  // If the contribution amount changes under the modal (e.g. after editing the amount and
+  // refetching), reset to the freshly-fetched tip so the selected percentage can't stay stale —
+  // otherwise the still-highlighted preset becomes a no-op click that keeps the old tip.
+  const prevOrderAmountRef = React.useRef(orderAmount);
+  React.useEffect(() => {
+    if (prevOrderAmountRef.current !== orderAmount) {
+      prevOrderAmountRef.current = orderAmount;
+      setTipAmount(storedTipAmount);
+      setSelectedTipOption(getPlatformTipOptionFromAmount(storedTipAmount, orderAmount, orderCurrency));
+    }
+  }, [orderAmount, storedTipAmount, orderCurrency]);
   const { isSubmittingPlatformTip, updatePlatformTip } = useUpdatePlatformTip({
     contribution: props.order,
     onSuccess: handleSuccess,
   });
   const isPaypal = props.order.paymentMethod.service === PAYMENT_METHOD_SERVICE.PAYPAL;
-  const currentTipAmount = props.order.platformTipAmount?.valueInCents || 0;
-  const totalAmount = props.order.totalAmount.valueInCents - currentTipAmount + tipAmount;
+  const totalAmount = props.order.totalAmount.valueInCents - storedTipAmount + tipAmount;
 
   return (
     <Dialog open={props.open} onOpenChange={props.setOpen}>
@@ -410,6 +419,7 @@ const EditPlatformTipModal = (props: Omit<EditOrderModalProps, 'action'>) => {
             currency={props.order.platformTipAmount?.currency || props.order.amount.currency}
             showHeader={false}
             showOptOutNudge={false}
+            disableAmountSync
             selectedOption={selectedTipOption}
             value={tipAmount}
             onChange={(selectedOption, value) => {

--- a/components/contribution-flow/NewPlatformTipContainer.tsx
+++ b/components/contribution-flow/NewPlatformTipContainer.tsx
@@ -48,12 +48,18 @@ type NewPlatformTipContainerProps = {
 type NewPlatformTipSelectorProps = Omit<NewPlatformTipContainerProps, 'step'>;
 
 export function NewPlatformTipSelector(
-  props: NewPlatformTipSelectorProps & { showHeader?: boolean; showOptOut?: boolean; showOptOutNudge?: boolean },
+  props: NewPlatformTipSelectorProps & {
+    showHeader?: boolean;
+    showOptOut?: boolean;
+    showOptOutNudge?: boolean;
+    disableAmountSync?: boolean;
+  },
 ) {
   const {
     amount,
     collectiveName,
     currency,
+    disableAmountSync = false,
     onChange,
     selectedOption,
     showHeader = true,
@@ -96,6 +102,12 @@ export function NewPlatformTipSelector(
   );
 
   React.useEffect(() => {
+    // In edit-tip contexts (e.g. updating the tip of an existing recurring contribution) the
+    // contribution amount isn't being edited, so the stored tip must be shown as-is. Re-syncing
+    // it to a percentage of the amount would overwrite the real tip with a wrong value.
+    if (disableAmountSync) {
+      return;
+    }
     if (selectedOption === PlatformTipOption.OTHER || selectedOption === PlatformTipOption.NONE) {
       return;
     }
@@ -103,7 +115,7 @@ export function NewPlatformTipSelector(
     if (nextValue !== value) {
       onChange(selectedOption, nextValue);
     }
-  }, [amount, getTipValueForOption, onChange, selectedOption, value]);
+  }, [amount, disableAmountSync, getTipValueForOption, onChange, selectedOption, value]);
 
   if (amount === 0) {
     return null;

--- a/components/recurring-contributions/UpdateOrderPopUp.js
+++ b/components/recurring-contributions/UpdateOrderPopUp.js
@@ -547,18 +547,27 @@ const UpdateOrderPopUp = ({ contribution, onCloseEdit }) => {
 
 export const UpdatePlatformTipPopUp = ({ contribution, onCloseEdit }) => {
   const { toast } = useToast();
-  const [tipAmount, setTipAmount] = useState(contribution.platformTipAmount?.valueInCents || 0);
+  const orderAmount = contribution.amount.valueInCents;
+  const orderCurrency = contribution.amount.currency;
+  const storedTipAmount = contribution.platformTipAmount?.valueInCents || 0;
+  const [tipAmount, setTipAmount] = useState(storedTipAmount);
   const [selectedTipOption, setSelectedTipOption] = useState(() =>
-    getPlatformTipOptionFromAmount(
-      contribution.platformTipAmount?.valueInCents || 0,
-      contribution.amount.valueInCents,
-      contribution.amount.currency,
-    ),
+    getPlatformTipOptionFromAmount(storedTipAmount, orderAmount, orderCurrency),
   );
+  // If the contribution amount changes under the popup (e.g. after editing the amount and
+  // refetching), reset to the freshly-fetched tip so the selected percentage can't stay stale —
+  // otherwise the still-highlighted preset becomes a no-op click that keeps the old tip.
+  const prevOrderAmountRef = React.useRef(orderAmount);
+  useEffect(() => {
+    if (prevOrderAmountRef.current !== orderAmount) {
+      prevOrderAmountRef.current = orderAmount;
+      setTipAmount(storedTipAmount);
+      setSelectedTipOption(getPlatformTipOptionFromAmount(storedTipAmount, orderAmount, orderCurrency));
+    }
+  }, [orderAmount, storedTipAmount, orderCurrency]);
   const { isSubmittingPlatformTip, updatePlatformTip } = useUpdatePlatformTip({ contribution, onSuccess: onCloseEdit });
   const isPaypal = contribution.paymentMethod.service === PAYMENT_METHOD_SERVICE.PAYPAL;
-  const currentTipAmount = contribution.platformTipAmount?.valueInCents || 0;
-  const totalAmount = contribution.totalAmount.valueInCents - currentTipAmount + tipAmount;
+  const totalAmount = contribution.totalAmount.valueInCents - storedTipAmount + tipAmount;
 
   return (
     <Fragment>
@@ -578,6 +587,7 @@ export const UpdatePlatformTipPopUp = ({ contribution, onCloseEdit }) => {
           selectedOption={selectedTipOption}
           showHeader={false}
           showOptOut={false}
+          disableAmountSync
           value={tipAmount}
           onChange={(selectedOption, value) => {
             setSelectedTipOption(selectedOption);


### PR DESCRIPTION
The platform tip edit modal rendered NewPlatformTipSelector, whose effect re-syncs the tip to a percentage of the contribution amount. After editing the amount (e.g. 100 -> 50), the frozen selected option (20%, derived against the old amount) no longer matched the live amount, so the effect overwrote the real stored tip (20) with 20% of the new amount (10). The modal then showed "10, 20% selected" while the actual tip was still 20.

Add an opt-out `disableAmountSync` prop to NewPlatformTipSelector and set it in the edit-tip contexts (EditPlatformTipModal and the legacy UpdatePlatformTipPopUp), where the amount isn't being edited and the stored tip must be shown as-is. The contribution flow keeps the default sync behavior.
