### PR TITLE
feat: open payment processor link in a new tab

### DIFF
--- a/components/DrawerHeader.tsx
+++ b/components/DrawerHeader.tsx
@@ -78,7 +78,7 @@ export default function DrawerHeader({
                   data-cy={action['data-cy']}
                 >
                   {action.href ? (
-                    <Link href={action.href} target={action.target}>
+                    <Link href={action.href} openInNewTab={action.openInNewTab}>
                       {action.Icon && <action.Icon size={16} />}
                       <span>{action.label}</span>
                     </Link>

--- a/components/contributions/ContributionTimeline.tsx
+++ b/components/contributions/ContributionTimeline.tsx
@@ -246,7 +246,7 @@ function ContributionTimeline(props: OrderTimelineProps) {
           <React.Fragment>
             <DropdownMenuItem asChild>
               <Button size="xs" variant="ghost" asChild className="w-full">
-                <Link href={a.data?.paymentProcessorUrl} className="justify-start">
+                <Link href={a.data?.paymentProcessorUrl} openInNewTab className="justify-start">
                   <FormattedMessage defaultMessage="View in payment processor" id="NgSLbI" />
                 </Link>
               </Button>
@@ -298,7 +298,7 @@ function ContributionTimeline(props: OrderTimelineProps) {
             {primaryTxn.paymentProcessorUrl && (
               <DropdownMenuItem asChild>
                 <Button size="xs" variant="ghost" asChild className="w-full justify-start">
-                  <Link href={primaryTxn.paymentProcessorUrl}>
+                  <Link href={primaryTxn.paymentProcessorUrl} openInNewTab>
                     <FormattedMessage defaultMessage="View in payment processor" id="NgSLbI" />
                   </Link>
                 </Button>

--- a/components/dashboard/sections/exports/index.tsx
+++ b/components/dashboard/sections/exports/index.tsx
@@ -367,7 +367,7 @@ const Exports = ({ accountSlug, subpath }: DashboardSectionProps) => {
           label: intl.formatMessage({ defaultMessage: 'Download', id: 'Download' }),
           Icon: Download,
           href: exportRequest.file.url,
-          target: '_blank',
+          openInNewTab: true,
         });
       }
 

--- a/components/dashboard/sections/transactions/actions.tsx
+++ b/components/dashboard/sections/transactions/actions.tsx
@@ -182,6 +182,7 @@ export function useTransactionActions<T extends TransactionsTableQueryNode | Tra
           key: 'view-payment-processor',
           label: intl.formatMessage({ defaultMessage: 'View in payment processor', id: 'NgSLbI' }),
           href: transaction.paymentProcessorUrl,
+          openInNewTab: true,
           Icon: ExternalLink,
           if: Boolean(transaction.paymentProcessorUrl),
         },

--- a/components/table/RowActionsMenu.tsx
+++ b/components/table/RowActionsMenu.tsx
@@ -33,7 +33,7 @@ function DropdownActionItemContent({ action }: { action: Action }) {
 export function DropdownActionItem({ action }: { action: Action }) {
   const item = action.href ? (
     <DropdownMenuItem asChild className="gap-2.5" disabled={action.disabled} data-cy={action['data-cy']}>
-      <Link href={action.href} target={action.target} onClick={action.onClick}>
+      <Link href={action.href} openInNewTab={action.openInNewTab} onClick={action.onClick}>
         <DropdownActionItemContent action={action} />
       </Link>
     </DropdownMenuItem>
@@ -110,7 +110,7 @@ export function RowActionsMenu<TData>({ row, actionsMenuTriggerRef, table }: Row
                 onClick={action.onClick}
               >
                 {action.href ? (
-                  <Link href={action.href} target={action.target}>
+                  <Link href={action.href} openInNewTab={action.openInNewTab}>
                     <action.Icon size={16} />
                   </Link>
                 ) : (

--- a/lib/actions/types.ts
+++ b/lib/actions/types.ts
@@ -5,7 +5,7 @@ export type Action = {
   label: string;
   onClick?: (e: React.MouseEvent) => void;
   href?: string; // used for links
-  target?: string; // used for links
+  openInNewTab?: boolean; // used for links
   Icon?: LucideIcon;
   isLoading?: boolean;
   disabled?: boolean;


### PR DESCRIPTION
## Description

The "View in payment processor" action (transactions table row menu and drawer) now opens the processor in a new tab, keeping the platform page open so both can be compared side by side.

Also applied the same behavior to the two matching links in the contribution timeline for consistency (using `openInNewTab`, which also sets `rel="noopener noreferrer"`).