### PR TITLE
fix(expenses): restore invoice download on host payment requests

### DIFF
--- a/components/dashboard/sections/expenses/actions.tsx
+++ b/components/dashboard/sections/expenses/actions.tsx
@@ -31,6 +31,7 @@ import { ExpenseStatus } from '../../../../lib/graphql/types/v2/graphql';
 import { useAsyncCall } from '../../../../lib/hooks/useAsyncCall';
 import useClipboard from '../../../../lib/hooks/useClipboard';
 import useLoggedInUser from '../../../../lib/hooks/useLoggedInUser';
+import { saveInvoice } from '../../../../lib/transactions';
 import { getDashboardRoute, getPermalinkUrl } from '../../../../lib/url-helpers';
 import { collectiveAdminsMustConfirmAccountingCategory } from '@/components/expenses/lib/accounting-categories';
 
@@ -306,20 +307,7 @@ export function useExpenseActions<T extends ExpenseQueryNode>({
     [getExpenseStatus],
   );
 
-  const { callWith: downloadInvoiceWith } = useAsyncCall(
-    async (expense: T) => {
-      const { saveAs } = await import('file-saver');
-      const { fetchFromPDFService } = await import('../../../../lib/api');
-      const { expenseInvoiceUrl } = await import('../../../../lib/url-helpers');
-
-      const invoiceUrl = expenseInvoiceUrl(expense.id);
-      const blob = await fetchFromPDFService(invoiceUrl);
-      const date = new Date().toISOString().split('T')[0];
-      const filename = `Expense-${expense.legacyId}-invoice-${date}.pdf`;
-      return saveAs(blob, filename);
-    },
-    { useErrorToast: true },
-  );
+  const { callWith: downloadInvoiceWith } = useAsyncCall(saveInvoice, { useErrorToast: true });
 
   const getActions: GetActions<T> = (
     expense: T,
@@ -373,11 +361,13 @@ export function useExpenseActions<T extends ExpenseQueryNode>({
     };
 
     const handleDownloadInvoice = () => {
-      return downloadInvoiceWith(expense)();
+      return downloadInvoiceWith({ expenseId: expense.id })();
     };
 
     const invoiceTypes = [expenseTypes.INVOICE, expenseTypes.SETTLEMENT, expenseTypes.PLATFORM_BILLING] as string[];
-    const canSeeInvoice = permissions.canSeeInvoiceInfo && invoiceTypes.includes(expense.type);
+    const hasAttachedInvoiceFile = Boolean(expense.invoiceFile?.url);
+    const canSeeInvoice =
+      permissions.canSeeInvoiceInfo && invoiceTypes.includes(expense.type) && !hasAttachedInvoiceFile;
 
     const transactionsUrl =
       dashboardAccount?.isHost && host?.id === dashboardAccount.id

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -377,13 +377,17 @@ export function get(path, options: { format?: string; allowExternal?: string } =
  * Fetch a file from PDF service.
  */
 export async function fetchFromPDFService(url) {
+  let parsedUrl;
+  let pdfServiceOrigin;
   try {
-    const parsedUrl = new URL(url);
-    if (parsedUrl.origin !== PDF_SERVICE_URL) {
-      throw new Error('PDF service URL is not properly set');
-    }
+    parsedUrl = new URL(url);
+    pdfServiceOrigin = new URL(PDF_SERVICE_URL).origin;
   } catch {
     throw new Error('Invalid URL provided');
+  }
+
+  if (parsedUrl.origin !== pdfServiceOrigin) {
+    throw new Error('PDF service URL is not properly set');
   }
 
   return fetch(url, { method: 'get', headers: addAuthTokenToHeader() }).then(response => {

--- a/lib/hooks/useAsyncCall.ts
+++ b/lib/hooks/useAsyncCall.ts
@@ -3,7 +3,7 @@ import { useIntl } from 'react-intl';
 
 import { useToast } from '../../components/ui/useToast';
 
-import { formatErrorMessage } from '../errors';
+import { formatErrorMessage, getErrorFromGraphqlException } from '../errors';
 
 export const useAsyncCall = <T extends (...args: any[]) => Promise<any>>(
   fn: T,
@@ -36,7 +36,7 @@ export const useAsyncCall = <T extends (...args: any[]) => Promise<any>>(
         // eslint-disable-next-line no-console
         console.error(e);
         if (useErrorToast) {
-          toast({ variant: 'error', message: formatErrorMessage(intl, e) });
+          toast({ variant: 'error', message: formatErrorMessage(intl, getErrorFromGraphqlException(e)) });
         }
       } finally {
         setLoading(false);


### PR DESCRIPTION
## Summary

- Fix invoice download from the All Payment Requests dashboard (and other DataTable expense views) by reusing `saveInvoice`, the same helper used for transaction invoice downloads
- Harden `fetchFromPDFService` URL validation by comparing origins instead of raw env strings (avoids failures when `PDF_SERVICE_URL` has a trailing slash)
- Normalize errors in `useAsyncCall` so PDF/fetch failures show readable toast messages instead of empty error toasts
- Hide the generated-invoice download action when an expense already has an uploaded invoice file

Fixes opencollective/opencollective#8858

## Test plan

- [ ] Open `/dashboard/{host}/host-payment-requests` on staging
- [ ] On an INVOICE expense without an uploaded file, use row actions **Download Invoice** and confirm a PDF downloads
- [ ] Open the expense drawer and use **Download generated invoice** - confirm it still works
- [ ] On an expense with an uploaded invoice file, confirm row **Download Invoice** is hidden (attached file shown in drawer instead)
- [ ] Trigger a failure (e.g. logged out) and confirm the error toast shows a readable message
- [ ] Regression: download invoice from host transactions still works
