### PR TITLE
fix: use canonical spelling of "Bluesky" instead of "BlueSky"

### DIFF
--- a/components/contribution-flow/ContributionFlowSuccess.tsx
+++ b/components/contribution-flow/ContributionFlowSuccess.tsx
@@ -20,7 +20,7 @@ import { SocialLinkType } from '../../lib/graphql/types/v2/graphql';
 import { iconForSocialLinkType } from '../../lib/social-links';
 import { getStripe } from '../../lib/stripe';
 import {
-  blueSkyShareURL,
+  blueskyShareURL,
   followOrderRedirectUrl,
   getCollectivePageRoute,
   linkedInShareURL,
@@ -120,7 +120,7 @@ const getShareProperties = (service, url, text) => {
       return {
         name: 'Bluesky',
         Icon: iconForSocialLinkType(SocialLinkType.BLUESKY),
-        url: blueSkyShareURL({ text: `${text} ${url}` }),
+        url: blueskyShareURL({ text: `${text} ${url}` }),
       };
     case SocialLinkType.LINKEDIN:
       return {

--- a/lib/social-links.tsx
+++ b/lib/social-links.tsx
@@ -82,7 +82,7 @@ const SocialLinkIcon: Record<SocialLinkType, typeof Discord | React.FunctionComp
 };
 
 export const SocialLinkLabel: Record<SocialLinkType, string> = {
-  [SocialLinkType.BLUESKY]: 'BlueSky',
+  [SocialLinkType.BLUESKY]: 'Bluesky',
   [SocialLinkType.DISCORD]: 'Discord',
   [SocialLinkType.DISCOURSE]: 'Discourse',
   [SocialLinkType.FACEBOOK]: 'Facebook',

--- a/lib/url-helpers.ts
+++ b/lib/url-helpers.ts
@@ -96,7 +96,7 @@ export const twitterProfileUrl = twitterHandle => {
  * @param opts {object} With the following attributes:
  *  - text: The message to share
  */
-export const blueSkyShareURL = opts => {
+export const blueskyShareURL = opts => {
   return `https://bsky.app/intent/compose${objectToQueryString(opts)}`;
 };
 


### PR DESCRIPTION
related issue: N/A

# Description

<!--
  Provide a short summary of the changes as well as - if necessary - instructions
  on how this should be tested.
-->
Hi, this is a small fix to fix the spelling of "Bluesky", which is the canonical one. I searched "bluesky" in entire github orgs (ref. https://github.com/search?q=org%3Aopencollective+bluesky&type=code) and it looks like those are only usages.

# Screenshots

<!--
  We love screenshots! If applicable, please try to include some in here.
  You can also post animated screencasts in GIF format.
-->
## Before
<img width="887" height="298" alt="screenshot of social feed selector showing 'BlueSky' with capital S in 'sky'" src="https://github.com/user-attachments/assets/915a5cd9-5296-47d1-8b9a-d60af85eb40a" />

## After
<img width="1241" height="413" alt="screenshot of social feed selector showing correctly spelled 'Bluesky'" src="https://github.com/user-attachments/assets/b201fdc3-90b2-4922-b949-7f74b22ca85a" />

