### PR TITLE
fix(I18nAddressFields): preserve structured address when country changes

### DIFF
--- a/components/I18nAddressFields.test.tsx
+++ b/components/I18nAddressFields.test.tsx
@@ -161,6 +161,10 @@ describe('I18nAddressFields', () => {
         city: 'San Francisco',
         postalCode: '94102',
       });
+
+      expect(document.getElementById('address1')).toHaveValue('123 Main St');
+      expect(document.getElementById('city')).toHaveValue('San Francisco');
+      expect(document.getElementById('postalCode')).toHaveValue('94102');
     });
 
     it('drops fields that are not supported by the new country', () => {

--- a/components/I18nAddressFields.test.tsx
+++ b/components/I18nAddressFields.test.tsx
@@ -111,6 +111,106 @@ describe('I18nAddressFields', () => {
 
       expect(mockGetAddressFormFields).toHaveBeenCalledWith('FR', expect.anything());
     });
+
+    it('preserves compatible structured values when country changes', () => {
+      const onCountryChange = jest.fn();
+      const structured: StructuredAddress = {
+        address1: '123 Main St',
+        city: 'San Francisco',
+        postalCode: '94102',
+        zone: 'CA',
+      };
+
+      mockGetAddressFormFields.mockReturnValue({
+        fields: [
+          { name: 'address1', label: 'Address', required: true },
+          { name: 'city', label: 'City', required: true },
+          { name: 'postalCode', label: 'Postal Code', required: true },
+        ],
+        optionalFields: [],
+      });
+
+      const { rerender } = render(
+        withRequiredProviders(
+          <I18nAddressFields
+            {...defaultProps}
+            selectedCountry="US"
+            value={structured}
+            onCountryChange={onCountryChange}
+          />,
+        ),
+      );
+
+      onCountryChange.mockClear();
+
+      // Simulate a parent that clears structured when the country changes (UserLocationInput bug).
+      rerender(
+        withRequiredProviders(
+          <I18nAddressFields
+            {...defaultProps}
+            selectedCountry="FR"
+            value={{}}
+            onCountryChange={onCountryChange}
+            Component={NewSimpleLocationFieldRenderer}
+          />,
+        ),
+      );
+
+      expect(onCountryChange).toHaveBeenCalledWith({
+        address1: '123 Main St',
+        city: 'San Francisco',
+        postalCode: '94102',
+      });
+    });
+
+    it('drops fields that are not supported by the new country', () => {
+      const onCountryChange = jest.fn();
+      const structured: StructuredAddress = {
+        address1: '123 Main St',
+        city: 'San Francisco',
+        postalCode: '94102',
+        zone: 'CA',
+      };
+
+      mockGetAddressFormFields.mockReturnValue({
+        fields: [
+          { name: 'address1', label: 'Address', required: true },
+          { name: 'city', label: 'City', required: true },
+          { name: 'postalCode', label: 'Postal Code', required: true },
+        ],
+        optionalFields: [],
+      });
+
+      const { rerender } = render(
+        withRequiredProviders(
+          <I18nAddressFields
+            {...defaultProps}
+            selectedCountry="US"
+            value={structured}
+            onCountryChange={onCountryChange}
+          />,
+        ),
+      );
+
+      onCountryChange.mockClear();
+
+      rerender(
+        withRequiredProviders(
+          <I18nAddressFields
+            {...defaultProps}
+            selectedCountry="DE"
+            value={structured}
+            onCountryChange={onCountryChange}
+          />,
+        ),
+      );
+
+      expect(onCountryChange).toHaveBeenCalledWith({
+        address1: '123 Main St',
+        city: 'San Francisco',
+        postalCode: '94102',
+      });
+    });
   });
 
   describe('callbacks', () => {
@@ -305,5 +405,18 @@ describe('NewSimpleLocationFieldRenderer', () => {
   it('does not show optional indicator for required fields', () => {
     render(withRequiredProviders(<NewSimpleLocationFieldRenderer {...defaultProps} required={true} />));
     expect(screen.queryByText(/optional/i)).not.toBeInTheDocument();
+  });
+
+  it('keeps the input controlled when value is undefined', () => {
+    const { rerender } = render(
+      withRequiredProviders(<NewSimpleLocationFieldRenderer {...defaultProps} value="Paris" />),
+    );
+
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveValue('Paris');
+
+    rerender(withRequiredProviders(<NewSimpleLocationFieldRenderer {...defaultProps} value={undefined} />));
+
+    expect(input).toHaveValue('');
   });
 });

--- a/components/I18nAddressFields.tsx
+++ b/components/I18nAddressFields.tsx
@@ -382,7 +382,7 @@ export const NewSimpleLocationFieldRenderer: React.FC<FieldRendererProps> = ({
     ...pickBy(
       {
         ...fieldProps,
-        value: value,
+        value: value ?? '',
         name: name || htmlFor,
         id: htmlFor,
         required,
@@ -482,10 +482,30 @@ const I18nAddressFields: React.FC<I18nAddressFieldsProps> = ({
     return convertToLegacyFormat(addressFormFields);
   }, [addressFormFields]);
 
+  // Keep the latest structured values so country changes can normalize them even if the
+  // parent briefly clears `value` when updating the country (e.g. UserLocationInput).
+  const structuredValuesRef = React.useRef<StructuredAddress>(value || {});
+
+  if (value && !isEmpty(value)) {
+    structuredValuesRef.current = value;
+  }
+
+  const getStructuredValues = React.useCallback((): StructuredAddress => {
+    return !isEmpty(value) ? value! : structuredValuesRef.current;
+  }, [value]);
+
+  const updateStructuredValues = React.useCallback(
+    (next: StructuredAddress) => {
+      structuredValuesRef.current = next;
+      onCountryChange(next);
+    },
+    [onCountryChange],
+  );
+
   // Notify parent when country changes and fields are updated
   React.useEffect(() => {
     if (fields && addressFormFields) {
-      onCountryChange(normalizeStructuredZone(value, fields));
+      updateStructuredValues(normalizeStructuredZone(getStructuredValues(), fields));
       try {
         onLoadSuccess?.({ countryInfo: addressFormFields, addressFields: fields });
       } catch (e) {
@@ -513,8 +533,11 @@ const I18nAddressFields: React.FC<I18nAddressFieldsProps> = ({
           error={errors?.[fieldName]}
           fieldProps={fieldProps}
           onChange={({ target: { name, value: fieldValue } }) =>
-            onCountryChange(
-              normalizeStructuredZone(set(cloneDeep(value || {}), name, fieldValue) as StructuredAddress, fields),
+            updateStructuredValues(
+              normalizeStructuredZone(
+                set(cloneDeep(getStructuredValues()), name, fieldValue) as StructuredAddress,
+                fields,
+              ),
             )
           }
         />

--- a/components/I18nAddressFields.tsx
+++ b/components/I18nAddressFields.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { FieldProps } from 'formik';
 import { Field } from 'formik';
-import { cloneDeep, isEmpty, isNil, omit, orderBy, pick, pickBy, set, truncate } from 'lodash-es';
+import { cloneDeep, isEmpty, isEqual, isNil, omit, orderBy, pick, pickBy, set, truncate } from 'lodash-es';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import type { AddressFieldConfig, StructuredAddress, Zone } from '@/lib/address';
@@ -482,30 +482,44 @@ const I18nAddressFields: React.FC<I18nAddressFieldsProps> = ({
     return convertToLegacyFormat(addressFormFields);
   }, [addressFormFields]);
 
-  // Keep the latest structured values so country changes can normalize them even if the
+  // Keep structured values locally so country changes can normalize them even if the
   // parent briefly clears `value` when updating the country (e.g. UserLocationInput).
-  const structuredValuesRef = React.useRef<StructuredAddress>(value || {});
+  const [structuredValues, setStructuredValues] = React.useState<StructuredAddress>(() => value || {});
+  const structuredValuesRef = React.useRef(structuredValues);
+  structuredValuesRef.current = structuredValues;
+  const lastPropagatedValuesRef = React.useRef<StructuredAddress | undefined>(undefined);
 
-  if (value && !isEmpty(value)) {
-    structuredValuesRef.current = value;
-  }
-
-  const getStructuredValues = React.useCallback((): StructuredAddress => {
-    return !isEmpty(value) ? value! : structuredValuesRef.current;
+  React.useEffect(() => {
+    if (value && !isEmpty(value)) {
+      setStructuredValues(prev => (isEqual(prev, value) ? prev : value!));
+    }
   }, [value]);
+
+  const propagateStructuredValues = React.useCallback(
+    (next: StructuredAddress) => {
+      if (!isEqual(lastPropagatedValuesRef.current, next)) {
+        lastPropagatedValuesRef.current = next;
+        onCountryChange(next);
+      }
+    },
+    [onCountryChange],
+  );
 
   const updateStructuredValues = React.useCallback(
     (next: StructuredAddress) => {
-      structuredValuesRef.current = next;
-      onCountryChange(next);
+      setStructuredValues(prev => (isEqual(prev, next) ? prev : next));
+      propagateStructuredValues(next);
     },
-    [onCountryChange],
+    [propagateStructuredValues],
   );
 
   // Notify parent when country changes and fields are updated
   React.useEffect(() => {
     if (fields && addressFormFields) {
-      updateStructuredValues(normalizeStructuredZone(getStructuredValues(), fields));
+      const normalized = normalizeStructuredZone(structuredValuesRef.current, fields);
+      setStructuredValues(prev => (isEqual(prev, normalized) ? prev : normalized));
+      lastPropagatedValuesRef.current = normalized;
+      onCountryChange(normalized);
       try {
         onLoadSuccess?.({ countryInfo: addressFormFields, addressFields: fields });
       } catch (e) {
@@ -519,25 +533,23 @@ const I18nAddressFields: React.FC<I18nAddressFieldsProps> = ({
   if (!selectedCountry || !fields || !addressFormFields) {
     return null;
   }
+
   return (
     <React.Fragment>
       {fields.map(([fieldName, fieldLabel, fieldInfo]) => (
         <Component
-          key={fieldName}
+          key={`${selectedCountry}-${fieldName}`}
           prefix={prefix}
           name={fieldName}
           label={fieldLabel}
           info={fieldInfo}
-          value={value?.[fieldName as keyof StructuredAddress]}
+          value={structuredValues[fieldName as keyof StructuredAddress]}
           required={required === false ? false : !addressFormFields.optionalFields.includes(fieldName)}
           error={errors?.[fieldName]}
           fieldProps={fieldProps}
           onChange={({ target: { name, value: fieldValue } }) =>
             updateStructuredValues(
-              normalizeStructuredZone(
-                set(cloneDeep(getStructuredValues()), name, fieldValue) as StructuredAddress,
-                fields,
-              ),
+              normalizeStructuredZone(set(cloneDeep(structuredValues), name, fieldValue) as StructuredAddress, fields),
             )
           }
         />

--- a/components/ui/LocationInput.test.tsx
+++ b/components/ui/LocationInput.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { withRequiredProviders } from '../../test/providers';
+
+import { UserLocationInput } from './LocationInput';
+
+type AddressFieldConfig = { name: string; label: string; required: boolean };
+
+const mockGetAddressFormFields = jest.fn<
+  { fields: AddressFieldConfig[]; optionalFields: string[] },
+  [string, string?]
+>();
+
+jest.mock('../../lib/address', () => ({
+  getAddressFormFields: (...args: [string, string?]) => mockGetAddressFormFields(...args),
+}));
+
+jest.mock('../InputCountry', () => {
+  return function MockInputCountry({ value, onChange }) {
+    return (
+      <select data-cy="country-select" value={value || ''} onChange={e => onChange(e.target.value)}>
+        <option value="">Select country</option>
+        <option value="US">United States</option>
+        <option value="FR">France</option>
+      </select>
+    );
+  };
+});
+
+const getByDataCy = (cy: string) => {
+  const element = document.querySelector(`[data-cy="${cy}"]`);
+  if (!element) {
+    throw new Error(`Unable to find an element with data-cy="${cy}"`);
+  }
+  return element as HTMLElement;
+};
+
+describe('UserLocationInput', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAddressFormFields.mockReturnValue({
+      fields: [
+        { name: 'address1', label: 'Address', required: true },
+        { name: 'address2', label: 'Apartment, suite, etc.', required: false },
+        { name: 'city', label: 'City', required: true },
+        { name: 'postalCode', label: 'Postal Code', required: true },
+      ],
+      optionalFields: ['address2'],
+    });
+  });
+
+  it('preserves structured address when country changes', () => {
+    const onChange = jest.fn();
+    const structured = {
+      address1: 'test',
+      city: 'test',
+      postalCode: '13600',
+    };
+
+    render(
+      withRequiredProviders(
+        <UserLocationInput location={{ country: 'US', structured }} onChange={onChange} required={true} />,
+      ),
+    );
+
+    onChange.mockClear();
+    fireEvent.change(getByDataCy('country-select'), { target: { value: 'FR' } });
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        country: 'FR',
+        structured,
+      }),
+    );
+  });
+
+  it('does not show required errors for filled fields after country change', () => {
+    const structured = {
+      address1: 'test',
+      city: 'test',
+      postalCode: '13600',
+    };
+
+    const { rerender } = render(
+      withRequiredProviders(
+        <UserLocationInput location={{ country: 'US', structured }} onChange={jest.fn()} required={true} />,
+      ),
+    );
+
+    fireEvent.change(getByDataCy('country-select'), { target: { value: 'FR' } });
+
+    rerender(
+      withRequiredProviders(
+        <UserLocationInput location={{ country: 'FR', structured }} onChange={jest.fn()} required={true} />,
+      ),
+    );
+
+    expect(screen.queryByText('Address is required')).not.toBeInTheDocument();
+    expect(screen.queryByText('City is required')).not.toBeInTheDocument();
+    expect(screen.queryByText('Postal Code is required')).not.toBeInTheDocument();
+    expect(document.getElementById('address1')).toHaveValue('test');
+    expect(document.getElementById('city')).toHaveValue('test');
+    expect(document.getElementById('postalCode')).toHaveValue('13600');
+  });
+});

--- a/components/ui/LocationInput.tsx
+++ b/components/ui/LocationInput.tsx
@@ -193,7 +193,9 @@ export const UserLocationInput = ({
         <Label className="leading-normal">Country</Label>
         <InputCountry
           value={location?.country}
-          onChange={country => onChange(pick({ ...(location || DEFAULT_LOCATION), country }, ['country']))}
+          onChange={country =>
+            onChange(pick({ ...(location || DEFAULT_LOCATION), country }, ['country', 'structured']))
+          }
         />
       </div>
       {hasCountry && !useFallback && !forceLegacyFormat ? (

--- a/components/ui/LocationInput.tsx
+++ b/components/ui/LocationInput.tsx
@@ -185,6 +185,17 @@ export const UserLocationInput = ({
   useStructuredForFallback = false,
 }) => {
   const [useFallback, setUseFallback] = React.useState(false);
+  const locationRef = React.useRef(location);
+  locationRef.current = location;
+
+  const updateLocation = React.useCallback(
+    patch => {
+      const currentLocation = locationRef.current || DEFAULT_LOCATION;
+      onChange(typeof patch === 'function' ? patch(currentLocation) : patch);
+    },
+    [onChange],
+  );
+
   const forceLegacyFormat = Boolean(!location?.structured && location?.address);
   const hasCountry = Boolean(location?.country);
   return (
@@ -194,7 +205,7 @@ export const UserLocationInput = ({
         <InputCountry
           value={location?.country}
           onChange={country =>
-            onChange(pick({ ...(location || DEFAULT_LOCATION), country }, ['country', 'structured']))
+            updateLocation(currentLocation => pick({ ...currentLocation, country }, ['country', 'structured']))
           }
         />
       </div>
@@ -210,7 +221,7 @@ export const UserLocationInput = ({
           prefix=""
           errors={errors?.structured}
           onCountryChange={structured =>
-            onChange(pick({ ...(location || DEFAULT_LOCATION), structured }, ['country', 'structured']))
+            updateLocation(currentLocation => pick({ ...currentLocation, structured }, ['country', 'structured']))
           }
         />
       ) : useFallback ? (
@@ -231,13 +242,10 @@ export const UserLocationInput = ({
             onChange={e => {
               const address = e.target.value;
               if (!useStructuredForFallback) {
-                onChange(pick({ ...(location || DEFAULT_LOCATION), address }, ['country', 'address']));
+                updateLocation(currentLocation => pick({ ...currentLocation, address }, ['country', 'address']));
               } else {
-                onChange(
-                  pick({ ...(location || DEFAULT_LOCATION), structured: { address1: address } }, [
-                    'country',
-                    'structured',
-                  ]),
+                updateLocation(currentLocation =>
+                  pick({ ...currentLocation, structured: { address1: address } }, ['country', 'structured']),
                 );
               }
             }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Resolve https://github.com/opencollective/opencollective/issues/8866

# Description

When changing the country in `UserLocationInput` (used in the dashboard Info form), address field values could remain visible in the UI while the submitted `structured` object was empty. The follow-up issue also showed false "is required" validation errors after changing country.

This happened because:
1. `I18nAddressFields` rendered fields from the parent `value` prop but edited a separate ref, so visible inputs and submitted state diverged after country changes.
2. `UserLocationInput` handlers could use stale `location` closures when combining country/structured updates.
3. `NewSimpleLocationFieldRenderer` kept `isTouched` state across country changes, showing validation errors for fields that looked filled.
4. `UserLocationInput` could drop `structured` when the country changed.

## Changes

- Manage structured address values in local state inside `I18nAddressFields`, synced from parent only when non-empty.
- Render all address fields from local structured state so display and submission stay aligned.
- Always propagate normalized structured values to the parent when the country changes.
- Reset field renderers on country change (`key={`${selectedCountry}-${fieldName}`}`) to clear stale touched/validation state.
- Keep `NewSimpleLocationFieldRenderer` inputs controlled with `value ?? ''`.
- Use functional location updates in `UserLocationInput` to avoid stale closures.

## Tests

Added/updated unit tests covering:
- Preserving compatible structured values when country changes with a cleared `value` prop
- Keeping displayed field values in sync with structured state
- Dropping fields unsupported by the new country (e.g. `zone`)
- `UserLocationInput` preserving structured address on country change
- No false required errors after country change
- Keeping inputs controlled when `value` is `undefined`

Ran:
- `npm test -- components/I18nAddressFields.test.tsx components/ui/LocationInput.test.tsx`
- `npx eslint` on changed files
- `npx prettier --write` on changed files
- `npm run type:check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f252175-f9e7-4ec7-9104-057e0f915e4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f252175-f9e7-4ec7-9104-057e0f915e4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

