### PR TITLE
Make the OSC tip experiment draw sticky per browser and collective

### DIFF
--- a/env.js
+++ b/env.js
@@ -50,7 +50,7 @@ const defaults = {
   DISABLE_CONTACT_FORM: false,
   NEW_PRICING: false,
   NEW_PLATFORM_TIP_FLOW_ROLLOUT_PERCENTAGE: 0,
-  OSC_PLATFORM_TIP_ROLLOUT_PERCENTAGE: 20,
+  OSC_PLATFORM_TIP_ROLLOUT_PERCENTAGE: 50,
 };
 
 if ((process.env.OC_ENV || process.env.NODE_ENV || 'production') === 'production') {

--- a/lib/experiments/experiments.test.ts
+++ b/lib/experiments/experiments.test.ts
@@ -47,20 +47,22 @@ describe('experiments', () => {
     ).toBe(false);
   });
 
-  it('keeps the new platform tip flow disabled for Open Source Collective host', () => {
-    process.env.NEW_PLATFORM_TIP_FLOW_ROLLOUT_PERCENTAGE = '100';
-    randomSpy.mockReturnValue(0);
+  it('always enables the new platform tip flow for Open Source Collective host', () => {
+    // Even with the rollout at 0, OSC gets the new tip UI deterministically
+    process.env.NEW_PLATFORM_TIP_FLOW_ROLLOUT_PERCENTAGE = '0';
+    randomSpy.mockReturnValue(0.99);
 
     expect(
       isExperimentEnabled(Experiment.NEW_PLATFORM_TIP_FLOW, undefined, {
         collective: { host: { slug: 'opensource' } },
       }),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       isExperimentEnabled(Experiment.NEW_PLATFORM_TIP_FLOW, undefined, {
         collective: { host: { legacyId: 11004 } },
       }),
-    ).toBe(false);
+    ).toBe(true);
+    expect(randomSpy).not.toHaveBeenCalled();
   });
 
   it('uses the configured rollout percentage for other hosts', () => {

--- a/lib/experiments/experiments.test.ts
+++ b/lib/experiments/experiments.test.ts
@@ -86,15 +86,15 @@ describe('experiments', () => {
     expect(isExperimentEnabled(Experiment.NEW_PLATFORM_TIP_FLOW)).toBe(true);
   });
 
-  it('defaults to a 20% rollout when the percentage is not configured', () => {
+  it('defaults to a 50% rollout when the percentage is not configured', () => {
     const context = { collective: { host: { slug: 'opensource' } } };
 
     // Below the default rollout percentage: tip proposed (experiment not enabled)
-    randomSpy.mockReturnValueOnce(0.19);
+    randomSpy.mockReturnValueOnce(0.49);
     expect(isExperimentEnabled(Experiment.OPENSOURCE_PLATFORM_TIP_AB, undefined, context)).toBe(false);
 
     // At or above the default rollout percentage: tip hidden (experiment enabled)
-    randomSpy.mockReturnValueOnce(0.2);
+    randomSpy.mockReturnValueOnce(0.5);
     expect(isExperimentEnabled(Experiment.OPENSOURCE_PLATFORM_TIP_AB, undefined, context)).toBe(true);
   });
 

--- a/lib/experiments/experiments.test.ts
+++ b/lib/experiments/experiments.test.ts
@@ -17,6 +17,7 @@ describe('experiments', () => {
     (process as any).browser = true;
     (window as any).__NEXT_DATA__ = { env: {} };
     window.history.replaceState({}, '', '/');
+    window.localStorage.clear();
   });
 
   afterEach(() => {
@@ -123,5 +124,68 @@ describe('experiments', () => {
         collective: { host: { slug: 'other-host' } },
       }),
     ).toBe(false);
+  });
+
+  it('keeps the OSC tip draw sticky per collective across page loads', () => {
+    const context = { collective: { slug: 'webpack', host: { slug: 'opensource' } } };
+
+    // First load draws the tip-hidden arm and persists it
+    randomSpy.mockReturnValueOnce(0.99);
+    expect(isExperimentEnabled(Experiment.OPENSOURCE_PLATFORM_TIP_AB, undefined, context)).toBe(true);
+
+    // Subsequent loads reuse the stored draw instead of re-rolling
+    randomSpy.mockReturnValueOnce(0);
+    expect(isExperimentEnabled(Experiment.OPENSOURCE_PLATFORM_TIP_AB, undefined, context)).toBe(true);
+    expect(randomSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('draws independently for different collectives', () => {
+    const webpack = { collective: { slug: 'webpack', host: { slug: 'opensource' } } };
+    const curl = { collective: { slug: 'curl', host: { slug: 'opensource' } } };
+
+    randomSpy.mockReturnValueOnce(0.99).mockReturnValueOnce(0);
+    expect(isExperimentEnabled(Experiment.OPENSOURCE_PLATFORM_TIP_AB, undefined, webpack)).toBe(true);
+    expect(isExperimentEnabled(Experiment.OPENSOURCE_PLATFORM_TIP_AB, undefined, curl)).toBe(false);
+
+    // Each collective keeps its own arm
+    expect(isExperimentEnabled(Experiment.OPENSOURCE_PLATFORM_TIP_AB, undefined, webpack)).toBe(true);
+    expect(isExperimentEnabled(Experiment.OPENSOURCE_PLATFORM_TIP_AB, undefined, curl)).toBe(false);
+  });
+
+  it('re-rolls stored draws when the rollout percentage changes', () => {
+    const context = { collective: { slug: 'webpack', host: { slug: 'opensource' } } };
+
+    setOscRolloutPercentage('20');
+    randomSpy.mockReturnValueOnce(0.99);
+    expect(isExperimentEnabled(Experiment.OPENSOURCE_PLATFORM_TIP_AB, undefined, context)).toBe(true);
+
+    // Percentage changed: the stored draw is stale, a new one is made under the new split
+    setOscRolloutPercentage('100');
+    randomSpy.mockReturnValueOnce(0.99);
+    expect(isExperimentEnabled(Experiment.OPENSOURCE_PLATFORM_TIP_AB, undefined, context)).toBe(false);
+
+    // And the new draw is sticky in turn
+    expect(isExperimentEnabled(Experiment.OPENSOURCE_PLATFORM_TIP_AB, undefined, context)).toBe(false);
+    expect(randomSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to a per-load draw when the context has no collective slug', () => {
+    const context = { collective: { host: { slug: 'opensource' } } };
+
+    randomSpy.mockReturnValueOnce(0.99).mockReturnValueOnce(0);
+    expect(isExperimentEnabled(Experiment.OPENSOURCE_PLATFORM_TIP_AB, undefined, context)).toBe(true);
+    expect(isExperimentEnabled(Experiment.OPENSOURCE_PLATFORM_TIP_AB, undefined, context)).toBe(false);
+  });
+
+  it('survives corrupted stored draws', () => {
+    window.localStorage.setItem('oscTipExperimentDraws', '{not json');
+    const context = { collective: { slug: 'webpack', host: { slug: 'opensource' } } };
+
+    randomSpy.mockReturnValueOnce(0.99);
+    expect(isExperimentEnabled(Experiment.OPENSOURCE_PLATFORM_TIP_AB, undefined, context)).toBe(true);
+
+    // The corrupted blob was replaced by a valid one holding the new draw
+    expect(isExperimentEnabled(Experiment.OPENSOURCE_PLATFORM_TIP_AB, undefined, context)).toBe(true);
+    expect(randomSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/lib/experiments/experiments.test.ts
+++ b/lib/experiments/experiments.test.ts
@@ -188,4 +188,15 @@ describe('experiments', () => {
     expect(isExperimentEnabled(Experiment.OPENSOURCE_PLATFORM_TIP_AB, undefined, context)).toBe(true);
     expect(randomSpy).toHaveBeenCalledTimes(1);
   });
+
+  it.each(['true', '42', '"foo"', '[]'])('survives stored draws holding valid but wrongly shaped JSON (%s)', stored => {
+    window.localStorage.setItem('oscTipExperimentDraws', stored);
+    const context = { collective: { slug: 'webpack', host: { slug: 'opensource' } } };
+
+    // Neither throws nor loses stickiness: the bad value is replaced by a fresh draw map
+    randomSpy.mockReturnValueOnce(0.99);
+    expect(isExperimentEnabled(Experiment.OPENSOURCE_PLATFORM_TIP_AB, undefined, context)).toBe(true);
+    expect(isExperimentEnabled(Experiment.OPENSOURCE_PLATFORM_TIP_AB, undefined, context)).toBe(true);
+    expect(randomSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/lib/experiments/experiments.ts
+++ b/lib/experiments/experiments.ts
@@ -148,9 +148,11 @@ const experiments: Record<Experiment, ExperimentConfig> = {
         return false;
       }
 
-      // Open Source Collective stays on the legacy flow for now, no A/B.
+      // Open Source Collective always uses the new platform tip UI, no A/B: the OSC tip
+      // experiment (opensourcePlatformTipAb) compares tip shown vs hidden, and when shown,
+      // the tip step uses the new interface.
       if (isOpenSourceCollectiveHost(context?.collective?.host)) {
-        return false;
+        return true;
       }
 
       return Math.random() * 100 < getNewPlatformTipFlowRolloutPercentage();

--- a/lib/experiments/experiments.ts
+++ b/lib/experiments/experiments.ts
@@ -27,7 +27,7 @@ const NON_RANDOMIZED_ENVS = ['ci', 'e2e', 'test'];
 const OPEN_SOURCE_COLLECTIVE_HOST_SLUG = 'opensource';
 const OPEN_SOURCE_COLLECTIVE_HOST_LEGACY_ID = 11004;
 const DEFAULT_NEW_PLATFORM_TIP_FLOW_ROLLOUT_PERCENTAGE = 0;
-const DEFAULT_OSC_PLATFORM_TIP_ROLLOUT_PERCENTAGE = 20;
+const DEFAULT_OSC_PLATFORM_TIP_ROLLOUT_PERCENTAGE = 50;
 
 function getRolloutPercentage(rawValue: string, defaultValue: number): number {
   const percentage = parseInt(rawValue, 10);
@@ -158,8 +158,10 @@ const experiments: Record<Experiment, ExperimentConfig> = {
   },
   // OSC-only experiment for measuring the impact of platform tips on contributions.
   // `true` means the tip step is hidden for this user. OSC_PLATFORM_TIP_ROLLOUT_PERCENTAGE
-  // is the share of eligible contributions that get the tip proposed (default 20); the
-  // remainder is the holdout where the tip is hidden. Set to 100 to end the holdout.
+  // is the share of eligible contributions that get the tip proposed (default 50); the
+  // remainder is the holdout where the tip is hidden. Equal arms keep the revenue comparison
+  // centered and unbiased under the site's heavy-tailed contribution amounts. Set to 100 to
+  // end the holdout.
   [Experiment.OPENSOURCE_PLATFORM_TIP_AB]: {
     enabled(_user, context): boolean {
       if (typeof window === 'undefined' || NON_RANDOMIZED_ENVS.includes(process.env.OC_ENV)) {

--- a/lib/experiments/experiments.ts
+++ b/lib/experiments/experiments.ts
@@ -108,7 +108,11 @@ type StoredDraws = Record<string, { enabled: boolean; pct: number }>;
 function getStickyDraw(collectiveSlug: string, rolloutPercentage: number): boolean {
   let draws: StoredDraws;
   try {
-    draws = JSON.parse(getFromLocalStorage(LOCAL_STORAGE_KEYS.OSC_TIP_EXPERIMENT_DRAWS)) || {};
+    const parsed = JSON.parse(getFromLocalStorage(LOCAL_STORAGE_KEYS.OSC_TIP_EXPERIMENT_DRAWS));
+    // Guard against stored values that parse but aren't a plain object (true, 42, "foo", []):
+    // assigning a property to a primitive throws in strict mode, and arrays don't stringify
+    // their named properties, so either would break or silently disable the stickiness.
+    draws = parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
   } catch {
     draws = {};
   }

--- a/lib/experiments/experiments.ts
+++ b/lib/experiments/experiments.ts
@@ -1,5 +1,6 @@
 import { AmountTypes, TierTypes } from '../constants/tiers-types';
 import { getEnvVar } from '../env-utils';
+import { getFromLocalStorage, LOCAL_STORAGE_KEYS, setLocalStorage } from '../local-storage';
 import type LoggedInUser from '../LoggedInUser';
 import { parseToBoolean } from '../utils';
 
@@ -14,6 +15,7 @@ type ExperimentConfig = {
 
 type ExperimentContext = {
   collective?: {
+    slug?: string;
     host?: {
       slug?: string;
       legacyId?: number | string;
@@ -94,6 +96,34 @@ export function isOscTipExperiment(collective?: PlatformTipCollective | null, ti
   return isOpenSourceCollectiveHost(collective?.host) && platformTipApplies(collective, tier);
 }
 
+// Sticky per-browser, per-collective draws for the OSC platform tip experiment. Without
+// persistence, every page load re-rolls the arm: a contributor who reloads mid-flow has an 80%
+// chance of leaving the tip arm, a one-way drift that selects deliberate (larger) contributions
+// into the holdout and biases the revenue comparison. Draws are stored per collective slug so a
+// visitor keeps their arm across visits to the same collective, while different collectives get
+// independent draws. Stored draws are keyed to the rollout percentage that produced them: when
+// the percentage changes, stale draws are re-rolled so the new split applies immediately.
+type StoredDraws = Record<string, { enabled: boolean; pct: number }>;
+
+function getStickyDraw(collectiveSlug: string, rolloutPercentage: number): boolean {
+  let draws: StoredDraws;
+  try {
+    draws = JSON.parse(getFromLocalStorage(LOCAL_STORAGE_KEYS.OSC_TIP_EXPERIMENT_DRAWS)) || {};
+  } catch {
+    draws = {};
+  }
+
+  const stored = draws[collectiveSlug];
+  if (stored && stored.pct === rolloutPercentage && typeof stored.enabled === 'boolean') {
+    return stored.enabled;
+  }
+
+  const enabled = Math.random() * 100 >= rolloutPercentage;
+  draws[collectiveSlug] = { enabled, pct: rolloutPercentage };
+  setLocalStorage(LOCAL_STORAGE_KEYS.OSC_TIP_EXPERIMENT_DRAWS, JSON.stringify(draws));
+  return enabled;
+}
+
 // Reads ?<experiment>=<value> from the current URL to force a variant.
 // Returns true/false to force, or undefined when not present.
 function getOverride(experiment: Experiment): boolean | undefined {
@@ -136,7 +166,13 @@ const experiments: Record<Experiment, ExperimentConfig> = {
         return false;
       }
 
-      return Math.random() * 100 >= getOscPlatformTipRolloutPercentage();
+      const rolloutPercentage = getOscPlatformTipRolloutPercentage();
+      const collectiveSlug = context?.collective?.slug;
+      if (!collectiveSlug) {
+        return Math.random() * 100 >= rolloutPercentage;
+      }
+
+      return getStickyDraw(collectiveSlug, rolloutPercentage);
     },
   },
 };

--- a/lib/local-storage.ts
+++ b/lib/local-storage.ts
@@ -13,6 +13,7 @@ export const LOCAL_STORAGE_KEYS = {
   RECENTLY_VISITED: 'recentlyVisited',
   PLAID_LINK_TOKEN: 'plaidLinkToken',
   GOCARDLESS_DATA: 'gocardlessData',
+  OSC_TIP_EXPERIMENT_DRAWS: 'oscTipExperimentDraws',
 };
 
 // The below helpers use a try-catch to gracefully fallback in these scenarios:


### PR DESCRIPTION
The OSC tip experiment arm was re-drawn on every page load. At 20/80 a mid-flow reload has an 80% chance of moving the contributor out of the tip arm, a one-way drift that biases the arm comparison, and the unequal split makes revenue metrics whale-dominated.

Changes:

- Persist the draw in localStorage per collective slug, using the existing `lib/local-storage` helpers. Falls back to per-load behavior when storage is unavailable; invalid or wrongly shaped stored values are discarded and re-drawn.
- Stored draws are keyed to the rollout percentage and re-rolled when it changes, so config updates apply to everyone at once.
- Default rollout moves from 20 to 50, in `env.js` (the live default in production, the var is not set there) and `experiments.ts`.
- OSC now always gets the new platform tip UI when the tip is shown. Other hosts keep the `NEW_PLATFORM_TIP_FLOW_ROLLOUT_PERCENTAGE` rollout.

Deploy notes: the split moves to 50/50 at deploy, no config change needed. Date-fence arm comparisons at this deploy (assignment, split and shown-arm UI all change). Repeat contributors to the same collective should stop appearing in both arms; that's the signal stickiness works.