### PR TITLE
fix(signin): block open redirect via NUL-prefixed next URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ public/static/cmaps
 
 lib/graphql/types/v2/index.ts
 lib/graphql/types/v2/gql.ts
+
+.codegraph

--- a/lib/__tests__/utils.test.js
+++ b/lib/__tests__/utils.test.js
@@ -22,7 +22,6 @@ describe('utils lib', () => {
       expect(utils.isValidRelativeUrl('/hello/world/test')).toEqual(true);
       expect(utils.isValidRelativeUrl('/hello/world/test/')).toEqual(true);
       expect(utils.isValidRelativeUrl('/about.html')).toEqual(true);
-      expect(utils.isValidRelativeUrl('//')).toEqual(true);
 
       // Without `/` prefix
       expect(utils.isValidRelativeUrl('a/b/c/d/e')).toEqual(true);
@@ -36,6 +35,7 @@ describe('utils lib', () => {
     });
 
     it('should return false for invalid urls', () => {
+      expect(utils.isValidRelativeUrl('//')).toEqual(false);
       expect(utils.isValidRelativeUrl('/\n/xxx')).toEqual(false);
       expect(utils.isValidRelativeUrl('/ /xxx')).toEqual(false);
       expect(utils.isValidRelativeUrl('/\\/xxx')).toEqual(false);
@@ -45,6 +45,18 @@ describe('utils lib', () => {
       expect(utils.isValidRelativeUrl('\\\n/example.com')).toEqual(false);
       expect(utils.isValidRelativeUrl('/ /xxx/')).toEqual(false);
       expect(utils.isValidRelativeUrl('/ /xxx/test')).toEqual(false);
+    });
+
+    it('should reject C0-prefixed and backslash protocol-relative urls', () => {
+      const nulPrefixed = new URLSearchParams('next=%00%2F%2Fevil.com').get('next');
+      const sohPrefixed = new URLSearchParams('next=%01%2F%2Fevil.com').get('next');
+      expect(utils.isValidRelativeUrl(nulPrefixed)).toEqual(false);
+      expect(utils.isValidRelativeUrl(sohPrefixed)).toEqual(false);
+      expect(utils.isValidRelativeUrl('\u0000//evil.com')).toEqual(false);
+      expect(utils.isValidRelativeUrl('\u0001//evil.com')).toEqual(false);
+      expect(utils.isValidRelativeUrl('/\\evil.com')).toEqual(false);
+      expect(utils.isValidRelativeUrl('\\evil.com')).toEqual(false);
+      expect(utils.isValidRelativeUrl('//evil.com')).toEqual(false);
     });
   });
 });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -40,6 +40,12 @@ export const isValidUrl = url => {
 };
 
 /**
+ * Dummy origin used only to decide whether `url` stays same-site when resolved.
+ * Must not depend on WEBSITE_URL (unset in some unit tests / SSR).
+ */
+const RELATIVE_URL_PARSE_BASE = 'https://opencollective.com';
+
+/**
  * Validate a relative path.
  * > isValidRelativeUrl('a/b/c/d/e/f/g')
  * true
@@ -53,8 +59,26 @@ export const isValidUrl = url => {
  * false
  */
 export const isValidRelativeUrl = url => {
-  url = url?.trim();
+  if (typeof url !== 'string') {
+    return false;
+  }
+
+  url = url.trim();
   if (!url) {
+    return false;
+  }
+
+  // WHATWG parsers strip leading C0 controls / DEL, so a NUL-prefixed "//evil.com"
+  // would otherwise look relative here and resolve off-site via `new URL(url, base)`.
+  for (let i = 0; i < url.length; i++) {
+    const code = url.charCodeAt(i);
+    if (code <= 0x1f || code === 0x7f) {
+      return false;
+    }
+  }
+
+  // Some URL parsers treat backslash as a slash (/\evil.com -> //evil.com).
+  if (url.includes('\\')) {
     return false;
   }
 
@@ -63,12 +87,17 @@ export const isValidRelativeUrl = url => {
     new URL(url);
     return false;
   } catch {
-    // Prevent URLs like //example.com or /\n/example.com or /\/example.com/
+    // Prevent URLs like //example.com or / /example.com
     if (url.match(/^[\s\\/]{2,}.+/)) {
       return false;
-    } else {
-      return true;
     }
+  }
+
+  try {
+    const parsed = new URL(url, RELATIVE_URL_PARSE_BASE);
+    return parsed.origin === new URL(RELATIVE_URL_PARSE_BASE).origin;
+  } catch {
+    return false;
   }
 };
 


### PR DESCRIPTION
## Summary
- Harden `isValidRelativeUrl` to reject C0 control characters, backslashes, and values that resolve off-site when parsed against the site origin
- Fixes an open redirect in the sign-in `next` parameter (e.g. `%00%2F%2Fevil.com`) that bypassed the untrusted-domain warning
- Add regression tests for NUL/SOH-prefixed, backslash, and protocol-relative bypass attempts

## Test plan
- [x] `npm test -- lib/__tests__/utils.test.js`
- [x] ESLint and Prettier on changed files
- [ ] Open `/signin?next=%00%2F%2Fevil.com`, sign in, and confirm the untrusted-domain warning appears instead of redirecting off-site
- [ ] Confirm legitimate relative redirects still work (e.g. `/signin?next=/dashboard`)