### PR TITLE
Hide Create Contribution Tier card in Connected Collectives section

### DIFF
--- a/components/collective-page/sections/ConnectedCollectives.js
+++ b/components/collective-page/sections/ConnectedCollectives.js
@@ -155,6 +155,7 @@ class ConnectedCollectives extends React.PureComponent {
                   draggingId={draggingId}
                   onMount={this.onConnectedCollectivesAdminReady}
                   enableReordering={true}
+                  hideCreateNew
                 />
               </Container>
             )}


### PR DESCRIPTION
## Problem

For admins of a collective, the Connected Collectives section on the profile page shows a "Create Contribution Tier" card. The admin view of this section uses `AdminContributeCardsContainer` (for drag-and-drop reordering), which appends a "Create New" card by default — and with no `createNewType` set, it falls back to the contribution tier variant, which isn't relevant here.

## Solution

Pass the existing `hideCreateNew` prop (already used by the Tickets section) so the card isn't rendered. Admins keep reordering; the non-admin view is unchanged.

Fixes opencollective/opencollective#8902