### PR TITLE
fix: remove doubled words in three component comments

### DIFF
--- a/components/AutoCollapse.tsx
+++ b/components/AutoCollapse.tsx
@@ -21,7 +21,7 @@ const CollapsedDisplayBox = styled.div<DisplayBoxProps>`
   mask-image: linear-gradient(to bottom, black 50%, transparent 100%);
 `;
 
-/* The the padding to apply to the collapse blur; useful in the case of making sure only the blur effect is not applied unnecessarily. For
+/* The padding to apply to the collapse blur; useful in the case of making sure only the blur effect is not applied unnecessarily. For
  * example maxCollapsedHeight=20 and collapsePadding=22 ensure that content is collapsed only when there's more than two lines and if there's
  * only two lines the blur effect is not applied.
  */

--- a/components/collective-page/ContributeCardsContainer.js
+++ b/components/collective-page/ContributeCardsContainer.js
@@ -5,7 +5,7 @@ import { CustomScrollbarCSS } from '../../lib/styled-components-shared-styles';
 
 import { Dimensions } from './_constants';
 
-/** An horizontally scrollable container to display contribute cards cards */
+/** An horizontally scrollable container to display contribute cards */
 const ContributeCardsContainer = styled.div.attrs(props => ({
   display: props.display ?? 'flex',
 }))`

--- a/components/ui/Stepper.tsx
+++ b/components/ui/Stepper.tsx
@@ -384,7 +384,7 @@ interface StepSharedProps extends StepProps {
   isLoading?: boolean;
 }
 
-// Props which shouldn't be passed to to the Step component from the user
+// Props which shouldn't be passed to the Step component from the user
 interface StepInternalConfig {
   index: number;
   isCompletedStep?: boolean;


### PR DESCRIPTION
Three doubled words in component comments: "The the padding" in
AutoCollapse.tsx, "contribute cards cards" in
ContributeCardsContainer.js, and "passed to to the Step component" in
ui/Stepper.tsx. Comments only.
