### PR TITLE
Hide internal platform tip kinds from profile transactions by default

### DIFF
--- a/components/collective-page/graphql/preload.js
+++ b/components/collective-page/graphql/preload.js
@@ -40,7 +40,7 @@ export const preloadCollectivePageGraphqlQueries = async (client, collective) =>
         queries.push(
           client.query({
             query: getBudgetSectionQuery(Boolean(collective.host), isIndividual),
-            variables: getBudgetSectionQueryVariables(slug, isIndividual, collective.host),
+            variables: getBudgetSectionQueryVariables(slug, isIndividual, collective.host, collective.isHost),
           }),
         );
       }
@@ -50,7 +50,7 @@ export const preloadCollectivePageGraphqlQueries = async (client, collective) =>
       queries.push(
         client.query({
           query: transactionsSectionQuery,
-          variables: getTransactionsSectionQueryVariables(slug),
+          variables: getTransactionsSectionQueryVariables(slug, collective.isHost),
         }),
       );
     }

--- a/components/collective-page/sections/Budget.js
+++ b/components/collective-page/sections/Budget.js
@@ -227,7 +227,7 @@ export const getBudgetSectionQuery = (hasHost, isIndividual) => {
   }
 };
 
-export const getBudgetSectionQueryVariables = (collectiveSlug, isIndividual, host) => {
+export const getBudgetSectionQueryVariables = (collectiveSlug, isIndividual, host, isHost) => {
   if (isIndividual) {
     return { slug: collectiveSlug, limit: 3, kind: getDefaultKinds().filter(kind => kind !== TransactionKind.EXPENSE) };
   } else {
@@ -235,7 +235,7 @@ export const getBudgetSectionQueryVariables = (collectiveSlug, isIndividual, hos
       slug: collectiveSlug,
       host: host ? { slug: host.slug } : null,
       limit: 3,
-      kind: getDefaultKinds(),
+      kind: getDefaultKinds({ isHost: Boolean(isHost) }),
       heavyAccount: isHeavyAccount(collectiveSlug),
     };
   }
@@ -333,7 +333,7 @@ const SectionBudget = ({ collective, LoggedInUser }) => {
   const [filter, setFilter] = React.useState('all');
   const isIndividual = isIndividualAccount(collective) && !collective.isHost;
   const budgetQueryResult = useQuery(getBudgetSectionQuery(Boolean(collective.host), isIndividual), {
-    variables: getBudgetSectionQueryVariables(collective.slug, isIndividual, collective.host),
+    variables: getBudgetSectionQueryVariables(collective.slug, isIndividual, collective.host, collective.isHost),
   });
   const { data, refetch } = budgetQueryResult;
 

--- a/components/collective-page/sections/Transactions.js
+++ b/components/collective-page/sections/Transactions.js
@@ -63,13 +63,18 @@ export const transactionsSectionQuery = gql`
   ${transactionsQueryCollectionFragment}
 `;
 
-export const getTransactionsSectionQueryVariables = slug => {
-  return { slug, limit: NB_DISPLAYED, kind: getDefaultKinds(), includeGiftCardTransactions: !isHeavyAccount(slug) };
+export const getTransactionsSectionQueryVariables = (slug, isHost) => {
+  return {
+    slug,
+    limit: NB_DISPLAYED,
+    kind: getDefaultKinds({ isHost: Boolean(isHost) }),
+    includeGiftCardTransactions: !isHeavyAccount(slug),
+  };
 };
 
 const SectionTransactions = props => {
   const transactionsQueryResult = useQuery(transactionsSectionQuery, {
-    variables: getTransactionsSectionQueryVariables(props.collective.slug),
+    variables: getTransactionsSectionQueryVariables(props.collective.slug, props.collective.isHost),
 
     // We keep notifyOnNetworkStatusChange to remove the flash of collectiveHasNoTransactions bug
     // See https://github.com/apollographql/apollo-client/blob/9c80adf65ccbbb88ea5b9313c002f85976c225e3/src/core/ObservableQuery.ts#L274-L304

--- a/components/dashboard/sections/collectives/AddFundsModal.tsx
+++ b/components/dashboard/sections/collectives/AddFundsModal.tsx
@@ -515,7 +515,7 @@ const AddFundsModalContentWithCollective = ({
       refetchQueries: [
         {
           query: getBudgetSectionQuery(true, false),
-          variables: getBudgetSectionQueryVariables(collective.slug, false, host),
+          variables: getBudgetSectionQueryVariables(collective.slug, false, host, account?.isHost),
         },
         {
           query: collectivePageQuery,

--- a/components/transactions/filters/TransactionsKindFilter.js
+++ b/components/transactions/filters/TransactionsKindFilter.js
@@ -1,13 +1,19 @@
 import { TransactionKind } from '../../../lib/constants/transactions';
 
-// (!) Remember that any changes made here should be applied to the cache in API > `getCacheKeyForBudgetOrTransactionsSections`
-export const getDefaultKinds = () => {
-  return [
+export const getDefaultKinds = ({ isHost = false } = {}) => {
+  const kinds = [
     TransactionKind.ADDED_FUNDS,
     TransactionKind.BALANCE_TRANSFER,
     TransactionKind.CONTRIBUTION,
     TransactionKind.EXPENSE,
-    TransactionKind.PLATFORM_TIP,
-    TransactionKind.APPLICATION_FEE,
   ];
+
+  // On a Fiscal Host profile, PLATFORM_TIP transactions are the tips collected on the internal
+  // "Platform Tips" child account (money owed to the platform, not host activity). For other
+  // accounts they are tips the account gave, which are part of its own financial activity.
+  if (!isHost) {
+    kinds.push(TransactionKind.PLATFORM_TIP);
+  }
+
+  return kinds;
 };


### PR DESCRIPTION
On fiscal host profiles (like @opensource), the transactions and budget sections currently show the platform tips collected on the internal Platform Tips child account, along with the APPLICATION_FEE legs that move that money to the platform. These are internal billing flows between the host and the platform, not host activity, so I'm removing them from the default view.

APPLICATION_FEE is removed from the default kinds everywhere, since it only ever appears on host-side accounts. PLATFORM_TIP is excluded from the defaults only when the profile is a fiscal host: contributors (individuals and organizations) still see the tips they gave, which are part of their own financial activity.

Both kinds remain available through the kind filter on the transactions page. Dashboard views, exports and the API are unchanged.