### PR TITLE
chore(security.txt): make it RFC 9116 compliant and redirect /security.txt

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -264,6 +264,12 @@ const nextConfig = {
   },
   async redirects() {
     return [
+      // Legacy security.txt location, see RFC 9116
+      {
+        source: '/security.txt',
+        destination: '/.well-known/security.txt',
+        permanent: true,
+      },
       // Legacy settings (/edit)
       {
         source: '/:slug/edit/:section*',

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,4 +1,5 @@
-Contact: security@opencollective.com
+Contact: mailto:security@opencollective.com
+Expires: 2027-09-01T00:00:00.000Z
 Preferred-Languages: en
 Canonical: https://opencollective.com/.well-known/security.txt
-Policy: https://github.com/opencollective/opencollective/blob/main/SECURITY.md
+Policy: https://github.com/opencollective/opencollective/security/policy


### PR DESCRIPTION
## Context

`public/.well-known/security.txt` has been in the repo since 2019 and is served correctly in production and staging (`200`, `content-type: text/plain`, `oc-backend: frontend`). But it isn't valid [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116), so scanners such as securitytxt.org reject it.

## Changes

**`public/.well-known/security.txt`**

- Add `Expires`. It is a required field per RFC 9116 §2.5.5 and was missing entirely.
- `Contact` must be a URI (RFC 9116 §2.5.3), so a bare email address is invalid, now `mailto:`.
- Point `Policy` at the rendered policy page rather than the raw `SECURITY.md` blob.

**`next.config.js`**

- Redirect the legacy top-level `/security.txt` to `/.well-known/security.txt`, which previously returned the Next.js 404 page. RFC 9116 §3 makes `/.well-known/` the required location and explicitly permits a redirect from the top-level path for legacy compatibility.

## Verification

Against a local dev server:

```
$ curl -i http://localhost:3000/security.txt
HTTP/1.1 308 Permanent Redirect
location: /.well-known/security.txt

$ curl -L http://localhost:3000/security.txt
HTTP/1.1 200 OK
Content-Type: text/plain; charset=UTF-8
```

**No change is needed in [opencollective-workers](https://github.com/opencollective/opencollective-workers).** `/security.txt` matches no rule in `getBackend()` (the `.json|.csv` rule excludes `.txt`, and the `logo.txt` rule requires a two-segment path), so it falls through to the `frontend` default. The `Location` header is relative, so the browser resolves it against `opencollective.com` and stays behind the worker instead of leaking `frontend.opencollective.com`.

## Note

Nothing tracks the `Expires` date, so the file silently goes stale on 2027-09-01. Worth bumping whenever the security policy is touched.