### PR TITLE
Fix expense drawer links for hidden accounts

### DIFF
--- a/components/budget/ExpenseBudgetItem.js
+++ b/components/budget/ExpenseBudgetItem.js
@@ -195,18 +195,18 @@ const ExpenseBudgetItem = ({
                   <span>
                     <StyledLink
                       $underlineOnHover
-                      {...(expenseAccountRoute
-                        ? useDrawer
+                      {...(useDrawer
+                        ? {
+                            as: 'button',
+                            type: 'button',
+                            onClick: expandExpense,
+                          }
+                        : expenseAccountRoute
                           ? {
                               as: Link,
                               href: `${expenseAccountRoute}/expenses/${expense.legacyId}`,
-                              onClick: expandExpense,
                             }
-                          : {
-                              as: Link,
-                              href: `${expenseAccountRoute}/expenses/${expense.legacyId}`,
-                            }
-                        : {})}
+                          : {})}
                     >
                       <AutosizeText
                         value={expense.description}


### PR DESCRIPTION
## Summary

- render expense titles as buttons whenever the expense drawer is enabled
- keep public expense-page links conditional on the account having a public profile
- restore title clicks for platform settlement expenses associated with hidden accounts

## Regression

This regressed in #12332 (`988f0658c8`) when expense title interactions were made conditional on `getCollectivePageRoute` returning a public account route. That was appropriate for links to standalone expense pages, but it also unintentionally removed the drawer click handler.

Platform settlement expenses can belong to hidden platform-tip accounts. For these expenses, `getCollectivePageRoute` returns an empty route, leaving the title as non-interactive text. Attachment links continued to open the drawer because they use a separate handler that is not conditional on the account's public profile.

This change separates both behaviors: drawer-backed titles always open the drawer, while standalone expense-page links still require a public account route.

## Validation

- `npx prettier --check components/budget/ExpenseBudgetItem.js`
- `npx eslint components/budget/ExpenseBudgetItem.js`
- `npm run type:check`

Fixes opencollective/opencollective#8904