### PR TITLE
fix: use shallow routing for "Go to Exports" link in export modal

### DIFF
--- a/components/dashboard/ExportTransactionsCSVModal.tsx
+++ b/components/dashboard/ExportTransactionsCSVModal.tsx
@@ -815,7 +815,7 @@ const ExportTransactionsCSVModal = ({
                   </div>
                   <div className="flex flex-col gap-3 sm:flex-row">
                     <Button variant="outline" asChild>
-                      <Link href={`/dashboard/${account?.slug}/exports`}>
+                      <Link href={`/dashboard/${account?.slug}/exports`} shallow>
                         <FormattedMessage id="GoToExports" defaultMessage="Go to Exports" />
                       </Link>
                     </Button>


### PR DESCRIPTION
The "Go to Exports" button in the transactions CSV export modal could trigger a full page reload instead of a client-side section switch.

All dashboard sections live on the same page (`pages/dashboard.tsx`), and the sidebar links navigate between them with the `shallow` prop. This link was missing it, so clicking it made Next.js re-fetch `getServerSideProps` data (`/_next/data/<buildId>/dashboard.json`). At best that is a needless server round-trip (the dashboard gSSP returns empty props); but if a deploy happened after the page was loaded, the stale buildId 404s and Next.js falls back to a hard navigation, a full page refresh. Since this modal is where users wait for an export to generate, running into a stale build there is common.

Reproduced by forcing the `_next/data` request to 404 via CDP: the non-shallow navigation reloads the document, while shallow navigation (like the sidebar) never makes the request at all.

Adding `shallow` makes the link behave like the rest of the dashboard navigation: instant section switch, no data fetch, no reload.