### PR TITLE
Add experiment props to contribution flow funnel events

### DIFF
--- a/components/contribution-flow/ContributionFlowButtons.js
+++ b/components/contribution-flow/ContributionFlowButtons.js
@@ -5,6 +5,7 @@ import { styled } from 'styled-components';
 
 import { AnalyticsEvent } from '../../lib/analytics/events';
 import { track } from '../../lib/analytics/plausible';
+import { AnalyticsProperty } from '../../lib/analytics/properties';
 
 import Currency from '../Currency';
 import { Box, Flex } from '../Grid';
@@ -35,6 +36,9 @@ class ContributionFlowButtons extends React.Component {
     tier: PropTypes.shape({ type: PropTypes.string }),
     stepDetails: PropTypes.object,
     stepSummary: PropTypes.object,
+    showPlatformTip: PropTypes.bool,
+    isOscTipExperiment: PropTypes.bool,
+    hostSlug: PropTypes.string,
   };
 
   state = { isLoadingNext: false };
@@ -49,7 +53,16 @@ class ContributionFlowButtons extends React.Component {
     }
 
     if (this.props.step.name === 'details') {
-      track(AnalyticsEvent.CONTRIBUTION_DETAILS_STEP_COMPLETED);
+      track(AnalyticsEvent.CONTRIBUTION_DETAILS_STEP_COMPLETED, {
+        props: {
+          [AnalyticsProperty.CONTRIBUTION_PLATFORM_TIP_VARIANT]: this.props.stepDetails?.isNewPlatformTip
+            ? 'new'
+            : 'old',
+          [AnalyticsProperty.CONTRIBUTION_PLATFORM_TIP_ENABLED]: Boolean(this.props.showPlatformTip),
+          [AnalyticsProperty.CONTRIBUTION_IS_OSC_TIP_EXPERIMENT]: Boolean(this.props.isOscTipExperiment),
+          [AnalyticsProperty.CONTRIBUTION_HOST_SLUG]: this.props.hostSlug,
+        },
+      });
     }
   };
 

--- a/components/contribution-flow/ContributionFlowStepContainer.js
+++ b/components/contribution-flow/ContributionFlowStepContainer.js
@@ -111,6 +111,8 @@ class ContributionFlowStepContainer extends React.Component {
         return (
           <StepPayment
             collective={this.props.collective}
+            showPlatformTip={this.props.showPlatformTip}
+            isOscTipExperiment={this.props.isOscTipExperiment}
             stepDetails={this.props.mainState.stepDetails}
             stepProfile={this.props.mainState.stepProfile}
             stepSummary={this.props.mainState.stepSummary}

--- a/components/contribution-flow/StepPayment.js
+++ b/components/contribution-flow/StepPayment.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { AnalyticsEvent } from '../../lib/analytics/events';
 import { track } from '../../lib/analytics/plausible';
+import { AnalyticsProperty } from '../../lib/analytics/properties';
 import useLoggedInUser from '../../lib/hooks/useLoggedInUser';
 import { require2FAForAdmins } from '../../lib/policies';
 
@@ -22,11 +23,21 @@ const StepPayment = ({
   hideCreditCardPostalCode = false,
   onNewCardFormReady,
   disabledPaymentMethodTypes,
+  showPlatformTip,
+  isOscTipExperiment,
 }) => {
   const { LoggedInUser } = useLoggedInUser();
 
   React.useEffect(() => {
-    track(AnalyticsEvent.CONTRIBUTION_PAYMENT_STEP);
+    track(AnalyticsEvent.CONTRIBUTION_PAYMENT_STEP, {
+      props: {
+        [AnalyticsProperty.CONTRIBUTION_PLATFORM_TIP_VARIANT]: stepDetails?.isNewPlatformTip ? 'new' : 'old',
+        [AnalyticsProperty.CONTRIBUTION_PLATFORM_TIP_ENABLED]: Boolean(showPlatformTip),
+        [AnalyticsProperty.CONTRIBUTION_IS_OSC_TIP_EXPERIMENT]: Boolean(isOscTipExperiment),
+        [AnalyticsProperty.CONTRIBUTION_HOST_SLUG]: collective?.host?.slug,
+      },
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   if (require2FAForAdmins(stepProfile) && !LoggedInUser?.hasTwoFactorAuth) {

--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -1029,6 +1029,9 @@ class ContributionFlow extends React.Component {
                       stepDetails={stepDetails}
                       stepSummary={stepSummary}
                       disabled={this.state.isInitializing || this.state.isNavigating}
+                      showPlatformTip={this.canHavePlatformTips()}
+                      isOscTipExperiment={this.isOscTipExperiment()}
+                      hostSlug={this.props.collective?.host?.slug}
                     />
                   </Box>
                   {!isEmbed && (

--- a/components/contribution-flow/index.js
+++ b/components/contribution-flow/index.js
@@ -222,7 +222,16 @@ class ContributionFlow extends React.Component {
 
       if (step !== 'details') {
         // started the contribution flow at advanced step with details picked.
-        track(AnalyticsEvent.CONTRIBUTION_DETAILS_STEP_COMPLETED);
+        track(AnalyticsEvent.CONTRIBUTION_DETAILS_STEP_COMPLETED, {
+          props: {
+            [AnalyticsProperty.CONTRIBUTION_PLATFORM_TIP_VARIANT]: this.state.stepDetails.isNewPlatformTip
+              ? 'new'
+              : 'old',
+            [AnalyticsProperty.CONTRIBUTION_PLATFORM_TIP_ENABLED]: this.canHavePlatformTips(),
+            [AnalyticsProperty.CONTRIBUTION_IS_OSC_TIP_EXPERIMENT]: this.isOscTipExperiment(),
+            [AnalyticsProperty.CONTRIBUTION_HOST_SLUG]: this.props.collective?.host?.slug,
+          },
+        });
       }
     }
   }


### PR DESCRIPTION
## Context

`Contribution Started` and `Contribution Submitted` already carry the OSC platform tip experiment props (`contributionPlatformTipEnabled`, `contributionIsOscTipExperiment`, tip variant, host slug), but the two mid-funnel events — `Contribution Details Step Completed` and `Contribution Payment Step` — are tracked without them. As a result we can see per-arm entry and per-arm submits, but not where in the flow the two arms diverge, which makes conversion dips (like the one on Aug 20–21) impossible to localize.

## Changes

- Track `Contribution Details Step Completed` (`ContributionFlowButtons`) with the same props as the other funnel events.
- Track `Contribution Payment Step` (`StepPayment`) with the same props.
- Thread `showPlatformTip` / `isOscTipExperiment` / `hostSlug` from the contribution flow root so all four events compute the arm from the same source (`canHavePlatformTips()` / `isOscTipExperiment()`).

After deploy, the full per-arm funnel (started → details completed → payment reached → submitted) becomes queryable in Plausible by filtering on `contributionIsOscTipExperiment` and breaking down by `contributionPlatformTipEnabled`.