### PR TITLE
Show the draft invite welcome card even without a recipient note

### DIFF
--- a/components/expenses/Expense.tsx
+++ b/components/expenses/Expense.tsx
@@ -308,7 +308,7 @@ function Expense(props: ExpenseProps) {
 
       <Box mb={3}>
         {(expense?.permissions?.canDeclineExpenseInvite ||
-          (expense?.status === ExpenseStatus.DRAFT && !isRecurring && draftKey && expense?.draft?.recipientNote)) && (
+          (expense?.status === ExpenseStatus.DRAFT && !isRecurring && draftKey)) && (
           <ExpenseInviteWelcome
             onContinueSubmissionClick={onContinueSubmissionClick}
             className="mb-6"

--- a/components/expenses/ExpenseInviteWelcome.test.tsx
+++ b/components/expenses/ExpenseInviteWelcome.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { withRequiredProviders } from '../../test/providers';
+
+import ExpenseInviteWelcome from './ExpenseInviteWelcome';
+
+const baseExpense = {
+  id: 'expense-id',
+  legacyId: 42,
+  createdAt: new Date('2026-01-01'),
+  createdByAccount: {
+    id: 'account-id',
+    legacyId: 1,
+    slug: 'inviter',
+    name: 'Inviter',
+    type: 'INDIVIDUAL',
+  },
+  permissions: {
+    canDeclineExpenseInvite: false,
+  },
+} as unknown as React.ComponentProps<typeof ExpenseInviteWelcome>['expense'];
+
+describe('ExpenseInviteWelcome', () => {
+  it('shows the continue button even when the draft has no recipient note', () => {
+    render(
+      withRequiredProviders(
+        <ExpenseInviteWelcome expense={baseExpense} draftKey="draft-key" onContinueSubmissionClick={jest.fn()} />,
+      ),
+    );
+
+    expect(screen.getByRole('button', { name: /continue submission/i })).toBeInTheDocument();
+  });
+
+  it('shows the recipient note when the draft has one', () => {
+    render(
+      withRequiredProviders(
+        <ExpenseInviteWelcome
+          expense={{ ...baseExpense, draft: { recipientNote: 'Please fill in your payout details' } }}
+          draftKey="draft-key"
+          onContinueSubmissionClick={jest.fn()}
+        />,
+      ),
+    );
+
+    expect(screen.getByText('Please fill in your payout details')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /continue submission/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
On the expense page, a viewer arriving with a valid `?key=` in the URL only got the welcome card with the "Continue submission" button when the draft had a `recipientNote`. Since the note is optional content inside the card (it already renders conditionally), it should not gate the entry point into the draft completion flow.

This drops the `recipientNote` condition so any valid key holder sees the card, and adds render tests for `ExpenseInviteWelcome` covering both with and without a note.

To reproduce: create a draft expense invite with an empty recipient note, then open the invite link. Before this change, only the read-only summary was shown; now the "Continue submission" button appears.