### PR TITLE
fix(Bank sync): keep last sync info up to date after requesting a resync

### DIFF
--- a/components/dashboard/sections/transactions-imports/OffPlatformConnections.tsx
+++ b/components/dashboard/sections/transactions-imports/OffPlatformConnections.tsx
@@ -68,13 +68,29 @@ export const OffPlatformConnections = ({ accountSlug }) => {
   const isUpgradeRequired = requiresUpgrade(account, FEATURES.OFF_PLATFORM_TRANSACTIONS);
   const queryFilter = useQueryFilter({ schema, filters: {} });
   const [importsWithSyncRequest, setImportsWithSyncRequest] = React.useState(new Set());
-  const [selectedImport, setSelectedImport] = React.useState(null);
+  const [selectedImportId, setSelectedImportId] = React.useState(null);
   const [showNewConnectionDialog, setShowNewConnectionDialog] = React.useState(false);
-  const { data, loading, refetch, error } = useQuery(offPlatformConnectionsQuery, {
+  const { data, loading, refetch, error, startPolling, stopPolling } = useQuery(offPlatformConnectionsQuery, {
     variables: { accountSlug, ...queryFilter.variables },
-    pollInterval: importsWithSyncRequest.size ? 5_000 : 0,
     skip: isUpgradeRequired,
   });
+
+  // Derive from query data so the modal reflects updates (e.g. `lastSyncAt`) while polling
+  const selectedImport = React.useMemo(
+    () =>
+      selectedImportId ? data?.host?.transactionsImports?.nodes?.find(node => node.id === selectedImportId) : null,
+    [data, selectedImportId],
+  );
+
+  // Poll while a sync was requested or is still running server-side, so `lastSyncAt`/`isSyncing` stay up to date
+  const hasSyncingImports = Boolean(data?.host?.transactionsImports?.nodes?.some(node => node.isSyncing));
+  const shouldPoll = importsWithSyncRequest.size > 0 || hasSyncingImports;
+  React.useEffect(() => {
+    if (shouldPoll) {
+      startPolling(5_000);
+      return () => stopPolling();
+    }
+  }, [shouldPoll, startPolling, stopPolling]);
   const onPlaidConnectSuccess = React.useCallback(
     async ({ transactionsImport }) => {
       refetch();
@@ -104,7 +120,7 @@ export const OffPlatformConnections = ({ accountSlug }) => {
     [intl, toast],
   );
   const onPlaidDialogOpen = React.useCallback(() => {
-    setSelectedImport(null);
+    setSelectedImportId(null);
     setShowNewConnectionDialog(false);
   }, []);
 
@@ -214,7 +230,7 @@ export const OffPlatformConnections = ({ accountSlug }) => {
                         </Button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent className="min-w-[180px]" align="end">
-                        <DropdownMenuItem onClick={() => setSelectedImport(row.original)}>
+                        <DropdownMenuItem onClick={() => setSelectedImportId(row.original.id)}>
                           <Settings size={16} />
                           <FormattedMessage defaultMessage="Settings" id="Settings" />
                         </DropdownMenuItem>
@@ -240,7 +256,7 @@ export const OffPlatformConnections = ({ accountSlug }) => {
         <TransactionsImportSettingsModal
           hostId={data.host.id}
           transactionsImport={selectedImport}
-          onOpenChange={() => setSelectedImport(null)}
+          onOpenChange={() => setSelectedImportId(null)}
           plaidStatus={plaidConnectDialog.status}
           showPlaidDialog={plaidConnectDialog.show}
           isOpen={true}
@@ -258,14 +274,14 @@ export const OffPlatformConnections = ({ accountSlug }) => {
             });
           }}
           onDelete={() => {
-            setSelectedImport(null);
+            setSelectedImportId(null);
             toast({
               variant: 'success',
               title: intl.formatMessage({ defaultMessage: 'Connection deleted', id: 'BOy+bE' }),
             });
           }}
           onArchived={() => {
-            setSelectedImport(null);
+            setSelectedImportId(null);
             toast({
               variant: 'success',
               title: intl.formatMessage({ defaultMessage: 'Connection archived', id: 'jZM4f3' }),

--- a/components/dashboard/sections/transactions-imports/TransactionsImportForceSyncButton.tsx
+++ b/components/dashboard/sections/transactions-imports/TransactionsImportForceSyncButton.tsx
@@ -14,6 +14,8 @@ const syncTransactionsImportMutation = gql`
   mutation SyncTransactionsImport($transactionImport: TransactionsImportReferenceInput!) {
     syncTransactionsImport(transactionImport: $transactionImport) {
       id
+      isSyncing
+      lastSyncAt
     }
   }
 `;
@@ -45,14 +47,16 @@ export const TransactionsImportForceSyncButton = ({
     };
   }, []);
 
-  // Reset wasClickedRecently when sync is done
+  // Reset hasRequestedSync when sync is done
   React.useEffect(() => {
     if (prevIsSyncing && !isSyncing) {
       if (setHasRequestedSyncTimeout.current) {
         clearTimeout(setHasRequestedSyncTimeout.current);
+        setHasRequestedSyncTimeout.current = null;
       }
+      setHasRequestedSync(false);
     }
-  }, [toast, intl, isSyncing, prevIsSyncing]);
+  }, [isSyncing, prevIsSyncing, setHasRequestedSync]);
 
   return (
     <Button

--- a/components/dashboard/sections/transactions-imports/TransactionsImportSettingsModal.tsx
+++ b/components/dashboard/sections/transactions-imports/TransactionsImportSettingsModal.tsx
@@ -96,6 +96,18 @@ export default function TransactionsImportSettingsModal({
   const [deleteConnectedAccount, { loading: isDisconnecting }] = useMutation(deleteConnectedAccountMutation);
   const [deleteTransactionsImport, { loading: isDeleting }] = useMutation(deleteTransactionsImportMutation);
 
+  // If the modal unmounts mid-sync, the sync button can't reset the request flag itself, which would leave
+  // the parent polling forever. Mirror the latest values in refs so the unmount cleanup can clear it.
+  const syncRequestRef = React.useRef({ hasRequestedSync, setHasRequestedSync });
+  syncRequestRef.current = { hasRequestedSync, setHasRequestedSync };
+  React.useEffect(() => {
+    return () => {
+      if (syncRequestRef.current.hasRequestedSync) {
+        syncRequestRef.current.setHasRequestedSync(false);
+      }
+    };
+  }, []);
+
   const handleDisconnect = async () => {
     try {
       await deleteConnectedAccount({


### PR DESCRIPTION
Fixes opencollective/opencollective#8768

### Problem

After triggering a bank account resync, the "Last sync" timestamp and sync status did not update until a full page refresh.

### Root causes

1. **Stale modal snapshot.** The settings modal rendered `selectedImport`, a frozen copy of the table row taken when it was opened, so polling updates to the Apollo cache never reached it.
2. **`hasRequestedSync` was never reset.** The effect meant to reset it only cleared the fallback timeout, the only other reset path, so the Synchronize button stayed loading and polling ran forever after a sync completed.
3. **Polling only tracked client-initiated syncs.** Syncs running server-side (automatic, other tab, page loaded mid-sync, or lasting over 30s) were never polled, leaving the "In progress" badge stuck with stale data.

### Changes

- **`OffPlatformConnections.tsx`**: resolve the modal's import from live query data by ID, and poll while a sync was requested **or** any import has `isSyncing: true`, with proper cleanup.
- **`TransactionsImportForceSyncButton.tsx`**: reset `hasRequestedSync` when the sync finishes, and select `isSyncing`/`lastSyncAt` in the mutation response so the UI updates immediately.

### Test plan

- [ ] Open a connection's Settings → Advanced, click "Synchronize": badge shows "In progress", and when the sync completes, the "Last sync" date updates in the modal and table without a refresh.
- [ ] Reload mid-sync: the list polls until done, then stops.