### PR TITLE
fix(Webhooks): offer collective.rejected in the activity picker

### DIFF
--- a/components/edit-collective/sections/Webhooks.tsx
+++ b/components/edit-collective/sections/Webhooks.tsx
@@ -73,6 +73,7 @@ const WEBHOOK_EVENT_GROUPS = defineMessages({
     events: [
       WebhookEvents.COLLECTIVE_APPLY,
       WebhookEvents.COLLECTIVE_APPROVED,
+      WebhookEvents.COLLECTIVE_REJECTED,
       WebhookEvents.COLLECTIVE_CREATED,
       WebhookEvents.CONNECTED_ACCOUNT_CREATED,
     ],

--- a/lib/constants/notificationEvents.js
+++ b/lib/constants/notificationEvents.js
@@ -5,6 +5,7 @@ export const WebhookEvents = {
   CONNECTED_ACCOUNT_CREATED: 'connected_account.created',
   COLLECTIVE_APPLY: 'collective.apply',
   COLLECTIVE_APPROVED: 'collective.approved',
+  COLLECTIVE_REJECTED: 'collective.rejected',
   COLLECTIVE_CREATED: 'collective.created',
   COLLECTIVE_COMMENT_CREATED: 'collective.comment.created',
   COLLECTIVE_EXPENSE_CREATED: 'collective.expense.created',

--- a/lib/i18n/webhook-event-type.js
+++ b/lib/i18n/webhook-event-type.js
@@ -19,6 +19,10 @@ const TypesI18n = defineMessages({
     id: 'WebhookEvents.COLLECTIVE_APPROVED',
     defaultMessage: 'Collective application approved',
   },
+  [WebhookEvents.COLLECTIVE_REJECTED]: {
+    id: 'WebhookEvents.COLLECTIVE_REJECTED',
+    defaultMessage: 'Collective application rejected',
+  },
   [WebhookEvents.COLLECTIVE_CREATED]: {
     id: 'WebhookEvents.COLLECTIVE_CREATED',
     defaultMessage: 'Collective created',


### PR DESCRIPTION
We got feedback from a fiscal host admin asking why the UI only offers a limited set of webhook activities while the API accepts many more. They wanted to be notified when they reject a hosting application, and had to fall back to the API to set that up.

The Fiscal Host group in the webhook picker offers `collective.apply`, `collective.approved` and `collective.created`, but not `collective.rejected`, even though the pairing with approved is the obvious one for a host tracking its application queue. The `WebhookEvents.COLLECTIVE_REJECTED` message id already existed and was translated in `lang/en.json` and `lang/fr.json`, so the event was simply never wired into the picker.

Here is what the PR does:

- add `COLLECTIVE_REJECTED` to `WebhookEvents`
- add its label to the webhook event type i18n map
- list it in the Fiscal Host group, right after `COLLECTIVE_APPROVED`

This only makes the event selectable. It needs opencollective/opencollective-api#12052 to actually be delivered, because host application activities are recorded on the applicant collective and were never fanned out to the host, and because the payload was being emptied by the sanitizer. Best to merge that one first.

The wider gap between the picker, the sanitizer and the API enum is documented in opencollective/opencollective#8908.