### PR TITLE
fix(ContributionDrawer): remove invalid showChargesSection prop in AcountDetail

### DIFF
--- a/components/dashboard/sections/community/AccountDetail.tsx
+++ b/components/dashboard/sections/community/AccountDetail.tsx
@@ -367,7 +367,6 @@ export function AccountDetails(props: AccountDetailsProps) {
           onClose={() => setOpenContributionId(null)}
           orderId={openContributionId}
           getActions={getContributionActions}
-          showChargesSection
         />
       )}
       {editVendor && query.data?.host && (


### PR DESCRIPTION
ContributionDrawer doesn't accept a showChargesSection prop, it computes the value internally from the order's payment method service. Passing it from the People tool account detail was a redundant prop that failed the typecheck.
