### PR TITLE
fix(Expenses): Process actions cache fixes

### DIFF
--- a/components/dashboard/sections/expenses/ApprovePaymentRequests.tsx
+++ b/components/dashboard/sections/expenses/ApprovePaymentRequests.tsx
@@ -69,8 +69,13 @@ const filters: FilterComponentConfigs<FilterValues, FilterMeta> = {
 /**
  * Remove the expense from the query cache if we're filtering by status and the expense status has changed.
  */
-const onExpenseUpdate = ({ updatedExpense, cache, variables }) => {
+const onExpenseUpdate = ({ updatedExpense, cache, variables, refetchList }) => {
   if (variables.status && updatedExpense.status !== variables.status) {
+    // Actions that go through the confirmation modal (e.g. unapprove) don't provide a cache; refetch instead
+    if (!cache) {
+      refetchList?.();
+      return;
+    }
     cache.updateQuery({ query: hostDashboardExpensesQuery, variables }, data => {
       return {
         ...data,
@@ -183,7 +188,12 @@ const ApprovePaymentRequests = ({ accountSlug: hostSlug }: DashboardSectionProps
             expenses={paginatedExpenses.nodes}
             view="admin"
             onProcess={(expense, cache) => {
-              onExpenseUpdate({ updatedExpense: expense, cache, variables });
+              onExpenseUpdate({
+                updatedExpense: expense,
+                cache,
+                variables,
+                refetchList: () => void expenses.refetch(),
+              });
             }}
             useDrawer
             openExpenseLegacyId={Number(router.query.openExpenseId)}

--- a/components/dashboard/sections/expenses/ApprovePaymentRequests.tsx
+++ b/components/dashboard/sections/expenses/ApprovePaymentRequests.tsx
@@ -66,29 +66,6 @@ const filters: FilterComponentConfigs<FilterValues, FilterMeta> = {
   kycStatus: expenseKYCStatusFilter.filter,
 };
 
-/**
- * Remove the expense from the query cache if we're filtering by status and the expense status has changed.
- */
-const onExpenseUpdate = ({ updatedExpense, cache, variables, refetchList }) => {
-  if (variables.status && updatedExpense.status !== variables.status) {
-    // Actions that go through the confirmation modal (e.g. unapprove) don't provide a cache; refetch instead
-    if (!cache) {
-      refetchList?.();
-      return;
-    }
-    cache.updateQuery({ query: hostDashboardExpensesQuery, variables }, data => {
-      return {
-        ...data,
-        expenses: {
-          ...data.expenses,
-          totalCount: data.expenses.totalCount - 1,
-          nodes: data.expenses.nodes?.filter(expense => updatedExpense.id !== expense.id),
-        },
-      };
-    });
-  }
-};
-
 const ROUTE_PARAMS = ['slug', 'section'];
 
 const ApprovePaymentRequests = ({ accountSlug: hostSlug }: DashboardSectionProps) => {
@@ -187,14 +164,10 @@ const ApprovePaymentRequests = ({ accountSlug: hostSlug }: DashboardSectionProps
             nbPlaceholders={paginatedExpenses.limit}
             expenses={paginatedExpenses.nodes}
             view="admin"
-            onProcess={(expense, cache) => {
-              onExpenseUpdate({
-                updatedExpense: expense,
-                cache,
-                variables,
-                refetchList: () => void expenses.refetch(),
-              });
-            }}
+            // Always refetch after a process action; we don't patch the Apollo cache manually
+            // because status filter values can include meta statuses (e.g. READY_TO_PAY) that
+            // can't be reliably evaluated client-side.
+            onProcess={() => void expenses.refetch()}
             useDrawer
             openExpenseLegacyId={Number(router.query.openExpenseId)}
             setOpenExpenseLegacyId={(legacyId, attachmentUrl) => {

--- a/components/dashboard/sections/expenses/PayDisbursements.tsx
+++ b/components/dashboard/sections/expenses/PayDisbursements.tsx
@@ -83,38 +83,16 @@ const filters: FilterComponentConfigs<FilterValues, FilterMeta> = {
 };
 
 /**
- * Remove the expense from the query cache if we're filtering by status and the expense status has changed.
+ * Refetch the list after a process action. We deliberately don't patch the Apollo cache manually:
+ * the status filter can contain meta statuses (e.g. READY_TO_PAY, ON_HOLD) that can't be reliably
+ * evaluated client-side against the expense's new status.
  */
-const onExpenseUpdate = ({
-  updatedExpense,
-  cache,
-  variables,
-  refetchMetaData,
-  refetchPipeline,
-  refetchList,
-  action,
-}) => {
+const onExpenseUpdate = ({ refetchMetaData, refetchPipeline, refetchList, action }) => {
   refetchMetaData(); // Refetch the metadata to update the view counts
   if (shouldRefetchExpensePipeline(action)) {
     refetchPipeline?.();
   }
-  if (variables.status && updatedExpense.status !== variables.status) {
-    // Actions that go through the confirmation modal (e.g. unapprove) don't provide a cache; refetch instead
-    if (!cache) {
-      refetchList?.();
-      return;
-    }
-    cache.updateQuery({ query: hostDashboardExpensesQuery, variables }, data => {
-      return {
-        ...data,
-        expenses: {
-          ...data.expenses,
-          totalCount: data.expenses.totalCount - 1,
-          nodes: data.expenses.nodes?.filter(expense => updatedExpense.id !== expense.id),
-        },
-      };
-    });
-  }
+  refetchList?.();
 };
 
 const ROUTE_PARAMS = ['slug', 'section'];
@@ -344,11 +322,8 @@ const PayDisbursements = ({ accountSlug: hostSlug }: DashboardSectionProps) => {
             nbPlaceholders={paginatedExpenses.limit}
             expenses={paginatedExpenses.nodes}
             view="admin"
-            onProcess={(expense, cache, action) => {
+            onProcess={action => {
               onExpenseUpdate({
-                updatedExpense: expense,
-                cache,
-                variables,
                 refetchMetaData,
                 refetchPipeline,
                 refetchList: () => void expenses.refetch(),

--- a/components/dashboard/sections/expenses/PayDisbursements.tsx
+++ b/components/dashboard/sections/expenses/PayDisbursements.tsx
@@ -85,12 +85,25 @@ const filters: FilterComponentConfigs<FilterValues, FilterMeta> = {
 /**
  * Remove the expense from the query cache if we're filtering by status and the expense status has changed.
  */
-const onExpenseUpdate = ({ updatedExpense, cache, variables, refetchMetaData, refetchPipeline, action }) => {
+const onExpenseUpdate = ({
+  updatedExpense,
+  cache,
+  variables,
+  refetchMetaData,
+  refetchPipeline,
+  refetchList,
+  action,
+}) => {
   refetchMetaData(); // Refetch the metadata to update the view counts
   if (shouldRefetchExpensePipeline(action)) {
     refetchPipeline?.();
   }
   if (variables.status && updatedExpense.status !== variables.status) {
+    // Actions that go through the confirmation modal (e.g. unapprove) don't provide a cache; refetch instead
+    if (!cache) {
+      refetchList?.();
+      return;
+    }
     cache.updateQuery({ query: hostDashboardExpensesQuery, variables }, data => {
       return {
         ...data,
@@ -332,7 +345,15 @@ const PayDisbursements = ({ accountSlug: hostSlug }: DashboardSectionProps) => {
             expenses={paginatedExpenses.nodes}
             view="admin"
             onProcess={(expense, cache, action) => {
-              onExpenseUpdate({ updatedExpense: expense, cache, variables, refetchMetaData, refetchPipeline, action });
+              onExpenseUpdate({
+                updatedExpense: expense,
+                cache,
+                variables,
+                refetchMetaData,
+                refetchPipeline,
+                refetchList: () => void expenses.refetch(),
+                action,
+              });
             }}
             useDrawer
             openExpenseLegacyId={Number(router.query.openExpenseId)}

--- a/components/dashboard/sections/expenses/PaymentRequests.tsx
+++ b/components/dashboard/sections/expenses/PaymentRequests.tsx
@@ -216,7 +216,7 @@ const PaymentRequests = ({ accountSlug }: DashboardSectionProps) => {
   );
 
   const onExpenseProcess = useCallback(
-    (_expense, _cache, action) => {
+    action => {
       refetchAfterExpenseChange({ refetchPipeline: shouldRefetchExpensePipeline(action) });
     },
     [refetchAfterExpenseChange],

--- a/components/expenses/ConfirmProcessExpenseModal.tsx
+++ b/components/expenses/ConfirmProcessExpenseModal.tsx
@@ -187,7 +187,7 @@ export type ConfirmProcessExpenseModalType =
 type ConfirmProcessExpenseModalProps = BaseModalProps & {
   type: ConfirmProcessExpenseModalType;
   expense: Pick<Expense, 'id' | 'legacyId'>;
-  onSuccess?: (action: ConfirmProcessExpenseModalType, updatedExpense?: Expense) => void;
+  onSuccess?: (action: ConfirmProcessExpenseModalType) => void;
 };
 
 export default function ConfirmProcessExpenseModal({
@@ -209,64 +209,49 @@ export default function ConfirmProcessExpenseModal({
 
   const onConfirm = React.useCallback(async () => {
     try {
-      let updatedExpense: Expense | undefined;
-
       switch (type) {
         case 'MARK_AS_INCOMPLETE': {
-          updatedExpense = await processExpense.markAsIncomplete({
-            message,
-          });
+          await processExpense.markAsIncomplete({ message });
           break;
         }
         case 'REQUEST_RE_APPROVAL': {
-          updatedExpense = await processExpense.requestReApproval({
-            message,
-          });
+          await processExpense.requestReApproval({ message });
           break;
         }
         case 'APPROVE': {
-          updatedExpense = await processExpense.approve({
-            message,
-          });
+          await processExpense.approve({ message });
           break;
         }
         case 'UNAPPROVE': {
-          updatedExpense = await processExpense.unapprove({
-            message,
-          });
+          await processExpense.unapprove({ message });
           break;
         }
         case 'REJECT': {
-          updatedExpense = await processExpense.reject({
-            message,
-          });
+          await processExpense.reject({ message });
           break;
         }
         case 'HOLD': {
-          updatedExpense = await processExpense.hold({
-            message,
-          });
+          await processExpense.hold({ message });
           break;
         }
         case 'RELEASE': {
-          updatedExpense = await processExpense.release({
-            message,
-          });
+          await processExpense.release({ message });
           break;
         }
         case 'MARK_AS_SPAM': {
-          updatedExpense = await processExpense.markAsSpam({
-            message,
-          });
+          await processExpense.markAsSpam({ message });
           break;
         }
       }
-
-      setOpen(false);
-      onSuccess?.(type, updatedExpense);
     } catch (error) {
       toast({ variant: 'error', message: i18nGraphqlException(intl, error) });
+      return;
     }
+
+    // Called outside the try/catch so errors thrown by consumers (e.g. refetch logic)
+    // don't surface as a misleading "processing failed" toast.
+    setOpen(false);
+    onSuccess?.(type);
   }, [type, message, intl, onSuccess, processExpense, setOpen]);
 
   const onCloseAutoFocus = (e: Event) => {

--- a/components/expenses/ProcessExpenseButtons.js
+++ b/components/expenses/ProcessExpenseButtons.js
@@ -146,7 +146,7 @@ const ProcessExpenseButtons = ({
   const [confirmProcessExpenseAction, setConfirmProcessExpenseAction] = React.useState();
   const [showApproveExpenseModal, setShowApproveExpenseModal] = React.useState(false);
   const [selectedAction, setSelectedAction] = React.useState(null);
-  const onUpdate = (cache, response) => onSuccess?.(response.data.processExpense, cache, selectedAction);
+  const onUpdate = () => onSuccess?.(selectedAction);
   const mutationOptions = { update: onUpdate };
   const [processExpense, { loading, error }] = useMutation(processExpenseMutation, mutationOptions);
   const intl = useIntl();
@@ -402,7 +402,7 @@ const ProcessExpenseButtons = ({
             }
           }}
           expense={expense}
-          onSuccess={(action, updatedExpense) => onSuccess?.(updatedExpense ?? expense, null, action)}
+          onSuccess={action => onSuccess?.(action)}
         />
       )}
       {showApproveExpenseModal && (

--- a/components/expenses/ProcessExpenseButtons.js
+++ b/components/expenses/ProcessExpenseButtons.js
@@ -146,9 +146,7 @@ const ProcessExpenseButtons = ({
   const [confirmProcessExpenseAction, setConfirmProcessExpenseAction] = React.useState();
   const [showApproveExpenseModal, setShowApproveExpenseModal] = React.useState(false);
   const [selectedAction, setSelectedAction] = React.useState(null);
-  const onUpdate = () => onSuccess?.(selectedAction);
-  const mutationOptions = { update: onUpdate };
-  const [processExpense, { loading, error }] = useMutation(processExpenseMutation, mutationOptions);
+  const [processExpense, { loading, error }] = useMutation(processExpenseMutation);
   const intl = useIntl();
   const { toast } = useToast();
   const { LoggedInUser } = useLoggedInUser();
@@ -228,12 +226,20 @@ const ProcessExpenseButtons = ({
       if (action === 'MARK_AS_PAID_WITH_STRIPE') {
         await waitExpenseStatus();
       }
-
-      return true;
     } catch (e) {
       toast({ variant: 'error', ...getErrorContent(intl, e, host) });
       return false;
     }
+
+    // Notify the parent after the mutation has resolved, and outside the try/catch:
+    // - calling it from the mutation `update` callback would trigger refetches while the
+    //   mutation result is still being written to the cache, preventing the updated expense
+    //   (e.g. its new status) from being broadcast to the list before the refetch completes;
+    // - calling it inside the try/catch would surface consumer errors (e.g. refetch logic)
+    //   as misleading "processing failed" toasts.
+    onSuccess?.(action);
+
+    return true;
   };
 
   const getButtonProps = action => {


### PR DESCRIPTION
## Summary

Three related fixes to expense processing.

Follow up to https://github.com/opencollective/opencollective-frontend/pull/12170 (fixing issue 1 below)
Resolve https://github.com/opencollective/opencollective/issues/8855 (issue 2 below)

### 1. Crash on actions going through the confirmation modal

Actions confirmed via `ConfirmProcessExpenseModal` (unapprove, request re-approval, reject, etc.) passed `null` as the Apollo cache to `onSuccess`, which then called `cache.updateQuery` on it, surfacing as an error toast (`Cannot read properties of null (reading 'updateQuery')`) even though the mutation succeeded. 

Introduced in https://github.com/opencollective/opencollective-frontend/pull/12170

### 2. Faulty cache update replaced by a refetch

The cache update itself was also broken: it compared the expense's new status (a string) against the status filter (an array), so the row was always evicted even when it still matched the filter. We now **always refetch the list after a process action** instead, a correct client-side check isn't feasible because the filter accepts meta statuses (`READY_TO_PAY`, `ON_HOLD`) that can only be evaluated server-side.

### 3. Stale status on direct actions (e.g. Approve)

Direct actions called `onSuccess` from the mutation's `update` callback, i.e. while the mutation result was still being written to the cache. Starting the list refetch at that point put the query in an in-flight network-only state, so the expense's new status was never broadcast to the list, the row sat stale until the refetch removed it. 

### Cleanup

Since no consumer reads the expense or cache anymore, the `onProcess`/`onSuccess` contract is simplified from `(expense, cache, action)` to `(action)`, making the null-cache crash structurally impossible. `ConfirmProcessExpenseModal` also drops its unused `updatedExpense` argument, and both it and `ProcessExpenseButtons` call `onSuccess` outside the `try/catch`, so consumer errors no longer show up as "processing failed" toasts.

## Test plan

- [x] From Pay Disbursements ("Ready to pay"), request re-approval on an expense: no error toast, row leaves the list, counts and pipeline overview update
- [x] Approve an expense from Approve Payment Requests: status flips to "Approved" immediately, then the list refetches and the row is removed
- [x] Process an expense whose new status still matches the active filter and confirm the row is *not* incorrectly removed
- [x] Verify a failing mutation still shows its error toast