### PR TITLE
Wise: Include date-of-birth field when creating Alipay payout methods

### DIFF
--- a/components/expenses/PayoutBankInformationForm.js
+++ b/components/expenses/PayoutBankInformationForm.js
@@ -88,6 +88,10 @@ const i18nFieldLabels = defineMessages({
     id: 'PayoutBankInformationForm.Field.AccountHolderName',
     defaultMessage: 'Full name of the account holder',
   },
+  'Date of birth': {
+    id: 'PayoutBankInformationForm.Field.DateOfBirth',
+    defaultMessage: 'Date of birth',
+  },
   'Bank code (BIC/SWIFT)': {
     id: 'PayoutBankInformationForm.Field.BankCode',
     defaultMessage: 'Bank code (BIC/SWIFT)',

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -3337,6 +3337,7 @@
   "PayoutBankInformationForm.Error.RequiredFields": "There was an error fetching the required fields",
   "PayoutBankInformationForm.Field.AccountHolderName": "Full name of the account holder",
   "PayoutBankInformationForm.Field.BankCode": "Bank code (BIC/SWIFT)",
+  "PayoutBankInformationForm.Field.DateOfBirth": "Date of birth",
   "PayoutBankInformationForm.Field.RecipientType": "Recipient type",
   "PayoutBankInformationForm.HolderAddress": "Bank account holder address (not the bank address)",
   "PayoutBankInformationForm.RecipientAddress": "Recipient's Address",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -3337,6 +3337,7 @@
   "PayoutBankInformationForm.Error.RequiredFields": "There was an error fetching the required fields",
   "PayoutBankInformationForm.Field.AccountHolderName": "Full name of the account holder",
   "PayoutBankInformationForm.Field.BankCode": "Bank code (BIC/SWIFT)",
+  "PayoutBankInformationForm.Field.DateOfBirth": "Date of birth",
   "PayoutBankInformationForm.Field.RecipientType": "Recipient type",
   "PayoutBankInformationForm.HolderAddress": "Bank account holder address (not the bank address)",
   "PayoutBankInformationForm.RecipientAddress": "Recipient's Address",

--- a/lang/de.json
+++ b/lang/de.json
@@ -3337,6 +3337,7 @@
   "PayoutBankInformationForm.Error.RequiredFields": "Beim Abrufen der erforderlichen Felder ist ein Fehler aufgetreten",
   "PayoutBankInformationForm.Field.AccountHolderName": "Full name of the account holder",
   "PayoutBankInformationForm.Field.BankCode": "Bank code (BIC/SWIFT)",
+  "PayoutBankInformationForm.Field.DateOfBirth": "Date of birth",
   "PayoutBankInformationForm.Field.RecipientType": "Recipient type",
   "PayoutBankInformationForm.HolderAddress": "Adresse des Bankkontoinhabers (nicht die Bankadresse)",
   "PayoutBankInformationForm.RecipientAddress": "Adresse des Empfängers",

--- a/lang/en.json
+++ b/lang/en.json
@@ -3337,6 +3337,7 @@
   "PayoutBankInformationForm.Error.RequiredFields": "There was an error fetching the required fields",
   "PayoutBankInformationForm.Field.AccountHolderName": "Full name of the account holder",
   "PayoutBankInformationForm.Field.BankCode": "Bank code (BIC/SWIFT)",
+  "PayoutBankInformationForm.Field.DateOfBirth": "Date of birth",
   "PayoutBankInformationForm.Field.RecipientType": "Recipient type",
   "PayoutBankInformationForm.HolderAddress": "Bank account holder address (not the bank address)",
   "PayoutBankInformationForm.RecipientAddress": "Recipient's Address",

--- a/lang/es.json
+++ b/lang/es.json
@@ -3337,6 +3337,7 @@
   "PayoutBankInformationForm.Error.RequiredFields": "Hubo un error al recuperar la información requerida",
   "PayoutBankInformationForm.Field.AccountHolderName": "Nombre completo del titular de la cuenta",
   "PayoutBankInformationForm.Field.BankCode": "Código bancario (BIC/SWIFT)",
+  "PayoutBankInformationForm.Field.DateOfBirth": "Date of birth",
   "PayoutBankInformationForm.Field.RecipientType": "Tipo de destinatario",
   "PayoutBankInformationForm.HolderAddress": "Dirección del titular de la cuenta bancaria (no la dirección del banco)",
   "PayoutBankInformationForm.RecipientAddress": "Dirección del Destinatario",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -3337,6 +3337,7 @@
   "PayoutBankInformationForm.Error.RequiredFields": "Une erreur s'est produite lors de la récupération des champs requis",
   "PayoutBankInformationForm.Field.AccountHolderName": "Nom complet du titulaire du compte",
   "PayoutBankInformationForm.Field.BankCode": "Code bancaire (BIC/SWIFT)",
+  "PayoutBankInformationForm.Field.DateOfBirth": "Date of birth",
   "PayoutBankInformationForm.Field.RecipientType": "Type de destinataire",
   "PayoutBankInformationForm.HolderAddress": "Adresse du titulaire du compte bancaire (pas l'adresse bancaire)",
   "PayoutBankInformationForm.RecipientAddress": "Adresse du destinataire",

--- a/lang/he.json
+++ b/lang/he.json
@@ -3337,6 +3337,7 @@
   "PayoutBankInformationForm.Error.RequiredFields": "היתה בעיה בהעלאת שדות נדרשים",
   "PayoutBankInformationForm.Field.AccountHolderName": "Full name of the account holder",
   "PayoutBankInformationForm.Field.BankCode": "Bank code (BIC/SWIFT)",
+  "PayoutBankInformationForm.Field.DateOfBirth": "Date of birth",
   "PayoutBankInformationForm.Field.RecipientType": "Recipient type",
   "PayoutBankInformationForm.HolderAddress": "כתובת בעל חשבון הבנק (לא כתובת הבנק)",
   "PayoutBankInformationForm.RecipientAddress": "כתובת הנמען",

--- a/lang/it.json
+++ b/lang/it.json
@@ -3337,6 +3337,7 @@
   "PayoutBankInformationForm.Error.RequiredFields": "There was an error fetching the required fields",
   "PayoutBankInformationForm.Field.AccountHolderName": "Full name of the account holder",
   "PayoutBankInformationForm.Field.BankCode": "Bank code (BIC/SWIFT)",
+  "PayoutBankInformationForm.Field.DateOfBirth": "Date of birth",
   "PayoutBankInformationForm.Field.RecipientType": "Recipient type",
   "PayoutBankInformationForm.HolderAddress": "Bank account holder address (not the bank address)",
   "PayoutBankInformationForm.RecipientAddress": "Indirizzo del destinatario",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -3337,6 +3337,7 @@
   "PayoutBankInformationForm.Error.RequiredFields": "There was an error fetching the required fields",
   "PayoutBankInformationForm.Field.AccountHolderName": "Full name of the account holder",
   "PayoutBankInformationForm.Field.BankCode": "Bank code (BIC/SWIFT)",
+  "PayoutBankInformationForm.Field.DateOfBirth": "Date of birth",
   "PayoutBankInformationForm.Field.RecipientType": "Recipient type",
   "PayoutBankInformationForm.HolderAddress": "Bank account holder address (not the bank address)",
   "PayoutBankInformationForm.RecipientAddress": "Recipient's Address",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -3337,6 +3337,7 @@
   "PayoutBankInformationForm.Error.RequiredFields": "There was an error fetching the required fields",
   "PayoutBankInformationForm.Field.AccountHolderName": "Full name of the account holder",
   "PayoutBankInformationForm.Field.BankCode": "Bank code (BIC/SWIFT)",
+  "PayoutBankInformationForm.Field.DateOfBirth": "Date of birth",
   "PayoutBankInformationForm.Field.RecipientType": "Recipient type",
   "PayoutBankInformationForm.HolderAddress": "Bank account holder address (not the bank address)",
   "PayoutBankInformationForm.RecipientAddress": "Recipient's Address",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -3337,6 +3337,7 @@
   "PayoutBankInformationForm.Error.RequiredFields": "Er is een fout opgetreden bij het ophalen van de vereiste velden",
   "PayoutBankInformationForm.Field.AccountHolderName": "Full name of the account holder",
   "PayoutBankInformationForm.Field.BankCode": "Bank code (BIC/SWIFT)",
+  "PayoutBankInformationForm.Field.DateOfBirth": "Date of birth",
   "PayoutBankInformationForm.Field.RecipientType": "Recipient type",
   "PayoutBankInformationForm.HolderAddress": "Bank account holder address (not the bank address)",
   "PayoutBankInformationForm.RecipientAddress": "Recipient's Address",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -3337,6 +3337,7 @@
   "PayoutBankInformationForm.Error.RequiredFields": "Wystąpił błąd przy pobieraniu wymaganych pól",
   "PayoutBankInformationForm.Field.AccountHolderName": "Full name of the account holder",
   "PayoutBankInformationForm.Field.BankCode": "Bank code (BIC/SWIFT)",
+  "PayoutBankInformationForm.Field.DateOfBirth": "Date of birth",
   "PayoutBankInformationForm.Field.RecipientType": "Recipient type",
   "PayoutBankInformationForm.HolderAddress": "Dane adresowe właściciela rachunku bankowego (nie adres banku)",
   "PayoutBankInformationForm.RecipientAddress": "Adres odbiorcy",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -3337,6 +3337,7 @@
   "PayoutBankInformationForm.Error.RequiredFields": "Ocorreu um erro ao buscar os dados necessários para a transferência",
   "PayoutBankInformationForm.Field.AccountHolderName": "Nome completo do titular da conta",
   "PayoutBankInformationForm.Field.BankCode": "Código do banco (BIC/SWIFT)",
+  "PayoutBankInformationForm.Field.DateOfBirth": "Date of birth",
   "PayoutBankInformationForm.Field.RecipientType": "Tipo de destinatário",
   "PayoutBankInformationForm.HolderAddress": "Endereço do titular da conta bancária (não o endereço do banco)",
   "PayoutBankInformationForm.RecipientAddress": "Endereço do destinatário",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -3337,6 +3337,7 @@
   "PayoutBankInformationForm.Error.RequiredFields": "There was an error fetching the required fields",
   "PayoutBankInformationForm.Field.AccountHolderName": "Full name of the account holder",
   "PayoutBankInformationForm.Field.BankCode": "Bank code (BIC/SWIFT)",
+  "PayoutBankInformationForm.Field.DateOfBirth": "Date of birth",
   "PayoutBankInformationForm.Field.RecipientType": "Recipient type",
   "PayoutBankInformationForm.HolderAddress": "Bank account holder address (not the bank address)",
   "PayoutBankInformationForm.RecipientAddress": "Recipient's Address",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -3337,6 +3337,7 @@
   "PayoutBankInformationForm.Error.RequiredFields": "There was an error fetching the required fields",
   "PayoutBankInformationForm.Field.AccountHolderName": "Full name of the account holder",
   "PayoutBankInformationForm.Field.BankCode": "Bank code (BIC/SWIFT)",
+  "PayoutBankInformationForm.Field.DateOfBirth": "Date of birth",
   "PayoutBankInformationForm.Field.RecipientType": "Recipient type",
   "PayoutBankInformationForm.HolderAddress": "Bank account holder address (not the bank address)",
   "PayoutBankInformationForm.RecipientAddress": "Recipient's Address",

--- a/lang/sk-SK.json
+++ b/lang/sk-SK.json
@@ -3337,6 +3337,7 @@
   "PayoutBankInformationForm.Error.RequiredFields": "Pri načítaní požadovaných polí nastala chyba",
   "PayoutBankInformationForm.Field.AccountHolderName": "Full name of the account holder",
   "PayoutBankInformationForm.Field.BankCode": "Bank code (BIC/SWIFT)",
+  "PayoutBankInformationForm.Field.DateOfBirth": "Date of birth",
   "PayoutBankInformationForm.Field.RecipientType": "Recipient type",
   "PayoutBankInformationForm.HolderAddress": "Adresa majiteľa bankového účtu (nie adresa banky)",
   "PayoutBankInformationForm.RecipientAddress": "Adresa príjemcu",

--- a/lang/sv-SE.json
+++ b/lang/sv-SE.json
@@ -3337,6 +3337,7 @@
   "PayoutBankInformationForm.Error.RequiredFields": "Det gick inte att hämta de obligatoriska fälten",
   "PayoutBankInformationForm.Field.AccountHolderName": "Full name of the account holder",
   "PayoutBankInformationForm.Field.BankCode": "Bank code (BIC/SWIFT)",
+  "PayoutBankInformationForm.Field.DateOfBirth": "Date of birth",
   "PayoutBankInformationForm.Field.RecipientType": "Recipient type",
   "PayoutBankInformationForm.HolderAddress": "Bankkontoinnehavarens adress (ej bankadress)",
   "PayoutBankInformationForm.RecipientAddress": "Mottagarens adress",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -3337,6 +3337,7 @@
   "PayoutBankInformationForm.Error.RequiredFields": "There was an error fetching the required fields",
   "PayoutBankInformationForm.Field.AccountHolderName": "Full name of the account holder",
   "PayoutBankInformationForm.Field.BankCode": "Bank code (BIC/SWIFT)",
+  "PayoutBankInformationForm.Field.DateOfBirth": "Date of birth",
   "PayoutBankInformationForm.Field.RecipientType": "Recipient type",
   "PayoutBankInformationForm.HolderAddress": "Bank account holder address (not the bank address)",
   "PayoutBankInformationForm.RecipientAddress": "Адреса одержувача",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -3337,6 +3337,7 @@
   "PayoutBankInformationForm.Error.RequiredFields": "在获取必要字段时出错",
   "PayoutBankInformationForm.Field.AccountHolderName": "Full name of the account holder",
   "PayoutBankInformationForm.Field.BankCode": "Bank code (BIC/SWIFT)",
+  "PayoutBankInformationForm.Field.DateOfBirth": "Date of birth",
   "PayoutBankInformationForm.Field.RecipientType": "Recipient type",
   "PayoutBankInformationForm.HolderAddress": "Bank account holder address (not the bank address)",
   "PayoutBankInformationForm.RecipientAddress": "收件地址",


### PR DESCRIPTION
Resolves https://github.com/opencollective/opencollective/issues/8905

Adds a localized label for the injected dateOfBirth field in the Alipay payout method creation form.