### PR TITLE
fix(Expenses): update fetchPolicy to prevent stale cache on mount

### DIFF
--- a/components/dashboard/sections/expenses/ApprovePaymentRequests.tsx
+++ b/components/dashboard/sections/expenses/ApprovePaymentRequests.tsx
@@ -120,6 +120,8 @@ const ApprovePaymentRequests = ({ accountSlug: hostSlug }: DashboardSectionProps
 
   const expenses = useQuery(hostDashboardExpensesQuery, {
     variables,
+    // Revalidate on mount so newly submitted expenses appear without a manual refresh
+    fetchPolicy: 'cache-and-network',
   });
 
   const paginatedExpenses = useLazyGraphQLPaginatedResults(expenses, 'expenses');
@@ -159,7 +161,7 @@ const ApprovePaymentRequests = ({ accountSlug: hostSlug }: DashboardSectionProps
       ) : (
         <React.Fragment>
           <ExpensesList
-            isLoading={loading}
+            isLoading={loading && !data}
             host={data?.host}
             nbPlaceholders={paginatedExpenses.limit}
             expenses={paginatedExpenses.nodes}

--- a/components/dashboard/sections/expenses/HostPaymentRequests.tsx
+++ b/components/dashboard/sections/expenses/HostPaymentRequests.tsx
@@ -346,6 +346,8 @@ const HostPaymentRequests = ({ accountSlug: hostSlug, subpath }: DashboardSectio
 
   const { data, error, loading, refetch } = useQuery(hostDashboardExpensesQuery, {
     variables,
+    // Revalidate on mount so newly submitted expenses appear without a manual refresh
+    fetchPolicy: 'cache-and-network',
   });
 
   const { data: metaData, refetch: refetchMetadata } = useQuery(hostPaymentRequestsMetadataQuery, {
@@ -353,6 +355,7 @@ const HostPaymentRequests = ({ accountSlug: hostSlug, subpath }: DashboardSectio
       hostSlug,
       hostContext: queryFilter.values.hostContext,
     },
+    fetchPolicy: 'cache-and-network',
   });
 
   const viewsWithCount: Views<FilterValues> = useMemo(
@@ -418,7 +421,7 @@ const HostPaymentRequests = ({ accountSlug: hostSlug, subpath }: DashboardSectio
             onClickRow={(row, menuRef) => openDrawer(row.id, menuRef)}
             getRowId={row => String(row.legacyId)}
             queryFilter={queryFilter}
-            loading={loading}
+            loading={loading && !data}
             getActions={getExpenseActions}
             nbPlaceholders={queryFilter.values.limit}
           />

--- a/components/dashboard/sections/expenses/IssuedPaymentRequests.tsx
+++ b/components/dashboard/sections/expenses/IssuedPaymentRequests.tsx
@@ -327,6 +327,8 @@ const IssuedPaymentRequests = ({ accountSlug, subpath }: DashboardSectionProps) 
     refetch: refetchExpenses,
   } = useQuery(dashboardExpensesQuery, {
     variables,
+    // Revalidate on mount so newly submitted expenses appear without a manual refresh
+    fetchPolicy: 'cache-and-network',
   });
 
   const expenses = data?.expenses;
@@ -340,6 +342,7 @@ const IssuedPaymentRequests = ({ accountSlug, subpath }: DashboardSectionProps) 
 
   const { data: metaData } = useQuery(issuedPaymentRequestsMetadataQuery, {
     variables: { ...accountVariables, unrepliedStatuses: unrepliedStatuses },
+    fetchPolicy: 'cache-and-network',
   });
 
   const viewsWithCount: Views<FilterValues> = useMemo(
@@ -421,7 +424,7 @@ const IssuedPaymentRequests = ({ accountSlug, subpath }: DashboardSectionProps) 
               onClickRow={(row, menuRef) => openDrawer(row.id, menuRef)}
               getRowId={row => String(row.legacyId)}
               queryFilter={queryFilter}
-              loading={loading}
+              loading={loading && !data}
               getActions={getExpenseActions}
               nbPlaceholders={queryFilter.values.limit}
             />

--- a/components/dashboard/sections/expenses/PaidDisbursements.tsx
+++ b/components/dashboard/sections/expenses/PaidDisbursements.tsx
@@ -334,6 +334,8 @@ export const PaidDisbursements = ({ accountSlug: hostSlug, subpath }: DashboardS
 
   const { data, error, loading, refetch } = useQuery(paidDisbursementsQuery, {
     variables,
+    // Revalidate on mount so recently paid expenses appear without a manual refresh
+    fetchPolicy: 'cache-and-network',
   });
 
   const { data: metaData } = useQuery(paidDisbursementsMetadataQuery, {
@@ -341,6 +343,7 @@ export const PaidDisbursements = ({ accountSlug: hostSlug, subpath }: DashboardS
       hostSlug,
       hostContext: queryFilter.values.hostContext,
     },
+    fetchPolicy: 'cache-and-network',
   });
 
   const viewsWithCount: Views<FilterValues> = useMemo(
@@ -402,7 +405,7 @@ export const PaidDisbursements = ({ accountSlug: hostSlug, subpath }: DashboardS
             onClickRow={(row, menuRef) => openDrawer(row.id, menuRef)}
             getRowId={row => String(row.legacyId)}
             queryFilter={queryFilter}
-            loading={loading}
+            loading={loading && !data}
             getActions={getExpenseActions}
           />
           <Pagination queryFilter={queryFilter} total={data?.expenses?.totalCount} />

--- a/components/dashboard/sections/expenses/PayDisbursements.tsx
+++ b/components/dashboard/sections/expenses/PayDisbursements.tsx
@@ -203,6 +203,7 @@ const PayDisbursements = ({ accountSlug: hostSlug }: DashboardSectionProps) => {
       hostSlug,
       hostContext: queryFilter.values.hostContext,
     },
+    fetchPolicy: 'cache-and-network',
   });
 
   const viewsWithCount: Views<FilterValues> = useMemo(
@@ -222,6 +223,8 @@ const PayDisbursements = ({ accountSlug: hostSlug }: DashboardSectionProps) => {
 
   const expenses = useQuery(hostDashboardExpensesQuery, {
     variables,
+    // Revalidate on mount so newly submitted expenses appear without a manual refresh
+    fetchPolicy: 'cache-and-network',
   });
 
   const paginatedExpenses = useLazyGraphQLPaginatedResults(expenses, 'expenses');
@@ -317,7 +320,7 @@ const PayDisbursements = ({ accountSlug: hostSlug }: DashboardSectionProps) => {
       ) : (
         <React.Fragment>
           <ExpensesList
-            isLoading={loading}
+            isLoading={loading && !data}
             host={data?.host}
             nbPlaceholders={paginatedExpenses.limit}
             expenses={paginatedExpenses.nodes}

--- a/components/dashboard/sections/expenses/PaymentRequests.tsx
+++ b/components/dashboard/sections/expenses/PaymentRequests.tsx
@@ -146,6 +146,8 @@ const PaymentRequests = ({ accountSlug }: DashboardSectionProps) => {
     refetch: refetchMetadata,
   } = useQuery(paymentRequestsMetadataQuery, {
     variables: { accountSlug },
+    // Revalidate on mount so counts aren't stale when navigating back to this page
+    fetchPolicy: 'cache-and-network',
   });
 
   const viewsWithCount: Views<FilterValues> = useMemo(
@@ -202,6 +204,8 @@ const PaymentRequests = ({ accountSlug }: DashboardSectionProps) => {
       fetchGrantHistory: false,
       ...queryFilter.variables,
     },
+    // Revalidate on mount so newly submitted expenses appear without a manual refresh
+    fetchPolicy: 'cache-and-network',
   });
 
   const refetchAfterExpenseChange = useCallback(
@@ -283,7 +287,7 @@ const PaymentRequests = ({ accountSlug }: DashboardSectionProps) => {
         ) : (
           <React.Fragment>
             <ExpensesList
-              isLoading={loading || loadingMetaData}
+              isLoading={(loading && !data) || (loadingMetaData && !metadata)}
               collective={metadata?.account}
               host={metadata?.account?.host}
               expenses={data?.expenses?.nodes}

--- a/components/dashboard/sections/expenses/ReceivedExpenses.tsx
+++ b/components/dashboard/sections/expenses/ReceivedExpenses.tsx
@@ -103,6 +103,7 @@ const ReceivedExpenses = ({ accountSlug }: DashboardSectionProps) => {
     refetch: refetchMetadata,
   } = useQuery(accountExpensesMetadataQuery, {
     variables: { accountSlug },
+    fetchPolicy: 'cache-and-network',
   });
 
   const isSelfHosted = metadata?.account && metadata.account.id === metadata.account.host?.id;
@@ -137,6 +138,8 @@ const ReceivedExpenses = ({ accountSlug }: DashboardSectionProps) => {
       fetchGrantHistory: false,
       ...queryFilter.variables,
     },
+    // Revalidate on mount so newly submitted expenses appear without a manual refresh
+    fetchPolicy: 'cache-and-network',
   });
 
   const pageRoute = `/dashboard/${accountSlug}/expenses`;
@@ -194,7 +197,7 @@ const ReceivedExpenses = ({ accountSlug }: DashboardSectionProps) => {
         ) : (
           <React.Fragment>
             <ExpensesList
-              isLoading={loading || loadingMetaData}
+              isLoading={(loading && !data) || (loadingMetaData && !metadata)}
               collective={metadata?.account}
               host={metadata?.account?.host}
               expenses={data?.expenses?.nodes}

--- a/components/dashboard/sections/expenses/SubmittedExpenses.tsx
+++ b/components/dashboard/sections/expenses/SubmittedExpenses.tsx
@@ -64,6 +64,8 @@ const SubmittedExpenses = ({ accountSlug }: DashboardSectionProps) => {
     refetch: refetchExpenses,
   } = useQuery(accountExpensesQuery, {
     variables,
+    // Revalidate on mount so newly submitted expenses appear without a manual refresh
+    fetchPolicy: 'cache-and-network',
   });
 
   const pageRoute = `/dashboard/${accountSlug}/submitted-expenses`;
@@ -102,7 +104,7 @@ const SubmittedExpenses = ({ accountSlug }: DashboardSectionProps) => {
         ) : (
           <React.Fragment>
             <ExpensesList
-              isLoading={loading}
+              isLoading={loading && !data}
               collective={data?.account}
               host={data?.account?.isHost ? data?.account : data?.account?.host}
               expenses={data?.expenses?.nodes}

--- a/components/dashboard/sections/overview/TodoList.tsx
+++ b/components/dashboard/sections/overview/TodoList.tsx
@@ -81,6 +81,8 @@ export const HostTodoList = () => {
     variables: {
       hostSlug: account.slug,
     },
+    // Revalidate on mount so todo counts reflect recent actions (e.g. paid expenses)
+    fetchPolicy: 'cache-and-network',
   });
 
   const filteredTodoList = React.useMemo(
@@ -233,7 +235,7 @@ export const HostTodoList = () => {
       </CardHeader>
 
       <div className="divide-y border-t">
-        {loading ? (
+        {loading && !data ? (
           <div className="px-6 py-4">
             <Skeleton className="h-6 w-36" />
           </div>
@@ -313,6 +315,8 @@ export const AccountTodoList = () => {
   const { data } = useQuery(moneyManagingOrgTodoQuery, {
     variables: { slug: account?.slug },
     skip: !isOrgWithMoneyManagment,
+    // Revalidate on mount so todo counts reflect recent actions (e.g. paid expenses)
+    fetchPolicy: 'cache-and-network',
   });
 
   const pendingExpenseCount = account?.pendingExpenses?.totalCount || 0;


### PR DESCRIPTION
Resolve https://github.com/opencollective/opencollective/issues/8767

# Description

- Updates fetchPolicy on several expense dashboard pages from default `cache-first` to `cache-and-network`
- Prevents loading state when there is data in the cache by providing `loading={query.loading && !query.data}` to the lists/tables.
