### PR TITLE
Pass return_url when confirming payments with saved payment methods

### DIFF
--- a/lib/stripe/confirm-payment.ts
+++ b/lib/stripe/confirm-payment.ts
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import type { PaymentIntentConfirmParams, PaymentIntentResult, Stripe, StripeElements } from '@stripe/stripe-js';
+import type { PaymentIntentResult, Stripe, StripeElements } from '@stripe/stripe-js';
 
 import { PAYMENT_METHOD_TYPE } from '../constants/payment-methods';
 
@@ -10,7 +10,7 @@ type PaymentData = {
   returnUrl?: string;
 };
 
-type ConfirmParams = PaymentIntentConfirmParams | { payment_method?: string };
+type ConfirmParams = { payment_method?: string; return_url?: string };
 
 export async function confirmPayment(
   stripe: Stripe,
@@ -18,11 +18,12 @@ export async function confirmPayment(
   paymentData: PaymentData,
   { redirect }: { redirect?: 'if_required' } = {},
 ) {
-  const confirmParams: ConfirmParams = paymentData?.paymentMethodId
-    ? {
-        payment_method: paymentData.paymentMethodId,
-      }
-    : undefined;
+  // `return_url` is required at confirmation whenever the PaymentIntent has automatic payment
+  // methods enabled with `allow_redirects: always` (the default), even for non-redirect methods.
+  const confirmParams: ConfirmParams = {
+    ...(paymentData?.paymentMethodId && { payment_method: paymentData.paymentMethodId }),
+    ...(paymentData?.returnUrl && { return_url: paymentData.returnUrl }),
+  };
 
   let paymentIntentResult: PaymentIntentResult;
   switch (paymentData.type) {


### PR DESCRIPTION
Our test Stripe account has been accumulating 400s on `POST /v1/payment_intents/*/confirm` (Stripe even emailed us about it). The cause: PaymentIntents created with `automatic_payment_methods` require a `return_url` at confirmation since `allow_redirects` defaults to `always`, even when the method being charged doesn't redirect. We only passed it in the Payment Element branch, so paying with a saved card / us_bank_account / sepa_debit failed on the first attempt.

I now build the confirm params with both `payment_method` and `return_url` and pass them to every confirm branch. Both call sites (contribution flow, pay expense with Stripe) already provide a `returnUrl`, so no changes needed there. I verified against the Stripe API that the same intent shape that 400s without `return_url` succeeds with it.